### PR TITLE
v2.11 fix(Address): Set name from firstname and lastname on update

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -84,6 +84,7 @@ module Spree
     # @return [Hash] hash of attributes contributing to value equality with optional merge
     def self.value_attributes(base_attributes, merge_attributes = {})
       base = base_attributes.stringify_keys.merge(merge_attributes.stringify_keys)
+      base.delete("name") unless Spree::Config.use_combined_first_and_last_name_in_address
 
       name_from_attributes = Spree::Address::Name.from_attributes(base)
       if base['firstname'].presence || base['first_name'].presence


### PR DESCRIPTION
**Description**

If `use_combined_first_and_last_name_in_address` is `false` (default in v2.11) and `firstname` and `lastname` are given in the changeset (ie. from a form) we need to make sure that name is set from it, otherwise data will be inconsistent.

Closes #4094

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
