### PR TITLE
Fix: `extension:test_app` rake task should detect if Solidus engines are available

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -22,9 +22,11 @@ namespace :common do
     sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
 
     begin
-      require "generators/#{ENV['LIB_NAME']}/install/install_generator"
+      generator_namespace = "#{ENV['LIB_NAMESPACE']&.underscore || ENV['LIB_NAME']}"
+
+      require "generators/#{generator_namespace}/install/install_generator"
       puts 'Running extension installation generator...'
-      "#{ENV['LIB_NAMESPACE'] || ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(["--auto-run-migrations"])
+      sh "bin/rails generate #{generator_namespace}:install --auto-run-migrations"
     rescue LoadError
       # No extension generator to run
     end

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -6,35 +6,43 @@ end
 
 require 'generators/spree/dummy/dummy_generator'
 
-namespace :common do
-  task :test_app, :user_class do |_t, args|
-    args.with_defaults(user_class: "Spree::LegacyUser")
-    require ENV['LIB_NAME']
+class CommonRakeTasks
+  include Rake::DSL
 
-    ENV["RAILS_ENV"] = 'test'
+  def initialize
+    namespace :common do
+      task :test_app, :user_class do |_t, args|
+        args.with_defaults(user_class: "Spree::LegacyUser")
+        require ENV['LIB_NAME']
 
-    Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+        ENV["RAILS_ENV"] = 'test'
 
-    puts "Setting up dummy database..."
+        Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
+        Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
 
-    sh "bin/rails db:environment:set RAILS_ENV=test"
-    sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
+        puts "Setting up dummy database..."
 
-    begin
-      generator_namespace = "#{ENV['LIB_NAMESPACE']&.underscore || ENV['LIB_NAME']}"
+        sh "bin/rails db:environment:set RAILS_ENV=test"
+        sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
 
-      require "generators/#{generator_namespace}/install/install_generator"
-      puts 'Running extension installation generator...'
-      sh "bin/rails generate #{generator_namespace}:install --auto-run-migrations"
-    rescue LoadError
-      # No extension generator to run
+        begin
+          generator_namespace = "#{ENV['LIB_NAMESPACE']&.underscore || ENV['LIB_NAME']}"
+
+          require "generators/#{generator_namespace}/install/install_generator"
+          puts 'Running extension installation generator...'
+          sh "bin/rails generate #{generator_namespace}:install --auto-run-migrations"
+        rescue LoadError
+          # No extension generator to run
+        end
+      end
+
+      task :seed do |_t, _args|
+        puts "Seeding ..."
+
+        sh "bundle exec rake db:seed RAILS_ENV=test"
+      end
     end
   end
-
-  task :seed do |_t, _args|
-    puts "Seeding ..."
-
-    sh "bundle exec rake db:seed RAILS_ENV=test"
-  end
 end
+
+CommonRakeTasks.new

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -25,14 +25,9 @@ class CommonRakeTasks
         sh "bin/rails db:environment:set RAILS_ENV=test"
         sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
 
-        begin
-          generator_namespace = "#{ENV['LIB_NAMESPACE']&.underscore || ENV['LIB_NAME']}"
-
-          require "generators/#{generator_namespace}/install/install_generator"
+        if extension_installation_generator_exists?
           puts 'Running extension installation generator...'
           sh "bin/rails generate #{generator_namespace}:install --auto-run-migrations"
-        rescue LoadError
-          # No extension generator to run
         end
       end
 
@@ -42,6 +37,20 @@ class CommonRakeTasks
         sh "bundle exec rake db:seed RAILS_ENV=test"
       end
     end
+  end
+
+  private
+
+  def extension_installation_generator_exists?
+    require "generators/#{generator_namespace}/install/install_generator"
+
+    true
+  rescue LoadError
+    false
+  end
+
+  def generator_namespace
+    "#{ENV['LIB_NAMESPACE']&.underscore || ENV['LIB_NAME']}"
   end
 end
 


### PR DESCRIPTION
Acceptance criteria
-------------------

Given a Solidus extension calls `SolidusSupport.x_available?` in its
Install generator to check if the engine is available

When the I run `bundle exec rake extension:test_app`

Then the `SolidusSupport.x_available?` should return true (since the dummy
app installed by `extension:test_app` includes the frontend, backend, and
api engines)

Bug description
---------------

When called within `bundle exec rake extension:test_app`, the install
generator of the extension is not able to detect the Solidus engines
within the dummy app, and as such, returns nil for any
`SolidusSupport.x_available?` call.

## Demonstration

### 2022-03-22 Original

https://user-images.githubusercontent.com/61476/158569774-f07fa3d9-7f98-4dd9-b8bd-33c9bfd76499.mp4

### 2022-03-22 Update

https://user-images.githubusercontent.com/61476/159423101-fb048bea-99ca-4f68-ac7b-ec98e7626817.mp4

You can find the SolidusHelloWorld extension at https://github.com/gsmendoza/solidus_hello_world.

Cause
-----

The `<Extension>::Generators::InstallGenerator.start` call within the
`common:test_app` rake task is not able to detect the Solidus engines that
were just installed by the rake task to the spec/dummy directory.

Bug fix
-------

Use the `bin/rails` executable to install the extension on the dummy app.

Possibly related issues
-----------------------

https://github.com/solidusio/solidus_support/pull/66

## Checklist

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- N/A - I have updated Guides and README accordingly to this change (if needed)
- N/A - I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
