### PR TITLE
Reintroduce inverse_of: :product for variants association

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -45,6 +45,7 @@ module Spree
 
     has_many :variants,
       -> { where(is_master: false).order(:position) },
+      inverse_of: :product,
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,


### PR DESCRIPTION
**Description**

`inverse_of: :product` was moved to the `variants_including_master` association with 7c37093, but there should be no problem in having this option specified in more than one association, in fact its removal is causing an issue as now the reference to the product changes is lost for records in the `variants` association:

    p = Spree::Product.first
    v = p.variants.first
    m = p.variants_including_master.find_by(is_master: true)

    p.name = "Foobar"

    m.product.name
     # => "Foobar"

    v.product.name
    # => "Solidus T-Shirt"

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
