### PR TITLE
Adds observability to the new event bus

### DIFF
--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -2,6 +2,7 @@
 
 require 'spree/event/event'
 require 'spree/event/listener'
+require 'spree/event/firing'
 
 module Spree
   module Event
@@ -32,12 +33,12 @@ module Spree
         end
 
         # @api private
-        def fire(event_name, opts = {})
-          Event.new(payload: opts).tap do |event|
-            listeners_for_event(event_name).each do |listener|
-              listener.call(event)
-            end
+        def fire(event_name, caller_location: caller_locations(1)[0], **payload)
+          event = Event.new(payload: payload, caller_location: caller_location)
+          executions = listeners_for_event(event_name).map do |listener|
+            listener.call(event)
           end
+          Firing.new(event: event, executions: executions)
         end
 
         # @api private

--- a/core/lib/spree/event/event.rb
+++ b/core/lib/spree/event/event.rb
@@ -12,15 +12,34 @@ module Spree
     #   Spree::Event.subscribe 'event_name' do |event|
     #     puts event.payload['foo'] #=> 'bar'
     #   end
+    #
+    # Besides, it can be accessed through the returned value in {Spree::Event.fire}.
+    # It can be useful for debugging and logging purposes, as it contains
+    # helpful metadata like the event time or the caller location.
     class Event
       # Hash with the options given to {Spree::Event.fire}
       #
       # @return [Hash]
       attr_reader :payload
 
+      # Time of the event firing
+      #
+      # @return [Time]
+      attr_reader :firing_time
+
+      # Location for the event caller
+      #
+      # It's usually set by {Spree::Event.fire}, and it points to the caller of
+      # that method.
+      #
+      # @return [Thread::Backtrace::Location]
+      attr_reader :caller_location
+
       # @api private
-      def initialize(payload:)
+      def initialize(payload:, caller_location:, firing_time: Time.now.utc)
         @payload = payload
+        @caller_location = caller_location
+        @firing_time = firing_time
       end
     end
   end

--- a/core/lib/spree/event/execution.rb
+++ b/core/lib/spree/event/execution.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # Execution of a {Spree::Event::Listener}
+    #
+    # When an event is fired, it executes all subscribed listeners. Every single
+    # execution is represented as an instance of this class. It contains the
+    # result value of the listener, along with helpful metadata as the time of
+    # the execution or a benchmark for it.
+    #
+    # You'll most likely interact with this class for debugging or logging
+    # purposes through the returned value in {Spree::Event.fire}.
+    class Execution
+      # The listener to which the execution belongs
+      #
+      # @return [Spree::Event::Listener]
+      attr_reader :listener
+
+      # The value returned by the {#listener}'s block
+      #
+      # @return [Any]
+      attr_reader :result
+
+      # Benchmark for the {#listener}'s block
+      #
+      # @return [Benchmark::Tms]
+      attr_reader :benchmark
+
+      # Time of execution
+      #
+      # @return [Time]
+      attr_reader :execution_time
+
+      # @private
+      def initialize(listener:, result:, benchmark:, execution_time: Time.now.utc)
+        @listener = listener
+        @result = result
+        @benchmark = benchmark
+        @execution_time = execution_time
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/firing.rb
+++ b/core/lib/spree/event/firing.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # The result of firing an event
+    #
+    # It encapsulates a fired {Spree::Event::Event} as well as the
+    # {Spree::Event::Execution}s it originated.
+    #
+    # This class is useful mainly for debugging and logging purposes. An
+    # instance of it is returned on {Spree::Event.fire}.
+    class Firing
+      # Fired event
+      #
+      # @return [Spree::Event::Event]
+      attr_reader :event
+
+      # Listener executions that the firing originated
+      #
+      # @return [Array<Spree::Event::Execution>]
+      attr_reader :executions
+
+      # @api private
+      def initialize(event:, executions:)
+        @event = event
+        @executions = executions
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/listener.rb
+++ b/core/lib/spree/event/listener.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'benchmark'
+require 'spree/event/execution'
+
 module Spree
   module Event
     # Subscription to an event
@@ -25,7 +28,12 @@ module Spree
 
       # @api private
       def call(event)
-        @block.call(event)
+        result = nil
+        benchmark = Benchmark.measure do
+          result = @block.call(event)
+        end
+
+        Execution.new(listener: self, result: result, benchmark: benchmark)
       end
 
       # @api private

--- a/core/spec/lib/spree/event/adapters/default_spec.rb
+++ b/core/spec/lib/spree/event/adapters/default_spec.rb
@@ -7,85 +7,59 @@ module Spree
   module Event
     module Adapters
       RSpec.describe Default do
