### PR TITLE
Wrap the checkout transitions within a database transaction

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -735,8 +735,7 @@ module Spree
         true
       else
         saved_errors = errors[:base]
-        payment_failed!
-        saved_errors.each { |error| errors.add(:base, error) }
+        fail_transition(:payment_processing, saved_errors)
         false
       end
     end
@@ -773,11 +772,12 @@ module Spree
         !adjustment.calculate_eligibility
       end
       if adjustment_changed
-        restart_checkout_flow
-        recalculate
-        errors.add(:base, I18n.t('spree.promotion_total_changed_before_complete'))
+        errors = [I18n.t('spree.promotion_total_changed_before_complete')]
+        fail_transition(:promotion_eligibility, errors)
+        false
+      else
+        true
       end
-      errors.empty?
     end
 
     def validate_line_item_availability

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Spree::Order, type: :model do
 
           it "should not complete the order" do
             expect(order.complete).to be false
-            expect(order.state).to eq("confirm")
+            expect(order.state).to eq("payment")
           end
         end
       end


### PR DESCRIPTION
**Description**

Previous to this commit, the order's checkout flow transitions weren't
running, by default, within a database transaction (e.g.,
`order.complete!` wasn't safe). The reason is a limitation on the state
machine itself: When enabled, defined transitions, including all
callbacks, like `on_failure`, run within a database transaction (see
https://github.com/state-machines/state_machines-activerecord/blob/94662c61eeea4783b9d0b2899693c43610246900/lib/state_machines/integrations/active_record.rb#L261).

However, sometimes we need to make a persistent change on a record when
a transition fails. For instance, when we go from `confirm` to
`complete`, we need to roll back and update the state field back to
`payment` if payment can't be processed.

On this commit, we prepend a
`Spree::Core::StateMachines::Order::AfterTransactionOverrides` module to
`Spree::Order` to work around that limitation. The module is meant to
override the needed generated transition methods (only `complete` at
this point), delegating to them and performing any needed
post-transaction logic. For that, the failure reason needs to be
collected during the transition. Errors meant to be added to the record
need to be processed after-transition persistence, as it will
reset the record errors.

A more solid solution will imply breaking up data and persistence
responsibilities, taking complete control of the transition with
something like a service object.

The change in a test expectation that we can see on the diff is not an
actual change in business behavior. The final state was indeed
`payment`, previous to enabling transactions, but the cache needed to be
reloaded (`order.reload`).

https://github.com/nebulab/solidus/commit/cb1e1ff2611247cd213bca8a0aa24d7ee16c4440 is the commit were transactions
were disabled. The parent commit, https://github.com/nebulab/solidus/commit/bf0aca0d46cd92b12254d4c716f47db26b24a077,
reveals the hidden intention.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
