### PR TITLE
Enforce event registration

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'spree/config'
+require 'spree/event'
+require 'spree/event/adapters/deprecation_handler'
 
 module Spree
   module Core
@@ -42,6 +44,18 @@ module Spree
 
       initializer "spree.core.checking_migrations", after: :load_config_initializers do |_app|
         Migrations.new(config, engine_name).check
+      end
+
+      # Register core events
+      initializer 'spree.core.register_events' do
+        unless Spree::Event::Adapters::DeprecationHandler.legacy_adapter?
+          %w[
+            order_finalized
+            order_recalculated
+            reimbursement_reimbursed
+            reimbursement_errored
+          ].each { |event_name| Spree::Event.register(event_name) }
+        end
       end
 
       # Setup Event Subscribers

--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -3,6 +3,7 @@
 require 'spree/event/event'
 require 'spree/event/listener'
 require 'spree/event/firing'
+require 'spree/event/registry'
 
 module Spree
   module Event
@@ -26,14 +27,21 @@ module Spree
       # be the default one.
       class Default
         # @api private
-        attr_reader :listeners
+        attr_reader :listeners, :registry
 
-        def initialize(listeners = [])
+        def initialize(listeners = [], registry = Registry.new)
           @listeners = listeners
+          @registry = registry
+        end
+
+        # @api private
+        def register(event_name, caller_location: caller_locations(1)[0])
+          registry.register(event_name, caller_location: caller_location)
         end
 
         # @api private
         def fire(event_name, caller_location: caller_locations(1)[0], **payload)
+          registry.check_event_name_registered(event_name)
           event = Event.new(payload: payload, caller_location: caller_location)
           executions = listeners_for_event(event_name).map do |listener|
             listener.call(event)
@@ -43,6 +51,7 @@ module Spree
 
         # @api private
         def subscribe(event_name_or_regexp, &block)
+          registry.check_event_name_registered(event_name_or_regexp) if event_name?(event_name_or_regexp)
           Listener.new(pattern: event_name_or_regexp, block: block).tap do |listener|
             @listeners << listener
           end
@@ -53,13 +62,14 @@ module Spree
           if subscriber_or_event_name.is_a?(Listener)
             unsubscribe_listener(subscriber_or_event_name)
           else
+            registry.check_event_name_registered(subscriber_or_event_name) if event_name?(subscriber_or_event_name)
             unsubscribe_event(subscriber_or_event_name)
           end
         end
 
         # @api private
         def with_listeners(listeners)
-          self.class.new(listeners)
+          self.class.new(listeners, registry)
         end
 
         private
@@ -78,6 +88,10 @@ module Spree
           @listeners.each do |listener|
             listener.unsubscribe(event_name)
           end
+        end
+
+        def event_name?(candidate)
+          candidate.is_a?(String)
         end
       end
     end

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -34,7 +34,7 @@ module Spree
 
             That will be the new default on Solidus 4.
 
-            Take into account there're two critical changes in behavior in the new adapter:
+            Take into account there're three critical changes in behavior in the new adapter:
 
             - Event names are no longer automatically suffixed with `.spree`, as
             they're no longer in the same bucket that Rails's ones. So, for
@@ -58,6 +58,15 @@ module Spree
 
               order.do_something
               Spree::Event.fire 'event_name', order: order
+
+          - You need to register your custom events before firing or subscribing
+            to them (not necessary for events provided by Solidus or other
+            extensions). It should be done at the end of the `spree.rb`
+            initializer. Example:
+
+              Spree::Event.register('foo')
+              Spree::Event.fire('foo')
+
 
           MSG
         end

