### PR TITLE
Make more room for long values in Order Summary

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -57,38 +57,6 @@ ul.text_list {
   padding-left: 0;
 }
 
-dl {
-  width: 100%;
-  overflow: hidden;
-  margin: 5px 0;
-  color: lighten($body-color, 15);
-
-  dt, dd {
-    float: left;
-    line-height: 16px;
-    padding: 5px;
-  }
-
-  dt {
-    width: 40%;
-    font-weight: $font-weight-bold;
-    padding-left: 0;
-    clear: left;
-  }
-
-  dd {
-    width: 60%;
-    padding-right: 0;
-    margin-left: 0;
-  }
-}
-
-.dl-collapse {
-  dt, dd {
-    width: auto;
-  }
-}
-
 // Helpers
 .align-center  { text-align: center  }
 .align-right   { text-align: right   }

--- a/backend/vendor/assets/stylesheets/solidus_admin/bootstrap/mixins/_lists.scss
+++ b/backend/vendor/assets/stylesheets/solidus_admin/bootstrap/mixins/_lists.scss
@@ -5,3 +5,37 @@
   padding-left: 0;
   list-style: none;
 }
+
+dl {
+  width: 100%;
+  overflow: hidden;
+  margin: 5px 0;
+  color: lighten($body-color, 15);
+
+  dt,
+  dd {
+    float: left;
+    line-height: 16px;
+    padding: 5px;
+  }
+
+  dt {
+    width: 40%;
+    font-weight: $font-weight-bold;
+    padding-left: 0;
+    clear: left;
+  }
+
+  dd {
+    width: 60%;
+    padding-right: 0;
+    margin-left: 0;
+  }
+}
+
+.dl-collapse {
+  dt,
+  dd {
+    width: auto;
+  }
+}

--- a/backend/vendor/assets/stylesheets/solidus_admin/bootstrap/mixins/_lists.scss
+++ b/backend/vendor/assets/stylesheets/solidus_admin/bootstrap/mixins/_lists.scss
@@ -7,6 +7,9 @@
 }
 
 dl {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
   width: 100%;
   overflow: hidden;
   margin: 5px 0;
@@ -14,20 +17,18 @@ dl {
 
   dt,
   dd {
-    float: left;
+    min-width: 40%;
     line-height: 16px;
     padding: 5px;
   }
 
   dt {
-    width: 40%;
     font-weight: $font-weight-bold;
     padding-left: 0;
-    clear: left;
   }
 
   dd {
-    width: 60%;
+    text-align: right;
     padding-right: 0;
     margin-left: 0;
   }


### PR DESCRIPTION
**Description**

Using flex box to be more flexible (pun intended) with long keys in the order summary.

### Before

![Lieferungen - R987654321 - Bestellungen 2022-04-22 10-42-01](https://user-images.githubusercontent.com/42868/164652463-34dc0ec1-93a5-4cb6-9026-cafaffe97458.png)

### After

![Lieferungen - R987654321 - Bestellungen 2022-04-22 10-42-21](https://user-images.githubusercontent.com/42868/164652456-9f6e683e-24b6-4d01-9165-6133659af900.png)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have attached screenshots to this PR for visual changes