+        let(:counter) do
+          Class.new do
+            attr_reader :count
+
+            def initialize
+              @count = 0
+            end
+
+            def inc
+              @count += 1
+            end
+          end
+        end
+
         describe '#fire' do
           it 'executes listeners subscribed as a string to the event name' do
             bus = described_class.new
-            dummy = Class.new do
-              attr_reader :run
-
-              def initialize
-                @run = false
-              end
-
-              def toggle
-                @run = true
-              end
-            end.new
-            bus.subscribe('foo') { dummy.toggle }
+            dummy = counter.new
+            bus.subscribe('foo') { dummy.inc }
 
             bus.fire 'foo'
 
-            expect(dummy.run).to be(true)
+            expect(dummy.count).to be(1)
           end
 
           it 'executes listeners subscribed as a regexp to the event name' do
             bus = described_class.new
-            dummy = Class.new do
-              attr_reader :run
-
-              def initialize
-                @run = false
-              end
-
-              def toggle
-                @run = true
-              end
-            end.new
-            bus.subscribe(/oo/) { dummy.toggle }
+            dummy = counter.new
+            bus.subscribe(/oo/) { dummy.inc }
 
             bus.fire 'foo'
 
-            expect(dummy.run).to be(true)
+            expect(dummy.count).to be(1)
           end
 
           it "doesn't execute listeners not subscribed to the event name" do
             bus = described_class.new
-            dummy = Class.new do
-              attr_reader :run
-
-              def initialize
-                @run = false
-              end
-
-              def toggle
-                @run = true
-              end
-            end.new
-            bus.subscribe('bar') { dummy.toggle }
+            dummy = counter.new
+            bus.subscribe('bar') { dummy.inc }
 
             bus.fire 'foo'
 
-            expect(dummy.run).to be(false)
+            expect(dummy.count).to be(0)
           end
 
           it "doesn't execute listeners partially matching as a string" do
             bus = described_class.new
-            dummy = Class.new do
-              attr_reader :run
-
-              def initialize
-                @run = false
-              end
-
-              def toggle
-                @run = true
-              end
-            end.new
-            bus.subscribe('bar') { dummy.toggle }
+            dummy = counter.new
+            bus.subscribe('bar') { dummy.inc }
 
             bus.fire 'barr'
 
-            expect(dummy.run).to be(false)
+            expect(dummy.count).to be(0)
           end
 
           it 'binds given options to the subscriber as the event payload' do
@@ -98,6 +72,30 @@ module Spree
             bus.fire 'foo', box: 'foo'
 
             expect(dummy.box).to eq('foo')
+          end
+
+          it 'adds the fired event with given caller location to the firing result object' do
+            bus = described_class.new
+            dummy = counter.new
+            bus.subscribe('foo') { :work }
+
+            firing = bus.fire 'foo', caller_location: caller_locations(0)[0]
+
+            expect(firing.event.caller_location.to_s).to include(__FILE__)
+          end
+
+          it 'adds the triggered executions to the firing result object', :aggregate_failures do
+            bus = described_class.new
+            dummy = counter.new
+            listener1 = bus.subscribe('foo') { dummy.inc }
+            listener2 = bus.subscribe('foo') { dummy.inc }
+
+            firing = bus.fire 'foo'
+
+            executions = firing.executions
+            expect(executions.count).to be(2)
+            expect(executions.map(&:listener)).to match([listener1, listener2])
+            expect(executions.map(&:result)).to match([1, 2])
           end
         end
 
@@ -133,114 +131,62 @@ module Spree
           context 'when given a listener' do
             it 'unsubscribes given listener' do
               bus = described_class.new
-              dummy = Class.new do
-                attr_reader :run
-
-                def initialize
-                  @run = false
-                end
-
-                def toggle
-                  @run = true
-                end
-              end.new
-              listener = bus.subscribe('foo') { dummy.toggle }
+              dummy = counter.new
+              listener = bus.subscribe('foo') { dummy.inc }
 
               bus.unsubscribe listener
               bus.fire 'foo'
 
-              expect(dummy.run).to be(false)
+              expect(dummy.count).to be(0)
             end
           end
 
           context 'when given an event name' do
             it 'unsubscribes all listeners for that event' do
               bus = described_class.new
-              dummy = Class.new do
-                attr_reader :run
+              dummy = counter.new
 
-                def initialize
-                  @run = false
-                end
-
-                def toggle
-                  @run = true
-                end
-              end.new
-
-              bus.subscribe('foo') { dummy.toggle }
+              bus.subscribe('foo') { dummy.inc }
               bus.unsubscribe 'foo'
               bus.fire 'foo'
 
