### PR TITLE
[Admin] Fix permission checks on some links

### DIFF
--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -38,7 +38,9 @@
             </span>
           </td>
           <td class="actions">
-            <%= link_to_edit adjustment_reason, no_text: true %>
+            <% if can? :edit, adjustment_reason %>
+              <%= link_to_edit adjustment_reason, no_text: true %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -12,7 +12,7 @@
 
 <%= render partial: 'adjustments_table' %>
 
-<% if @order.can_add_coupon? %>
+<% if @order.can_add_coupon? && can?(:update, @order) %>
   <div data-hook="adjustments_new_coupon_code">
     <%= text_field_tag "coupon_code", "", placeholder: t('spree.coupon_code') %>
     <%= button_tag t('spree.add_coupon_code'), id: "add_coupon_code", class: 'btn btn-primary' %>

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -25,7 +25,7 @@
         <td><%= price.currency %></td>
         <td><%= price.money.to_html %></td>
         <td class="actions">
-          <% if can?(:update, price) %>
+          <% if can?(:edit, price) %>
             <%= link_to_edit(price, no_text: true) unless price.discarded? %>
           <% end %>
           <% if can?(:destroy, price) %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -20,7 +20,7 @@
           <td><%= price.currency %></td>
           <td><%= price.money.to_html %></td>
           <td class="actions">
-            <% if can?(:update, price) %>
+            <% if can?(:edit, price) %>
               <%= link_to_edit(price, no_text: true) unless price.discarded? %>
             <% end %>
             <% if can?(:destroy, price) %>

--- a/backend/spec/features/admin/adjustment_reasons_spec.rb
+++ b/backend/spec/features/admin/adjustment_reasons_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Adjustment reasons", type: :feature do
+  stub_authorization!
+
+  context "when visiting the list page" do
+    let!(:adjustment_reason) { create(:adjustment_reason) }
+
+    before { visit spree.admin_adjustment_reasons_path }
+
+    context "when the user cannot edit adjustment reasons" do
+      custom_authorization! do |_user|
+        cannot :edit, Spree::AdjustmentReason
+      end
+
+      it "lists reasons but doesn't show their edit buttons" do
+        within '#listing_adjustment_reasons' do
+          expect(page).to have_content adjustment_reason.name
+          expect(page).not_to have_selector('a[data-action="edit"]')
+        end
+      end
+    end
+
+    context "when the user can edit adjustment reasons" do
+      custom_authorization! do |_user|
+        can :edit, Spree::AdjustmentReason
+      end
+
+      it "lists reasons and their edit buttons" do
+        within '#listing_adjustment_reasons' do
+          expect(page).to have_content adjustment_reason.name
+          expect(page).to have_selector('a[data-action="edit"]')
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -5,130 +5,167 @@ require 'spec_helper'
 describe "Adjustments", type: :feature do
   stub_authorization!
 
-  let!(:ship_address) { create(:address) }
-  let!(:tax_zone) { create(:global_zone) } # will include the above address
-  let!(:tax_rate) { create(:tax_rate, amount: 0.20, zone: tax_zone, tax_categories: [tax_category]) }
+  context "when the order is completed" do
+    let!(:ship_address) { create(:address) }
+    let!(:tax_zone) { create(:global_zone) } # will include the above address
+    let!(:tax_rate) { create(:tax_rate, amount: 0.20, zone: tax_zone, tax_categories: [tax_category]) }
 
-  let!(:order) do
-    create(
-      :completed_order_with_totals,
-      line_items_attributes: [{ price: 10, variant: variant }] * 5,
-      ship_address: ship_address,
-    )
-  end
-  let!(:line_item) { order.line_items[0] }
-
-  let(:tax_category) { create(:tax_category) }
-  let(:variant) { create(:variant, tax_category: tax_category) }
-
-  let!(:non_eligible_adjustment) { order.adjustments.create!(order: order, label: 'Non-Eligible', amount: 10, eligible: false) }
-  let!(:adjustment) { order.adjustments.create!(order: order, label: 'Rebate', amount: 10) }
-
-  before(:each) do
-    order.recalculate
-
-    visit spree.admin_path
-    click_link "Orders"
-    within_row(1) { click_icon :edit }
-    click_link "Adjustments"
-  end
-
-  context "admin managing adjustments" do
-    it "should display the correct values for existing order adjustments" do
-      within first('table tr', text: 'Tax') do
-        expect(column_text(2)).to match(/TaxCategory - \d+ 20\.000%/)
-        expect(column_text(3)).to eq("$2.00")
-      end
+    let!(:order) do
+      create(
+        :completed_order_with_totals,
+        line_items_attributes: [{ price: 10, variant: variant }] * 5,
+        ship_address: ship_address,
+      )
     end
