### PR TITLE
Authorize uuid for existing object in sortable table

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
+++ b/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
@@ -1,6 +1,14 @@
 //= require solidus_admin/Sortable
 /* eslint no-unused-vars: "off" */
 
+/* Check if string is valid UUID */
+function isAValidUUID(str) {
+  // https://stackoverflow.com/a/13653180/8170555
+  const regexExp = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  return regexExp.test(str);
+}
+
 Spree.SortableTable = {
   refresh: function() {
     var sortable_tables = document.querySelectorAll('table.sortable');
@@ -16,7 +24,7 @@ Spree.SortableTable = {
             var idAttr = el.id;
             if (idAttr) {
               var objId = idAttr.split('_').slice(-1);
-              if (!isNaN(objId)) {
+              if (!isNaN(objId) || isAValidUUID(objId)) {
                 positions['positions['+objId+']'] = index + 1;
               }
             }


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->
In the backend section, from Ref #3591 we can't sort object list when we use uuid for the object's id.
We need to allow `objId` to be an uuid.
This change need to be backported until the version 2.11

Hope it can help.

PR v2.11 : #4299 
PR v3.0 : #4300 
PR v3.1 : #4301

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~~- [ ] I have updated Guides and README accordingly to this change (if needed)~~
~~- [ ] I have added tests to cover this change (if needed)~~ On this point i have encoutered many issues with teaspoon on docker and i don't see existing tests about that part of the backend.
~~- [ ] I have attached screenshots to this PR for visual changes (if needed)~~
