### PR TITLE
Rename spree_products.discontinue_on into spree_products.available_until

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -123,14 +123,14 @@
         <% end %>
       </div>
 
-      <div data-hook="admin_product_form_discontinue_on">
-        <%= f.field_container :discontinue_on do %>
-          <%= f.label :discontinue_on %>
-          <%= f.field_hint :discontinue_on %>
+      <div data-hook="admin_product_form_available_until">
+        <%= f.field_container :available_until do %>
+          <%= f.label :available_until %>
+          <%= f.field_hint :available_until %>
 
-          <%= render "spree/admin/shared/datepicker", f: f, date_attr: :discontinue_on %>
+          <%= render "spree/admin/shared/datepicker", f: f, date_attr: :available_until %>
 
-          <%= f.error_message_on :discontinue_on %>
+          <%= f.error_message_on :available_until %>
         <% end %>
       </div>
 

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -314,12 +314,12 @@ describe "Products", type: :feature do
         expect(Spree::Product.last.available_on).to eq('Tue, 25 Dec 2012 00:00:00 UTC +00:00')
       end
 
-      it 'should correctly update discontinue_on', :js do
+      it 'should correctly update available_until', :js do
         visit spree.admin_product_path(product)
-        fill_in "product_discontinue_on", with: "2020/12/4"
+        fill_in "product_available_until", with: "2020/12/4"
         click_button "Update"
         expect(page).to have_content("successfully updated!")
-        expect(product.reload.discontinue_on.to_s).to eq('2020-12-04 00:00:00 UTC')
+        expect(product.reload.available_until.to_s).to eq('2020-12-04 00:00:00 UTC')
       end
 
       context "when there is a default tax category" do

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -72,6 +72,9 @@ module Spree
         .where(master: { spree_prices: Spree::Config.default_pricing_options.desired_attributes })
     }
 
+    alias_attribute :discontinue_on, :available_until
+    deprecate discontinue_on: :available_until, deprecator: Spree::Deprecation
+
     def find_or_build_master
       master || build_master
     end
@@ -176,7 +179,7 @@ module Spree
     #
     # @return [Boolean] true if this product is available
     def available?
-      !deleted? && available_on&.past? && !discontinued?
+      !deleted? && available_on&.past? && !unavailable?
     end
 
     # Determines if product is discontinued.
@@ -185,9 +188,12 @@ module Spree
     # is not nil and in the past.
     #
     # @return [Boolean] true if this product is discontinued
-    def discontinued?
-      !!discontinue_on&.past?
+    def unavailable?
+      !!available_until&.past?
     end
+
+    alias_method :discontinued?, :unavailable?
+    deprecate discontinued?: :unavailable?, deprecator: Spree::Deprecation
 
     # Poor man's full text search.
     #

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -185,8 +185,8 @@ module Spree
           def self.available(available_on = nil)
             with_master_price
               .where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
-              .where("#{Spree::Product.quoted_table_name}.discontinue_on IS NULL OR" \
-                     "#{Spree::Product.quoted_table_name}.discontinue_on >= ?", Time.current)
+              .where("#{Spree::Product.quoted_table_name}.available_until IS NULL OR" \
+                     "#{Spree::Product.quoted_table_name}.available_until >= ?", Time.current)
           end
           search_scopes << :available
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -32,9 +32,10 @@ module Spree
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
     belongs_to :shipping_category, class_name: "Spree::ShippingCategory", optional: true
 
-    delegate :name, :description, :slug, :available_on, :discontinue_on, :discontinued?,
-             :meta_description, :meta_keywords,
+    delegate :name, :description, :slug, :available_on, :discontinue_on, :available_until, :discontinued?,
+             :meta_description, :meta_keywords, :unavailable?,
              to: :product
+
     delegate :tax_category, to: :product, prefix: true
     delegate :shipping_category, :shipping_category_id,
       to: :product, prefix: true

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -164,11 +164,12 @@ en:
         variant: Variant
       spree/product:
         available_on: Available On
+        available_until: Available Until
         cost_currency: Cost Currency
         cost_price: Cost Price
         depth: Depth
         description: Description
-        discontinue_on: Discontinue on
+        discontinue_on: Available Until
         height: Height
         master_price: Master Price
         meta_description: Meta Description
@@ -1623,7 +1624,7 @@ en:
         options: These options are used to create variants in the variants table. They can be changed in the variants tab
       spree/product:
         available_on: This sets the availability date for the product. If this value is not set, or it is set to a date in the future, then the product is not available on the storefront.
-        discontinue_on: This sets the discontinue date for the product. If this value is set to a date, then the product is not available on the storefront from that day on anymore.
+        available_until: This sets the retirement date for the product. If this value is set to a date, then the product is not available on the storefront from that day on anymore.
         promotionable: 'This determines whether or not promotions can apply to this product.<br>Default: Checked'
         shipping_category: 'This determines what kind of shipping this product requires.<br> Default: Default'
         tax_category: 'This determines what kind of taxation is applied to this product.<br> Default: %{default_tax_category}'

