### PR TITLE
Accept nested addresses attributes for User

### DIFF
--- a/api/spec/requests/spree/api/users_spec.rb
+++ b/api/spec/requests/spree/api/users_spec.rb
@@ -70,6 +70,37 @@ module Spree::Api
         expect(json_response['ship_address']).to_not be_nil
       end
 
+      it "can update own details in JSON with unwrapped parameters (Rails default)" do
+        country = create(:country)
+        put spree.api_user_path(user.id),
+          headers: { "CONTENT_TYPE": "application/json" },
+          params: {
+            token: user.spree_api_key,
+            email: "mine@example.com",
+            bill_address_attributes: {
+              name: 'First Last',
+              address1: '1 Test Rd',
+              city: 'City',
+              country_id: country.id,
+              state_id: 1,
+              zipcode: '55555',
+              phone: '5555555555'
+            },
+            ship_address_attributes: {
+              name: 'First Last',
+              address1: '1 Test Rd',
+              city: 'City',
+              country_id: country.id,
+              state_id: 1,
+              zipcode: '55555',
+              phone: '5555555555'
+            }
+          }.to_json
+        expect(json_response['email']).to eq 'mine@example.com'
+        expect(json_response['bill_address']).to_not be_nil
+        expect(json_response['ship_address']).to_not be_nil
+      end
+
       it "cannot update other users details" do
         put spree.api_user_path(stranger.id), params: { token: user.spree_api_key, user: { email: "mine@example.com" } }
         assert_not_found!

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -37,6 +37,9 @@ module Spree
 
       has_one :default_user_ship_address, ->{ default_shipping }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
       has_one :ship_address, through: :default_user_ship_address, source: :address
+
+      accepts_nested_attributes_for :ship_address
+      accepts_nested_attributes_for :bill_address
     end
 
     # saves address in address book


### PR DESCRIPTION
**Description**

With https://github.com/solidusio/solidus/commit/64d7dd04ee9a08ffd4928fad794be02ca130c973#diff-dcb949431d51052e7c37a15cfd67590fd291e46783c4ca282fa7072834c0f7db, the AddressBook functionality has been added to Solidus, giving the opportunity to associate multiple addresses with a user.

At that time, it was acceptable to replace the `accepts_nested_attributes_for` calls for addresses with just having the setter methods defined, as we can see in [a code comment of that commit](https://github.com/solidusio/solidus/commit/64d7dd04ee9a08ffd4928fad794be02ca130c973#diff-dcb949431d51052e7c37a15cfd67590fd291e46783c4ca282fa7072834c0f7dbR26-R28), later removed:

```ruby
      def ship_address_attributes=(attributes)
        # see "Nested Attributes Examples" section of http://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for
        # this #{fieldname}_attributes= method works with fields_for in the views
        # even without declaring accepts_nested_attributes_for
        self.ship_address = Address.immutable_merge(ship_address, attributes)
      end
```

But not having the explicit `accepts_nested_attributes_for` calls has currently other implications, starting from Rails 5.

In fact, Rails' [ParamsWrapper], which automatically wraps all unwrapped parameters into a nested hash works with nested attributes by checking the allowed nested attributes of a model via the accepts_nested_attributes_for configuration. Please note that [ParamsWrapper] is turned on with an initializer for all new Rails applications.

Suppose we are running this legit API request to update the user's bill address using unwrapped parameters in JSON:

```sh
	curl 'https://domain.com/api/users/123' \
	  -X 'PATCH' \
	  -H 'authorization: ¯\_(ツ)_/¯ ' \
	  -H 'content-type: application/json' \
	  -H 'accept: application/json, text/plain, */*' \
	  --data-raw '{"bill_address_attributes":{"name":"Mary Jane","address1":"1 Test Rd","city":"New York","country_id":123,"state_id":456,"zipcode":"55555","phone":"5555555555"}}'
```

Before this change we have:

```ruby
	Spree::User.nested_attributes_options
	{}
```

And the API request failing to update the record. What happens under the hood is Rails not being able to understand that it should move those parameters into the `'user': {}` key, making those params be excluded with the strong parameters rules.

After this change:

```ruby
	Spree::User.nested_attributes_options
	{:bill_address=>{:allow_destroy=>false, :update_only=>false}, :ship_address=>{:allow_destroy=>false, :update_only=>false}}
```

And the REST API request successfully updates the record! 🙌

[ParamsWrapper]: https://api.rubyonrails.org/v6.1.2/classes/ActionController/ParamsWrapper.html

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
