### PR TITLE
Relax Factory Bot version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,8 @@ group :backend, :frontend, :core, :api do
   gem 'rails-controller-testing', require: false
   gem 'puma', require: false
 
-  # Ensure the requirement is also updated in core/lib/spree/testing_support.rb
-  gem 'factory_bot_rails', '~> 4.8', require: false
+  # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
+  gem 'factory_bot_rails', '>= 4.8', require: false
 end
 
 group :backend, :frontend do

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -26,14 +26,19 @@ FactoryBot.define do
 
     state do |address|
       Spree::State.joins(:country).where('spree_countries.iso = (?)', country_iso_code).find_by(abbr: state_code) ||
-        address.association(:state, country_iso: country_iso_code, state_code: state_code)
+        address.association(
+          :state,
+          strategy: :create,
+          country_iso: country_iso_code,
+          state_code: state_code
+        )
     end
 
     country do |address|
       if address.state
         address.state.country
       else
-        address.association(:country, iso: country_iso_code)
+        address.association(:country, strategy: :create, iso: country_iso_code)
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       stock_location { nil }
     end
 
-    variant
+    association :variant, strategy: :create
     line_item do
       if order
         build(:line_item, variant: variant, order: order)

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     ship_address
     completed_at { nil }
     email { user.try(:email) }
-    store
+    association :store, strategy: :create
 
     transient do
       line_items_price { BigDecimal(10) }

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -20,7 +20,10 @@ FactoryBot.define do
     sku { generate(:sku) }
     available_on { 1.year.ago }
     deleted_at { nil }
-    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
+    shipping_category do |r|
+      Spree::ShippingCategory.first ||
+        r.association(:shipping_category, strategy: :create)
+    end
 
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -11,11 +11,11 @@ end
 
 FactoryBot.define do
   factory :store_credit, class: 'Spree::StoreCredit' do
-    user
-    association :created_by, factory: :user
-    association :category, factory: :store_credit_category
+    association :user, strategy: :create
+    association :created_by, factory: :user, strategy: :create
+    association :category, factory: :store_credit_category, strategy: :create
     amount { 150.00 }
     currency { "USD" }
-    association :credit_type, factory: :primary_credit_type
+    association :credit_type, factory: :primary_credit_type, strategy: :create
   end
 end

--- a/core/lib/spree/testing_support/factory_bot.rb
+++ b/core/lib/spree/testing_support/factory_bot.rb
@@ -44,7 +44,7 @@ module Spree
       def self.check_version
         require "factory_bot/version"
 
-        requirement = Gem::Requirement.new("~> 4.8")
+        requirement = Gem::Requirement.new(">= 4.8")
         version = Gem::Version.new(::FactoryBot::VERSION)
 
         unless requirement.satisfied_by? version

--- a/core/spec/models/spree/asset_spec.rb
+++ b/core/spec/models/spree/asset_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Spree::Asset, type: :model do
   describe "#viewable" do
     it "touches association" do
-      product = build(:custom_product)
+      product = create(:custom_product)
 
       expect do
         Spree::Asset.create! { |a| a.viewable = product.master }

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -372,7 +372,7 @@ module Spree
 
     context "#persist_order_address" do
       context "when automatic_default_address preference is at a default of true" do
-        let(:order) { build :order }
+        let(:order) { create :order }
 
         it 'will save both bill/ship_address references' do
           user.persist_order_address(order)
@@ -387,7 +387,7 @@ module Spree
       end
 
       context "when automatic_default_address preference is false" do
-        let(:order) { build :order }
+        let(:order) { create :order }
 
         before do
           stub_spree_preferences(automatic_default_address: false)

--- a/core/spec/models/spree/order_promotion_spec.rb
+++ b/core/spec/models/spree/order_promotion_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Spree::OrderPromotion do
       order_promotion.errors[:promotion_code]
     end
 
-    let(:order_promotion) { build(:order_promotion) }
+    let(:order_promotion) { create(:order_promotion) }
     let(:promotion) { order_promotion.promotion }
 
     context "when the promotion does not have a code" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1630,14 +1630,13 @@ RSpec.describe Spree::Order, type: :model do
   end
 
   describe '#create_shipments_for_line_item' do
-    subject { create :order_with_line_items }
+    subject { order.create_shipments_for_line_item(line_item) }
 
-    let(:line_item) { build(:line_item) }
+    let(:order) { create :order_with_line_items }
+    let(:line_item) { build(:line_item, order: order) }
 
     it 'creates at least one new shipment for the order' do
-      expect do
-        subject.create_shipments_for_line_item(line_item)
-      end.to change { subject.shipments.count }.by 1
+      expect { subject }.to change { order.shipments.count }.by 1
     end
   end
 

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -159,11 +159,10 @@ RSpec.describe Spree::ReturnItem, type: :model do
   end
 
   describe "amount calculations on create" do
-    let(:inventory_unit) { build(:inventory_unit) }
-    before { subject.save! }
+    let(:inventory_unit) { create(:inventory_unit) }
 
     context "amount is not specified" do
-      subject { build(:return_item, inventory_unit: inventory_unit) }
+      subject { create(:return_item, inventory_unit: inventory_unit) }
 
       context "not an exchange" do
         it { expect(subject.amount).to eq Spree::Calculator::Returns::DefaultRefundAmount.new.compute(subject) }
@@ -184,7 +183,7 @@ RSpec.describe Spree::ReturnItem, type: :model do
   end
 
   describe ".from_inventory_unit" do
-    let(:inventory_unit) { build(:inventory_unit) }
+    let(:inventory_unit) { create(:inventory_unit) }
 
     subject { Spree::ReturnItem.from_inventory_unit(inventory_unit) }
 
@@ -732,8 +731,6 @@ RSpec.describe Spree::ReturnItem, type: :model do
   describe "valid exchange variant" do
     subject { return_item }
 
-    before  { subject.save }
-
     context "return item doesn't have an exchange variant" do
       let(:return_item) { create(:return_item) }
 
@@ -756,7 +753,7 @@ RSpec.describe Spree::ReturnItem, type: :model do
 
       context "the exchange variant is not eligible" do
         context "new return item" do
-          let(:return_item)      { build(:return_item) }
+          let(:return_item)      { create(:return_item) }
           let(:exchange_variant) { create(:variant, product: return_item.inventory_unit.variant.product) }
 
           before { return_item.exchange_variant = exchange_variant }

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -667,12 +667,13 @@ RSpec.describe Spree::Shipment, type: :model do
   end
 
   context "don't require shipment" do
+    let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
     let(:stock_location) { create(:stock_location, fulfillable: false) }
     let(:unshippable_shipment) do
       create(
         :shipment,
-        stock_location: stock_location,
-        inventory_units: [build(:inventory_unit)]
+        order: order,
+        stock_location: stock_location
       )
     end
 


### PR DESCRIPTION
**Description**

It's not clear to me from the original PR (#3814), nor the Factory Bot changelog why we'd want to stick on version 4.x. This relaxes the constraint to allow for any version equal to or higher than 4.8.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
