### PR TITLE
Refactor promotion usage counts

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -62,6 +62,7 @@ module Spree
                .distinct
       exclude_canceled ? result.merge(Spree::Order.not_canceled) : result
     end
+    deprecate :in_completed_orders, "Please don't use this and rather go through Spree::Promotion#discounted_orders"
 
     def finalize!
       update!(finalized: true)

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -67,6 +67,19 @@ module Spree
       ).first
     end
 
+    # All orders that have been discounted using this promotion
+    def discounted_orders
+      Spree::Order.
+        joins(:all_adjustments).
+        where(
+          spree_adjustments: {
+            source_type: "Spree::PromotionAction",
+            source_id: actions.map(&:id),
+            eligible: true
+          }
+        ).distinct
+    end
+
     def as_json(options = {})
       options[:except] ||= :code
       super

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -228,21 +228,12 @@ module Spree
     end
 
     def used_by?(user, excluded_orders = [])
-      [
-        :adjustments,
-        :line_item_adjustments,
-        :shipment_adjustments
-      ].any? do |adjustment_type|
-        user.orders.complete.joins(adjustment_type).where(
-          spree_adjustments: {
-            source_type: "Spree::PromotionAction",
-            source_id: actions.map(&:id),
-            eligible: true
-          }
-        ).where.not(
-          id: excluded_orders.map(&:id)
-        ).any?
-      end
+      discounted_orders.
+        complete.
+        where.not(id: excluded_orders.map(&:id)).
+        where(user: user).
+        where.not(spree_orders: { state: :canceled }).
+        exists?
     end
 
     # Removes a promotion and any adjustments or other side effects from an

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -203,11 +203,11 @@ module Spree
     # @param excluded_orders [Array<Spree::Order>] Orders to exclude from usage count
     # @return [Integer] usage count
     def usage_count(excluded_orders: [])
-      Spree::Adjustment.promotion.
-        eligible.
-        in_completed_orders(excluded_orders: excluded_orders, exclude_canceled: true).
-        where(source_id: actions).
-        count(:order_id)
+      discounted_orders.
+        complete.
+        where.not(id: [excluded_orders.map(&:id)]).
+        where.not(spree_orders: { state: :canceled }).
+        count
     end
 
     def line_item_actionable?(order, line_item, promotion_code: nil)

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -28,10 +28,14 @@ class Spree::PromotionCode < Spree::Base
   # @param excluded_orders [Array<Spree::Order>] Orders to exclude from usage count
   # @return [Integer] usage count
   def usage_count(excluded_orders: [])
-    adjustments.
-    eligible.
-    in_completed_orders(excluded_orders: excluded_orders, exclude_canceled: true).
-    count(:order_id)
+    promotion.
+      discounted_orders.
+      complete.
+      where.not(spree_orders: { state: :canceled }).
+      joins(:order_promotions).
+      where(spree_orders_promotions: { promotion_code_id: self.id }).
+      where.not(id: excluded_orders.map(&:id)).
+      count
   end
 
   def usage_limit


### PR DESCRIPTION
Refactors Spree::Promotion#usage_count, Spree::PromotionCode#usage_count and Spree::Promotion#used_by? to use a common method on Spree::Promotion. 

This is extracted work from #4296 and makes that work easier. 

All of these methods are well-tested, so I'm not adding more specs here. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message