### PR TITLE
Fix: solidus:install adds the frontend assets even if the repo does not have solidus_frontend

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -83,16 +83,16 @@ module Solidus
       empty_directory 'app/assets/images'
 
       %w{javascripts stylesheets images}.each do |path|
-        empty_directory "vendor/assets/#{path}/spree/frontend" if defined? Spree::Frontend || Rails.env.test?
-        empty_directory "vendor/assets/#{path}/spree/backend" if defined? Spree::Backend || Rails.env.test?
+        empty_directory "vendor/assets/#{path}/spree/frontend" if defined?(Spree::Frontend) || Rails.env.test?
+        empty_directory "vendor/assets/#{path}/spree/backend" if defined?(Spree::Backend) || Rails.env.test?
       end
 
-      if defined? Spree::Frontend || Rails.env.test?
+      if defined?(Spree::Frontend) || Rails.env.test?
         template "vendor/assets/javascripts/spree/frontend/all.js"
         template "vendor/assets/stylesheets/spree/frontend/all.css"
       end
 
-      if defined? Spree::Backend || Rails.env.test?
+      if defined?(Spree::Backend) || Rails.env.test?
         template "vendor/assets/javascripts/spree/backend/all.js"
         template "vendor/assets/stylesheets/spree/backend/all.css"
       end


### PR DESCRIPTION
Expected behavior
-----------------

Given I have a Rails app

And the Rails app only has the following Solidus gems:

* solidus_core
* solidus_backend
* solidus_api
* solidus_sample

When I run `bin/rails generate solidus:install --auto-accept`

Then I should see that the `vendor/assets/*/spree` directories do not include frontend directories with its assets.

Actual behavior
---------------

The `vendor/assets/*/spree` directories include the frontend directories with their assets.

Cause
-----

The `defined? Spree::Frontend || Rails.env.test?` in https://github.com/solidusio/solidus/blob/f524772df264fc4fffa971b992d2724f5060c1b7/core/lib/generators/solidus/install/install_generator.rb returns `"expression"`.

Fix
---

Wrapping the argument of the `defined?` call in a parenthesis fixes the issue, for example:

```rb
defined?(Spree::Frontend) || Rails.env.test?
```

Similar issues
--------------

The backend assets have the same issue and fix.

Tested in
---------

* Ruby 2.5.3p105
* Rails 6.1.4.4
* Solidus master (7e0a386f4345629829dc47b4049100667dccab4f)

Demo
----

https://drive.google.com/file/d/1R-rWkHXfTmVOmv32_jV3QliMybFJ2YSP/view?usp=sharing

(Sorry, my lips are not in sync with the audio.)

**Checklist:**

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- N/A: I have updated Guides and README accordingly to this change (if needed)
- N/A: I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
