### PR TITLE
Product Promotion Rule: Use in-memory objects

### DIFF
--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -31,17 +31,19 @@ module Spree
           return true if eligible_products.empty?
 
           case preferred_match_policy
-          when 'all'
-            unless eligible_products.all? { |product| order.products.include?(product) }
+          when "all"
+            unless eligible_products.all? { |product| order_products(order).include?(product) }
               eligibility_errors.add(:base, eligibility_error_message(:missing_product), error_code: :missing_product)
             end
-          when 'any'
-            unless order.products.any? { |product| eligible_products.include?(product) }
-              eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products), error_code: :no_applicable_products)
+          when "any"
+            unless order_products(order).any? { |product| eligible_products.include?(product) }
+              eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products),
+                                     error_code: :no_applicable_products)
             end
-          when 'none'
-            unless order.products.none? { |product| eligible_products.include?(product) }
-              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product), error_code: :has_excluded_product)
+          when "none"
+            unless order_products(order).none? { |product| eligible_products.include?(product) }
+              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product),
+                                     error_code: :has_excluded_product)
             end
           else
             raise "unexpected match policy: #{preferred_match_policy.inspect}"
@@ -67,6 +69,12 @@ module Spree
 
         def product_ids_string=(product_ids)
           self.product_ids = product_ids.to_s.split(',').map(&:strip)
+        end
+
+        private
+
+        def order_products(order)
+          order.line_items.map(&:variant).map(&:product)
         end
       end
     end

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
     end
 
     context "with 'any' match policy" do
-      let(:rule_options) { super().merge(preferred_match_policy: 'any') }
+      let(:rule_options) { super().merge(preferred_match_policy: "any") }
 
       it "should be eligible if any of the products is in eligible products" do
-        allow(order).to receive_messages(products: [@product1, @product2])
+        allow(rule).to receive_messages(order_products: [@product1, @product2])
         allow(rule).to receive_messages(eligible_products: [@product2, @product3])
         expect(rule).to be_eligible(order)
       end
 
       context "when none of the products are eligible products" do
         before do
-          allow(order).to receive_messages(products: [@product1])
+          allow(rule).to receive_messages(order_products: [@product1])
           allow(rule).to receive_messages(eligible_products: [@product2, @product3])
         end
         it { expect(rule).not_to be_eligible(order) }
@@ -47,17 +47,17 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
     end
 
     context "with 'all' match policy" do
-      let(:rule_options) { super().merge(preferred_match_policy: 'all') }
+      let(:rule_options) { super().merge(preferred_match_policy: "all") }
 
       it "should be eligible if all of the eligible products are ordered" do
-        allow(order).to receive_messages(products: [@product3, @product2, @product1])
+        allow(rule).to receive_messages(order_products: [@product3, @product2, @product1])
         allow(rule).to receive_messages(eligible_products: [@product2, @product3])
         expect(rule).to be_eligible(order)
       end
 
       context "when any of the eligible products is not ordered" do
         before do
-          allow(order).to receive_messages(products: [@product1, @product2])
+          allow(rule).to receive_messages(order_products: [@product1, @product2])
           allow(rule).to receive_messages(eligible_products: [@product1, @product2, @product3])
         end
         it { expect(rule).not_to be_eligible(order) }
@@ -75,17 +75,17 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
     end
 
     context "with 'none' match policy" do
-      let(:rule_options) { super().merge(preferred_match_policy: 'none') }
+      let(:rule_options) { super().merge(preferred_match_policy: "none") }
 
       it "should be eligible if none of the order's products are in eligible products" do
-        allow(order).to receive_messages(products: [@product1])
+        allow(rule).to receive_messages(order_products: [@product1])
         allow(rule).to receive_messages(eligible_products: [@product2, @product3])
         expect(rule).to be_eligible(order)
       end
 
       context "when any of the order's products are in eligible products" do
         before do
-          allow(order).to receive_messages(products: [@product1, @product2])
+          allow(rule).to receive_messages(order_products: [@product1, @product2])
           allow(rule).to receive_messages(eligible_products: [@product2, @product3])
         end
         it { expect(rule).not_to be_eligible(order) }


### PR DESCRIPTION
The chance for any request to preload `order.products` is very slim, and
the chance for any request to preload `order.line_items` is much better.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
