### PR TITLE
[Doc] Good commit message link fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Though in some cases the Core Team may choose not to merge a PR that meets these
 people are reviewing your pull request
 * Good commit messages are also encouraged. Here are some resources on writing
 good commit messages:
-  * [Notes from Linus](https://github.com/torvalds/subsurface/commit/b6590150d68df528efd40c889ba6eea476b39873)
+  * [Notes from Linus](https://github.com/subsurface/subsurface/commit/b6590150d68df528efd40c889ba6eea476b39873)
   * [Erlang's guide](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
   * [An often-cited post](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->
Hi,

I was going through the contributing guide and the link for writing good commit messages in the `Pull Request guidelines` section seems to be broken. The link points to a commit which is now moved to a different repo in another namespace. I have fixed it please have a look. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
