### PR TITLE
Promotion Rule CreateItemAdjustments: Use in-memory objects

### DIFF
--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -83,13 +83,8 @@ module Spree
         end
 
         def line_items_to_adjust(promotion, order)
-          excluded_ids = adjustments.
-            where(adjustable_id: order.line_items.pluck(:id), adjustable_type: 'Spree::LineItem').
-            pluck(:adjustable_id).
-            to_set
-
           order.line_items.select do |line_item|
-            !excluded_ids.include?(line_item.id) &&
+            line_item.adjustments.none? { |adjustment| adjustment.source == self } &&
               promotion.line_item_actionable?(order, line_item)
           end
         end


### PR DESCRIPTION
This changes the function that obtains the line items of an order to
create adjustments for to use in-memory objects rather than querying the
database for line items that have no adjustments with a source from the
current rule.

Promotion rules can easily be preloaded, and there's no need for the DB
call in the previous code.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
