### PR TITLE
Update warning with copy/pastable code

### DIFF
--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -28,7 +28,7 @@ module Spree
 
             Spree.config do |config|
               # ...
-              config.events.adapter = Spree::Event::Adapters.Default.new
+              config.events.adapter = Spree::Event::Adapters::Default.new
               # ...
             end
 


### PR DESCRIPTION
**Description**

Fix typo in the the code sample deprecation warning for the Spree event adapters

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
