### PR TITLE
Admin users did not work with custom user models

### DIFF
--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -70,6 +70,6 @@
   <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::StoreCredit,
-                 new_resource_url: new_object_url %>
+                 new_resource_url: spree.new_admin_user_store_credit_url %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -87,10 +87,10 @@
         <td class="align-center"><%= l user.created_at.to_date %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">
           <% if can?(:edit, user) %>
-            <%= link_to_edit user, no_text: true %>
+            <%= link_to_edit user, no_text: true, url: spree.admin_user_path(user) %>
           <% end %>
           <% if can?(:destroy, user) && user.orders.count.zero? %>
-            <%= link_to_delete user, no_text: true %>
+            <%= link_to_delete user, no_text: true, url: spree.admin_user_path(user) %>
           <% end %>
         </td>
       </tr>

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -59,6 +59,33 @@ describe Spree::Admin::UsersController, type: :controller do
         expect(assigns(:collection)).to eq [user]
       end
     end
+
+    context "when Spree.user_class have a different namespace than Spree" do
+      class UserModel < ApplicationRecord
+        self.table_name = 'spree_users'
+        include Spree::UserMethods
+      end
+
+      around do |example|
+        actual_user_class = Spree.user_class
+        Spree.user_class = 'UserModel'
+        UserModel.create(email: "a@solidus.io")
+        example.run
+        Spree.user_class = actual_user_class.name
+      end
+
+      render_views
+
+      it "renders the edit and delete links correctly" do
+        allow(Spree.user_class).to receive(:find_by).
+            with(hash_including(:spree_api_key)).
+            and_return(Spree.user_class.new)
+
+        get :index
+
+        expect(response).to be_successful
+      end
+    end
   end
 
   context "#show" do


### PR DESCRIPTION
# Description
If Spree.user_class was other than Spree::User, it was failing
to create edit and delete url's in Admin::UsersController#index,
using CustomUser for example, it tried to generate: admin_custom_user_url
instead of using the existing admin_user_url

# Checklist:
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
