### PR TITLE
Fix discarded duplicated products bug

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -66,7 +66,7 @@ module Spree
 
     validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :price,      numericality: { greater_than_or_equal_to: 0, allow_nil: true }
-    validates_uniqueness_of :sku, allow_blank: true, case_sensitive: true, if: :enforce_unique_sku?
+    validates_uniqueness_of :sku, allow_blank: true, case_sensitive: true, conditions: -> { where(deleted_at: nil) }, if: :enforce_unique_sku?
 
     after_create :create_stock_items
     after_create :set_position

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -87,6 +87,11 @@ module Spree
       it "will not duplicate the option values" do
         expect{ duplicator.duplicate }.to change{ Spree::OptionValue.count }.by(0)
       end
+
+      it "will duplicate the variants after initial duplicate is discarded" do
+        duplicator.duplicate.discard
+        expect { duplicator.duplicate }.to change { Spree::Variant.count }.by(3)
+      end
     end
   end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe Spree::Variant, type: :model do
       variant.price = nil
       expect(variant).to be_invalid
     end
+
+    it "should have a unique sku" do
+      variant_with_same_sku = build(:variant, sku: variant.sku)
+      expect(variant_with_same_sku).to be_invalid
+    end
   end
 
   context "after create" do


### PR DESCRIPTION
**Description**
When a product is cloned and then discarded without changing the cloned variants SKU, if the product is ever cloned again then the cloning process will fail with a variant and master variant SKU validation error. This issue occurs because products and their variants are soft-deleted and therefore the copied SKU will not be unique during the second cloning.

This change will allow multiple cloning and deleting of cloned products without an SKU validation error. This change uses the count of duplicated records in the SKU variants name. This will allow every record to be unique even if it is deleted.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
