### PR TITLE
Deprecate Spree::PromotionRule.for

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -151,7 +151,7 @@ module Spree
       return [] if rules.none?
 
       eligible = lambda { |rule| rule.eligible?(promotable, options) }
-      specific_rules = rules.for(promotable)
+      specific_rules = rules.select { |rule| rule.applicable?(promotable) }
       return [] if specific_rules.none?
 
       if match_all?

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -17,6 +17,7 @@ module Spree
     def self.for(promotable)
       all.select { |rule| rule.applicable?(promotable) }
     end
+    deprecate :for, "Please select promotion rules by their applicable status on the promotable instead."
 
     def applicable?(_promotable)
       raise NotImplementedError, "applicable? should be implemented in a sub-class of Spree::PromotionRule"

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -765,8 +765,6 @@ RSpec.describe Spree::Promotion, type: :model do
           allow(rule2).to receive_messages(eligible?: true, applicable?: true)
 
           promotion.promotion_rules = [rule1, rule2]
-          allow(promotion).to receive_message_chain(:rules, :none?).and_return(false)
-          allow(promotion).to receive_message_chain(:rules, :for).and_return(promotion.promotion_rules)
         end
         it "returns the eligible rules" do
           expect(promotion.eligible_rules(promotable)).to eq [rule1, rule2]
@@ -784,8 +782,6 @@ RSpec.describe Spree::Promotion, type: :model do
           allow(rule2).to receive_messages(eligible?: false, applicable?: true, eligibility_errors: errors)
 
           promotion.promotion_rules = [rule1, rule2]
-          allow(promotion).to receive_message_chain(:rules, :none?).and_return(false)
-          allow(promotion).to receive_message_chain(:rules, :for).and_return(promotion.promotion_rules)
         end
         it "returns nil" do
           expect(promotion.eligible_rules(promotable)).to be_nil
@@ -807,7 +803,6 @@ RSpec.describe Spree::Promotion, type: :model do
       it "should have eligible rules if any of the rules are eligible" do
         true_rule = stub_model(Spree::PromotionRule, eligible?: true, applicable?: true)
         promotion.promotion_rules = [true_rule]
-        allow(promotion.rules).to receive(:for) { promotion.rules }
         expect(promotion.eligible_rules(promotable)).to eq [true_rule]
       end
 
@@ -818,8 +813,6 @@ RSpec.describe Spree::Promotion, type: :model do
           allow(rule).to receive_messages(eligible?: false, applicable?: true, eligibility_errors: errors)
 
           promotion.promotion_rules = [rule]
-          allow(promotion).to receive_message_chain(:rules, :for).and_return(promotion.promotion_rules)
-          allow(promotion).to receive_message_chain(:rules, :none?).and_return(false)
         end
         it "returns nil" do
           expect(promotion.eligible_rules(promotable)).to be_nil
@@ -842,7 +835,6 @@ RSpec.describe Spree::Promotion, type: :model do
     before do
       promotion.promotion_rules = rules
       promotion.promotion_actions = [Spree::PromotionAction.new]
-      allow(promotion.rules).to receive(:for) { rules }
     end
 
     subject { promotion.line_item_actionable? order, line_item }


### PR DESCRIPTION
This class method is only called from Spree::Promotion#eligible_rules,
where it adds a `.all` to the method chain. This `.all` causes a request
to the database while making no changes to the array of possibly
preloaded rules. Additionally, it adds a layer of indirection to the
already complex promotion code.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message

