### PR TITLE
Optimize Spree::PromotionHandler::Cart

### DIFF
--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -15,6 +15,10 @@ module Spree
         before_destroy :remove_adjustments_from_incomplete_orders
         before_discard :remove_adjustments_from_incomplete_orders
 
+        def preload_relations
+          [:calculator]
+        end
+
         # Creates the adjustment related to a promotion for the order passed
         # through options hash
         #

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -15,6 +15,10 @@ module Spree
         before_destroy :remove_adjustments_from_incomplete_orders
         before_discard :remove_adjustments_from_incomplete_orders
 
+        def preload_relations
+          [:calculator]
+        end
+
         def perform(payload = {})
           order = payload[:order]
           promotion = payload[:promotion]

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -12,6 +12,10 @@ module Spree
                                            class_name: 'Spree::ProductPromotionRule'
         has_many :products, class_name: 'Spree::Product', through: :product_promotion_rules
 
+        def preload_relations
+          [:products]
+        end
+
         MATCH_POLICIES = %w(any all none)
 
         validates_inclusion_of :preferred_match_policy, in: MATCH_POLICIES

--- a/core/app/models/spree/promotion/rules/store.rb
+++ b/core/app/models/spree/promotion/rules/store.rb
@@ -9,6 +9,10 @@ module Spree
                                          dependent: :destroy
         has_many :stores, through: :promotion_rule_stores, class_name: "Spree::Store"
 
+        def preload_relations
+          [:stores]
+        end
+
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)
         end

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -8,6 +8,10 @@ module Spree
           dependent: :destroy
         has_many :taxons, through: :promotion_rule_taxons, class_name: 'Spree::Taxon'
 
+        def preload_relations
+          [:taxons]
+        end
+
         MATCH_POLICIES = %w(any all none)
 
         validates_inclusion_of :preferred_match_policy, in: MATCH_POLICIES

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -9,6 +9,10 @@ module Spree
                                         dependent: :destroy
         has_many :users, through: :promotion_rule_users, class_name: Spree::UserClassHandle.new
 
+        def preload_relations
+          [:users]
+        end
+
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)
         end

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -16,6 +16,10 @@ module Spree
     scope :of_type, ->(type) { where(type: Array.wrap(type).map(&:to_s)) }
     scope :shipping, -> { of_type(Spree::Config.environment.promotions.shipping_actions.to_a) }
 
+    def preload_relations
+      []
+    end
+
     # Updates the state of the order or performs some other action depending on
     # the subclass options will contain the payload from the event that
     # activated the promotion. This will include the key :user which allows

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -37,18 +37,23 @@ module Spree
       end
 
       def connected_order_promotions
-        Spree::Promotion.active.includes(:promotion_rules).
-          joins(:order_promotions).
-          where(spree_orders_promotions: { order_id: order.id }).readonly(false).to_a
+        order.promotions.active.includes(promotion_includes)
       end
 
       def sale_promotions
-        Spree::Promotion.where(apply_automatically: true).active.includes(:promotion_rules)
+        Spree::Promotion.where(apply_automatically: true).active.includes(promotion_includes)
       end
 
       def promotion_code(promotion)
         order_promotion = Spree::OrderPromotion.where(order: order, promotion: promotion).first
         order_promotion.present? ? order_promotion.promotion_code : nil
+      end
+
+      def promotion_includes
+        [
+          :promotion_rules,
+          :promotion_actions,
+        ]
       end
     end
   end

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -54,7 +54,7 @@ module Spree
       end
 
       def promotion_code(promotion)
-        order_promotion = Spree::OrderPromotion.where(order: order, promotion: promotion).first
+        order_promotion = order.order_promotions.detect { |op| op.promotion_id == promotion.id }
         order_promotion.present? ? order_promotion.promotion_code : nil
       end
 

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -33,7 +33,16 @@ module Spree
       private
 
       def promotions
-        connected_order_promotions | sale_promotions
+        promos = connected_order_promotions | sale_promotions
+        preloader = ActiveRecord::Associations::Preloader.new
+        promos.map do |promotion|
+          preloader.preload(promotion.rules.select { |r| r.type == "Spree::Promotion::Rules::Product" }, :products)
+          preloader.preload(promotion.rules.select { |r| r.type == "Spree::Promotion::Rules::Store" }, :stores)
+          preloader.preload(promotion.rules.select { |r| r.type == "Spree::Promotion::Rules::Taxon" }, :taxons)
+          preloader.preload(promotion.rules.select { |r| r.type == "Spree::Promotion::Rules::User" }, :users)
+          preloader.preload(promotion.actions.select { |a| a.respond_to?(:calculator) }, :calculator)
+          promotion
+        end
       end
 
       def connected_order_promotions

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -14,6 +14,10 @@ module Spree
     validates :promotion, presence: true
     validate :unique_per_promotion, on: :create
 
+    def preload_relations
+      []
+    end
+
     def self.for(promotable)
       all.select { |rule| rule.applicable?(promotable) }
     end


### PR DESCRIPTION

This speeds up the default cart promotion handler by preloading records and taking advantage of already preloaded records where possible. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
