### PR TITLE
Enhance refund admin UI

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_number_with_currency.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_number_with_currency.scss
@@ -1,5 +1,6 @@
 .number-with-currency {
   $currency-width: 5.5rem;
+  flex-wrap: nowrap;
 
   &-symbol {
     min-width: 2.5em;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -147,16 +147,17 @@ span.info {
     }
   }
 
-  &.withError {
-    .field_with_errors {
-      label {
-        color: theme-color("danger");
-      }
-
-      input {
-        border-color: theme-color("danger");
-      }
+  .field_with_errors {
+    label {
+      color: theme-color("danger");
     }
+
+    input {
+      border-color: theme-color("danger");
+    }
+  }
+
+  &.withError {
     .formError {
       color: lighten(theme-color("danger"), 15);
       font-style: italic;

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -58,7 +58,7 @@
             <% allowed_actions = payment.actions.select { |a| can?(a.to_sym, payment) } %>
             <% allowed_actions.each do |action| %>
               <% if action == 'credit' %>
-                <%= link_to_with_icon 'reply', t('spree.refund'), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
+                <%= link_to_with_icon 'mail-reply', t('spree.actions.refund'), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
               <% elsif action == 'capture' && !@order.completed? %>
                 <%# no capture prior to completion. payments get captured when the order completes. %>
               <% else %>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -10,7 +10,7 @@
       <div class="col-3">
         <div class="field">
           <%= f.label :amount %><br/>
-          <%= @refund.amount %>
+          <%= @refund.display_amount %>
         </div>
       </div>
       <div class="col-3">

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -10,14 +10,14 @@
     <div data-hook="admin_refund_form_fields" class="row">
       <div class="col-3">
         <div class="field">
-          <%= t('spree.payment_amount') %><br/>
-          <%= @refund.payment.amount %>
+          <label><%= t('spree.payment_amount') %></label><br>
+          <%= Spree::Money.new(@refund.payment.amount) %>
         </div>
       </div>
       <div class="col-3">
         <div class="field">
-          <%= t('spree.credit_allowed') %><br/>
-          <%= @refund.payment.credit_allowed %>
+          <label><%= t('spree.credit_allowed') %></label><br/>
+          <%= Spree::Money.new(@refund.payment.credit_allowed) %>
         </div>
       </div>
       <div class="col-3">
@@ -29,13 +29,13 @@
       <div class="col-3">
         <div class="field">
           <%= f.label :refund_reason_id %><br/>
-          <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'custom-select fullwidth'}) %>
+          <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {prompt: t("spree.choose_reason")}, {class: 'custom-select fullwidth'}) %>
         </div>
       </div>
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= f.submit Spree::Refund.model_name.human, class: 'btn btn-primary' %>
+      <%= f.submit t('spree.actions.refund'), class: 'btn btn-primary' %>
       <%= link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order), class: 'btn btn-primary' %>
     </div>
   </fieldset>


### PR DESCRIPTION
**Description**

This makes the refund form look better in non-english locales.

- Use proper localization of amounts
- Use actions translations in buttons and links
- Fix refund icon class
- Add a prompt to refund reason select

### New Refund before

![New Refund - Payment 1 - Payments - #R406003024 - Orders 2022-04-20 22-42-06](https://user-images.githubusercontent.com/42868/164319486-36d3a34f-b335-4534-8cf8-e87800303449.png)

### New Refund after

![New Refund - Payment 1 - Payments - #R406003024 - Orders 2022-04-20 22-39-17](https://user-images.githubusercontent.com/42868/164319505-2e83c35a-138c-4499-8007-6a6731691d9e.png)

### Payments before

![Payments - #R406003024 - Orders 2022-04-20 22-41-44](https://user-images.githubusercontent.com/42868/164319499-08439039-5065-40fe-accb-d859571a42d7.png)

### Payments after

![Payments - #R406003024 - Orders 2022-04-20 22-39-34](https://user-images.githubusercontent.com/42868/164319501-a15ae3f0-70d4-4837-b2d0-75ed55278eb9.png)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have attached screenshots to this PR for visual changes
