### PR TITLE
v3.1 - Use SSL on fonts.googleapis.com scss import

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -39,6 +39,7 @@ require 'spree/testing_support/capybara_ext'
 require 'spree/testing_support/precompiled_assets'
 require 'spree/testing_support/translations'
 require 'spree/testing_support/job_helpers'
+require 'spree/testing_support/blacklist_urls'
 
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
@@ -96,9 +97,6 @@ RSpec.configure do |config|
 
   config.before do
     Rails.cache.clear
-    if RSpec.current_example.metadata[:js] && page.driver.browser.respond_to?(:url_blacklist)
-      page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
-    end
   end
 
   config.include BaseFeatureHelper, type: :feature
@@ -112,6 +110,7 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Flash
   config.include Spree::TestingSupport::Translations
   config.include Spree::TestingSupport::JobHelpers
+  config.include Spree::TestingSupport::BlacklistUrls
 
   config.extend WithModel
 

--- a/core/lib/spree/testing_support/blacklist_urls.rb
+++ b/core/lib/spree/testing_support/blacklist_urls.rb
@@ -5,7 +5,7 @@ module Spree
     module BlacklistUrls
       def setup_url_blacklist(browser)
         if browser.respond_to?(:url_blacklist)
-          browser.url_blacklist = ['http://fonts.googleapis.com']
+          browser.url_blacklist = ['https://fonts.googleapis.com']
         end
       end
     end

--- a/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
@@ -21,7 +21,7 @@ $cart_total_text_color: #FFFFFF !default;
 /*--------------------------------------*/
 /* Fonts import from remote
 /*--------------------------------------*/
-@import url(//fonts.googleapis.com/css?family=Ubuntu:400,700,400italic,700italic|&subset=latin,cyrillic,greek,greek-ext,latin-ext,cyrillic-ext);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic,700italic|&subset=latin,cyrillic,greek,greek-ext,latin-ext,cyrillic-ext);
 
 /*--------------------------------------*/
 /* Font families


### PR DESCRIPTION
Since 23/11/2021, @import url(//fonts.googleapis.com/css...) began to
cause errors; Breaking Solidus and all extensions that depend on
solidus_frontend. Explicitly using HTTPS protocol fixed this.

Error example:
https://app.circleci.com/pipelines/github/solidusio/solidus/2791/workflows/e62ff646-9ae6-4e65-b20f-e1f7a109d3a1/jobs/26572

Blocking of this URL in testing_support was updated to keep performance
improvement.

Checklist:

- [x]  I have followed Pull Request guidelines
- [x]  I have added a detailed description into each commit message