### PR TITLE
Add filter and pagination to tax rates admin view

### DIFF
--- a/backend/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/backend/app/controllers/spree/admin/tax_rates_controller.rb
@@ -12,6 +12,17 @@ module Spree
         @available_categories = Spree::TaxCategory.order(:name)
         @calculators = Rails.application.config.spree.calculators.tax_rates
       end
+
+      def collection
+        @search = Spree::TaxRate.ransack(params[:q])
+        @collection = @search.result
+        @collection = @collection
+          .includes(:tax_categories)
+          .order(:zone_id)
+        @collection = @collection
+          .page(params[:page])
+          .per(Spree::Config[:admin_products_per_page])
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -83,7 +83,7 @@
         <td><%=tax_rate.included_in_price? ? t('spree.say_yes') : t('spree.say_no') %></td>
         <td><%=tax_rate.show_rate_in_label? ? t('spree.say_yes') : t('spree.say_no') %></td>
         <td><%=tax_rate.expires_at.to_date.to_s(:short_date) if tax_rate.expires_at %></td>
-        <td><%=tax_rate.calculator.to_s %></td>
+        <td><%=tax_rate.calculator && tax_rate.calculator.class.model_name.human %></td>
         <td class="actions">
           <% if can?(:update, tax_rate) %>
             <%= link_to_edit tax_rate, no_text: true %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -13,7 +13,35 @@
   <% end %>
 <% end %>
 
+<% content_for :table_filter_title do %>
+  <%= t("spree.filter") %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <%= search_form_for [:admin, @search], url: spree.admin_tax_rates_path do |f| %>
+    <div class= "row">
+      <div class="col-md-6">
+        <div class="field">
+          <%= f.label :zone_id_eq, Spree::Zone.model_name.human %>
+          <%= f.collection_select :zone_id_eq, @available_zones, :id, :name, { include_blank: t("spree.all") }, class: 'select2 fullwidth' %>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="field">
+          <%= f.label :tax_categories_id_eq, Spree::TaxCategory.model_name.human %>
+          <%= f.collection_select :tax_categories_id_eq, @available_categories, :id, :name, { include_blank: t("spree.all") }, class: 'select2 fullwidth' %>
+        </div>
+      </div>
+    </div>
+    <div class="filter-actions">
+      <%= button_tag t("spree.filter_results"), class: "btn btn-primary" %>
+    </div>
+  <% end %>
+<% end %>
+
 <% if @tax_rates.any? %>
+  <%= paginate @tax_rates, scope: spree, theme: "solidus_admin" %>
+
   <table class="index">
     <colgroup>
       <col style="width: 15%">
@@ -68,6 +96,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <%= paginate @tax_rates, scope: spree, theme: "solidus_admin" %>
 <% else %>
   <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',

--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -30,8 +30,9 @@ describe "Tax Rates", type: :feature do
   end
 
   describe "listing" do
-    let!(:tax_rate_1) { create(:tax_rate, name: "Tax Rate 1") }
-    let!(:tax_rate_2) { create(:tax_rate, name: "Tax Rate 2") }
+    let(:calculator) { create(:default_tax_calculator) }
+    let!(:tax_rate_1) { create(:tax_rate, name: "Tax Rate 1", calculator: calculator) }
+    let!(:tax_rate_2) { create(:tax_rate, name: "Tax Rate 2", calculator: calculator) }
 
     it "shows all tax rates if no filter is applied" do
       visit spree.admin_tax_rates_path
@@ -58,6 +59,13 @@ describe "Tax Rates", type: :feature do
       within "table" do
         expect(page).to have_content tax_rate_2.name
         expect(page).to_not have_content tax_rate_1.name
+      end
+    end
+
+    it "it displays the translated calculator name" do
+      visit spree.admin_tax_rates_path
+      within "table" do
+        expect(page).to have_content calculator.class.model_name.human
       end
     end
   end

--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -28,4 +28,37 @@ describe "Tax Rates", type: :feature do
     click_button "Create"
     expect(page).to have_content("Tax Rate has been successfully created!")
   end
+
+  describe "listing" do
+    let!(:tax_rate_1) { create(:tax_rate, name: "Tax Rate 1") }
+    let!(:tax_rate_2) { create(:tax_rate, name: "Tax Rate 2") }
+
+    it "shows all tax rates if no filter is applied" do
+      visit spree.admin_tax_rates_path
+      within "table" do
+        expect(page).to have_content tax_rate_1.name
+        expect(page).to have_content tax_rate_2.name
+      end
+    end
+
+    it "it is possible to filter by zone" do
+      visit spree.admin_tax_rates_path
+      select tax_rate_1.zone.name, from: "Zone"
+      click_on "Filter Results"
+      within "table" do
+        expect(page).to have_content tax_rate_1.name
+        expect(page).to_not have_content tax_rate_2.name
+      end
+    end
+
+    it "it is possible to filter by tax category" do
+      visit spree.admin_tax_rates_path
+      select tax_rate_2.tax_categories.first.name, from: "Tax Category"
+      click_on "Filter Results"
+      within "table" do
+        expect(page).to have_content tax_rate_2.name
+        expect(page).to_not have_content tax_rate_1.name
+      end
+    end
+  end
 end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -27,6 +27,8 @@ module Spree
 
     validates :amount, presence: true, numericality: true
 
+    self.whitelisted_ransackable_associations = %w[tax_categories zone]
+
     # Finds all tax rates whose zones match a given address
     scope :for_address, ->(address) { joins(:zone).merge(Spree::Zone.for_address(address)) }
     scope :for_country,


### PR DESCRIPTION
**Description**

Managing a lot of tax rates is currently not very user friendly.

Adding pagination, filtering by zone and tax category and a default
order by zone makes managing tax much nicer. And who does not love
managing taxes.

**Screenshots**

<img alt="Tax Rates - Taxes - Settings 2021-12-13 21-08-23" src="https://user-images.githubusercontent.com/42868/145881054-497bf48c-5021-40ad-b991-9b96e6e14e5f.png">

<img alt="Tax Rates - Taxes - Settings 2021-12-13 21-08-34" src="https://user-images.githubusercontent.com/42868/145881044-2b505214-0924-4e80-9db3-b020f6a73b1e.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
- [x] I have attached screenshots to this PR for visual changes
