### PR TITLE
Update in-memory shipments of order in order_shipping

### DIFF
--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -214,6 +214,21 @@ RSpec.describe Spree::OrderShipping do
       end
     end
 
+    context "when a second shipment is shipped" do
+      let(:order) { create(:order_ready_to_ship) }
+
+      it "sets the order to shipped state" do
+        order.shipping.ship_shipment(order.shipments.first)
+
+        unshipped_shipment = create(:shipment, order: order, state: "ready")
+
+        order.reload
+        order.recalculate
+
+        expect { order.shipping.ship_shipment(unshipped_shipment) }.to(change { order.shipment_state }.from("partial").to("shipped"))
+      end
+    end
+
     context "when told to suppress the mailer" do
       subject do
         order.shipping.ship_shipment(


### PR DESCRIPTION
**Description**

Since we update the shipments state in the database,
but we read the shipsments from memory in the
OrderUpdater#determine_shipment_state we need to set the new
values here on the object as well.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change