### PR TITLE
Update API docs link to point to the new domain

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -40,5 +40,5 @@ version is released.
   easily extend it with the endpoints provided by your Solidus extensions!
 
 [docs-dir]: https://github.com/solidusio/solidus/tree/master/api/openapi
-[live-docs]: https://solidus.docs.stoplight.io
+[live-docs]: https://solidus.stoplight.io
 [studio]: https://stoplight.io/p/studio

--- a/guides/data/nav/developers.yml
+++ b/guides/data/nav/developers.yml
@@ -17,7 +17,7 @@
   - title: "API"
     dropdown:
       - title: "Reference"
-        href: "https://solidus.docs.stoplight.io"
+        href: "https://solidus.stoplight.io"
 
 -
   - title: "Adjustments"


### PR DESCRIPTION
**Description**

Stoplight discontinued the product we were using to publish our REST API doc. As a temporary fix, I manually generated a new version of it in their new product and now we need to update the links that were pointing to the old API Docs. 

We still need to address how to autogenerate and publish the docs anytime a commit is made on master (or any other old-version branches). 