### PR TITLE
List order customer returns only once

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -102,7 +102,7 @@ module Spree
     # Returns
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :return_items, through: :inventory_units
-    has_many :customer_returns, through: :return_items
+    has_many :customer_returns, -> { distinct }, through: :return_items
     has_many :reimbursements, inverse_of: :order
     has_many :refunds, through: :payments
 


### PR DESCRIPTION
Customer returns are associated to orders via return items. This means that, if an order has multiple line items and a single customer return for all of them, then the customer return will be listed twice. Listing customer returns multiple times adds noise without any significant benefit, and can be misleading when calling `order.customer_returns.size` and similars.

Given this is an ActiveRecord feature, it doesn't make much sense to add a spec in the codebase for covering it, considering also that the spec would require the creation of many different records, but for the curious ones it can be verified with:

```
order = create(:order_with_line_items, line_items_count: 2)

customer_return = build(:customer_return)

return_items = (0..1).each do |n|
  customer_return.return_items << create(:return_item, inventory_unit: order.inventory_units[n])
end

customer_return.save!

customer_return.order.customer_returns.size
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
