### PR TITLE
Deprecate public visibility of order#finalize!

### DIFF
--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -119,7 +119,7 @@ module Spree
                 before_transition to: :complete, do: :process_payments_before_complete
               end
 
-              after_transition to: :complete, do: :finalize!
+              after_transition to: :complete, do: :finalize
               after_transition to: :resumed,  do: :after_resume
               after_transition to: :canceled, do: :after_cancel
 

--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -97,7 +97,7 @@ module Spree
     #
     # @example Trigger an event named 'order_finalized'
     #   Spree::Event.fire 'order_finalized', order: @order do
-    #     @order.finalize!
+    #     @order.complete!
     #   end
     #
     # TODO: Change signature so that `opts` are keyword arguments, and include

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -3,62 +3,31 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
-  context "#finalize!" do
+  context "#complete!" do
     let(:order) { create(:order_ready_to_complete) }
 
-    before do
-      order.update_column :state, 'complete'
-    end
-
     it "should set completed_at" do
-      expect(order).to receive(:touch).with(:completed_at)
-      order.finalize!
+      expect { order.complete! }.to change { order.completed_at }
     end
 
     it "should sell inventory units" do
-      order.shipments.each do |shipment|
-        expect(shipment).to receive(:update_state)
-        expect(shipment).to receive(:finalize!)
-      end
-      order.finalize!
+      inventory_unit = order.shipments.first.inventory_units.first
+
+      order.payments.map(&:complete!)
+
+      expect { order.complete! }.to change { inventory_unit.reload.pending }.from(true).to(false)
     end
 
     it "should change the shipment state to ready if order is paid" do
-      allow(order).to receive_messages(paid?: true, complete?: true)
-      order.finalize!
-      order.reload # reload so we're sure the changes are persisted
-      expect(order.shipment_state).to eq('ready')
-    end
+      order.payments.map(&:complete!)
 
-    it "should send an order confirmation email" do
-      mail_message = double "Mail::Message"
-      expect(Spree::OrderMailer).to receive(:confirm_email).with(order).and_return mail_message
-      expect(mail_message).to receive :deliver_later
-      order.finalize!
-    end
-
-    it "sets confirmation delivered when finalizing" do
-      expect(order.confirmation_delivered?).to be false
-      order.finalize!
-      expect(order.confirmation_delivered?).to be true
-    end
-
-    it "should not send duplicate confirmation emails" do
-      order.update(confirmation_delivered: true)
-      expect(Spree::OrderMailer).not_to receive(:confirm_email)
-      order.finalize!
+      expect { order.complete! }.to change { order.shipments.first.state }.from('pending').to('ready')
     end
 
     it "should freeze all adjustments" do
-      # Stub this method as it's called due to a callback
-      # and it's irrelevant to this test
-      allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_later
-      adjustments = [double]
-      expect(order).to receive(:all_adjustments).and_return(adjustments)
-      adjustments.each do |adj|
-        expect(adj).to receive(:finalize!)
-      end
-      order.finalize!
+      adjustment = create(:adjustment, order: order)
+
+      expect { order.complete! }.to change { adjustment.reload.finalized }.from(false).to(true)
     end
 
     context "order is considered risky" do
@@ -72,7 +41,8 @@ RSpec.describe Spree::Order, type: :model do
         end
 
         it "should leave order in complete state" do
-          order.finalize!
+          order.complete!
+
           expect(order.state).to eq 'complete'
         end
       end
@@ -84,9 +54,84 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "should set completed_at" do
-        order.finalize!
+        order.complete!
+
         expect(order.completed_at).to be_present
       end
