### PR TITLE
Make display_price optional on admin variants list

### DIFF
--- a/backend/app/views/spree/admin/variants/_table.html.erb
+++ b/backend/app/views/spree/admin/variants/_table.html.erb
@@ -27,7 +27,7 @@
         <% end %>
       </td>
       <td><%= variant.options_text %></td>
-      <td><%= variant.display_price.to_html %></td>
+      <td><%= variant.display_price&.to_html %></td>
       <td><%= variant.sku %></td>
       <td class="actions">
         <% if can?(:update, variant) %>

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -70,6 +70,19 @@ describe "Variants", type: :feature do
         expect(page).to have_content(discarded_variant.sku)
       end
     end
+
+    context 'displaying variants with unconfigured prices' do
+      let!(:variant) { create(:variant, sku: 'priceless_variant', product: product) }
+
+      before { variant.prices.delete_all }
+
+      it 'renders the listing correctly' do
+        visit spree.admin_product_variants_path(product)
+
+        expect(page.status_code).to be(200)
+        expect(page).to have_content('priceless_variant')
+      end
+    end
   end
 
   context "editing existent variant" do


### PR DESCRIPTION
When there are variants which respond `nil` as `#default_price` (e.g. because admin is creating them and they still don't have all prices set up, or they don't have a price matching `Spree::Variant.default_price_attributes`), the `/admin/products/<product>/variants` page returns 500 and it's not obvious why to the admin.

This small fix allows for the variants list page to be displayed anyway.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
