### PR TITLE
[RFC] Just touch taxons in Product#touch_taxons

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -115,7 +115,7 @@ module Spree
     after_initialize :ensure_master
 
     after_save :run_touch_callbacks, if: :saved_changes?
-    after_touch :touch_taxons
+    after_commit :touch_taxons
 
     before_validation :normalize_slug, on: :update
     before_validation :validate_master

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -349,15 +349,11 @@ module Spree
       run_callbacks(:touch)
     end
 
-    # Iterate through this product's taxons and taxonomies and touch their timestamps in a batch
+    # Iterate through this product's taxons and touch their timestamps in a batch
+    # The `after_touch` callback of `Spree::Taxon` will make sure the ancestors and
+    # the taxonomy will be touched as well.
     def touch_taxons
-      taxons_to_touch = taxons.flat_map(&:self_and_ancestors).uniq
-      unless taxons_to_touch.empty?
-        Spree::Taxon.where(id: taxons_to_touch.map(&:id)).update_all(updated_at: Time.current)
-
-        taxonomy_ids_to_touch = taxons_to_touch.flat_map(&:taxonomy_id).uniq
-        Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.current)
-      end
+      taxons.each(&:touch)
     end
 
     def remove_taxon(taxon)

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -23,8 +23,7 @@ module Spree
     validates :meta_title, length: { maximum: 255 }
     validates :taxonomy_id, uniqueness: { scope: :parent_id, message: :can_have_only_one_root }, if: -> { root? }
 
-    after_save :touch_ancestors_and_taxonomy
-    after_touch :touch_ancestors_and_taxonomy
+    after_commit :touch_ancestors_and_taxonomy
 
     include ::Spree::Config.taxon_attachment_module
 

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -140,11 +140,11 @@ module Spree
 
     private
 
+    # Touches all ancestors at once to avoid recursive taxonomy touch, and reduce queries.
     def touch_ancestors_and_taxonomy
-      # Touches all ancestors at once to avoid recursive taxonomy touch, and reduce queries.
-      self.class.default_scoped.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.current)
+      ancestors.touch_all
       # Have taxonomy touch happen in #touch_ancestors_and_taxonomy rather than association option in order for imports to override.
-      taxonomy.try!(:touch)
+      taxonomy&.touch
     end
   end
 end


### PR DESCRIPTION
**Description**

And make use of the `after_touch` callback of `Spree::Taxon`,
that already handles touching ancestors and its taxonomy.

This hopefully fixes #3931 as well, because it runs each `touch`
callback in it's own transaction instead of one large transaction
that might cause dead locks.

This IS slower than the optimized approach before, but this should not
be that much of an issue, since we are updating a product here
and this will a) not happen that much and b) there will not be many taxons
one single product will be attached to, right? Even in large stores this
will most likely be in single to double digits, instead of hundreds
or thousands. But I might be painfully wrong here.

This also has the advantage that a `after_touch` callback a store or an
extension might have will be triggered and caches will be invalidated
correctly.

~~DISCLAIMER: I did not added any tests on purpose, because I want to discuss if this is an approach we want to try first.~~

~~Actually I added a spec that creates a taxon tree of 1000 taxons nested 10 random levels deep. The product that then will be updated is attached to 50 random taxons. We expect no errors.~~

Removed that spec again

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
