### PR TITLE
Move carton in another tab in admin UI

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -4,7 +4,7 @@ module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
       before_action :initialize_order_events
-      before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm]
+      before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm, :cartons]
       around_action :lock_order, only: [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
@@ -69,6 +69,7 @@ module Spree
       def edit
         require_ship_address
       end
+      alias_method :cartons, :edit
 
       def cart
         if @order.shipped_shipments.count > 0

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -3,7 +3,6 @@
     <%= render partial: 'spree/shared/error_messages', locals: { target: @line_item } %>
   <% end %>
 
-  <%= render :partial => "spree/admin/orders/carton", collection: @order.cartons.order(:shipped_at), locals: { order: order } %>
   <%= render :partial => "spree/admin/orders/shipment", collection: @order.shipments.order(:created_at), locals: { order: order } %>
 
   <%= render "spree/admin/orders/order_details", { order: order } %>

--- a/backend/app/views/spree/admin/orders/cartons.html.erb
+++ b/backend/app/views/spree/admin/orders/cartons.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Cartons'} %>
+<% admin_breadcrumb(plural_resource_name(Spree::Carton)) %>
+
+<div data-hook="admin_order_form_fields">
+  <%= render :partial => "spree/admin/orders/carton", collection: @order.cartons.order(:shipped_at), locals: { order: @order } %>
+</div>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -20,6 +20,12 @@
       <%= link_to plural_resource_name(Spree::Shipment), spree.edit_admin_order_url(@order) %>
     </li>
 
+    <% if @order.cartons.count > 0 && can?(:show, Spree::Carton) %>
+      <li class="<%= "active" if current == "Cartons" %>" data-hook='admin_order_tabs_cartons'>
+        <%= link_to plural_resource_name(Spree::Carton), spree.cartons_admin_order_url(@order) %>
+      </li>
+    <% end %>
+
     <% if can? :show, Spree::Adjustment %>
       <li class="<%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
         <%= link_to plural_resource_name(Spree::Adjustment), spree.admin_order_adjustments_url(@order) %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -82,6 +82,7 @@ Spree::Core::Engine.routes.draw do
         put :approve
         put :cancel
         put :resume
+        get :cartons
       end
 
       resource :customer, controller: "orders/customer_details"

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -61,6 +61,7 @@ describe "New Order", type: :feature do
     click_on "Shipments"
     click_on "Ship"
 
+    click_on "Cartons"
     within '.carton-state' do
       expect(page).to have_content('Shipped')
     end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -372,7 +372,9 @@ describe "Order Details", type: :feature, js: true do
               visit spree.cart_admin_order_path(order)
 
               expect(page.current_path).to eq(spree.edit_admin_order_path(order))
-              expect(page).not_to have_text 'Cart'
+              within '[data-hook="admin_order_tabs_order_details"]' do
+                expect(page).not_to have_text 'Cart'
+              end
               expect(page).not_to have_selector('.fa-arrows-h')
               expect(page).not_to have_selector('.fa-trash')
             end
@@ -619,9 +621,11 @@ describe "Order Details", type: :feature, js: true do
   context 'as Fakedispatch' do
     custom_authorization! do |_user|
       # allow dispatch to :admin, :index, and :edit on Spree::Order
-      can [:admin, :edit, :index, :show], Spree::Order
+      can [:admin, :edit, :index, :show, :manage], Spree::Order
       # allow dispatch to :index, :show, :create and :update shipments on the admin
       can [:admin, :manage, :show, :ship], Spree::Shipment
+      # allow dispatch to :show cartons on the admin
+      can [:show], Spree::Carton
     end
 
     before do
@@ -659,6 +663,7 @@ describe "Order Details", type: :feature, js: true do
 
       find(".ship-shipment-button").click
 
+      click_on "Cartons"
       within '.carton-state' do
         expect(page).to have_content('Shipped')
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -696,6 +696,9 @@ en:
       spree/shipment:
         one: Shipment
         other: Shipments
+      spree/carton:
+        one: Carton
+        other: Cartons
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories


### PR DESCRIPTION
**Description**
The existing UX for a shipped order is somewhat confusing. The "Shipments" tab of the completed order renders both shipments and cartons, which ends up making it seem like there are duplicated shipments. Instead, maybe it's better to split this out. 

This PR adds a separate tab to the order bar for cartons, and render the cartons separately. It also removes the carton rendering from the default shipment view.

Ref: https://github.com/solidusio/solidus/issues/3357

**Result**
<img width="1102" alt="Screenshot 2022-03-25 at 12 38 55" src="https://user-images.githubusercontent.com/1719696/160114324-c8820818-6737-46b1-98f7-fe7de3ace63f.png">
<img width="1094" alt="Screenshot 2022-03-25 at 12 38 47" src="https://user-images.githubusercontent.com/1719696/160114331-db783a43-cc35-44ae-b8a6-af24ed6eddbf.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
