### PR TITLE
Revert 21300973408b1b02b67d7d05cffaccab8c6d489c

### DIFF
--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -123,7 +123,6 @@ Spree.config do |config|
   config.raise_with_invalid_currency = false
   config.redirect_back_on_unauthorized = true
   config.run_order_validations_on_order_updater = true
-  config.use_combined_first_and_last_name_in_address = true
   config.use_legacy_order_state_machine = false
   config.use_custom_cancancan_actions = false
   config.consider_actionless_promotion_active = false


### PR DESCRIPTION
In Solidus v2.11 we still use `false` for this setting.
Using `true` in specs per default is giving false positives
and issues like #4094 where not found.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
