### PR TITLE
Adds the missing en-CA localization for the select2 dropdown in admin

### DIFF
--- a/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_en-CA.js
+++ b/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_en-CA.js
@@ -1,0 +1,10 @@
+/**
+ * Select2 English Canada translations
+ */
+(function ($) {
+    "use strict";
+
+    $.fn.select2.locales['en-CA'] = {};
+
+    $.extend($.fn.select2.defaults, $.fn.select2.locales['en-CA']);
+})(jQuery);


### PR DESCRIPTION
**Description**
Inspired by #3895 which added other locales for the select2 dropdown. This fixes an error that occurs when trying to access solidus admin with the `en-CA` locale.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
