### PR TITLE
Fixes defining thumbnail sizes through ActiveStorage adapter

### DIFF
--- a/core/spec/models/spree/concerns/active_storage_adapter/attachment_spec.rb
+++ b/core/spec/models/spree/concerns/active_storage_adapter/attachment_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+unless ENV['DISABLE_ACTIVE_STORAGE']
+  RSpec.describe Spree::ActiveStorageAdapter::Attachment do
+    describe '#variant' do
+      it "converts to resize_to_limit when definition doesn't contain any special symbol" do
+        image = create(:image)
+
+        attachment = described_class.new(image.attachment.attachment, styles: { mini: '10x10' })
+
+        expect(
+          attachment.variant(:mini).variation.transformations
+        ).to include(resize_to_limit: [10, 10])
+      end
+
+      it 'converts to resize_to_limit when definition ends with >' do
+        image = create(:image)
+
+        attachment = described_class.new(image.attachment.attachment, styles: { mini: '10x10>' })
+
+        expect(
+          attachment.variant(:mini).variation.transformations
+        ).to include(resize_to_limit: [10, 10])
+      end
+
+      it 'converts to resize_to_fill when definition ends with ^' do
+        image = create(:image)
+
+        attachment = described_class.new(image.attachment.attachment, styles: { mini: '10x10^' })
+
+        expect(
+          attachment.variant(:mini).variation.transformations
+        ).to include(resize_to_fill: [10, 10])
+      end
+
+      it 'strips definitions' do
+        image = create(:image)
+
+        attachment = described_class.new(image.attachment.attachment, styles: { mini: ' 10x10 ' })
+
+        expect(
+          attachment.variant(:mini).variation.transformations
+        ).to include(resize_to_limit: [10, 10])
+      end
+
+
+      it "defaults to the image's width and height" do
+        image = create(:image)
+
+        attachment = described_class.new(image.attachment.attachment, styles: {})
+
+        expect(
+          attachment.variant(:mini).variation.transformations
+        ).to include(resize_to_limit: [attachment.width, attachment.height])
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description**

The adapter intends to make it possible to work with ActiveStorage as it was Paperclip. We had been using Paperclip until Rails 6.1 introduced ActiveStorage's public links. We moved to ActiveStorage as the default file attachment backend from that point on, but we tried to make its API compatible with Paperclip's one. See https://github.com/solidusio/solidus/pull/3501 for details.

When trying to translate [Paperclip's style definitions](https://github.com/solidusio/solidus/blob/564b4fe54648537b6b1420eed5a05cba6854e915/core/lib/spree/app_configuration.rb#L494) (based on [ImageMagick](https://legacy.imagemagick.org/Usage/thumbnails/)) to what ActiveStorage expects (which is [image_processing syntax](https://github.com/janko/image_processing), common for ImageMagick and libvips), we were transforming everything to a [`resize_to_limit`](https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit)
option. However, that corresponds to the `>` symbol in ImageMagick, but not to other options that can be given.

Whit this commit, we add support for defining other kinds of transformations in ActiveStorage. However, we're still missing more
advanced options that can be given when using [standalone Paperclip](https://www.rubydoc.info/gems/kt-paperclip/7.1.1) (example `{ geometry: '100x100', format: :jpg }`)  or [standalone ActiveStorage](https://github.com/janko/image_processing/blob/master/doc/minimagick.md#methods) (example `rotate: 90`). In the long run, we should aim to completely
differentiate how definitions are given for each library.

Needs to be backported.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
