### PR TITLE
Check for existence of `product_path` instead of `Spree::Frontend::Engine`

### DIFF
--- a/backend/app/helpers/spree/admin/products_helper.rb
+++ b/backend/app/helpers/spree/admin/products_helper.rb
@@ -3,6 +3,10 @@
 module Spree
   module Admin
     module ProductsHelper
+      def frontend_product_path(product)
+        Spree::Backend::Config[:frontend_product_path].call(self, product)
+      end
+
       def show_rebuild_vat_checkbox?
         Spree::TaxRate.included_in_price.exists?
       end

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -4,9 +4,9 @@
       <%= link_to t('spree.new_product'), new_object_url, id: 'admin_new_product', class: 'btn btn-primary' %>
     </li>
   <% end %>
-  <% if defined?(Spree::Frontend::Engine) %>
+  <% if Spree::Backend::Config[:frontend_product_path].call(self, @product) %>
     <li id="view_product_link">
-      <%= link_to t('spree.view_product'), spree.product_path(@product), id: 'admin_view_product', class: 'btn btn-default ml-2' %>
+      <%= link_to t('spree.view_product'), Spree::Backend::Config[:frontend_product_path].call(self, @product), id: 'admin_view_product', class: 'btn btn-default ml-2' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -4,9 +4,9 @@
       <%= link_to t('spree.new_product'), new_object_url, id: 'admin_new_product', class: 'btn btn-primary' %>
     </li>
   <% end %>
-  <% if Spree::Backend::Config[:frontend_product_path].call(self, @product) %>
+  <% if frontend_product_path(@product) %>
     <li id="view_product_link">
-      <%= link_to t('spree.view_product'), Spree::Backend::Config[:frontend_product_path].call(self, @product), id: 'admin_view_product', class: 'btn btn-default ml-2' %>
+      <%= link_to t('spree.view_product'), frontend_product_path(@product), id: 'admin_view_product', class: 'btn btn-default ml-2' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -6,6 +6,16 @@ module Spree
   class BackendConfiguration < Preferences::Configuration
     preference :locale, :string, default: I18n.default_locale
 
+    preference :frontend_product_path,
+      :proc,
+      default: proc {
+        ->(template_context, product) {
+          return unless template_context.spree.respond_to?(:product_path)
+
+          template_context.spree.product_path(product)
+        }
+      }
+
     ORDER_TABS         ||= [:orders, :payments, :creditcard_payments,
                             :shipments, :credit_cards, :return_authorizations,
                             :customer_returns, :adjustments, :customer_details]

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -40,4 +40,43 @@ RSpec.describe Spree::BackendConfiguration do
       end
     end
   end
+
+  describe '#frontend_product_path' do
+    let(:configuration) { described_class.new }
+    let(:spree_routes) { double('spree_routes') }
+    let(:template_context) { double('template_context', spree: spree_routes) }
+    let(:product) { instance_double('Spree::Product', id: 1) }
+
+    subject(:frontend_product_path) do
+      configuration.frontend_product_path.call(template_context, product)
+    end
+
+    context 'by default' do
+      context 'when there is no product path route' do
+        before do
+          expect(:spree_routes).to_not respond_to(:product_path)
+        end
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'when there is a product path route' do
+        let(:expected_path) { "/products/#{product.id}" }
+
+        let(:spree_routes_class) do
+          Class.new do
+            def product_path(product)
+              "/products/#{product.id}"
+            end
+          end
+        end
+
+        let(:spree_routes) { spree_routes_class.new }
+
+        it 'returns the product path' do
+          expect(frontend_product_path).to eq("/products/#{product.id}")
+        end
+      end
+    end
+  end
 end

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -84,6 +84,12 @@ Spree::Backend::Config.configure do |config|
   #   'icon-name',
   #   url: 'https://solidus.io/'
   # )
+
+  # Custom frontend product path
+  #
+  # config.frontend_product_path = ->(template_context, product) {
+  #   template_context.spree.product_path(product)
+  # }
 end
 <% end -%>
 


### PR DESCRIPTION
## Goal

We want to update the Edit Product page to check for existence of
`product_path` instead of `Spree::Frontend::Engine` so that the Edit
Product page would work with a frontend generated by
SolidusStarterFrontend.

## Background

This PR is part of an ongoing effort to replace `solidus_frontend` in Solidus with SolidusStarterFrotntend:

https://user-images.githubusercontent.com/61476/155290479-e116d427-4222-4b53-8403-6762d70185e8.mp4

## Requirements

### Admin can find a link to the product in the Edit Product page if the app has a frontend

Given I am an admin of a Solidus app
And the app has a product page i.e. it has a frontend
When I go to the Edit Product page
Then I should see a link to the product page

### Admin won't find a link to the product in the Edit Product page if the app does not have a frontend

Given I am an admin of a Solidus app
And the app has does not have a product page i.e. it does not have a
frontend
When I go to the Edit Product page
Then I should not see a link to the product page

## Manual tests

https://user-images.githubusercontent.com/61476/155290524-d17ff2d7-ec60-47d0-9fbb-578ebc5cece9.mp4

### 2022-03-02 update

https://user-images.githubusercontent.com/61476/156317692-f7cf2e8f-7f8f-40b3-bc49-1024821a04a2.mp4

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- N/A: I have updated Guides and README accordingly to this change (if needed)
- N/A: I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
