### PR TITLE
Introduce a configuration value for `migration_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Solidus 3.2.0.alpha (master, unreleased)
 
+### Core
+
+- Add configuration option for `migration_path` [#4190](https://github.com/solidusio/solidus/pull/4190) ([SuperGoodSoft](https://github.com/supergoodsoft/))
+
 ## Solidus 3.1.1 (v3.1, 2021-09-20)
 
 - Add deprecation path for arity-zero preference defaults [#4170](https://github.com/solidusio/solidus/pull/4170) ([waiting-for-dev](https://github.com/waiting-for-dev))

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -263,7 +263,6 @@ module Spree
     #   @return [] Track on_hand values for variants / products. (default: true)
     preference :track_inventory_levels, :boolean, default: true
 
-
     # Other configurations
 
     # Allows restricting what currencies will be available.
@@ -524,6 +523,17 @@ module Spree
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface
     class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::ActiveStorageAttachment'
+
+    # Configures the absolute path that contains the Solidus engine
+    # migrations. This will be checked at app boot to confirm that all Solidus
+    # migrations are installed.
+    #
+    # @!attribute [rw] migration_path
+    # @return [Pathname] the configured path. (default: `Rails.root.join('db', 'migrate')`)
+    attr_writer :migration_path
+    def migration_path
+      @migration_path ||= ::Rails.root.join('db', 'migrate')
+    end
 
     # Allows providing your own class instance for generating order numbers.
     #

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -40,7 +40,7 @@ module Spree
         ]
       end
 
-      initializer "spree.core.checking_migrations", before: :load_config_initializers do |_app|
+      initializer "spree.core.checking_migrations", after: :load_config_initializers do |_app|
         Migrations.new(config, engine_name).check
       end
 

--- a/core/lib/spree/migrations.rb
+++ b/core/lib/spree/migrations.rb
@@ -66,7 +66,7 @@ module Spree
     end
 
     def app_dir
-      "#{Rails.root}/db/migrate"
+      Spree::Config.migration_path
     end
 
     def engine_dir

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -129,6 +129,26 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  describe "#migration_path" do
+    subject { config_instance.migration_path }
+
+    let(:config_instance) { described_class.new }
+
+    it "has a default value" do
+      expect(subject.to_s).to end_with "db/migrate"
+    end
+
+    context "with a custom value" do
+      before do
+        config_instance.migration_path = "db/secondary_database"
+      end
+
+      it "returns the configured value" do
+        expect(subject).to eq "db/secondary_database"
+      end
+    end
+  end
+
   it 'has a default admin VAT location with nil values by default' do
     expect(prefs.admin_vat_location).to eq(Spree::Tax::TaxLocation.new)
     expect(prefs.admin_vat_location.state_id).to eq(nil)

--- a/core/spec/lib/spree/migrations_spec.rb
+++ b/core/spec/lib/spree/migrations_spec.rb
@@ -10,9 +10,13 @@ module Spree
     let(:config) { double("Config", root: "dir") }
 
     let(:engine_dir) { "dir/db/migrate" }
-    let(:app_dir) { "#{Rails.root}/db/migrate" }
+    let(:app_dir) { 'app/db/migrate' }
 
     subject { described_class.new(config, "spree") }
+
+    before do
+      stub_spree_preferences(migration_path: app_dir)
+    end
 
     it "detects missing migrations" do
       expect(Dir).to receive(:entries).with(app_dir).and_return app_migrations


### PR DESCRIPTION
**Description**
Since Rails 6 multiple database support is a native feature, which
allows users to configure separate read/write databases. This change
allows users to configure the path to the migrations folder from the
default "db/migrate" if they are using the multiple database support and
have specified a different database for the Solidus engine. This will
ensure the check that all migrations are installed can look at a user
configurable folder.

One change required to make the folder path configurable is to run the
migration check after 'load_config_initializers' instead of before. This
will allow the value of `migration_path` configuration to be set in an
initializer.

Ref #4182

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] ~I have attached screenshots to this PR for visual changes (if needed)~
