### PR TITLE
Removes Stoplight API docu auto build orb.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  stoplight: nebulab/stoplight@6.0.0
-
 executors:
   base:
     working_directory: &workdir ~/solidus
@@ -151,18 +148,3 @@ workflows:
       - postgres_rails60
       - postgres_rails52
       - event_bus_legacy_adapter
-      - stoplight/push:
-          context: "Solidus Core Team"
-          project: solidus/solidus-api
-          git_token: $STOPLIGHT_GIT_TOKEN
-          source_dir: api/openapi
-          username: $STOPLIGHT_USERNAME
-          version: "`cat /tmp/workspace/solidus-version`"
-          requires:
-            - persist_version
-      - stoplight/publish:
-          context: "Solidus Core Team"
-          api_token: $STOPLIGHT_API_TOKEN
-          domain: solidus.docs.stoplight.io
-          requires:
-            - stoplight/push


### PR DESCRIPTION
[Stoplight](https://stoplight.io) changed its system to build the API documentation. 

We can't trigger the build as we used to but on the bright side [circleci](https://circleci.com) can now watch the GitHub repository and triggers the build by itself. That is already configured (kudos to @kennyadsl). This PR removes the old `.circleci/config.yaml` configuration for the `stoplight/push` and `stoplight/build`.

**Warning:** I did run `circleci config validate` but other than that I had no way to test this.

## To-Do

- Remove `$STOPLIGHT_GIT_TOKEN` and `$STOPLIGHT_API_TOKEN` as env variables in the CI.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
