### PR TITLE
Fix typo in Payments Overview guide

### DIFF
--- a/guides/source/developers/payments/overview.html.md
+++ b/guides/source/developers/payments/overview.html.md
@@ -36,7 +36,7 @@ The rest of this article summarizes these parts of the system.
 In order for you to successfully process payments, your  `Spree::PaymentMethod`s
 need to send information to a [payment service provider][psp] (PSP).
 
-The Solidus community has created a number of Solidus extensions to connect you
+The Solidus community has created a number of Solidus extensions to connect
 popular PSPs like Braintree, Adyen, Affirm, and Paybright.
 
 Typically, PSP integrations use the `Spree::PaymentMethod` base class to build


### PR DESCRIPTION
**Description**
From:
> The Solidus community has created a number of Solidus extensions to
connect you popular PSPs like Braintree, Adyen, Affirm, and Paybright.

To:
> The Solidus community has created a number of Solidus extensions to
connect popular PSPs like Braintree, Adyen, Affirm, and Paybright.

(removed superfluous 'you')

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
