### PR TITLE
Let solidus:install use original environment instead of unbundled one

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -181,7 +181,7 @@ module Solidus
         gem plugin_name
       end
 
-      bundle_cleanly{ run "bundle install" } if @plugins_to_be_installed.any?
+      Bundler.with_original_env{ run "bundle install" } if @plugins_to_be_installed.any?
       run "spring stop" if defined?(Spring)
 
       @plugin_generators_to_run.each do |plugin_generator_name|
@@ -253,12 +253,6 @@ module Solidus
         puts " "
         puts "Enjoy!"
       end
-    end
-
-    private
-
-    def bundle_cleanly(&block)
-      Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&block) : Bundler.with_clean_env(&block)
     end
   end
 end


### PR DESCRIPTION
Goal
----

TODO

Background
----------

TODO

Reference
---------

From
https://makandracards.com/makandra/15649-how-to-discard-a-surrounding-bundler-environment:

> Use Bundler.with_original_env to restore the environment's state
before Bundler was launched. Do this whenever you want to execute shell
commands inside other bundles.

> If you want a completely Bundler-free environment, you can use
Bundler.with_unbundled_env on modern Bundler (2.1+). If you started with
an environment that already held env variables related to Bundler, this
will restore the original environment with such keys discarded as well.
On older Bundlers, this method was called Bundler.with_clean_env.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
