### PR TITLE
Deprecate SolidusFrontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ config.allow_promotions_any_match_policy = true
 - Add configuration option for `migration_path` [#4190](https://github.com/solidusio/solidus/pull/4190) ([SuperGoodSoft](https://github.com/supergoodsoft/))
 - Deprecate Promotion `any` Match Policy [#4304](https://github.com/solidusio/solidus/pull/4304) ([mamhoff](https://www.github.com/mamhoff))
 
+### Frontend
+
+DEPRECATION WARNING: SolidusFrontend is deprecated. It will be removed from the
+solidus meta-package gem in Solidus v4. Furthermore, its code will be extracted
+from https://github.com/solidusio/solidus to a new repo. Once extracted, you'll
+need to explicitly add `solidus_frontend` to your Gemfile in order to continue
+using it.
+
+For fresh Solidus applications, we recommend you use 
+[SolidusStarterFrontend](https://github.com/solidusio/solidus_starter_frontend) 
+instead.
+
 ## Solidus 3.1.5 (v3.1, 2021-12-20)
 
 - Fix CSRF forgery protection bypass for Spree::OrdersController#populate [GHSA-h3fg-h5v3-vf8m](https://github.com/solidusio/solidus/security/advisories/GHSA-h3fg-h5v3-vf8m)

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -23,6 +23,19 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
+  s.post_install_message = <<~MESSAGE
+    ----------------------------------------------------------------------------
+    DEPRECATION WARNING: SolidusFrontend is deprecated. It will be removed from
+    the solidus meta-package gem in a Solidus v4. Furthermore, its code will be
+    extracted from https://github.com/solidusio/solidus to a new repo. Once
+    extracted, you'll need to explicitly add `solidus_frontend` to your Gemfile
+    in order to continue using it.
+
+    For fresh Solidus applications, we recommend you use SolidusStarterFrontend
+    instead.
+    ----------------------------------------------------------------------------
+  MESSAGE
+
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 


### PR DESCRIPTION
Goal
----

We want to deprecate SolidusFrontend so that developers, especially those
building fresh Solidus apps, will choose to SolidusStarterFrontend instead.

## Background

This is part of an epic to replace the SolidusFrontend gem with SolidusStarterFrontend.

## Screenshots

```
frontend 14:51:29 $ gem install solidus_frontend-3.2.0.alpha.gem
----------------------------------------------------------------------------
DEPRECATION WARNING: SolidusFrontend is deprecated. It will be removed from
the solidus meta-package gem in a Solidus v4. Furthermore, its code will be
extracted from https://github.com/solidusio/solidus to a new repo. Once
extracted, you'll need to explicitly add `solidus_frontend` to your Gemfile
in order to continue using it.

For fresh Solidus applications, we recommend you use SolidusStarterFrontend
instead.
----------------------------------------------------------------------------
Successfully installed solidus_frontend-3.2.0.alpha
Parsing documentation for solidus_frontend-3.2.0.alpha
Done installing documentation for solidus_frontend after 0 seconds
1 gem installed
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- N/A: I have updated Guides and README accordingly to this change (if needed)
- N/A: I have added tests to cover this change (if needed)
- N/A: I have attached screenshots to this PR for visual changes (if needed)