### PR TITLE
Improve email validation regexp

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -13,11 +13,16 @@ module Spree
   #
   class EmailValidator < ActiveModel::EachValidator
     EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP
+    EMAIL_DOMAIN_REGEXP = /\.[a-z]+/i
 
     def validate_each(record, attribute, value)
-      unless EMAIL_REGEXP.match? value
+      unless valid_email?(value)
         record.errors.add(attribute, :invalid, { value: value }.merge!(options))
       end
+    end
+
+    def valid_email?(value)
+      EMAIL_REGEXP.match?(value) && EMAIL_DOMAIN_REGEXP.match?(value)
     end
   end
 end

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Spree::EmailValidator do
       'invalidemailemail.com',
       '@invalid.email@email.com',
       'invalid@email@email.com',
-      'invalid.email@@email.com'
+      'invalid.email@@email.com',
+      'invalid.email@gmail'
     ]
   }
 


### PR DESCRIPTION
**Description**

`URI::MailTo::EMAIL_REGEXP` matches email addresses based on the specification in the original email RFC. Its pretty broad and not a good reflection of email addresses used in the real world. 

For example, `URI::MailTo::EMAIL_REGEXP` will return `true` for addresses such as `test@test`:
```
irb(main):004:0> 'test@test'.match? URI::MailTo::EMAIL_REGEXP
=> true
```

While that is technically a valid address according to the RFC, in practicality nobody uses an address in this style.

This patch better matches the significant majority of email addresses in reality. Tightening up the regex used for validation should prevent customers from inputting incorrect (but valid) email addresses.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
