### PR TITLE
Fix order create permissions

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -191,11 +191,9 @@
   </table>
 <% else %>
   <div class="no-objects-found">
-    <% if can? :manage, Spree::Order %>
-      <%= render 'spree/admin/shared/no_objects_found',
-                   resource: Spree::Order,
-                   new_resource_url: spree.new_admin_order_path %>
-    <% end %>
+    <%= render 'spree/admin/shared/no_objects_found',
+               resource: Spree::Order,
+               new_resource_url: spree.new_admin_order_path %>
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -7,7 +7,7 @@
   <li>
     <%= link_to t('spree.new_order'), new_admin_order_url, id: 'admin_new_order', class: 'btn btn-primary' %>
   </li>
-<% end if can? :manage, Spree::Order %>
+<% end if can? :create, Spree::Order %>
 
 <% content_for :table_filter_title do %>
   <%= t('spree.filter') %>

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -7,7 +7,14 @@ module Spree
         can :read, Country
         can :read, OptionType
         can :read, OptionValue
-        can :create, Order
+        can :create, Order do |order, token|
+          # same user, or both nil
+          order.user == user ||
+          # guest checkout order
+          order.email.present? ||
+          # via API, just like with show and update
+          (order.guest_token.present? && token == order.guest_token)
+        end
         can [:show, :update], Order, Order.where(user: user) do |order, token|
           order.user == user || (order.guest_token.present? && token == order.guest_token)
         end

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Spree::Ability, type: :model do
       context 'requested by other user' do
         before(:each) { resource.user = Spree.user_class.new }
         it { expect(ability).not_to be_able_to(:show, resource) }
-        it_should_behave_like 'create only'
+        it { expect(ability).to_not be_able_to(:create, resource) }
       end
 
       context 'requested with proper token' do
@@ -189,7 +189,7 @@ RSpec.describe Spree::Ability, type: :model do
         let(:token) { 'FAIL' }
         before(:each) { allow(resource).to receive_messages guest_token: 'TOKEN123' }
         it { expect(ability).not_to be_able_to(:show, resource, token) }
-        it_should_behave_like 'create only'
+        it { expect(ability).to_not be_able_to(:create, resource, token) }
       end
     end
 


### PR DESCRIPTION
**Description**
Ref #4248 

This PR aims at fixing permission checks for showing the `new order` button in the admin area. 

We're currently using the `manage` permission, which seems to be a bit too much for just showing a button, given that `manage` is the maximum level of permission for a resource. Checking for the `create` permission would be much more appropriate.

In order to achieve the goal, the `DefaultCustomer` permission rule for creating orders has been made stricter, so by default users can create a order only when:

* the order includes the `email` field (guest checkout);
* the order they're creating is for the same user;
* the order guest token is the same as the passed token;

A few specs were updated, as a consequence.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
