### PR TITLE
Fix product prices table pagination

### DIFF
--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -18,7 +18,7 @@ module Spree
           .currently_valid
           .for_variant
           .order(:variant_id, :country_iso, :currency)
-          .page(params[:page]).per(Spree::Config.admin_variants_per_page)
+          .page(params[:variants_page]).per(Spree::Config.admin_variants_per_page)
       end
 
       def edit

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -1,6 +1,6 @@
 <fieldset class="no-border-bottom <%= "no-border-top" if !variants %>">
   <% if variants %>
-    <legend align="center"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
+    <legend align="center"><%= t(".master_variant") %> <%= admin_hint t(".master_variant"), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
   <% end %>
 
   <%= paginate master_prices, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -1,9 +1,9 @@
-<%= paginate master_prices, theme: "solidus_admin" %>
-
 <fieldset class="no-border-bottom <%= "no-border-top" if !variants %>">
   <% if variants %>
     <legend align="center"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
   <% end %>
+
+  <%= paginate master_prices, theme: "solidus_admin" %>
   <table class="index master_prices">
     <colgroup>
       <col style="width: 30%">
@@ -36,6 +36,5 @@
       </tr>
     <% end %>
   </table>
+  <%= paginate master_prices, theme: "solidus_admin" %>
 </fieldset>
-
-<%= paginate master_prices, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="no-border-bottom" data-hook="variant_prices_table">
-  <legend align="center"><%= I18n.t(:variant_pricing, scope: :spree) %></legend>
+  <legend align="center"><%= t(".variant_pricing") %></legend>
 
   <%= paginate variant_prices, theme: "solidus_admin", param_name: :variants_page %>
   <table class="index prices">

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,7 +1,7 @@
-<%= paginate variant_prices, theme: "solidus_admin" %>
-
-<fieldset class="no-border-bottom">
+<fieldset class="no-border-bottom" data-hook="variant_prices_table">
   <legend align="center"><%= I18n.t(:variant_pricing, scope: :spree) %></legend>
+
+  <%= paginate variant_prices, theme: "solidus_admin", param_name: :variants_page %>
   <table class="index prices">
     <thead data-hook="prices_header">
       <tr>
@@ -32,6 +32,5 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate variant_prices, theme: "solidus_admin", param_name: :variants_page %>
 </fieldset>
-
-<%= paginate variant_prices, theme: "solidus_admin" %>

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -22,11 +22,12 @@ describe 'Pricing' do
     let(:master_price) { product.master.default_price }
     let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "RUB", country_iso: "DE") }
 
-    before do
+    subject do
       visit spree.admin_product_prices_path(product)
     end
 
     it 'displays a table with the prices' do
+      subject
       expect(page).to have_content(product.name)
       within(".tabs .active") do
         expect(page).to have_content("Prices")
@@ -51,6 +52,7 @@ describe 'Pricing' do
       end
 
       it 'has a working table filter' do
+        subject
         expect(page).to have_selector("#table-filter")
         within "#table-filter" do
           within "fieldset legend" do
@@ -64,12 +66,48 @@ describe 'Pricing' do
       end
     end
 
+    context "pagination" do
+      let(:product) do
+        create(:product).tap do |product|
+          product.master.prices << create(:price)
+        end
+      end
+
+      let!(:variants) do
+        v = []
+        3.times do |i|
+          v << create(:variant, price: i * 10, product: product)
+        end
+        v
+      end
+
+      before do
+        allow(Spree::Config).to receive(:admin_variants_per_page) { 1 }
+      end
+
+      it "paginates products and variants independently" do
+        subject
+        within '[data-hook="variant_prices_table"] > nav:first-of-type > .pagination' do
+          click_link "2"
+        end
+        product_prices = product.prices.for_master.order(:variant_id, :country_iso, :currency)
+        expect(page).to have_content(product_prices[0].display_amount)
+        expect(page).to_not have_content(product_prices[1].display_amount)
+        expect(page).to_not have_content(product_prices[2].display_amount)
+        variant_prices = product.prices.for_variant.order(:variant_id, :country_iso, :currency)
+        expect(page).to_not have_content(variant_prices[0].display_price)
+        expect(page).to have_content(variant_prices[1].display_price)
+        expect(page).to_not have_content(variant_prices[2].display_price)
+      end
+    end
+
     context "editing" do
       let(:product) { create(:product, price: 123.99) }
       let!(:variant) { product.master }
       let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "EUR") }
 
       it 'has a working edit page' do
+        subject
         within "#spree_price_#{product.master.prices.first.id}" do
           click_icon :edit
         end
@@ -87,6 +125,7 @@ describe 'Pricing' do
       end
 
       it "will not reset the currency to default" do
+        subject
         within "#spree_price_#{other_price.id}" do
           click_icon :edit
         end
@@ -104,6 +143,7 @@ describe 'Pricing' do
       let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "EUR") }
 
       it "will delete the non-default price" do
+        subject
         within "#spree_price_#{other_price.id}" do
           accept_alert do
             click_icon :trash
@@ -113,6 +153,7 @@ describe 'Pricing' do
       end
 
       it "does not break when default price is deleted" do
+        subject
         within "#spree_price_#{variant.default_price.id}" do
           accept_alert do
             click_icon :trash

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -866,6 +866,10 @@ en:
           new_price: New Price
         new:
           new_price: New Price
+        master_variant_table:
+          master_variant: Master Variant Prices
+        table:
+          variant_pricing: Variant Prices
       promotions:
         actions:
           calculator_label: Calculated by
@@ -2248,7 +2252,6 @@ en:
     value: Value
     variant: Variant
     variant_placeholder: Choose a Variant
-    variant_pricing: Variant Pricing
     variant_properties: Variant Properties
     variant_search: Variant Search
     variant_search_placeholder: SKU or Option Value


### PR DESCRIPTION
**Description**

- Move the pagination into the fieldset of its table,
  makes it more easily to distinguish the buttons
- Paginate prices of variants and products independently
- Scopes pricing table headers to the template path. 
  That way it can better be translating in context.

### Before

![localhost_3000_admin_products_solidus-long-sleeve_prices(Full-HD TV)](https://user-images.githubusercontent.com/42868/149363887-bb0dc0f9-aaef-4f9c-8aaa-45038b244222.png)

### After

![localhost_3000_admin_products_solidus-long-sleeve_prices_variants_page=3(Full-HD TV)](https://user-images.githubusercontent.com/42868/149363922-b1d51793-227b-48d4-a589-d2245822b101.png)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
- [x] I have attached screenshots to this PR for visual changes
