### PR TITLE
fix backbone shipment item view when split

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -180,7 +180,7 @@ var ShipmentItemView = Backbone.View.extend({
     Spree.ajax({
       type: "GET",
       url: Spree.pathFor('api/variants/' + this.variant_id),
-    }).success(function(variant){
+    }).done(function(variant){
       var split = new ShipmentSplitItemView({
         shipmentItemView: _this,
         shipment_number: _this.shipment_number,

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -142,4 +142,24 @@ describe "Shipments", type: :feature do
       end
     end
   end
+
+  context "when split shipment", js: true do
+    let(:location_name) { "WA Warehouse" }
+    let!(:location) { create(:stock_location, name: location_name)}
+
+    it "can split item" do
+      visit spree.edit_admin_order_path(order)
+      find_all('.split-item').first.click
+      within '.stock-item-split' do
+        find('.save-split').click
+        alert_text = page.driver.browser.switch_to.alert.text
+        expect(alert_text).to include 'Please select the split destination'
+        page.driver.browser.switch_to.alert.accept
+        find('.select2-container').click
+        find(:xpath, '//body').all('.select2-drop li.select2-result', text: "#{location_name} (0 on hand)")[1].click
+        find('.save-split').click
+      end
+      expect(page).to have_content /Pending package from '#{location_name}'/i
+    end
+  end
 end


### PR DESCRIPTION
This PR is sponsored by [MagmaLabs](https://www.magmalabs.io/)

**Description**
This will fix current build for `solidus_product_assembly` https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_product_assembly/194/workflows/a9e6929f-4d14-4234-bdcf-5266a359875a/jobs/464

Since we updated to use jquery3 in https://github.com/solidusio/solidus/commit/bdfa09409477d94198f5db96605600b93f066ef8, we need to update ajax callback to avoid use `success`, `error` and `complete` that are deprecated now https://api.jquery.com/jquery.ajax/

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
