### PR TITLE
OrderContents: Initialize line item with empty adjustments

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -89,6 +89,7 @@ module Spree
       line_item ||= order.line_items.new(
         quantity: 0,
         variant: variant,
+        adjustments: [],
       )
 
       line_item.quantity += quantity.to_i


### PR DESCRIPTION
If we do not explicitly add an empty array here, a subsequent call to
`line_item.adjustments` will trigger an unnecessary DB hit.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