+    let!(:line_item) { order.line_items[0] }
 
-    it "shows both eligible and non-eligible adjustments" do
-      expect(page).to have_content("Rebate")
-      expect(page).to have_content("Non-Eligible")
-      expect(find('tr', text: 'Rebate')[:class]).not_to eq('adjustment-ineligible')
-      expect(find('tr', text: 'Non-Eligible')[:class]).to eq('adjustment-ineligible')
-    end
-  end
+    let(:tax_category) { create(:tax_category) }
+    let(:variant) { create(:variant, tax_category: tax_category) }
 
-  context "admin creating a new adjustment" do
+    let!(:non_eligible_adjustment) { order.adjustments.create!(order: order, label: 'Non-Eligible', amount: 10, eligible: false) }
+    let!(:adjustment) { order.adjustments.create!(order: order, label: 'Rebate', amount: 10) }
+
     before(:each) do
-      click_link "New Adjustment"
+      order.recalculate
+
+      visit spree.admin_path
+      click_link "Orders"
+      within_row(1) { click_icon :edit }
+      click_link "Adjustments"
     end
 
-    context "successfully" do
-      it "should create a new adjustment" do
-        fill_in "adjustment_amount", with: "10"
-        fill_in "adjustment_label", with: "rebate"
-        click_button "Continue"
+    context "admin managing adjustments" do
+      it "should display the correct values for existing order adjustments" do
+        within first('table tr', text: 'Tax') do
+          expect(column_text(2)).to match(/TaxCategory - \d+ 20\.000%/)
+          expect(column_text(3)).to eq("$2.00")
+        end
+      end
 
-        order.reload.all_adjustments.each do |adjustment|
-          expect(adjustment.order_id).to equal(order.id)
+      it "shows both eligible and non-eligible adjustments" do
+        expect(page).to have_content("Rebate")
+        expect(page).to have_content("Non-Eligible")
+        expect(find('tr', text: 'Rebate')[:class]).not_to eq('adjustment-ineligible')
+        expect(find('tr', text: 'Non-Eligible')[:class]).to eq('adjustment-ineligible')
+      end
+    end
+
+    context "admin creating a new adjustment" do
+      before(:each) do
+        click_link "New Adjustment"
+      end
+
+      context "successfully" do
+        it "should create a new adjustment" do
+          fill_in "adjustment_amount", with: "10"
+          fill_in "adjustment_label", with: "rebate"
+          click_button "Continue"
+
+          order.reload.all_adjustments.each do |adjustment|
+            expect(adjustment.order_id).to equal(order.id)
+          end
+        end
+      end
+
+      context "with validation errors" do
+        it "should not create a new adjustment" do
+          fill_in "adjustment_amount", with: ""
+          fill_in "adjustment_label", with: ""
+          click_button "Continue"
+          expect(page).to have_content("Label can't be blank")
+          expect(page).to have_content("Amount is not a number")
         end
       end
     end
 
-    context "with validation errors" do
-      it "should not create a new adjustment" do
-        fill_in "adjustment_amount", with: ""
-        fill_in "adjustment_label", with: ""
-        click_button "Continue"
-        expect(page).to have_content("Label can't be blank")
-        expect(page).to have_content("Amount is not a number")
+    context "admin editing an adjustment" do
+      before(:each) do
+        within('table tr', text: 'Rebate') do
+          click_icon :edit
+        end
+      end
+
+      context "successfully" do
+        it "should update the adjustment" do
+          fill_in "adjustment_amount", with: "99"
+          fill_in "adjustment_label", with: "rebate 99"
+          click_button "Continue"
+          expect(page).to have_content("successfully updated!")
+          expect(page).to have_content("rebate 99")
+          within(".adjustments") do
+            expect(page).to have_content("$99.00")
+          end
+
+          expect(page).to have_content("Total: $259.00")
+        end
+      end
+
+      context "with validation errors" do
+        it "should not update the adjustment" do
+          fill_in "adjustment_amount", with: ""
+          fill_in "adjustment_label", with: ""
+          click_button "Continue"
+          expect(page).to have_content("Label can't be blank")
+          expect(page).to have_content("Amount is not a number")
+        end
+      end
+    end
+
+    context "deleting an adjustment" do
+      context 'when the adjustment is finalized' do
+        let!(:adjustment) { super().tap(&:finalize!) }
+
+        it 'should not be possible' do
+          within('table tr', text: 'Rebate') do
+            expect(page).not_to have_css('.fa-trash')
+          end
+        end
+      end
+
+      it "should update the total", js: true do
+        accept_alert do
+          within('table tr', text: 'Rebate') do
+            click_icon(:trash)
+          end
+        end
+
+        expect(page).to have_content('Total: $170.00', normalize_ws: true)
       end
     end
   end
 
