### PR TITLE
Fix Country factory states_required attribute

### DIFF
--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -523,14 +523,15 @@ module Spree::Api
       let(:billing_address) {
         { name: "Tiago Motta", address1: "Av Paulista",
                                 city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
-                                country_id: country.id }
+                                country_id: country.id, state_id: state.id }
       }
       let(:shipping_address) {
         { name: "Tiago Motta", address1: "Av Paulista",
                                  city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
-                                 country_id: country.id }
+                                 country_id: country.id, state_id: state.id }
       }
       let(:country) { create(:country, { name: "Brazil", iso_name: "BRAZIL", iso: "BR", iso3: "BRA", numcode: 76 }) }
+      let(:state) { create(:state, country_iso: 'BR')  }
 
       before { allow_any_instance_of(Spree::Order).to receive_messages user: current_api_user }
 

--- a/api/spec/requests/spree/api/users_spec.rb
+++ b/api/spec/requests/spree/api/users_spec.rb
@@ -44,6 +44,8 @@ module Spree::Api
 
       it "can update own details" do
         country = create(:country)
+        state = create(:state)
+
         put spree.api_user_path(user.id), params: { token: user.spree_api_key, user: {
           email: "mine@example.com",
           bill_address_attributes: {
@@ -51,7 +53,7 @@ module Spree::Api
             address1: '1 Test Rd',
             city: 'City',
             country_id: country.id,
-            state_id: 1,
+            state_id: state.id,
             zipcode: '55555',
             phone: '5555555555'
           },
@@ -60,7 +62,7 @@ module Spree::Api
             address1: '1 Test Rd',
             city: 'City',
             country_id: country.id,
-            state_id: 1,
+            state_id: state.id,
             zipcode: '55555',
             phone: '5555555555'
           }
@@ -72,6 +74,8 @@ module Spree::Api
 
       it "can update own details in JSON with unwrapped parameters (Rails default)" do
         country = create(:country)
+        state = create(:state)
+
         put spree.api_user_path(user.id),
           headers: { "CONTENT_TYPE": "application/json" },
           params: {
@@ -82,7 +86,7 @@ module Spree::Api
               address1: '1 Test Rd',
               city: 'City',
               country_id: country.id,
-              state_id: 1,
+              state_id: state.id,
               zipcode: '55555',
               phone: '5555555555'
             },
@@ -91,7 +95,7 @@ module Spree::Api
               address1: '1 Test Rd',
               city: 'City',
               country_id: country.id,
-              state_id: 1,
+              state_id: state.id,
               zipcode: '55555',
               phone: '5555555555'
             }

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -20,7 +20,6 @@ FactoryBot.define do
     iso3 { carmen_country.alpha_3_code }
     numcode { carmen_country.numeric_code }
 
-    # FIXME: We should set states required, but it causes failing tests
-    # states_required { carmen_country.subregions? }
+    states_required { carmen_country.subregions? }
   end
 end

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -17,9 +17,15 @@ FactoryBot.define do
       carmen_subregion do
         carmen_country = Carmen::Country.coded(country.iso)
 
-        carmen_country.subregions.coded(state_code) ||
-          carmen_country.subregions.sort_by(&:name).first ||
+        unless carmen_country.subregions?
           fail("Country #{country.iso} has no subregions")
+        end
+
+        carmen_regions = carmen_country.subregions
+        carmen_regions = carmen_regions.flat_map(&:subregions) if carmen_regions.first.subregions?
+        region_collection = Carmen::RegionCollection.new(carmen_regions)
+
+        region_collection.coded(state_code) || region_collection.sort_by(&:name).first
       end
     end
 

--- a/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
@@ -31,17 +31,19 @@ RSpec.describe 'address factory' do
     end
   end
 
-  describe 'when passing in a state and country' do
-    subject { build(:address, country_iso_code: country_iso_code, state_code: state_code) }
+  context 'states and countries' do
+    describe 'when passing in a state and country' do
+      subject { build(:address, country_iso_code: country_iso_code, state_code: state_code) }
 
-    context 'when the country has a state with proper code' do
-      let(:country_iso_code) { "US" }
-      let(:state_code) { "NY" }
+      context 'when the country has a state with proper code' do
+        let(:country_iso_code) { "US" }
+        let(:state_code) { "NY" }
 
-      it 'works' do
-        expect(subject).to be_valid
-        expect(subject.state.abbr).to eq("NY")
-        expect(subject.country.iso).to eq("US")
+        it 'works' do
+          expect(subject).to be_valid
+          expect(subject.state.abbr).to eq("NY")
+          expect(subject.country.iso).to eq("US")
+        end
       end
     end
   end

--- a/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
@@ -32,7 +32,53 @@ RSpec.describe 'address factory' do
   end
 
   context 'states and countries' do
-    describe 'when passing in a state and country' do
+    describe 'country requiring a state' do
+      let(:state) { create(:state, country_iso: 'IT', state_code: 'PE' )}
+      let(:country) { create(:country, iso: 'IT' )}
+
+      context 'when given a state but no country' do
+        subject { build(:address, state: state) }
+
+        it 'infers the country from the state' do
+          expect(subject).to be_valid
+          expect(subject.state.abbr).to eq("PE")
+          expect(subject.country.iso).to eq("IT")
+        end
+      end
+
+      context 'when given a country but no state' do
+        subject { build(:address, country: country) }
+
+        it 'automatically finds or creates an appropriate state' do
+          expect(subject).to be_valid
+          expect(subject.state.abbr).to eq("AL")
+          expect(subject.country.iso).to eq("IT")
+        end
+      end
+
+      context 'when given a country, no state but a state_name' do
+        subject { build(:address, country: country, state_name: 'Bogus state') }
+
+        it 'does not automatically find or create an appropriate state' do
+          expect(subject).to be_valid
+          expect(subject.state).to be_nil
+          expect(subject.state_name).to eq('Bogus state')
+        end
+      end
+    end
+
+    describe 'country not requiring a state' do
+      subject { build(:address, country: country) }
+      let(:country) { create(:country, iso: 'AI' )}
+
+      it 'does not automatically find or create an appropriate state' do
+        expect(subject).to be_valid
+        expect(subject.state).to be_nil
+        expect(subject.country.iso).to eq("AI")
+      end
+    end
+
+    describe 'when passing in a state and country ISO' do
       subject { build(:address, country_iso_code: country_iso_code, state_code: state_code) }
 
       context 'when the country has a state with proper code' do

--- a/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe 'state factory' do
     end
   end
 
+  describe 'for a country with nested carmen states' do
+    context 'when not given a state_iso' do
+      let(:state) { build(:state, country_iso: "IT") }
+
+      it 'creates the first state for that country it finds in carmen' do
+        expect(state.abbr).to eq("AL")
+        expect(state.name).to eq("Alessandria")
+      end
+    end
+
+    context 'when given a state_iso' do
+      let(:state) { build(:state, country_iso: "IT", state_code: 'PE' ) }
+
+      it 'finds the corresponding state' do
+        expect(state.abbr).to eq("PE")
+        expect(state.name).to eq("Pescara")
+      end
+    end
+  end
+
   describe 'when given a country record' do
     let(:country) { build(:country, iso: "DE") }
     let(:state) { build(:state, country: country) }


### PR DESCRIPTION
**Description**
Resolves issue: https://github.com/solidusio/solidus/issues/4270

Some tests were modified to give a state with the address parameters
as they used a country which will now get the states_required attribute
of true, meaning a state must be present on the address.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
