### PR TITLE
[v3.0] Fix creating refund with amount in foreign format

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -31,6 +31,14 @@ module Spree
       end
     end
 
+    # Sets this price's amount to a new value, parsing it if the new value is
+    # a string.
+    #
+    # @param price [String, #to_d] a new amount
+    def amount=(price)
+      self[:amount] = Spree::LocalizedNumber.parse(price)
+    end
+
     def description
       payment.payment_method.name
     end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe Spree::Refund, type: :model do
     it "does not attempt to process a transaction" do
       expect(subject.transaction_id).to be_nil
     end
+
+    context "with a european price format" do
+      let(:amount) { "100,00" }
+      let(:payment_amount) { 200.0 }
+
+      before do
+        expect(I18n).to receive(:t).with(:'number.currency.format.separator') do
+          ","
+        end
+      end
+
+      it "creates a refund record" do
+        expect { subject }.to change { Spree::Refund.count }.by(1)
+      end
+    end
   end
 
   describe "#perform!" do


### PR DESCRIPTION
**Same as #4344 but for v3.0**

The numericality validation in rails cannot handle prices
in non-float based amounts (Ie. 100,00 EUR).

Using `Spree::LocalizedNumber` to convert the amount before validation.
