### PR TITLE
Use Variant Searcher for Autocomplete

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -25,8 +25,14 @@ module Spree
       # we render on the view so we better update it any time a node is included
       # or removed from the views.
       def index
-        @variants = scope.includes(include_list)
-          .ransack(params[:q]).result
+        @variants =
+          if params[:variant_search_term]
+            Spree::Config.variant_search_class.new(
+              params[:variant_search_term], scope: scope
+            ).results.includes(include_list)
+          else
+            scope.includes(include_list).ransack(params[:q]).result
+          end
 
         @variants = paginate(@variants)
         respond_with(@variants)

--- a/api/spec/requests/spree/api/variants_spec.rb
+++ b/api/spec/requests/spree/api/variants_spec.rb
@@ -38,7 +38,14 @@ module Spree::Api
         expect(json_response['pages']).to eq(3)
       end
 
-      it 'can query the results through a paramter' do
+      it 'can query the results through the search class' do
+        expected_result = create(:variant, sku: 'FOOBAR')
+        get spree.api_variants_path, params: { variant_search_term: 'FOO' }
+        expect(json_response['count']).to eq(1)
+        expect(json_response['variants'].first['sku']).to eq expected_result.sku
+      end
+
+      it 'can query the results through ransack' do
         expected_result = create(:variant, sku: 'FOOBAR')
         get spree.api_variants_path, params: { q: { sku_cont: 'FOO' } }
         expect(json_response['count']).to eq(1)

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -31,9 +31,7 @@
         },
         data: function(term, page) {
           var searchData = {
-            q: {
-              product_name_or_sku_cont: term
-            },
+            variant_search_term: term,
             token: Spree.api_key
           };
           return _.extend(searchData, searchOptions);


### PR DESCRIPTION
**Description**

Update `/api/variants` to be able to search either using the configurable `variant_search_class` or Ransack. This makes it possible for users to more easily override the search behaviour of `variantAutocomplete` based on their needs. (e.g.: If they're using Globalize and need to search the translated fields instead of just the base columns that won't be in use.)

The existing behaviour is maintained to ensure the API is completely backwards compatible.

Ref #4175

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
