### PR TITLE
[v2.11] Fix deprecated deliver_order_confirmation_email method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -476,8 +476,8 @@ module Spree
         "Spree::MailerSubscriber#order_finalized.",
         caller(1)
 
-      Spree::Config.order_mailer_class.confirm_email(order).deliver_later
-      order.update_column(:confirmation_delivered, true)
+      Spree::Config.order_mailer_class.confirm_email(self).deliver_later
+      update_column(:confirmation_delivered, true)
     end
 
     # Helper methods for checkout steps

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1735,4 +1735,18 @@ RSpec.describe Spree::Order, type: :model do
       expect(subject).to eq 40
     end
   end
+
+  describe "#deliver_order_confirmation_email" do
+    subject { order.deliver_order_confirmation_email }
+
+    around do |example|
+      Spree::Deprecation.silence do
+        example.run
+      end
+    end
+
+    it "raises no errors" do
+      expect { subject }.not_to raise_exception
+    end
+  end
 end


### PR DESCRIPTION
This method on the Spree::Order class was trying to call the `order`
method. I think what it means to say is  `self`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
