### PR TITLE
Update contributor logo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ As a community-driven project, Solidus relies on funds and time donated by devel
 ### Main Contributor & Director
 At present, Nebulab is the main code contributor and director of Solidus, providing technical guidance and coordinating community efforts and activities.
 
-[![Nebulab](https://nebulab.com/assets/img/logo-nebulab_black.svg)](https://nebulab.com/)
+[![Nebulab](https://nebulab.com/assets/img/logo-nebulab_gh-dark-light-mode.svg)](https://nebulab.com/)
 
 ### Ambassadors
 Support this project by becoming a Solidus Ambassador. Your logo will show up here with a link to your website. [Become an Ambassador](https://opencollective.com/solidus).


### PR DESCRIPTION
The Nebulab logo has a white background now, so it is visible also with dark mode enabled.

**Description**
This is how the logo is displayed with dark-mode enabled:

<img width="864" alt="Screenshot 2022-02-04 at 17 34 03" src="https://user-images.githubusercontent.com/46188345/152566731-b503a07f-d660-461a-ab51-d0ae9fe47fd5.png">

This is how it is changed:

<img width="854" alt="Screenshot 2022-02-04 at 17 33 53" src="https://user-images.githubusercontent.com/46188345/152566758-70ffa2d7-5fff-432a-972a-828ce0bd0ba8.png">

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
