### PR TITLE
Fix(OrderMerger): Do not carry line item adjustments to new order

### DIFF
--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -115,8 +115,8 @@ module Spree
         current_line_item.quantity += other_order_line_item.quantity
         handle_error(current_line_item) unless current_line_item.save
       else
-        order.line_items << other_order_line_item
-        handle_error(other_order_line_item) unless other_order_line_item.save
+        new_line_item = order.line_items.build(other_order_line_item.attributes.except("id"))
+        handle_error(new_line_item) unless new_line_item.save
       end
     end
 

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -141,6 +141,20 @@ module Spree
         expect(order_1.line_items.pluck(:quantity)).to match_array([1, 1])
         expect(order_1.line_items.pluck(:variant_id)).to match_array([variant.id, variant_2.id])
       end
+
+      context "with line item promotion applied to order 2" do
+        let!(:promotion) { create(:promotion, :with_line_item_adjustment, apply_automatically: true) }
+
+        before do
+          Spree::PromotionHandler::Cart.new(order_2).activate
+          expect(order_2.line_items.flat_map(&:adjustments)).not_to be_empty
+        end
+
+        it "does not carry a line item adjustments with the wrong order ID over" do
+          subject.merge!(order_2)
+          expect(order_1.line_items.flat_map(&:adjustments)).to be_empty
+        end
+      end
     end
 
     context "merging together orders with invalid line items" do


### PR DESCRIPTION
**Description**

Adjustments are connected to the spree_orders table via two ways:
- via their adjustable's (line item's) order ID
- via their own order ID

If we move a line item with adjustments to new order, the adjustment's
order ID will not be changed to the new order.

Instead of changing the foreign key of an existing line item here, let's
build a new line item with the old line item's attributes.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
