### PR TITLE
v2.9 - Update importing fonts.googleapis.com to use SSL

### DIFF
--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -8,7 +8,7 @@ module Spree
         links = []
         @order_events.sort.each do |event|
           next unless @order.send("can_#{event}?")
-          links << button_to(t(event, scope: 'spree'), [event, :admin, @order],
+          links << button_to(t(event, scope: 'spree'), [event.to_sym, :admin, @order],
                              method: :put,
                              data: { confirm: t('spree.order_sure_want_to', event: t(event, scope: 'spree')) })
         end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -36,6 +36,7 @@ require 'spree/testing_support/flash'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/capybara_ext'
+require 'spree/testing_support/blacklist_urls'
 
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
@@ -89,9 +90,6 @@ RSpec.configure do |config|
 
   config.before do
     Rails.cache.clear
-    if RSpec.current_example.metadata[:js] && page.driver.browser.respond_to?(:url_blacklist)
-      page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
-    end
   end
 
   config.include BaseFeatureHelper, type: :feature
@@ -111,6 +109,7 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
+  config.include Spree::TestingSupport::BlacklistUrls
 
   config.extend WithModel
 

--- a/core/lib/spree/testing_support/blacklist_urls.rb
+++ b/core/lib/spree/testing_support/blacklist_urls.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module TestingSupport
+    module BlacklistUrls
+      def setup_url_blacklist(browser)
+        if browser.respond_to?(:url_blacklist)
+          browser.url_blacklist = ['https://fonts.googleapis.com']
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:each, type: :feature) do
+    setup_url_blacklist(page.driver.browser)
+  end
+
+  config.before(:each, type: :system) do
+    setup_url_blacklist(page.driver.browser)
+  end
+end

--- a/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
@@ -21,7 +21,7 @@ $cart_total_text_color: #FFFFFF !default;
 /*--------------------------------------*/
 /* Fonts import from remote
 /*--------------------------------------*/
-@import url(//fonts.googleapis.com/css?family=Ubuntu:400,700,400italic,700italic|&subset=latin,cyrillic,greek,greek-ext,latin-ext,cyrillic-ext);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic,700italic|&subset=latin,cyrillic,greek,greek-ext,latin-ext,cyrillic-ext);
 
 /*--------------------------------------*/
 /* Font families


### PR DESCRIPTION
On 23/11/2021, google started to require ssl to access `//fonts.googleapis.com/css`, causing the import in the solidus frontend stylesheet to fail in CI. This breaks solidus and tests that run against the solidus_frontend. We can resolve this by explicitly using the https protocol.

Error example:
https://app.circleci.com/pipelines/github/solidusio/solidus/2791/workflows/e62ff646-9ae6-4e65-b20f-e1f7a109d3a1/jobs/26572

Blocking of this URL in testing_support was updated to bring it inline
with how url's are blacklisted in future solidus versions.

Even though solidus 2.9 is at end of life, some solidus extensions still test and maintain support against this version of solidus, such as SuperGoodSoft/solidus_taxjar, so it's important to continue to enable that testing.

This PR was based off the three PRs that cover actively maintained solidus versions created by @RyanofWoods 

* [v3.1 - Use SSL on fonts.googleapis.com scss import #4210](https://github.com/solidusio/solidus/pull/4210)
* [v3.0 - Use SSL on fonts.googleapis.com scss import #4211](https://github.com/solidusio/solidus/pull/4211)
* [v2.11 - Use SSL on fonts.googleapis.com scss import #4212](https://github.com/solidusio/solidus/pull/4212)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
