### PR TITLE
Stay below v7 with kt-paperclip

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'mini_magick', '~> 4.10'
   s.add_dependency 'monetize', '~> 1.8'
-  s.add_dependency 'kt-paperclip', '>= 4.4.0'
+  s.add_dependency 'kt-paperclip', ['>= 4.4.0', '< 7']
   s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '~> 2.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'


### PR DESCRIPTION
**Description**

We backported the usage of kt-paperclip to v2.11.15,
but did not added a upper boundary. Since v3.0.5 only
allows v6.3 and above, we do the same for v2.11 as well.

Closes #4308 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
