### PR TITLE
Bugfix: Changing Default Addresses

### DIFF
--- a/api/spec/requests/spree/api/address_books_spec.rb
+++ b/api/spec/requests/spree/api/address_books_spec.rb
@@ -65,6 +65,25 @@ module Spree::Api
           expect(JSON.parse(response.body).first).to include(harry_address_attributes)
         end
 
+        context "when updating a default address" do
+          let(:user) { create(:user, spree_api_key: 'galleon') }
+          let(:changes) { { name: "Hermione Granger", id: user.ship_address.id} }
+          before do
+            # Create "Harry Potter" default shipping address
+            user.save_in_address_book(harry_address_attributes, true)
+          end
+
+          it "changes the address and marks the changed address as default" do
+            expect {
+              put "/api/users/#{user.id}/address_book",
+                params:  { address_book: harry_address_attributes.merge(changes) },
+                headers: { Authorization: 'Bearer galleon' }
+            }.to change { user.reload.ship_address.name }.from("Harry Potter").to("Hermione Granger")
+
+            expect(response.status).to eq(200)
+          end
+        end
+
         context 'when creating an address' do
           it 'marks the update_target' do
             user = create(:user, spree_api_key: 'galleon')

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -107,12 +107,19 @@ module Spree
       return new_address unless new_address.valid?
 
       first_one = user_addresses.empty?
+      user_address = prepare_user_address(new_address)
 
       if address_attributes[:id].present? && new_address.id != address_attributes[:id]
+        if ship_address&.id == address_attributes[:id].to_i
+          user_addresses.mark_default(user_address, address_type: :shipping)
+        end
+
+        if bill_address&.id == address_attributes[:id].to_i
+          user_addresses.mark_default(user_address, address_type: :billing)
+        end
         remove_from_address_book(address_attributes[:id])
       end
 
-      user_address = prepare_user_address(new_address)
       user_addresses.mark_default(user_address, address_type: address_type) if default || first_one
 
       if persisted?

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -13,9 +13,9 @@ module Spree
     describe "#save_in_address_book" do
       context "saving a default shipping address" do
         let(:user_address) { user.user_addresses.find_first_by_address_values(address.attributes) }
-
+        let(:force_default) { true }
         subject do
-          -> { user.save_in_address_book(address.attributes, true) }
+          -> { user.save_in_address_book(address.attributes, force_default) }
         end
 
         context "the address is a new record" do
@@ -56,6 +56,7 @@ module Spree
           let(:original_default_bill_address) { create(:bill_address) }
           let(:original_user_address) { user.user_addresses.find_first_by_address_values(original_default_address.attributes) }
           let(:original_user_bill_address) { user.user_addresses.find_first_by_address_values(original_default_bill_address.attributes) }
+          let(:force_default) { false }
 
           before do
             user.user_addresses.create(address: original_default_address, default: true)
@@ -64,7 +65,7 @@ module Spree
 
           context "saving a shipping address" do
             context "makes all the other associated shipping addresses not be the default and ignores the billing ones" do
-              it { is_expected.to change { original_user_address.reload.default }.from(true).to(false) }
+              it { is_expected.not_to change { original_user_address.reload.default }.from(true) }
               it { is_expected.not_to change { original_user_bill_address.reload.default_billing } }
             end
 


### PR DESCRIPTION
Solidus' immutable addresses allow "changing" an address by passing its
ID to the `save_in_address_book` method. If one does that with an
address that was marked as default shipping or billing of the user, the
old address would be archived, and the new address would not become the
user's default address. This change addresses that by handling that
situation for both default billing and default shipping addresses.

Prerequisite for #3852 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)

