### PR TITLE
V2.11 - Fix non auto populated customer info

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/order/address.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/address.js
@@ -1,5 +1,5 @@
 Spree.Views.Order.Address = Backbone.View.extend({
-  initialize: function(options) {
+  initialize: function() {
     // read initial values from page
     this.onChange();
 

--- a/backend/app/assets/javascripts/spree/backend/views/order/address.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/address.js
@@ -23,8 +23,9 @@ Spree.Views.Order.Address = Backbone.View.extend({
 
   eachField: function(callback){
     var view = this;
-    var fields = ["name", "company", "address1", "address2",
-      "city", "zipcode", "phone", "country_id", "state_name"];
+    var fields = ["name", "firstname", "lastname", "company", "address1",
+                  "address2", "city", "zipcode", "phone", "country_id",
+                  "state_name"];
     _.each(fields, function(field) {
       var el = view.$('[name$="[' + field + ']"]');
       if (el.length) callback(field, el);

--- a/backend/spec/javascripts/fixtures/order/combined_name_address.html.erb
+++ b/backend/spec/javascripts/fixtures/order/combined_name_address.html.erb
@@ -7,5 +7,30 @@
             <%= f.label :name %>
             <%= f.text_field :name, class: 'fullwidth' %>
         </div>
+
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :address1 %>
+            <%= f.text_field :address1, class: 'fullwidth' %>
+        </div>
+
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :address2 %>
+            <%= f.text_field :address2, class: 'fullwidth' %>
+        </div>
+
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :city %>
+            <%= f.text_field :city, class: 'fullwidth' %>
+        </div>
+
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :zipcode %>
+            <%= f.text_field :zipcode, class: 'fullwidth' %>
+        </div>
+
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :phone %>
+            <%= f.phone_field :phone, class: 'fullwidth' %>
+        </div>
     </div>
 <% end %>

--- a/backend/spec/javascripts/fixtures/order/combined_name_address.html.erb
+++ b/backend/spec/javascripts/fixtures/order/combined_name_address.html.erb
@@ -1,0 +1,11 @@
+<% type = 'billing' %>
+<%= fields_for :bill_address do |f| %>
+    <% s_or_b = type.chars.first %>
+
+    <div id="<%= type %>" data-hook="address_fields">
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :name %>
+            <%= f.text_field :name, class: 'fullwidth' %>
+        </div>
+    </div>
+<% end %>

--- a/backend/spec/javascripts/fixtures/order/separate_name_address.html.erb
+++ b/backend/spec/javascripts/fixtures/order/separate_name_address.html.erb
@@ -1,0 +1,13 @@
+<% type = 'billing' %>
+<%= fields_for :bill_address do |f| %>
+    <div id="<%= type %>" data-hook="address_fields">
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :firstname %>
+            <%= f.text_field :firstname, class: 'fullwidth' %>
+        </div>
+        <div class="field <%= "#{type}-row" %>">
+            <%= f.label :lastname %>
+            <%= f.text_field :lastname, class: 'fullwidth' %>
+        </div>
+    </div>
+<% end %>

--- a/backend/spec/javascripts/views/order/address_spec.js
+++ b/backend/spec/javascripts/views/order/address_spec.js
@@ -19,21 +19,43 @@ describe("Spree.Views.Order.Address", function() {
 
   describe("will set name fields upon a model change", function() {
     describe("with combined firstname and lastname", function() {
-      var $name;
+      var $name, $address1, $address2, $city, $zipcode, $phone;
 
       beforeEach(function() {
         loadFixture("order/combined_name_address");
         loadView();
 
         $name = $el.find('[name$="[name]"]');
+        $address1 = $el.find('[name$="[address1]"]');
+        $address2 = $el.find('[name$="[address2]"]');
+        $city = $el.find('[name$="[city]"]');
+        $zipcode = $el.find('[name$="[zipcode]"]');
+        $phone = $el.find('[name$="[phone]"]');
       });
 
-      it("sets the name field on change", function() {
+      it("updates the name field on change", function() {
         model.set({ name: 'John Doe' });
         expect(model.get('name')).to.eq('John Doe');
 
         view.render();
         expect($name).to.have.$val('John Doe');
+      });
+
+      it("updates the address lines on change", function() {
+        model.set({
+          address1: '80697 Cole Parks',
+          address2: 'Apt. 986',
+          city: 'Keeblerfort',
+          zipcode: '16804',
+          phone: '1-744-701-0536 x30504'
+        });
+
+        view.render();
+        expect($address1).to.have.$val('80697 Cole Parks');
+        expect($address2).to.have.$val('Apt. 986');
+        expect($city).to.have.$val('Keeblerfort');
+        expect($zipcode).to.have.$val('16804');
+        expect($phone).to.have.$val('1-744-701-0536 x30504');
       });
     });
 
@@ -48,7 +70,7 @@ describe("Spree.Views.Order.Address", function() {
         $lastname = $el.find('[name$="[lastname]"]');
       });
 
-      it("sets the name field on change", function() {
+      it("updates the name field on change", function() {
         model.set({ firstname: 'John', lastname: 'Doe' });
         expect(model.get('firstname')).to.eq('John');
         expect(model.get('lastname')).to.eq('Doe');

--- a/backend/spec/javascripts/views/order/address_spec.js
+++ b/backend/spec/javascripts/views/order/address_spec.js
@@ -1,0 +1,62 @@
+fixture.preload("order/combined_name_address", "order/separate_name_address");
+
+describe("Spree.Views.Order.Address", function() {
+  var model, view, $el;
+
+  var loadFixture = function(path) {
+    var fixtures = fixture.load(path, true);
+    $el = $(fixtures[0]);
+  }
+
+  var loadView = function() {
+    model = new Spree.Models.Address();
+    view = new Spree.Views.Order.Address({
+      model: model,
+      el: $el,
+    });
+    view.render();
+  }
+
+  describe("will set name fields upon a model change", function() {
+    describe("with combined firstname and lastname", function() {
+      var $name;
+
+      beforeEach(function() {
+        loadFixture("order/combined_name_address");
+        loadView();
+
+        $name = $el.find('[name$="[name]"]');
+      });
+
+      it("sets the name field on change", function() {
+        model.set({ name: 'John Doe' });
+        expect(model.get('name')).to.eq('John Doe');
+
+        view.render();
+        expect($name).to.have.$val('John Doe');
+      });
+    });
+
+    describe("with separate firstname and lastname", function() {
+      var $firstname, $lastname;
+
+      beforeEach(function() {
+        loadFixture("order/separate_name_address");
+        loadView();
+
+        $firstname = $el.find('[name$="[firstname]"]');
+        $lastname = $el.find('[name$="[lastname]"]');
+      });
+
+      it("sets the name field on change", function() {
+        model.set({ firstname: 'John', lastname: 'Doe' });
+        expect(model.get('firstname')).to.eq('John');
+        expect(model.get('lastname')).to.eq('Doe');
+
+        view.render();
+        expect($firstname).to.have.$val('John');
+        expect($lastname).to.have.$val('Doe');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves #3966

**Description**
- Includes a fix for #3966.
- Includes spec tests that verify the render behavior of the Backbone View [Spree.Views.Order.Address](https://github.com/solidusio/solidus/blob/3fac51e1d6307eb5768f11eb87870699312eca5c/backend/app/assets/javascripts/spree/backend/views/order/address.js).

The spec tests verify the behavior of the Address Backbone View based on two fixtures, these are extracts from the partial `spree/admin/shared/address_form` as I was unable to render the partial itself (due to the country and state fields).  Because of this, the fixtures do not render the country and state fields, nor does the spec test verify that they are updated.  Since this is unrelated to the original issue I don't think this is a problem for this PR.

It looks like this issue also exists on Solidus v3.x, so perhaps we should also merge these changes into the master branch?  I would need some advice on how to do this correctly.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~~I have updated Guides and README accordingly to this change (if needed)~~
- [x] I have added tests to cover this change (if needed)
- ~~I have attached screenshots to this PR for visual changes (if needed)~~