--- a/core/db/migrate/20220426165309_rename_discontinue_on_to_unavailable_at.rb
+++ b/core/db/migrate/20220426165309_rename_discontinue_on_to_unavailable_at.rb
@@ -1,0 +1,5 @@
+class RenameDiscontinueOnToUnavailableAt < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :spree_products, :discontinue_on, :available_until
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -74,7 +74,7 @@ module Spree
     @@product_properties_attributes = [:property_name, :value, :position]
 
     @@product_attributes = [
-      :name, :description, :available_on, :discontinue_on, :meta_description,
+      :name, :description, :available_on, :available_until, :discontinue_on, :meta_description,
       :meta_keywords, :price, :sku, :deleted_at,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -136,22 +136,22 @@ RSpec.describe "Product scopes", type: :model do
         expect(Spree::Product.available).to match_array([product])
       end
 
-      context "with no discontinue_on" do
+      context "with no available_until" do
         it "includes the product" do
           expect(Spree::Product.available).to match_array([product])
         end
       end
 
-      context "with future discontinue_on" do
-        before { product.update!(discontinue_on: 1.day.from_now) }
+      context "with future available_until" do
+        before { product.update!(available_until: 1.day.from_now) }
 
         it "includes the product" do
           expect(Spree::Product.available).to match_array([product])
         end
       end
 
-      context "with past discontinue_on" do
-        before { product.update!(discontinue_on: 1.day.ago) }
+      context "with past available_until" do
+        before { product.update!(available_until: 1.day.ago) }
 
         it "doesn't include the product" do
           expect(Spree::Product.available).to match_array([])

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -186,24 +186,24 @@ RSpec.describe Spree::Product, type: :model do
         end
       end
 
-      context "if discontinue_on is in the past" do
-        let(:product) { build(:product, discontinue_on: 1.day.ago) }
+      context "if available_until is in the past" do
+        let(:product) { build(:product, available_until: 1.day.ago) }
 
         it "should not be available" do
           expect(product).not_to be_available
         end
       end
 
-      context "if discontinue_on is nil" do
-        let(:product) { build(:product, discontinue_on: nil) }
+      context "if available_until is nil" do
+        let(:product) { build(:product, available_until: nil) }
 
         it "should be available" do
           expect(product).to be_available
         end
       end
 
-      context "if discontinue_on is in the future" do
-        let(:product) { build(:product, discontinue_on: 1.day.from_now) }
+      context "if available_until is in the future" do
+        let(:product) { build(:product, available_until: 1.day.from_now) }
 
         it "should be available" do
           expect(product).to be_available
@@ -219,23 +219,23 @@ RSpec.describe Spree::Product, type: :model do
       end
     end
 
-    describe "#discontinued?" do
-      subject { product.discontinued? }
+    describe "#unavailable?" do
+      subject { product.unavailable? }
 
-      context "if discontinue_on is in the past" do
-        let(:product) { build(:product, discontinue_on: 1.day.ago) }
+      context "if available_until is in the past" do
+        let(:product) { build(:product, available_until: 1.day.ago) }
 
         it { is_expected.to be(true) }
       end
 
-      context "if discontinue_on is nil" do
-        let(:product) { build(:product, discontinue_on: nil) }
+      context "if available_until is nil" do
+        let(:product) { build(:product, available_until: nil) }
 
         it { is_expected.to be(false) }
       end
 
-      context "if discontinue_on is in the future" do
-        let(:product) { build(:product, discontinue_on: 1.day.from_now) }
+      context "if available_until is in the future" do
+        let(:product) { build(:product, available_until: 1.day.from_now) }
 
         it { is_expected.to be(false) }
       end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Spree::Variant, type: :model do
   it { is_expected.to be_invalid }
 
   let!(:variant) { create(:variant) }
 
-  describe 'delegates' do
+  describe "delegates" do
     let(:product) { build(:product) }
     let(:variant) { build(:variant, product: product) }
 
-    it 'discontinue_on to product' do
-      expect(product).to receive(:discontinue_on)
-      variant.discontinue_on
+    it "available_until to product" do
+      expect(product).to receive(:available_until)
+      variant.available_until
     end
 
-    it 'discontinued? to product' do
-      expect(product).to receive(:discontinued?)
-      variant.discontinued?
+    it "unavailable? to product" do
+      expect(product).to receive(:unavailable?)
+      variant.unavailable?
     end
   end
 


### PR DESCRIPTION
In our business, the semantics of availability and discontinuation are
not aligned with Solidus' nomenclature: A product can both be available
and discontinued (i.e. we still have stock of it, but won't be producing
any more).

When communicating the meaning of the discontinue_on column, it's often
hard (because there is a date when we decide to discontinue, and there's
another date when we sell out and the product becomes unavailable).

From reading the code, Solidus' `discontinue_on` is actually a mirror of
`available_until`.

What this commit does is it adds an `available_until` column, populates that with the data from `discontinue_on` and changes all scopes within Solidus to reference the new column. In the next major upgrade, we can then remove the `discontinue_on` column.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have adapted tests to cover this change (if needed)