### PR TITLE
Remove Spree::Order#add_default_payment_from_wallet checkout transition

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -684,6 +684,11 @@ module Spree
     end
 
     def add_default_payment_from_wallet
+      Spree::Deprecation.warn(
+        "`Spree::Order#add_default_payment_from_wallet` transition is deprecated and will be removed." \
+        "Disable it by setting `Spree::Config.disable_adding_default_payment_to_order = true`."
+      )
+
       builder = Spree::Config.default_payment_builder_class.new(self)
 
       if payment = builder.build

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -374,7 +374,12 @@ module Spree
     # @!attribute [rw] default_payment_builder_class
     # @return [Class] a class with the same public interfaces as
     #   Spree::Wallet::DefaultPaymentBuilder.
-    class_name_attribute :default_payment_builder_class, default: 'Spree::Wallet::DefaultPaymentBuilder'
+    attr_writer :default_payment_builder_class
+    def default_payment_builder_class
+      Spree::Deprecation.warn("`Spree::Config.default_payment_builder_class` is deprecated and will be removed.")
+
+      @default_payment_builder_class ||= Spree::Wallet::DefaultPaymentBuilder
+    end
 
     # Allows providing your own class for managing the contents of an order.
     #

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -263,6 +263,11 @@ module Spree
     #   @return [] Track on_hand values for variants / products. (default: true)
     preference :track_inventory_levels, :boolean, default: true
 
+    # @!attribute [rw] disable_adding_default_payment_to_order
+    #   @return [Boolean] Disable Spree::Order#add_default_payment_from_wallet transition (default: +false+)
+    preference :disable_adding_default_payment_to_order, :boolean, default: false
+
+
     # Other configurations
 
     # Allows restricting what currencies will be available.

--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -82,7 +82,9 @@ module Spree
                 end
 
                 after_transition to: :complete, do: :add_payment_sources_to_wallet
-                before_transition to: :payment, do: :add_default_payment_from_wallet
+                unless Spree::Config.disable_adding_default_payment_to_order
+                  before_transition to: :payment, do: :add_default_payment_from_wallet
+                end
                 before_transition to: :payment, do: :ensure_billing_address
 
                 before_transition to: :confirm, do: :add_store_credit_payments

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -369,6 +369,9 @@ RSpec.describe Spree::Order, type: :model do
       let(:default_credit_card) { create(:credit_card) }
 
       before do
+        stub_spree_preferences(disable_adding_default_payment_to_order: disable_adding_default_payment_to_order)
+        Spree::Order.define_state_machine!
+
         user = create(:user, email: 'solidus@example.org', bill_address: user_bill_address)
         default_credit_card.update(user: user)
         wallet_payment_source = user.wallet.add(default_credit_card)
@@ -383,23 +386,50 @@ RSpec.describe Spree::Order, type: :model do
         order.reload
       end
 
-      it "assigns the user's default credit card" do
-        expect(order.state).to eq 'payment'
-        expect(order.payments.count).to eq 1
-        expect(order.payments.first.source).to eq default_credit_card
-      end
+      context "with default payment transition enabled" do
+        let(:disable_adding_default_payment_to_order) { false }
 
-      context "order already has a billing address" do
-        let(:order_bill_address) { create(:address) }
+        it "assigns the user's default credit card" do
+          expect(order.state).to eq 'payment'
+          expect(order.payments.count).to eq 1
+          expect(order.payments.first.source).to eq default_credit_card
+        end
 
-        it "keeps the order's billing address" do
-          expect(order.bill_address).to eq order_bill_address
+        context "order already has a billing address" do
+          let(:order_bill_address) { create(:address) }
+
+          it "keeps the order's billing address" do
+            expect(order.bill_address).to eq order_bill_address
+          end
+        end
+
+        context "order doesn't have a billing address" do
+          it "assigns the user's default_credit_card's address to the order" do
+            expect(order.bill_address).to eq default_credit_card.address
+          end
         end
       end
 
-      context "order doesn't have a billing address" do
-        it "assigns the user's default_credit_card's address to the order" do
-          expect(order.bill_address).to eq default_credit_card.address
+      context "with default payment transition disabled" do
+        let(:disable_adding_default_payment_to_order) { true }
+
+        it "assigns no default credit card" do
+          expect(order.state).to eq 'payment'
+          expect(order.payments).to eq []
+        end
+
+        context "order already has a billing address" do
+          let(:order_bill_address) { create(:address) }
+
+          it "keeps the order's billing address" do
+            expect(order.bill_address).to eq order_bill_address
+          end
+        end
+
+        context "order doesn't have a billing address" do
+          it "does not assign default credit card address" do
+            expect(order.bill_address).to_not eq default_credit_card.address
+          end
         end
       end
     end


### PR DESCRIPTION
This PR is still work in progress.

I'm currently building a shop with solidus and found some logic that seems unnecessary that originated from a 7 year old PR from before the fork: https://github.com/spree/spree/pull/5148

The current behaviour is this:

1. A user with an existing payment source transitions from `delivery` to `payment` state
2. [Spree::Order#add_default_payment_from_wallet](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L686-L698) gets triggered by the [state machine](https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/state_machines/order.rb#L85) and creates a payment record.
3. User transitions to `confirm` state
4. Through how the checkout logic works with [Spree::OrderUpdateAttributes](https://github.com/codegestalt/solidus/blob/ec4bdf33325d29ca4243dbccfd699c628b4a9576/core/app/models/spree/order_update_attributes.rb#L35-L39), that default payment does not get reused and is always replaced with a new payment, resulting every time in an invalid payment record:

![image](https://user-images.githubusercontent.com/507849/135239652-ffc98aff-f003-43ae-b4b3-140f829ba481.png)

My expectations would be one of the following:

1. The default payment record has some kind of use (so far I haven't found one) and gets updated instead of invalidated (I'm also not sure how this affects fraud detection)
2. No default payment record gets created as it has no use

I started this PR by removing `Spree::Order#add_default_payment_from_wallet` to see what breaks. So far only the spec removed in this [commit](https://github.com/codegestalt/solidus/commit/ec4bdf33325d29ca4243dbccfd699c628b4a9576#diff-c2434636d311e5db5ab103cdd58bd3f44b947d4d384525b6d0c4c475adf1b1ad) have been affected but it seems to me that these are directly tied to the creation of the default payment source and have no further use. The only spec I'm unsure about is the one about assigning a billing address if none exists yet, but I can't think of a scenario where this should be the case.

Another thing the removal of `Spree::Order#add_default_payment_from_wallet` would affect is that it makes [Spree::Wallet::DefaultPaymentBuilder](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/wallet/default_payment_builder.rb) obsolete. So I guess there is a concern about breaking compatibility with existing shops that rely on that one. Although I'm not sure what a use case could be.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
