### PR TITLE
[DRAFT] Allow solidus_starter_frontend to be installed with Solidus

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -28,6 +28,7 @@ module Solidus
                  enum: PAYMENT_METHODS.keys,
                  default: PAYMENT_METHODS.keys.first,
                  desc: "Indicates which payment method to install."
+    class_option :with_frontend, type: :string, default: 'spree/frontend'
 
     def self.source_paths
       paths = superclass.source_paths
@@ -246,6 +247,14 @@ module Solidus
       end
     end
 
+    def install_solidus_starter_frontend
+      return unless install_solidus_starter_frontend?
+
+      say_status :install, "Solidus Starter Frontend"
+      ENV['LOCATION'] ||= 'https://raw.githubusercontent.com/nebulab/solidus_starter_frontend/master/template.rb'
+      run 'bin/rails app:template'
+    end
+
     def complete
       unless options[:quiet]
         puts "*" * 50
@@ -256,6 +265,10 @@ module Solidus
     end
 
     private
+
+    def install_solidus_starter_frontend?
+      options[:with_frontend] == 'solidus_starter_frontend'
+    end
 
     def bundle_cleanly(&block)
       Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&block) : Bundler.with_clean_env(&block)


### PR DESCRIPTION
## Blockers

In draft mode until https://github.com/nebulab/solidus_starter_frontend/pull/185 is merged.

Goal
----

As a Solidus user

I want `solidus:install` to have the option to install with `solidus_starter_frontend`

So that I won't have to install them separately

Requirement
-----------

User should be able to install solidus with the frontend using the following command:

```bash
rails g solidus:install --with-frontend=solidus_starter_frontend
```

## Demo

https://www.loom.com/share/bde3eb91c58d4a12917a8bcef8a1ebe2

## Tests

This is the script I ran to test the changes. The scripts builds and installs a local copy of `solidus_core`. The local gem is based on v3.1.x since it's not yet possible to build gems for all of the component gems of v3.2.x.

[test-solidus-install-with-solidus-starter-frontend.txt](https://github.com/solidusio/solidus/files/7243068/test-solidus-install-with-solidus-starter-frontend.txt)

In order for the store app to find the local version of `solidus_core`, the store repo and the solidus repo must share the same Ruby version and gem bundle.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
