### PR TITLE
Use default spree event adapter

### DIFF
--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -1,3 +1,5 @@
+require "spree/event/adapters/default"
+
 # Configure Solidus Preferences
 # See http://docs.solidus.io/Spree/AppConfiguration.html for details
 
@@ -31,6 +33,8 @@ Spree.config do |config|
   # to a custom users role:
   # config.roles.assign_permissions :role_name, ['Spree::PermissionSets::CustomPermissionSet']
 
+  # Default event adapter:
+  config.events.adapter = Spree::Event::Adapters::Default.new
 
   # Frontend:
 


### PR DESCRIPTION
**Description**
On installing this version (currenlty unreleased) of Solidus, we
no longer support the ActiveSupport Notification adaptor, but rather
the new `Spree::Event::Adapters::Default`

This commit add that configuration to the spree.rb template so every
generated install is using the new defaults.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
