### PR TITLE
Handle empty values as quantity adding to cart via API

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -13,7 +13,7 @@ module Spree
         variant = Spree::Variant.find(params[:line_item][:variant_id])
         @line_item = @order.contents.add(
           variant,
-          params[:line_item][:quantity] || 1,
+          params[:line_item][:quantity].presence || 1,
           options: line_item_params[:options].to_h
         )
 

--- a/api/spec/requests/spree/api/line_items_spec.rb
+++ b/api/spec/requests/spree/api/line_items_spec.rb
@@ -95,11 +95,25 @@ module Spree::Api
         expect(response.status).to eq(201)
       end
 
-      it "default quantity to 1 if none is given" do
+      it "sets default quantity to 1 if none is given" do
         post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param } }
         expect(response.status).to eq(201)
         expect(json_response).to have_attributes(attributes)
         expect(json_response[:quantity]).to eq 1
+      end
+
+      it "sets default quantity to 1 if empty values are given" do
+        post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: '' } }
+        expect(response.status).to eq(201)
+        expect(json_response).to have_attributes(attributes)
+        expect(json_response[:quantity]).to eq 1
+      end
+
+      it "allows to explicitely set quantity to 0" do
+        post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: 0 } }
+        expect(response.status).to eq(201)
+        expect(json_response).to have_attributes(attributes)
+        expect(json_response[:quantity]).to eq 0
       end
 
       it "increases a line item's quantity if it exists already" do


### PR DESCRIPTION
**Description**

Right now, when empty values are passed as quantity in the API call that creates line items, the line item is populated with quantity 0.

This is not the expected behavior, as it makes no sense to have a line item with 0 as quantity.

Still, if someone wants to force the value to 0, this is still possible but 0 needs to be explicitly passed as quantity value. A spec has been added for this scenario as well.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
