### PR TITLE
Fix update generator taking non-comparable values as changes in a default

### DIFF
--- a/core/lib/spree/preferences/preferable_class_methods.rb
+++ b/core/lib/spree/preferences/preferable_class_methods.rb
@@ -49,7 +49,7 @@ module Spree::Preferences
 
                       If you want to branch on the provided Solidus version, you can do like the following:
 
-                      preference :foo, :string, default: by_version(true, "3.2.0" => false)
+                      versioned_preference :foo, :string, initial_value: true, boundaries: { "3.2.0" => false }
 
                     MSG
                     ->(_default_context) { given.call }

--- a/core/lib/spree/preferences/preference_differentiator.rb
+++ b/core/lib/spree/preferences/preference_differentiator.rb
@@ -12,7 +12,8 @@ module Spree
       def call(from:, to:)
         preferences_from = config_class.new.load_defaults(from)
         preferences_to = config_class.new.load_defaults(to)
-        preferences_from.reduce({}) do |changes, (pref_key, value_from)|
+        config_class.versioned_preferences.reduce({}) do |changes, pref_key|
+          value_from = preferences_from[pref_key]
           value_to = preferences_to[pref_key]
           if value_from == value_to
             changes

--- a/core/spec/lib/generators/solidus/update/update_generator_spec.rb
+++ b/core/spec/lib/generators/solidus/update/update_generator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Solidus::UpdateGenerator do
   context 'core' do
     it 'adds changes when present' do
       config_class = Class.new(Spree::Preferences::Configuration) do
-        preference :foo, :boolean, default: by_version(true, '3.0' => false)
+        versioned_preference :foo, :boolean, initial_value: true, boundaries: { '3.0' => false }
       end
       stub_const('Spree::AppConfiguration', config_class)
 
@@ -62,7 +62,7 @@ RSpec.describe Solidus::UpdateGenerator do
 
     it 'adds changes when present' do
       config_class = Class.new(Spree::Preferences::Configuration) do
-        preference :foo, :boolean, default: by_version(true, '3.0' => false)
+        versioned_preference :foo, :boolean, initial_value: true, boundaries: { '3.0' => false }
       end
       stub_const('Spree::FrontendConfiguration', config_class)
 
@@ -99,7 +99,7 @@ RSpec.describe Solidus::UpdateGenerator do
 
     it 'adds changes when present' do
       config_class = Class.new(Spree::Preferences::Configuration) do
-        preference :foo, :boolean, default: by_version(true, '3.0' => false)
+        versioned_preference :foo, :boolean, initial_value: true, boundaries: { '3.0' => false }
       end
       stub_const('Spree::BackendConfiguration', config_class)
 
@@ -136,7 +136,7 @@ RSpec.describe Solidus::UpdateGenerator do
 
     it 'adds changes when present' do
       config_class = Class.new(Spree::Preferences::Configuration) do
-        preference :foo, :boolean, default: by_version(true, '3.0' => false)
+        versioned_preference :foo, :boolean, initial_value: true, boundaries: { '3.0' => false }
       end
       stub_const('Spree::ApiConfiguration', config_class)
 

--- a/core/spec/lib/spree/preferences/preference_differentiator_spec.rb
+++ b/core/spec/lib/spree/preferences/preference_differentiator_spec.rb
@@ -7,7 +7,7 @@ require 'spree/preferences/configuration'
 RSpec.describe Spree::Preferences::PreferenceDifferentiator do
   it 'includes defaults that have changed' do
     config_class = Class.new(Spree::Preferences::Configuration) do
-      preference :foo, :boolean, default: by_version(true, '3.0' => false)
+      versioned_preference :foo, :boolean, initial_value: true, boundaries: { '3.0' => false }
     end
 
     changes = described_class.new(config_class).call(from: '2.0', to: '3.0')
@@ -17,7 +17,17 @@ RSpec.describe Spree::Preferences::PreferenceDifferentiator do
 
   it "doesn't include defaults that have not changed" do
     config_class = Class.new(Spree::Preferences::Configuration) do
-      preference :foo, :boolean, default: by_version(true, '3.0' => false)
+      versioned_preference :foo, :boolean, initial_value: true, boundaries: { '3.0' => false }
+    end
+
+    changes = described_class.new(config_class).call(from: '2.0', to: '2.5')
+
+    expect(changes.keys).not_to include(:foo)
+  end
+
+  it "doesn't include not versioned defaults that can'be compared for equality" do
+    config_class = Class.new(Spree::Preferences::Configuration) do
+      preference :foo, :boolean, default: proc { proc { } }
     end
 
     changes = described_class.new(config_class).call(from: '2.0', to: '2.5')

--- a/core/spec/models/spree/preferences/configuration_spec.rb
+++ b/core/spec/models/spree/preferences/configuration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Preferences::Configuration, type: :model do
   let(:config) do
     Class.new(Spree::Preferences::Configuration) do
       preference :color, :string, default: :blue
-      preference :foo, :boolean, default: by_version(true, "3.0" => false)
+      versioned_preference :foo, :boolean, initial_value: true, boundaries: { "3.0" => false }
     end.new
   end
 


### PR DESCRIPTION
Preference defaults are declared at the class level. To allow them to
reference other parts of the code base regardless of the loading order,
they're internally wrapped within a proc (whey they aren't already one)
to be lazily evaluated. When the default for a preference is itself a
proc, it needs to be declared one level nested to bypass that first
outer layer. E.g.

```ruby
preference :foo, :proc, default: proc { proc { true } }
```

The `solidus:update` generator compared the resolved preferences for
equality for different Solidus versions to add changes in the
`new_solidus_defaults.rb` initializer. However, procs can't be compared
in that way (and the same is true for other mutable types). E.g:

```ruby
proc { true } == proc { true } => false
```

Because of that, the update generator was fooled and added those kinds
of settings as a change. To reproduce, run `bin/rails g solidus:update`
from the parent commit and see how the generated
`Spree::Backend::Config.configure` block in
`config/initializers/new_solidus_defaults.rb` contains something similar
to:

```ruby
config.frontend_product_path = #<Proc:0x00007facd4c30928 /home/solidus_user/app/backend/lib/spree/backend_configuration.rb:12 (lambda)>
```

With this commit, we're moving the information of the changes in default
values from the value itself (which, as told, is not reliable) to make
it explicit to the class that defines the preference. In that way, the
update generator can directly ask for those and do its job. We're
introducing a new `.versioned_preference` method in the configuration
class that, besides doing the same as the `.preference` method, helps
keep track.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
