### PR TITLE
OrderInventory: Use variant stock items

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe "Order Details", type: :feature, js: true do
   include OrderFeatureHelper
 
-  let!(:stock_location) { create(:stock_location_with_items) }
+  let!(:stock_location) { create(:stock_location) }
   let!(:product) { create(:product, name: 'spree t-shirt', price: 20.00) }
   let(:order) { create(:order, state: 'complete', completed_at: "2011-02-01 12:36:15", number: "R100") }
   let(:state) { create(:state) }
@@ -271,7 +271,7 @@ describe "Order Details", type: :feature, js: true do
     end
 
     context 'Shipment edit page' do
-      let!(:stock_location2) { create(:stock_location_with_items, name: 'Clarksville') }
+      let!(:stock_location2) { create(:stock_location, name: 'Clarksville') }
 
       before do
         product.master.stock_items.first.update_column(:backorderable, true)

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -274,9 +274,10 @@ describe "Order Details", type: :feature, js: true do
       let!(:stock_location2) { create(:stock_location, name: 'Clarksville') }
 
       before do
-        product.master.stock_items.first.update_column(:backorderable, true)
-        product.master.stock_items.first.update_column(:count_on_hand, 100)
-        product.master.stock_items.last.update_column(:count_on_hand, 100)
+        product.master.stock_items.reload.each do |stock_item|
+          stock_item.update(backorderable: false)
+          stock_item.set_count_on_hand 100
+        end
       end
 
       context 'splitting to location' do

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -62,7 +62,7 @@ module Spree
       potential_shipments.detect do |shipment|
         shipment.include?(variant)
       end || potential_shipments.detect do |shipment|
-        stock_item = shipment.stock_location.stock_item(variant.id)
+        stock_item = variant.stock_items.detect { |stock_item| stock_item.stock_location == shipment.stock_location }
         if stock_item
           stock_item.backorderable? || stock_item.count_on_hand >= quantity
         end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
       order.line_items.reload
     end
 
-    subject { described_class.new(order, new_line_item) }
+    subject { described_class.new(order, new_line_item.reload) }
 
     it 'creates a new shipment' do
       expect do


### PR DESCRIPTION
This class, which is executed as a callback when saving line items,
should get any inventory information not through all stock location's
stock items, but much rather through the stock items connected to its
variant. Less data to care about.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
