### PR TITLE
Fix loading core on Rails < 6.1

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -62,12 +62,23 @@ module Spree
   end
 
   module Core
-    def self.has_install_generator_been_run?
-      (Rails.env.test? && Rails.application.class.name == 'DummyApp::Application') ||
-        Rails.application.paths['config/initializers'].paths.any? do |path|
-          File.exist?(path.join('spree.rb'))
-        end
+    # @api private
+    def self.has_install_generator_been_run?(rails_paths: Rails.application.paths, initializer_name: 'spree.rb', dummy_app_name: 'DummyApp::Application')
+      does_spree_initializer_exist?(rails_paths, initializer_name) ||
+        running_solidus_test_suite_with_dummy_app?(dummy_app_name)
     end
+
+    def self.running_solidus_test_suite_with_dummy_app?(dummy_app_name)
+      Rails.env.test? && Rails.application.class.name == dummy_app_name
+    end
+    private_class_method :running_solidus_test_suite_with_dummy_app?
+
+    def self.does_spree_initializer_exist?(rails_paths, initializer_name)
+      rails_paths['config/initializers'].any? do |path|
+        File.exist?(Pathname.new(path).join(initializer_name))
+      end
+    end
+    private_class_method :does_spree_initializer_exist?
 
     class GatewayError < RuntimeError; end
   end

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'spree/core'
 
 RSpec.describe Spree::Core do
@@ -33,6 +33,45 @@ RSpec.describe Spree::Core do
       expect(api).to receive(:load_defaults).with(Spree.solidus_version)
 
       Spree.load_defaults(Spree.solidus_version)
+    end
+  end
+
+  describe '.has_install_generator_been_run?' do
+    let(:rails_paths) do
+      Rails::Paths::Root.new('/').tap do |paths|
+        paths.add('config/initializers')
+        paths['config/initializers'] << File.dirname(__FILE__)
+      end
+    end
+
+    context 'when spree initializer exists' do
+      it 'returns true' do
+        initializer_name = File.basename(__FILE__)
+
+        expect(
+          Spree::Core.has_install_generator_been_run?(rails_paths: rails_paths, initializer_name: initializer_name, dummy_app_name: 'Foo')
+        ).to be(true)
+      end
+    end
+
+    context "when initializer doesn't exist in initializers directory" do
+      it 'returns false' do
+        initializer_name = 'xxxxxxxxxxxxxxxxxxxxxx'
+
+        expect(
+          Spree::Core.has_install_generator_been_run?(rails_paths: rails_paths, initializer_name: initializer_name, dummy_app_name: 'Foo')
+        ).to be(false)
+      end
+    end
+
+    context 'when running test suite with the dummy application loaded' do
+      it 'returns true' do
+        initializer_name = 'xxxxxxxxxxxxxxxxxxxxxx'
+
+        expect(
+          Spree::Core.has_install_generator_been_run?(rails_paths: rails_paths, initializer_name: initializer_name)
+        ).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
This is just a backport from master to fix this issue in 3.1 as well. 

To avoid warning about `Spree.load_defaults` not being defined at a
moment when `bin/rails g solidus:install` has not even been called, the
`Spree::Core` engine is checking whether the `spree.rb` initializer
already exists (as it's there where `#load_defaults` should be called).

We're looking for `spree.rb` within the directories associated with the
`Rails::Paths::Path` instance for initializers. However, before this
commit, we were using `Rails::Paths::Path#paths` method, which is only
available on Rails >= 6.1.0. That made the loading of `Spree::Core`
crash.

As `Rails::Paths::Path` is an `Enumberable`, we can use `any?` directly
from the instance and manually build the `Pathname` for each yielded
string instead.

We also added tests to cover the previous failure and changed the naming
to make the purpose clearer.

Fixes #4178

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
