### PR TITLE
Fix tests after two conflicting merges

### DIFF
--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -49,6 +49,8 @@ describe 'Pricing' do
       end
 
       it "shows edit links" do
+        subject
+
         expect(page).to have_selector('a[data-action="edit"]')
       end
     end
@@ -59,6 +61,8 @@ describe 'Pricing' do
       end
 
       it "doesn't show edit links" do
+        subject
+
         expect(page).not_to have_selector('a[data-action="edit"]')
       end
     end


### PR DESCRIPTION
PR #4243 (19800b7bd0ef0ae8683669efa3861da1e3113b0c) changed the `"in the
prices"` RSpec's context of the
`backend/spec/features/admin/products/pricing_spec.rb` to visit the
prices page in a `subject` instead of a `before` block. The reason is
that the former needs to be called explicitly, and we wanted it to be
called after the pagination was stubbed in a new test (see
https://github.com/tvdeyen/solidus/blob/12864a8aa578339173428cf4e1cd8f3f65bbc418/backend/spec/features/admin/products/pricing_spec.rb#L85-L89).
All the other tests within that context were updated accordingly to call
`subject` manually.

On the other side, #4244 (218229d648e7179c59b80e2ae3305d6560552d2a)
added new tests within the same RSpec's context, still using the version
with `before`.

Once both commits have been merged, we need to update the new tests from #4244 to call `subject`.