### PR TITLE
[v2.11] Enhance refund admin UI

### DIFF
--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -58,7 +58,7 @@
             <% allowed_actions = payment.actions.select { |a| can?(a.to_sym, payment) } %>
             <% allowed_actions.each do |action| %>
               <% if action == 'credit' %>
-                <%= link_to_with_icon 'reply', t('spree.refund'), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
+                <%= link_to_with_icon 'mail-reply', t('spree.actions.refund'), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
               <% elsif action == 'capture' && !@order.completed? %>
                 <%# no capture prior to completion. payments get captured when the order completes. %>
               <% else %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -10,14 +10,16 @@
     <div data-hook="admin_refund_form_fields" class="row">
       <div class="col-3">
         <div class="field">
-          <%= t('spree.payment_amount') %><br/>
-          <%= @refund.payment.amount %>
+          <label><%= t('spree.payment_amount') %></label><br>
+          <%= number_to_currency @refund.payment.amount,
+            unit: Spree::Config.available_currencies.find { |c| c.iso_code == @refund.currency }&.symbol %>
         </div>
       </div>
       <div class="col-3">
         <div class="field">
-          <%= t('spree.credit_allowed') %><br/>
-          <%= @refund.payment.credit_allowed %>
+          <label><%= t('spree.credit_allowed') %></label><br/>
+          <<%= number_to_currency @refund.payment.credit_allowed,
+            unit: Spree::Config.available_currencies.find { |c| c.iso_code == @refund.currency }&.symbol %>
         </div>
       </div>
       <div class="col-3">
@@ -29,13 +31,13 @@
       <div class="col-3">
         <div class="field">
           <%= f.label :refund_reason_id %><br/>
-          <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'custom-select fullwidth'}) %>
+          <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {prompt: t("spree.choose_reason")}, {class: 'custom-select fullwidth'}) %>
         </div>
       </div>
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= f.submit Spree::Refund.model_name.human, class: 'btn btn-primary' %>
+      <%= f.submit t('spree.actions.refund'), class: 'btn btn-primary' %>
       <%= link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order), class: 'btn btn-primary' %>
     </div>
   </fieldset>


### PR DESCRIPTION
**Same as #4348 but for v2.11**

This makes the refund form look better in non-english locales.

- Use proper localization of amounts
- Use actions translations in buttons and links
- Fix refund icon class
- Add a prompt to refund reason select
