### PR TITLE
[3.1] Fixes using ActiveStorage adapter with libvips as variant processor

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -qq \
     curl \
     git \
     imagemagick \
+    libvips \
     libmariadb-dev \
     sqlite3 \
     libsqlite3-dev \

--- a/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
+++ b/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
@@ -30,7 +30,9 @@ module Spree
         size = style_to_size(style)
         @attachment.variant(
           resize_to_limit: size,
-          strip: true
+          saver: {
+            strip: true
+          }
         ).processed
       end
 
@@ -58,7 +60,7 @@ module Spree
       end
 
       def normalize_styles(styles)
-        styles.transform_values { |v| v.split('x') }
+        styles.transform_values { |v| v.split('x').map(&:to_i) }
       end
 
       def style_to_size(style)

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -96,6 +96,7 @@ module DummyApp
           }
         }
         config.active_storage.service = :test
+        config.active_storage.variant_processor = ENV.fetch('ACTIVE_STORAGE_VARIANT_PROCESSOR', :mini_magick).to_sym
       end
     end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       HISTFILE: "/home/solidus_user/history/bash_history"
       MYSQL_HISTFILE: "/home/solidus_user/history/mysql_history"
       RAILS_ENV: development
+      ACTIVE_STORAGE_VARIANT_PROCESSOR: "mini_magick"
     ports:
       - "${SANDBOX_PORT:-3000}:${SANDBOX_PORT:-3000}"
     volumes:


### PR DESCRIPTION
Backports https://github.com/solidusio/solidus/pull/4317

[Rails 6.0 introduced](https://github.com/rails/rails/blob/6-0-stable/activestorage/CHANGELOG.md#rails-600beta1-january-18-2019) the option of using libvips as an alternative to imagemagick as a backend image processor.

Both processors are handled using the [image_processing](https://github.com/janko/image_processing) library as adapter. However, the API for both is not fully compatible. What it's important for us when generating a variant, the `strip` option
needs to be within the `saver` group to work with both adapters. See https://gist.github.com/brenogazzola/a4369965a1da426d50f11d080fe2e563#1-move-everything-that-has-to-do-with-compression-to-a-saver-hash
for details. We also need to explicitly coerce size values to integers for libvips.

We're also adding libvips to the development docker image and allowing to run tests with that adapter by setting the
`ACTIVE_STORAGE_VARIANT_PROCESSOR` env variable. However, we still default it to `:mime_magick` (Ruby's wrapper for imagemagick), Rail's default previous to 7.0. We'll update it once we integrate support for Rails 7.0.

I also manually tested that metadata is still stripped when using both adapters.