### PR TITLE
Ensure promotion codes don't trigger ActiveRecord::RecordNotUnique errors on save

### DIFF
--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -5,11 +5,11 @@ class Spree::PromotionCode < Spree::Base
   belongs_to :promotion_code_batch, class_name: "Spree::PromotionCodeBatch", optional: true
   has_many :adjustments
 
+  before_validation :normalize_code
+
   validates :value, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
   validates :promotion, presence: true
   validate :promotion_not_apply_automatically, on: :create
-
-  before_save :normalize_code
 
   self.whitelisted_ransackable_attributes = ['value']
 

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -8,22 +8,54 @@ RSpec.describe Spree::PromotionCode do
 
     describe '#normalize_code' do
       let(:promotion) { create(:promotion, code: code) }
-      let(:promotion_code) { promotion.codes.first }
 
       before { subject }
 
-      context 'with mixed case' do
-        let(:code) { 'NewCoDe' }
+      context 'when no other code with the same value exists' do
+        let(:promotion_code) { promotion.codes.first }
 
-        it 'downcases the value before saving' do
-          expect(promotion_code.value).to eq('newcode')
+        context 'with mixed case' do
+          let(:code) { 'NewCoDe' }
+
+          it 'downcases the value before saving' do
+            expect(promotion_code.value).to eq('newcode')
+          end
+        end
+
+        context 'with extra spacing' do
+          let(:code) { ' new code ' }
+
+          it 'removes surrounding whitespace' do
+            expect(promotion_code.value).to eq 'new code'
+          end
         end
       end
 
-      context 'with extra spacing' do
-        let(:code) { ' new code ' }
-        it 'removes surrounding whitespace' do
-          expect(promotion_code.value).to eq 'new code'
+      context 'when another code with the same value exists' do
+        let(:promotion_code) { promotion.codes.build(value: code) }
+
+        context 'with mixed case' do
+          let(:code) { 'NewCoDe' }
+
+          it 'does not save the record and marks it as invalid' do
+            expect(promotion_code.valid?).to eq false
+
+            expect(promotion_code.errors.messages[:value]).to contain_exactly(
+              'has already been taken'
+            )
+          end
+        end
+
+        context 'with extra spacing' do
+          let(:code) { ' new code ' }
+
+          it 'does not save the record and marks it as invalid' do
+            expect(promotion_code.valid?).to eq false
+
+            expect(promotion_code.errors.messages[:value]).to contain_exactly(
+              'has already been taken'
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Promotion codes are always stored in the database in lowercase. Up to this PR, the transformation of the in-memory value of a code was performed in a [`before_save`][before_save] callback.

This implementation led to a weird behavior that can easily be reproduced with a fresh Solidus install:

https://user-images.githubusercontent.com/4389323/147362573-a615fcc6-0013-4f02-87cc-46c9d5cb78c9.mov

The expected error handling would be that any input that would end up matching an existing code (after having been stripped of spaces & downcased) should trigger the same flash error rather than crash the page.

This behavior can be achieved by normalizing values earlier in a `before_validation` callback: that way, the validation callback will query the database using a stripped/downcased value and, should a match be found, set an error on the model instance as expected.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)

[before_save]: https://github.com/solidusio/solidus/blob/d467123b9b9b303a68b2817c21ca4c72b694f3b0/core/app/models/spree/promotion_code.rb#L12