+    end
+
+    context 'with event notifications' do
+      it 'sends an email' do
+        expect(Spree::Config.order_mailer_class).to receive(:confirm_email).and_call_original
+
+        order.complete!
+      end
+
+      it 'marks the order as confirmation_delivered' do
+        expect do
+          order.complete!
+        end.to change(order, :confirmation_delivered).to true
+      end
+
+      it 'sends the email' do
+        expect(Spree::Config.order_mailer_class).to receive(:confirm_email).and_call_original
+
+        order.complete!
+      end
+
+      it "doesn't send duplicate confirmation emails" do
+        order.update(confirmation_delivered: true)
+
+        expect(Spree::OrderMailer).not_to receive(:confirm_email)
+
+        order.complete!
+      end
+
+      # These specs show how notifications can be removed, one at a time or
+      # all the ones set by MailerSubscriber module
+      context 'when removing the default email notification subscription' do
+        before do
+          Spree::MailerSubscriber.deactivate(:order_finalized)
+        end
+
+        after do
+          Spree::MailerSubscriber.activate
+        end
+
+        it 'does not send the email' do
+          expect(Spree::Config.order_mailer_class).not_to receive(:confirm_email)
+
+          order.complete!
+        end
+      end
+
+      context 'when removing all the email notification subscriptions' do
+        before do
+          Spree::MailerSubscriber.deactivate
+        end
+
+        after do
+          Spree::MailerSubscriber.activate
+        end
+
+        it 'does not send the email' do
+          expect(Spree::Config.order_mailer_class).not_to receive(:confirm_email)
+
+          order.complete!
+        end
+      end
+    end
+  end
+
+  context '#finalize!' do
+    it 'deprecates method and goes ahead' do
+      order = create(:order_ready_to_complete)
+
+      expect(Spree::Deprecation).to receive(:warn).with(/discouraged/)
+
+      order.finalize!
+
+      expect(order.state).to eq("confirm")
     end
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -15,58 +15,6 @@ RSpec.describe Spree::Order, type: :model do
   end
   let(:code) { promotion.codes.first }
 
-  describe '#finalize!' do
-    context 'with event notifications' do
-      it 'sends an email' do
-        expect(Spree::Config.order_mailer_class).to receive(:confirm_email).and_call_original
-        order.finalize!
-      end
-
-      it 'marks the order as confirmation_delivered' do
-        expect do
-          order.finalize!
-        end.to change(order, :confirmation_delivered).to true
-      end
-
-      it 'sends the email' do
-        expect(Spree::Config.order_mailer_class).to receive(:confirm_email).and_call_original
-        order.finalize!
-      end
-
-      # These specs show how notifications can be removed, one at a time or
-      # all the ones set by MailerSubscriber module
-      context 'when removing the default email notification subscription' do
-        before do
-          Spree::MailerSubscriber.deactivate(:order_finalized)
-        end
-
-        after do
-          Spree::MailerSubscriber.activate
-        end
-
-        it 'does not send the email' do
-          expect(Spree::Config.order_mailer_class).not_to receive(:confirm_email)
-          order.finalize!
-        end
-      end
-
-      context 'when removing all the email notification subscriptions' do
-        before do
-          Spree::MailerSubscriber.deactivate
-        end
-
-        after do
-          Spree::MailerSubscriber.activate
-        end
-
-        it 'does not send the email' do
-          expect(Spree::Config.order_mailer_class).not_to receive(:confirm_email)
-          order.finalize!
-        end
-      end
-    end
-  end
-
   context '#store' do
     it { is_expected.to respond_to(:store) }
 

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -123,7 +123,7 @@ and an optional code block can be passed:
 
 ```ruby
 Spree::Event.fire 'order_finalized', order: @order do
-  @order.finalize!
+  @order.complete!
 end
 ```
 
@@ -131,7 +131,7 @@ This is an alternative way to basically have the same functionality but
 without the block:
 
 ```ruby
-@order.finalize!
+@order.complete!
 Spree::Event.fire 'order_finalized', order: @order
 ```
 


### PR DESCRIPTION
**Description**

The only invocation of `order#finalize!` comes from the state machine
transaction to `complete`:

https://github.com/solidusio/solidus/blob/e18f34541bcb9b396cc026f9579d01bfae12182e/core/lib/spree/core/state_machines/order.rb#L122

Calling it standalone should not be encouraged, as all the safety checks
implemented as before hooks would be skipped.

As a deprecation strategy, we're renaming the old `#finalize!` method to
`#finalize` and updating the state machine to call the latter. In turn,
`#finalize!` deprecates but still delegates to the new method.

Consequently, we're updating the test suite only to reference the public
API. I.e, `Spree::Order#complete!`. That has forced us to refactor some
tests. From `core/spec/models/spree/order/finalizing_spec.rb`:

- `should set completed_at`: Before being called with `:completed_at`
as an argument, `touch` is called by the state machine transition. It's
easier if we just assert on the field value.

- `should sell inventory units`: During the transaction, the shipment's
`#object_id` gets changed, so we can't longer assert on those instances.
Instead, we test the actual behavior. The assertion about
`#update_state` is already covered in the following test.

- `should change the shipment state to ready if order is paid`: We take
the ocassion to assert on the actual behavior.

- `should freeze all adjustments`: There're other methods called on the
collection of adjustments that are not covered by the double. It's
easier to test the actual behavior.

Besides, we're moving some tests about the order completion from
`order_spec.rb` to `finalizing_spec.rb`, also adapting them to test
`#complete!` instead of `finalize!`. These added tests explain the
removal of others which were simple duplication.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
