### PR TITLE
Remove deprecated_address_id column from shipments

### DIFF
--- a/core/db/migrate/20220413095534_drop_deprecated_address_id_from_shipments.rb
+++ b/core/db/migrate/20220413095534_drop_deprecated_address_id_from_shipments.rb
@@ -1,0 +1,11 @@
+class DropDeprecatedAddressIdFromShipments < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :spree_shipments, column: [:deprecated_address_id], name: :index_spree_shipments_on_deprecated_address_id
+    remove_column :spree_shipments, :deprecated_address_id
+  end
+
+  def down
+    add_column :spree_shipments, :deprecated_address_id
+    add_index :spree_shipments, :deprecated_address_id, name: :index_spree_shipments_on_deprecated_address_id
+  end
+end


### PR DESCRIPTION
We have not used this column since we removed all references to it in
2016.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message

