### PR TITLE
Add flexibility to `Spree::Order#restart_checkout_flow`

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -517,7 +517,7 @@ module Spree
         state: 'cart',
         updated_at: Time.current
       )
-      next! if !line_items.empty?
+      self.next
     end
 
     def refresh_shipment_rates


### PR DESCRIPTION
**Description**

When the checkout flow is customized, the current version of the method `Spree::Order#restart_checkout_flow` may raise `StateMachines::InvalidTransition` which are not really necessary and meaningful. The error is caused by the line

    next! if !line_items.empty?

that force-advances the order state from cart to the next state. This doesn't seem to be necessary, and forces stores that experience this situation to override the method definition or find workarounds in order to handle these scenarios. The bang version `next!` was introduced with c9eb45d7456f0f095b1be6df1fac3134036d52b8 apparently only for fixing specs.

Please refer to this PR commit messages for further details. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