-  context "admin editing an adjustment" do
-    before(:each) do
-      within('table tr', text: 'Rebate') do
-        click_icon :edit
-      end
+  context "when the order is not completed" do
+    let(:order) { create(:order_ready_to_complete) }
+
+    before do
+      visit spree.edit_admin_order_path(order)
+      click_link "Adjustments"
     end
 
-    context "successfully" do
-      it "should update the adjustment" do
-        fill_in "adjustment_amount", with: "99"
-        fill_in "adjustment_label", with: "rebate 99"
-        click_button "Continue"
-        expect(page).to have_content("successfully updated!")
-        expect(page).to have_content("rebate 99")
-        within(".adjustments") do
-          expect(page).to have_content("$99.00")
+    context "when the order is not complete" do
+      context "when the user can edit and update orders" do
+        custom_authorization! do |_user|
+          can :update, Spree::Order
+          can :edit, Spree::Order
         end
 
-        expect(page).to have_content("Total: $259.00")
-      end
-    end
-
-    context "with validation errors" do
-      it "should not update the adjustment" do
-        fill_in "adjustment_amount", with: ""
-        fill_in "adjustment_label", with: ""
-        click_button "Continue"
-        expect(page).to have_content("Label can't be blank")
-        expect(page).to have_content("Amount is not a number")
-      end
-    end
-  end
-
-  context "deleting an adjustment" do
-    context 'when the adjustment is finalized' do
-      let!(:adjustment) { super().tap(&:finalize!) }
-
-      it 'should not be possible' do
-        within('table tr', text: 'Rebate') do
-          expect(page).not_to have_css('.fa-trash')
-        end
-      end
-    end
-
-    it "should update the total", js: true do
-      accept_alert do
-        within('table tr', text: 'Rebate') do
-          click_icon(:trash)
+        it "allows to enter a coupon code", :js do
+          expect(page).to have_content('Add Coupon Code')
+          expect(page).to have_selector('input#coupon_code')
         end
       end
 
-      expect(page).to have_content('Total: $170.00', normalize_ws: true)
+      context "when the user can edit but cannot update orders" do
+        custom_authorization! do |_user|
+          cannot :update, Spree::Order
+          can :edit, Spree::Order
+        end
+
+        it "doesn't allow to enter a coupon code" do
+          expect(page).not_to have_content('Add Coupon Code')
+          expect(page).not_to have_selector('input#coupon_code')
+        end
+      end
     end
   end
 end

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -42,6 +42,26 @@ describe 'Pricing' do
       end
     end
 
+    context "when the user can edit prices" do
+      custom_authorization! do |_user|
+        can :edit, Spree::Price
+      end
+
+      it "shows edit links" do
+        expect(page).to have_selector('a[data-action="edit"]')
+      end
+    end
+
+    context "when the user cannot edit prices" do
+      custom_authorization! do |_user|
+        cannot :edit, Spree::Price
+      end
+
+      it "doesn't show edit links" do
+        expect(page).not_to have_selector('a[data-action="edit"]')
+      end
+    end
+
     context "searching" do
       let(:variant) { create(:variant, price: 20) }
       let(:product) { variant.product }


### PR DESCRIPTION
**Description**

In the admin area there are a few links, mostly to `edit` actions, that are not visible unless the user has `update` permissions on the resource. 
Unfortunately, this is preventing read-only users to access the resource data, since often the `edit` page acts as `show`, the latter being missing from routes, see for example [what happens for prices](https://github.com/solidusio/solidus/blob/9f54d19d1ae591dda3b9ad6fe4f1a389fa802a5a/backend/config/routes.rb#L56). 

On a different note, on the adjustments page the `Add coupon` button together with its text field should be visible only to users that have `update` permissions because showing it doesn't add any information to unprivileged users.

A further UX improvement left for the future may be to hide `Update` buttons on edit pages when the user doesn't have `update` abilities.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
