### PR TITLE
Incorrect display store credit reason

### DIFF
--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -85,7 +85,7 @@
         <th><%= t('spree.admin.store_credits.created_by') %></th>
         <th><%= Spree::StoreCreditEvent.human_attribute_name(:user_total_amount) %></th>
         <th><%= Spree::StoreCreditEvent.human_attribute_name(:amount_remaining) %></th>
-        <th><%= Spree::StoreCreditReason.human_attribute_name(:name) %></th>
+        <th><%= t('spree.admin.store_credits.reason_for_updating') %></th>
       </tr>
     </thead>
     <tbody>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -72,9 +72,10 @@
       <col style="width: 20%;" />
       <col style="width: 10%;" />
       <col style="width: 10%;" />
-      <col style="width: 25%;" />
+      <col style="width: 20%;" />
       <col style="width: 10%;" />
-      <col style="width: 25%;" />
+      <col style="width: 10%;" />
+      <col style="width: 20%;" />
     </colgroup>
     <thead>
       <tr>


### PR DESCRIPTION
Resolves #4264

_This PR is exactly the same as #4265 but changes the name of the branch to trigger the CI._

**Description**
This change resolves a layout issue in store credit events table.  Here the last column is used to present the name of the `Spree::StoreCreditReason` associated with the event.  However, by default the column is given no width and therefore looks cramped.

In addition the column name used is not very descriptive, I've made use of an existing (but unused) locale key under `store_credits` to provide the column with a more descriptive name.

See #4264 for the before image.  See below for the after image.

<img width="794" alt="cramped-credit-event-after" src="https://user-images.githubusercontent.com/7622933/153558060-fa6e06be-5659-4a53-a8a3-909c51c523c2.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have attached screenshots to this PR for visual changes (if needed)
- ~I have updated Guides and README accordingly to this change (if needed)~
- ~I have added tests to cover this change (if needed)~
