### PR TITLE
Fix for advancing carts correctly in admin checkout

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -31,7 +31,7 @@ module Spree
             end
 
             unless @order.completed?
-              @order.next
+              @order.contents.advance
               @order.refresh_shipment_rates
             end
 

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -64,12 +64,13 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
 
     context "#update" do
       let(:order) { create(:order, number: "R123456789") }
+      let(:contents) { order.contents }
 
       before { allow(Spree::Order).to receive_message_chain(:includes, :find_by!) { order } }
 
       it "updates + advances the order" do
-        expect(order).to receive_message_chain(:contents, :update_cart) { true }
-        expect(order).to receive_message_chain(:contents, :advance) { false }
+        expect(contents).to receive(:update_cart) { true }
+        expect(contents).to receive(:advance) { false }
         attributes = { order_id: order.number, order: { email: "" } }
         put :update, params: attributes
       end

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -67,9 +67,9 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
 
       before { allow(Spree::Order).to receive_message_chain(:includes, :find_by!) { order } }
 
-      it "updates + progresses the order" do
-        expect(order).to receive(:update) { true }
-        expect(order).to receive(:next) { false }
+      it "updates + advances the order" do
+        expect(order).to receive_message_chain(:contents, :update_cart) { true }
+        expect(order).to receive_message_chain(:contents, :advance) { false }
         attributes = { order_id: order.number, order: { email: "" } }
         put :update, params: attributes
       end

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -225,7 +225,7 @@ describe "New Order", type: :feature do
       user.wallet.add(credit_card)
     end
 
-    it "transitions to delivery not to complete" do
+    it "transitions to confirm not to complete" do
       add_line_item product.name
 
       expect(page).to have_css('.line-item')
@@ -233,7 +233,7 @@ describe "New Order", type: :feature do
       click_link "Customer"
       targetted_select2 user.email, from: "#s2id_customer_search"
       click_button "Update"
-      expect(page).to have_css('.order-state', text: 'Delivery')
+      expect(page).to have_css('.order-state', text: 'Confirm')
     end
   end
 


### PR DESCRIPTION
**Description:**

This PR adds a minor fix for cart behavior in Admin. When updating the customer details, the current code only calls `next`. This will move th order *one* state down the checkout flow - so, for instance, from `address` to `delivery`. But if the order could move further, it won't. And this can leave orders in a slightly unexpected state.

As an example, in our store, when the order is in the `delivery` state, there is no admin UI element to cause it to move into the `payment` state, short of selecting a different shipping method or adding a new item to the cart. And since for us, taxes aren't calculated until the order reaches the `payment` state, we can't render the correct cost in the payment detail admin page to allow our admins to enter the correct payment.

This fix is rather simple - rather than moving only *one* state, move as far as possible via `advance`. This essentially preserves the same behavior as before if the order could not advance, but allows the order to move forward into payment if the shipments all have shipping rates selected. By default, the default estimator should be selecting a shipping rate for every shipment when the shipments are proposed.

I tested this in my store with shipments which had multiple shipment rates, and observed no problem advancing to the `payment` state. We could potentially make this opt-in if desired, but that felt like slight overkill.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
