### PR TITLE
Fix test assertion due to staled cache

### DIFF
--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Spree::Order, type: :model do
 
           it "should not complete the order" do
             expect(order.complete).to be false
-            expect(order.state).to eq("confirm")
+            expect(order.reload.state).to eq("payment")
           end
         end
       end


### PR DESCRIPTION
**Description**

When payment fails, the order is transitioned to the `payment` state:

https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/state_machines/order.rb#L80-L82

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