--- a/core/lib/spree/event/registry.rb
+++ b/core/lib/spree/event/registry.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # Registry of known events
+    #
+    # @api privte
+    class Registry
+      class Registration
+        attr_reader :event_name, :caller_location
+
+        def initialize(event_name:, caller_location:)
+          @event_name = event_name
+          @caller_location = caller_location
+        end
+      end
+
+      attr_reader :registrations
+
+      def initialize(registrations: [])
+        @registrations = registrations
+      end
+
+      def register(event_name, caller_location: caller_locations(1)[0])
+        registration = registration(event_name)
+        if registration
+          raise <<~MSG
+            Can't register #{event_name} event as it's already registered.
+
+            The registration happened at:
+
+            #{registration.caller_location}
+          MSG
+        else
+          @registrations << Registration.new(event_name: event_name, caller_location: caller_location)
+        end
+      end
+
+      def unregister(event_name)
+        raise <<~MSG unless registered?(event_name)
+          #{event_name} is not registered.
+
+          Known events are:
+
+            '#{event_names.join("' '")}'
+        MSG
+
+        @registrations.delete_if { |regs| regs.event_name == event_name }
+      end
+
+      def registration(event_name)
+        registrations.find { |reg| reg.event_name == event_name }
+      end
+
+      def registered?(event_name)
+        !registration(event_name).nil?
+      end
+
+      def event_names
+        registrations.map(&:event_name)
+      end
+
+      def check_event_name_registered(event_name)
+        return true if registered?(event_name)
+
+        raise <<~MSG
+            '#{event_name}' is not registered as a valid event name.
+            #{suggestions_message(event_name)}
+
+            All known events are:
+
+              '#{event_names.join(" ")}'
+
+            You can register the new events at the end of the `spree.rb`
+            initializer:
+
+              Spree::Event.register('#{event_name}')
+        MSG
+      end
+
+      private
+
+      def suggestions(event_name)
+        dictionary = DidYouMean::SpellChecker.new(dictionary: event_names)
+
+        dictionary.correct(event_name)
+      end
+
+      def suggestions_message(event_name)
+        DidYouMean::PlainFormatter.new.message_for(suggestions(event_name))
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/test_interface.rb
+++ b/core/lib/spree/event/test_interface.rb
@@ -72,6 +72,13 @@ module Spree
         def performing_nothing(&block)
           performing_only(&block)
         end
+
+        # Unregisters a previously registered event
+        #
+        # @param [String, Symbol] event_name
+        def unregister(event_name)
+          registry.unregister(normalize_name(event_name))
+        end
       end
 
       extend Methods

