### PR TITLE
[RFC] Nest carton into shipment view

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -74,17 +74,6 @@
         </td>
       </tr>
 
-      <% if carton.orders.size > 1 %>
-        <tr class='order-numbers'>
-          <td colspan="5">
-            <strong><%= t('spree.carton_orders') %>:&nbsp;</strong>
-            <% (carton.orders - [order]).each do |order| %>
-              <%= link_to order.number, edit_admin_order_path(order) %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-
       <% if carton.external_number.present? %>
         <tr class="external-number">
           <td colspan="5">

--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -5,8 +5,7 @@
       -
       <span class="carton-state"><%= t('spree.shipment_states.shipped') %></span>
       <span class="carton-exchange"><%= Spree::Exchange.model_name.human if carton.any_exchanges? %></span>
-      <%= t('spree.package_from') %>
-      <strong class="stock-location-name" data-hook="stock-location-name">'<%= carton.stock_location.name %>'</strong>
+      <%= Spree::Carton.model_name.human %>
     </legend>
   </fieldset>
 
@@ -29,16 +28,6 @@
     <tbody data-hook="carton-details" data-shipment-number="<%= carton.number %>" data-order-number="<%= order.number %>">
       <%= render 'spree/admin/orders/carton_manifest', carton: carton, order: order %>
 
-      <tr class="show-method total">
-        <% if method = carton.shipping_method %>
-          <td colspan="5">
-            <strong><%= method.name %></strong>
-          </td>
-        <% else %>
-          <td colspan='5'><%= t('spree.no_shipping_method_selected') %></td>
-        <% end %>
-      </tr>
-
       <% if order.special_instructions.present? %>
         <tr class='special_instructions'>
           <td colspan="5">
@@ -47,32 +36,18 @@
         </tr>
       <% end %>
 
-      <tr class="show-tracking total">
-        <td colspan="5">
-          <% if carton.tracking.present? %>
-            <strong><%= Spree::Carton.human_attribute_name(:tracking) %>:</strong>
+      <% if carton.tracking.present? %>
+        <tr class="show-tracking total">
+          <th><%= Spree::Carton.human_attribute_name(:tracking) %></th>
+          <td colspan="4">
             <% if carton.tracking_url %>
               <%= link_to carton.tracking, carton.tracking_url, target: "_blank" %>
             <% else %>
               <%= carton.tracking %>
             <% end %>
-          <% else %>
-            <i><%= t('spree.no_tracking_present') %></i>
-          <% end %>
-        </td>
-      </tr>
-
-      <tr class='shipment-numbers'>
-        <td colspan="5">
-          <strong><%= t('spree.shipment_numbers') %>:&nbsp;</strong><%= carton.shipment_numbers.join(", ") %>
-        </td>
-      </tr>
-
-      <tr class='ship-date'>
-        <td colspan="5">
-          <strong><%= t('spree.shipment_date') %>:&nbsp;</strong><%= carton.display_shipped_at %>
-        </td>
-      </tr>
+          </td>
+        </tr>
+      <% end %>
 
       <% if carton.external_number.present? %>
         <tr class="external-number">

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -3,7 +3,6 @@
     <%= render partial: 'spree/shared/error_messages', locals: { target: @line_item } %>
   <% end %>
 
-  <%= render :partial => "spree/admin/orders/carton", collection: @order.cartons.order(:shipped_at), locals: { order: order } %>
   <%= render :partial => "spree/admin/orders/shipment", collection: @order.shipments.order(:created_at), locals: { order: order } %>
 
   <%= render "spree/admin/orders/order_details", { order: order } %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -66,3 +66,5 @@
     </tbody>
   </table>
 </div>
+
+<%= render partial: "spree/admin/orders/carton", collection: shipment.cartons.sort_by(&:shipped_at), locals: { order: order } %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -10,7 +10,7 @@
       <span class="shipment-number"><%= shipment.number %></span>
       -
       <span class="shipment-state"><%= t(shipment.state, scope: "spree.shipment_states") %></span>
-      <%= t('spree.package_from') %>
+      <%= t('spree.shipment_from') %>
       <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
     </legend>
 
@@ -35,20 +35,38 @@
       <col style="width: 10%;" />
     </colgroup>
 
-    <thead>
-      <tr>
-        <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
-        <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
-        <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
-        <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
-        <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
-      </tr>
-    </thead>
+    <% unless shipment.shipped? %>
+      <thead>
+        <tr>
+          <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+          <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+          <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+          <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
+          <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
+        </tr>
+      </thead>
+    <% end %>
 
     <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
-      <%= render 'spree/admin/orders/shipment_manifest', { shipment_number: shipment.number, shipment_manifest: manifest_items } %>
+      <% if shipment.shipped? %>
+        <tr class="shipping-method vertical-middle">
+          <th><%= Spree::Shipment.human_attribute_name(:shipping_method) %></th>
+          <td colspan="4">
+            <%= shipment.shipping_method.name %>
+          </td>
+          <td class="align-right total">
+            <%= shipment.display_total %>
+          </td>
+        </tr>
+        <tr class="shipped-at vertical-middle">
+          <th><%= Spree::Shipment.human_attribute_name(:shipped_at) %></th>
+          <td colspan="5">
+            <%= l shipment.shipped_at, format: :short %>
+          </td>
+        </tr>
+      <% else %>
+        <%= render 'spree/admin/orders/shipment_manifest', { shipment_number: shipment.number, shipment_manifest: manifest_items } %>
 
-      <% unless shipment.shipped? %>
         <tr class="edit-shipping-method vertical-middle">
         </tr>
       <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2007,6 +2007,7 @@ en:
     shipment_adjustments: Shipment adjustments
     shipment_date: Shipment date
     shipment_details: From %{stock_location} via %{shipping_method}
+    shipment_from: shipment from
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,


### PR DESCRIPTION
**Description**

**WIP**

Cartons belong to a shipment. Also they can belong to mulitple orders, but IMO this feature should be moved into an extension instead.

This declutters the order shipments view in order to remove confusion around shipments/cartons.

There have some assumptions been made here:

A shipment has only one shipping method, even if it is shipped in several packages (cartons). They also share the same tracking number. Carriers usually group multiple cartons under the same tracking number. If a store handles this differently there is still a programmatic way to store a tracking number on a carton and it will still be displayed.

These assumptions have been made under the impression, that if stores have other fulfillment then Solidus default backend can provide, they will most likely have overwritten this view anyway.

#### Multiple cartons

![Solidus - Multiple cartons](https://user-images.githubusercontent.com/42868/160620791-d4e89c0f-7761-4056-a605-51982476e3d1.png)

#### Shipped split shipment

![Solidus - Shipped split shipment](https://user-images.githubusercontent.com/42868/160620803-bdb1db1b-12c9-47a6-889f-d0c7541d7c4d.png)

#### partially shipped

![Solidus - partially shipped](https://user-images.githubusercontent.com/42868/160620809-0b1e3f06-35fe-470c-97c9-b7e9fe379dea.png)

#### Split ready shipment

![Solidus - Split ready shipment](https://user-images.githubusercontent.com/42868/160620819-fe2232e5-e786-4f53-b68b-53b3cd52716b.png)

#### ready order

![Solidus - ready order](https://user-images.githubusercontent.com/42868/160620821-b86511ca-5624-4bed-944d-4178be3f5adf.png)

#### Shipped order

![solidus - shipped order](https://user-images.githubusercontent.com/42868/160620823-04442b37-c537-4bb5-bad1-195e1a8e99fd.png)

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
