### PR TITLE
Enable rubygems_mfa_required on solidus

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.files = Dir['README.md', 'lib/**/*']
 
   s.required_ruby_version = '>= 2.5.0'


### PR DESCRIPTION
Goal
----

As a Solidus maintainer
I want to enable rubygems_mfa_required on the gem's gemspec
So that MFA will be required when performing privileged operations on the gem

Reference
---------

https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiremfa

https://guides.rubygems.org/mfa-requirement-opt-in/

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- N/A: I have updated Guides and README accordingly to this change (if needed)
- N/A: I have added tests to cover this change (if needed)
- N/A: I have attached screenshots to this PR for visual changes (if needed)