-              expect(dummy.run).to be(false)
+              expect(dummy.count).to be(0)
             end
           end
 
           it 'unsubscribes listeners that match event with a regexp' do
             bus = described_class.new
-            dummy = Class.new do
-              attr_reader :run
-
-              def initialize
-                @run = false
-              end
-
-              def toggle
-                @run = true
-              end
-            end.new
-            bus.subscribe(/foo/) { dummy.toggle }
+            dummy = counter.new
+            bus.subscribe(/foo/) { dummy.inc }
             bus.unsubscribe 'foo'
 
             bus.fire 'foo'
 
-            expect(dummy.run).to be(false)
+            expect(dummy.count).to be(0)
           end
 
           it "doesn't unsubscribe listeners for other events" do
             bus = described_class.new
-            dummy = Class.new do
-              attr_reader :run
+            dummy = counter.new
 
-              def initialize
-                @run = false
-              end
-
-              def toggle
-                @run = true
-              end
-            end.new
-
-            bus.subscribe('foo') { dummy.toggle }
+            bus.subscribe('foo') { dummy.inc }
             bus.unsubscribe 'bar'
             bus.fire 'foo'
 
-            expect(dummy.run).to be(true)
+            expect(dummy.count).to be(1)
           end
 
-          it 'can resubscribe other listeners to the same event' do
+          it 'can resubscribe other listeners to the same event', :aggregate_failures do
             bus = described_class.new
-            dummy1, dummy2 = Array.new(2) do
-              Class.new do
-                attr_reader :run
+            dummy1, dummy2 = Array.new(2) { counter.new }
 
-                def initialize
-                  @run = false
-                end
-
-                def toggle
-                  @run = true
-                end
-              end.new
-            end
-
-            bus.subscribe('foo') { dummy1.toggle }
+            bus.subscribe('foo') { dummy1.inc }
             bus.unsubscribe 'foo'
-            bus.subscribe('foo') { dummy2.toggle }
+            bus.subscribe('foo') { dummy2.inc }
             bus.fire 'foo'
 
-            expect(dummy1.run).to be(false)
-            expect(dummy2.run).to be(true)
+            expect(dummy1.count).to be(0)
+            expect(dummy2.count).to be(1)
           end
         end
       end

--- a/core/spec/lib/spree/event/listener_spec.rb
+++ b/core/spec/lib/spree/event/listener_spec.rb
@@ -1,13 +1,38 @@
 # frozen_string_literal: true
 
 require 'spree/event/listener'
+require 'spree/event/execution'
 
 RSpec.describe Spree::Event::Listener do
   describe '#call' do
-    it 'returns the result of calling block with given event' do
-      listener = described_class.new(pattern: 'foo', block: ->(event) { event[:bar] })
+    it 'returns an execution instance' do
+      listener = described_class.new(pattern: 'foo', block: proc {})
 
-      expect(listener.call(bar: 'bar')).to eq('bar')
+      expect(listener.call(:event)).to be_a(Spree::Event::Execution)
+    end
+
+    it "binds the event and sets execution's result" do
+      listener = described_class.new(pattern: 'foo', block: ->(event) { event[:foo] })
+
+      execution = listener.call(foo: :bar)
+
+      expect(execution.result).to eq(:bar)
+    end
+
+    it 'sets itself as the execution listener' do
+      listener = described_class.new(pattern: 'foo', block: proc { 'foo' })
+
+      execution = listener.call(:event)
+
+      expect(execution.listener).to be(listener)
+    end
+
+    it "sets the execution's benchmark" do
+      listener = described_class.new(pattern: 'foo', block: proc { 'foo' })
+
+      execution = listener.call(:event)
+
+      expect(execution.benchmark).to be_a(Benchmark::Tms)
     end
   end
 


### PR DESCRIPTION
This commit adds observability abilities to the new event bus adapter:

- It adds creation time and caller location to the `Spree::Event::Event`
  instance bound to the subscribers.
- It wraps the execution of listeners within a new
  `Spree::Event::Execution` class, which wraps the execution time, a
  benchmark of the operation, and the result returned by the
  subscription.

Both the `Spree::Event::Event` and the list of `Spree::Event::Execution`
are wrapped within a new `Spree::Event::Firing` object, which is
returned on `Spree::Event.fire`. Therefore, a typical flow could be
getting the event's caller from within the subscriber block and then
inspecting the firing object from there if needed.

Having all the metadata collected in a single place when we do
`Spree::Event.fire` will simplify things if we implement some event
store in the future.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