--- a/core/spec/lib/spree/event/registry_spec.rb
+++ b/core/spec/lib/spree/event/registry_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spree/event/registry'
+
+RSpec.describe Spree::Event::Registry do
+  describe '#register' do
+    it 'adds given event name to the registry' do
+      registry = described_class.new
+
+      registry.register('foo')
+
+      expect(registry.registered?('foo')).to be(true)
+    end
+
+    it 'adds given caller location to the registration' do
+      registry = described_class.new
+
+      registry.register('foo', caller_location: caller_locations(0)[0])
+
+      expect(registry.registration('foo').caller_location.to_s).to include(__FILE__)
+    end
+
+    it 'raises with the registration location info when the event has already been registered' do
+      registry = described_class.new
+
+      registry.register('foo', caller_location: caller_locations(0)[0])
+
+      expect {
+        registry.register('foo', caller_location: caller_locations(2)[0])
+      }.to raise_error(/already registered.*#{__FILE__}/m)
+    end
+  end
+
+  describe '#unregister' do
+    it 'removes given event name from the registry' do
+      registry = described_class.new
+      registry.register('foo')
+
+      registry.unregister('foo')
+
+      expect(registry.registered?('foo')).to be(false)
+    end
+
+    it "raises when the event hasn't been registered" do
+      registry = described_class.new
+      registry.register('bar')
+
+      expect {
+        registry.unregister('foo')
+      }.to raise_error(/not registered.*bar/m)
+    end
+  end
+
+  describe '#registration' do
+    it 'finds the registration from given name' do
+      registry = described_class.new
+
+      registry.register('foo')
+
+      expect(registry.registration('foo').event_name).to eq('foo')
+    end
+
+    it 'returns nil when the event name is not found' do
+      registry = described_class.new
+
+      expect(registry.registration('foo')).to be_nil
+    end
+  end
+
+  describe '#registered?' do
+    it 'returns true when given event name is registered' do
+      registry = described_class.new
+      registry.register('foo')
+
+      expect(registry.registered?('foo')).to be(true)
+    end
+
+    it 'returns false when given event name is not registered' do
+      registry = described_class.new
+
+      expect(registry.registered?('foo')).to be(false)
+    end
+  end
+
+  describe '#event_names' do
+    it 'returns array with the registered event names' do
+      registry = described_class.new
+      registry.register('foo')
+      registry.register('bar')
+
+      expect(registry.event_names).to match_array(['foo', 'bar'])
+    end
+  end
+
+  describe '#check_event_name_registered' do
+    it 'returns true if the event is registered' do
+      registry = described_class.new
+      registry.register('foo')
+
+      expect(registry.check_event_name_registered('foo')).to be(true)
+    end
+
+    it 'raises when the event is not registered' do
+      registry = described_class.new
+
+      expect {
+        registry.check_event_name_registered('foo')
+      }.to raise_error(/not registered/)
+    end
+
+    it 'includes all available events on the error message' do
+      registry = described_class.new
+      registry.register('bar')
+      registry.register('baz')
+
+      expect {
+        registry.check_event_name_registered('foo')
+      }.to raise_error(/bar.*baz/)
+    end
+
+    it 'hints on the event name on the error message' do
+      registry = described_class.new
+      registry.register('order_canceled')
+
+      expect {
+        registry.check_event_name_registered('order_canceed')
+      }.to raise_error(/Did you mean\?  order_canceled/)
+    end
+  end
+end

--- a/core/spec/lib/spree/event/subscriber_registry_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_registry_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Spree::Event::SubscriberRegistry do
     end
   end
 
+  unless Spree::Event::Adapters::DeprecationHandler.legacy_adapter?
+    before do
+      Spree::Event.register(:event_name)
+      Spree::Event.register(:other_event)
+    end
+
+    after do
+      Spree::Event.unregister(:event_name)
+      Spree::Event.unregister(:other_event)
+    end
+  end
+
   describe "#activate_all_subscribers" do
     before { subject.register(N) }
 

--- a/core/spec/lib/spree/event/subscriber_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_spec.rb
@@ -8,6 +8,20 @@ require 'spree/event/adapters/deprecation_handler'
 require 'spree/event/listener'
 
 RSpec.describe Spree::Event::Subscriber do
+  is_legacy_adapter = Spree::Event::Adapters::DeprecationHandler.legacy_adapter?
+
+  unless is_legacy_adapter
+    before do
+      Spree::Event.register(:event_name)
+      Spree::Event.register(:foo)
+    end
+
+    after do
+      Spree::Event.unregister(:event_name)
+      Spree::Event.unregister(:foo)
+    end
+  end
+
   module M
     include Spree::Event::Subscriber
 
@@ -70,12 +84,18 @@ RSpec.describe Spree::Event::Subscriber do
 
       it 'does not subscribe the action' do
         expect(M).not_to receive(:other_event)
+        Spree::Event.register('other_event')
+
         Spree::Event.fire 'other_event'
+
+      ensure
+        Spree::Event.unregister('other_event') unless is_legacy_adapter
       end
     end
 
     context 'when the action is declared' do
       before do
+        Spree::Event.register('other_event')
         M.event_action :other_event
         M.activate
       end
@@ -83,6 +103,7 @@ RSpec.describe Spree::Event::Subscriber do
       after do
         M.deactivate
         M.event_actions.delete(:other_event)
+        Spree::Event.unregister('other_event') unless is_legacy_adapter
       end
 
       it 'subscribe the action' do
@@ -92,7 +113,7 @@ RSpec.describe Spree::Event::Subscriber do
     end
   end
 
-  unless Spree::Event::Adapters::DeprecationHandler.legacy_adapter?
+  unless is_legacy_adapter
     describe '::listeners' do
         before { M.activate }
         after { M.deactivate }

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -9,6 +9,10 @@ DummyApp.setup(
   gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_core'
 )
+unless Spree::Event::Adapters::DeprecationHandler.legacy_adapter?
+  require 'spree/event/test_interface'
+  Spree::Event.enable_test_interface
+end
 
 require 'rspec/rails'
 require 'rspec-activemodel-mocks'


### PR DESCRIPTION
**Description**

Make it mandatory to register an event before being fired, subscribed
, or unsubscribed.

It helps with two scenarios:

- It avoids typo errors, like subscribing to an event `ordr_finalized`
  instead of `order_finalized`.

- It avoids naming collisions between user-defined events and core ones.

Example:

```ruby
Spree::Event.register('foo')
Spree::Event.fire('foo')
```

We add this behavior only to the new, recommended adapter. However, we
add into the deprecation error for the legacy adapter the instructions
to update.

We also add a new `#unregister` method for the test interface.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
