### PR TITLE
Allow OrderWalkThrough to take a user

### DIFF
--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -3,11 +3,11 @@
 module Spree
   module TestingSupport
     class OrderWalkthrough
-      def self.up_to(state)
-        new.up_to(state)
+      def self.up_to(state, user: nil)
+        new.up_to(state, user: user)
       end
 
-      def up_to(state)
+      def up_to(state, user: nil)
         # Need to create a valid zone too...
         @zone = ::FactoryBot.create(:zone)
         @country = ::FactoryBot.create(:country)
@@ -23,6 +23,7 @@ module Spree
         end
 
         order = Spree::Order.create!(
+          user: user,
           email: "solidus@example.com",
           store: Spree::Store.first || ::FactoryBot.create(:store)
         )
@@ -61,7 +62,7 @@ module Spree
       end
 
       def payment(order)
-        credit_card = ::FactoryBot.create(:credit_card)
+        credit_card = ::FactoryBot.create(:credit_card, user: order.user)
         order.payments.create!(payment_method: credit_card.payment_method, amount: order.total, source: credit_card)
         # TODO: maybe look at some way of making this payment_state change automatic
         order.payment_state = 'paid'

--- a/frontend/spec/features/checkout_confirm_insufficient_stock_spec.rb
+++ b/frontend/spec/features/checkout_confirm_insufficient_stock_spec.rb
@@ -8,7 +8,7 @@ describe "Checkout confirm page submission", type: :feature do
   context "when the product from the order is not backorderable but has enough stock quantity" do
     let(:user) { create(:user) }
 
-    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment, user: user) }
     let(:order_product) { order.products.first }
     let(:order_stock_item) { order_product.stock_items.first }
 


### PR DESCRIPTION
The OrderWalkThrough creates an order that can't be completed because
the credit card associated with the order has a different user (some
user) than the order it's being associated to (nil). This leads to
failures on trying to add that credit card to the user's wallet.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
