### PR TITLE
Documentation fixes

### DIFF
--- a/guides/source/developers/customizations/customizing-mailers.html.md
+++ b/guides/source/developers/customizations/customizing-mailers.html.md
@@ -91,7 +91,7 @@ Solidus initializer:
 # config/initializers/spree.rb
 
 Spree.config do |config|
-  config.order_mailer_class = 'c'
+  config.order_mailer_class = 'Spree::CustomOrderMailer'
 end
 ```
 

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -97,7 +97,7 @@ happens in the system. If the `event_name` argument is not specified,
 the event name and the method name should match.
 
 These subscriber modules are loaded with the rest of your application, you
-don't need to manually subscribe them when:
+don't need to manually subscribe to them when:
 
 * `Spree::Config.events.autoload_subscribers` returns a truthy value (default);
 * you put them in the directory (or any subdirectory of) `app/subscribers`;

--- a/guides/source/developers/extensions/writing-extensions.html.md
+++ b/guides/source/developers/extensions/writing-extensions.html.md
@@ -16,7 +16,7 @@ There is also a series of curated extensions available under the
 
 ## Developing a Solidus extension locally
 
-### Install the solidus_dev_support gem
+### Install the solidus\_dev\_support gem
 A Solidus extension is just a Rails engine, you can build the extension in
 exactly the same way you'd build any other Rails engine.
 

--- a/guides/source/developers/payments/payments.html.md
+++ b/guides/source/developers/payments/payments.html.md
@@ -44,6 +44,8 @@ While some payment service providers may not require a payment identifier, other
 services may require or recommend them. In the past, some services have
 erroneously reported duplicate payments when not recording a payment identifier.
 
+[payment-service-providers]: payment-service-providers.html
+
 ## Response codes
 
 `Spree::Payment`s store AVS and CVV2 response codes that are sent back from the

--- a/guides/source/developers/preferences/add-model-preferences.html.md
+++ b/guides/source/developers/preferences/add-model-preferences.html.md
@@ -68,7 +68,7 @@ We encourage the usage of environment variables for keeping your secrets,
 but in case when this is not possible you can use a preference of type
 `encrypted_string`.
 
-A preference of type `encrypted_string` accept an option named `encryption_key`,
+A preference of type `encrypted_string` accepts an option named `encryption_key`,
 the value of the option will be used as key for the encryption of the preference.
 
 If no `encryption_key` is passed the application would use the value of the

--- a/guides/source/developers/returns/customer-returns.html.md
+++ b/guides/source/developers/returns/customer-returns.html.md
@@ -36,7 +36,7 @@ Once a store administrator has created a customer return in the
 [reimbursements][reimbursements] can be made.
 
 For example, you can specify whether return items are resellable, whether your
-stock location has received each item, and what they reason for the return is.
+stock location has received each item, and what the reason for the return is.
 All of this information is stored in a `Spree::ReturnItem` object's attributes.
 
 Once an item is marked as "Received", you can create a `Spree::Reimbursement`


### PR DESCRIPTION
**Description**
While reading [the developer guides](https://guides.solidus.io/developers) I found a few typos, a missing link, one formatting error, and a missing piece of code.  In this PR I have included a fix/update for each of these (each as separate commit). 

| Before | After |
| ------- | ----- |
| <img width="708" alt="Screenshot 2022-01-13 at 11 31 09" src="https://user-images.githubusercontent.com/7622933/149313635-8a9d37b3-dea6-4be0-be21-4c2e42b94eef.png"> | <img width="708" alt="Screenshot 2022-01-13 at 11 31 05" src="https://user-images.githubusercontent.com/7622933/149313654-601b3dc4-1917-4669-9c5a-2cb380d9e1c2.png"> |

The missing piece fo code is defined in [guides/source/developers/customizations/customizing-mailers.html.md](https://github.com/solidusio/solidus/blob/master/guides/source/developers/customizations/customizing-mailers.html.md).  I believe to have updated it correctly, such that it matches the section that comes after it (which introduces the `Spree::CustomOrderMailer`).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [ ] ~I have added tests to cover this change (if needed)~
- [x] I have attached screenshots to this PR for visual changes (if needed)
- [x] Verified that the changes are correct using `middleman server`
