### PR TITLE
Fix AddPaymentSourcesToWallet changing default when reused

### DIFF
--- a/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
+++ b/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
@@ -24,19 +24,19 @@ class Spree::Wallet::AddPaymentSourcesToWallet
       # add valid sources to wallet and optionally set a default
       if sources.any?
         # arbitrarily sort by id for picking a default
-        sources.sort_by(&:id).each do |source|
+        order_wallet_payment_sources = sources.sort_by(&:id).map do |source|
           order.user.wallet.add(source)
         end
 
-        make_default
+        make_default(order_wallet_payment_sources)
       end
     end
   end
 
   protected
 
-  def make_default
-    order.user.wallet.default_wallet_payment_source = order.user.wallet_payment_sources.last
+  def make_default(sources)
+    order.user.wallet.default_wallet_payment_source = sources.last
   end
 
   private

--- a/core/spec/models/spree/wallet/add_payment_sources_to_wallet_spec.rb
+++ b/core/spec/models/spree/wallet/add_payment_sources_to_wallet_spec.rb
@@ -4,14 +4,41 @@ require 'rails_helper'
 
 RSpec.describe Spree::Wallet::AddPaymentSourcesToWallet, type: :model do
   let(:order) { create(:order_ready_to_complete) }
+  let(:user) { order.user }
 
   describe '#add_to_wallet' do
     subject { described_class.new(order) }
+
+    before do
+      # Ensure the payment is reusable, otherwise false positives occur
+      allow_any_instance_of(Spree::CreditCard).to receive(:reusable?).and_return(true)
+    end
 
     it 'saves the payment source' do
       expect { subject.add_to_wallet }.to change {
         order.user.wallet.wallet_payment_sources.count
       }.by(1)
+    end
+
+    context "when the default wallet payment source is used and a more recent wallet payment exists" do
+      before do
+        credit_card_one = user.wallet.add(create(:credit_card, user: user))
+        user.wallet.add(create(:credit_card, user: user))
+        user.wallet.default_wallet_payment_source = credit_card_one # must be the first created card
+        order.payments.first.update!(source: credit_card_one.payment_source)
+      end
+
+      it 'does not make a new wallet payment source' do
+        expect { subject.add_to_wallet }.to_not change {
+          order.user.wallet.wallet_payment_sources.count
+        }
+      end
+
+      it 'does not change the default wallet payment source' do
+        expect { subject.add_to_wallet }.to_not change {
+          user.wallet.default_wallet_payment_source
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes issue #4004 [1]

PR #2913 [2] changed how the new default WalletPaymentSource was set,
from using the last one found/created * within the Order's
PaymentSources to the user's last WalletPaymentSource. A subtle
difference which assumes that the user's last WalletPaymentSource was
just created by add_to_wallet.

However, if the Order's PaymentSource was from the User's wallet default
and add_to_wallet is called, a new WalletPaymentSource would not be
created * and make_default would try to set the new default as the last
WalletPaymentSource. This would change the default if the last
WalletPaymentSource was not the default.

Now, the WalletPaymentSources are scoped to the order's PaymentSources
and the last one is given to Wallet#default_wallet_payment_source=.
Meaning that in this scenario, the default would be given and ignored as it
is already the default.

[1] https://github.com/solidusio/solidus/issues/4004
[2] https://github.com/solidusio/solidus/pull/2913/
* Wallet#add creates or finds the WalletPaymentSource if exists.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
