### PR TITLE
Wrap the checkout transitions within a database transaction

### DIFF
--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -41,7 +41,7 @@ module Spree
             # To avoid multiple occurrences of the same transition being defined
             # On first definition, state_machines will not be defined
             state_machines.clear if respond_to?(:state_machines)
-            state_machine :state, initial: :cart, use_transactions: false do
+            state_machine :state, initial: :cart do
               klass.next_event_transitions.each { |state| transition(state.merge(on: :next)) }
 
               # Persist the state on the order


### PR DESCRIPTION
**Description**

Previous to this commit, the order's checkout flow transitions weren't
running, by default, within a database transaction (e.g.,
`order.complete!` wasn't safe). The reason is a limitation on the state
machine itself: When enabled, defined transitions, including all
callbacks, like `on_failure`, run within a database transaction (see
https://github.com/state-machines/state_machines-activerecord/blob/94662c61eeea4783b9d0b2899693c43610246900/lib/state_machines/integrations/active_record.rb#L261).

However, sometimes we need to make a persistent change on a record when
a transition fails. For instance, when we go from `confirm` to
`complete`, we need to roll back and update the state field back to
`payment` if payment can't be processed.

This hack allows us to add a per-instance `after_rollback` callback.
We're creating an object that will quack like a record for that purpose,
adding it to the current transaction.

We prefer to leave the class definition inline to avoid giving
first-class citizenship to the hack. The sound solution will imply
breaking up data and persistence responsibilities, taking complete
control of the transition with something like a service object.

We considered another approach that consisted of monkey-patching the
state machine itself (see
https://github.com/solidusio/solidus/pull/4256). However, we'll need to
add another `after_commit` hook in upcoming work related to the firing
of events, which will also be required outside the state machine
transitions. Therefore, it's better to use a single type of hack for
everything.

cb1e1ff2611247cd213bca8a0aa24d7ee16c4440 is the commit were transactions
were disabled. The parent commit, bf0aca0d46cd92b12254d4c716f47db26b24a077,
reveals the hidden intention.

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
