### PR TITLE
Fix install generator on namespaced extensions

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -27,7 +27,7 @@ class CommonRakeTasks
 
         if extension_installation_generator_exists?
           puts 'Running extension installation generator...'
-          sh "bin/rails generate #{generator_namespace}:install --auto-run-migrations"
+          sh "bin/rails generate #{rake_generator_namespace}:install --auto-run-migrations"
         end
       end
 
@@ -51,6 +51,10 @@ class CommonRakeTasks
 
   def generator_namespace
     "#{ENV['LIB_NAMESPACE']&.underscore || ENV['LIB_NAME']}"
+  end
+
+  def rake_generator_namespace
+    generator_namespace.gsub("/", ":")
   end
 end
 


### PR DESCRIPTION
**Description**

Prior to solidusio/solidus#4302, `camelize` was called on the
`LIB_NAME` value which converts `/` to `::`. This behaviour worked for
namespaced extensions because we were invoking the class directly,
instead of through the `bin/rails` bin stub.

The change to run the generator through the binstub breaks for extensions with a LIB_NAME like  “super_good/solidus_taxjar” because Rails will not be able to find he task correctly.

To fix this, we convert to a "rake style" namespace by replacing `/`
with `:`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
