### PR TITLE
Fix issues loading serialized logs

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -39,6 +39,30 @@ module Spree
       end
     end
 
+    # Raised when YAML contains aliases and they're not enabled
+    class BadAlias < RuntimeError
+      attr_reader :psych_exception
+
+      def initialize(psych_exception:)
+        @psych_exception = psych_exception
+        super(default_message)
+      end
+
+      private
+
+      def default_message
+        <<~MSG
+          #{psych_exception.message}
+
+          You can explicitly enable aliases in config/initializers/spree.rb. E.g:
+
+          Spree.config do |config|
+            config.log_entry_allow_aliases = true
+          end
+        MSG
+      end
+    end
+
     def self.permitted_classes
       CORE_PERMITTED_CLASSES + Spree::Config.log_entry_permitted_classes.map(&:constantize)
     end
@@ -46,9 +70,15 @@ module Spree
     belongs_to :source, polymorphic: true, optional: true
 
     def parsed_details
-      @details ||= YAML.safe_load(details, permitted_classes: self.class.permitted_classes)
+      @details ||= YAML.safe_load(
+        details,
+        permitted_classes: self.class.permitted_classes,
+        aliases: Spree::Config.log_entry_allow_aliases
+      )
     rescue Psych::DisallowedClass => e
       raise DisallowedClass.new(psych_exception: e)
+    rescue Psych::BadAlias => e
+      raise BadAlias.new(psych_exception: e)
     end
   end
 end

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -2,10 +2,53 @@
 
 module Spree
   class LogEntry < Spree::Base
+    # Classes used in core that can be present in serialized details
+    #
+    # Users can add their own classes in
+    # `Spree::Config#log_entry_permitted_classes`.
+    #
+    # @see Spree::AppConfiguration#log_entry_permitted_classes
+    CORE_PERMITTED_CLASSES = [
+      ActiveMerchant::Billing::Response,
+      ActiveSupport::TimeWithZone,
+      Time,
+      ActiveSupport::TimeZone
+    ].freeze
+
+    # Raised when a disallowed class is tried to be loaded
+    class DisallowedClass < RuntimeError
+      attr_reader :psych_exception
+
+      def initialize(psych_exception:)
+        @psych_exception = psych_exception
+        super(default_message)
+      end
+
+      private
+
+      def default_message
+        <<~MSG
+          #{psych_exception.message}
+
+          You can specify custom classes to be loaded in config/initializers/spree.rb. E.g:
+
+          Spree.config do |config|
+            config.log_entry_permitted_classes = ['MyClass']
+          end
+        MSG
+      end
+    end
+
+    def self.permitted_classes
+      CORE_PERMITTED_CLASSES + Spree::Config.log_entry_permitted_classes.map(&:constantize)
+    end
+
     belongs_to :source, polymorphic: true, optional: true
 
     def parsed_details
-      @details ||= YAML.safe_load(details, permitted_classes: [ActiveMerchant::Billing::Response])
+      @details ||= YAML.safe_load(details, permitted_classes: self.class.permitted_classes)
+    rescue Psych::DisallowedClass => e
+      raise DisallowedClass.new(psych_exception: e)
     end
   end
 end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -179,6 +179,13 @@ module Spree
     #     config.log_entry_permitted_classes = ['Date']
     preference :log_entry_permitted_classes, :array, default: []
 
+    # @!attribute [rw] log_entry_allow_aliases
+    #   @return [Boolean] Whether YAML aliases are allowed when loading
+    #     serialized data in {Spree::LogEntry}. It defaults to true. Depending
+    #     on the source of your data, you may consider disabling it to prevent
+    #     entity expansion attacks.
+    preference :log_entry_allow_aliases, :boolean, default: true
+
     # @!attribute [rw] mails_from
     #   @return [String] Email address used as +From:+ field in transactional emails.
     preference :mails_from, :string, default: 'solidus@example.com'

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -170,6 +170,15 @@ module Spree
     #   @return [String] URL of logo used on frontend (default: +'logo/solidus.svg'+)
     preference :logo, :string, default: 'logo/solidus.svg'
 
+    # @!attribute [rw] log_entry_permitted_classes
+    #   @return [Array<String>] An array of extra classes that are allowed to be
+    #     loaded from a serialized YAML as details in {Spree::LogEntry}
+    #     (defaults to a non-frozen empty array, so that extensions can add
+    #     their own classes).
+    #   @example
+    #     config.log_entry_permitted_classes = ['Date']
+    preference :log_entry_permitted_classes, :array, default: []
+
     # @!attribute [rw] mails_from
     #   @return [String] Email address used as +From:+ field in transactional emails.
     preference :mails_from, :string, default: 'solidus@example.com'

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -4,6 +4,25 @@ require 'rails_helper'
 
 RSpec.describe Spree::LogEntry, type: :model do
   describe '#parsed_details' do
+    it 'allow aliases by default' do
+      x = []
+      x << x
+
+      log_entry = described_class.new(details: x.to_yaml)
+
+      expect { log_entry.parsed_details }.not_to raise_error
+    end
+
+    it 'can disable aliases and raises a meaningful exception when used' do
+      stub_spree_preferences(log_entry_allow_aliases: false)
+      x = []
+      x << x
+
+      log_entry = described_class.new(details: x.to_yaml)
+
+      expect { log_entry.parsed_details }.to raise_error(described_class::BadAlias, /log_entry_allow_aliases/)
+    end
+
     it 'can parse ActiveMerchant::Billing::Response instances' do
       response = ActiveMerchant::Billing::Response.new('success', 'message')
 

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::LogEntry, type: :model do
+  describe '#parsed_details' do
+    it 'can parse ActiveMerchant::Billing::Response instances' do
+      response = ActiveMerchant::Billing::Response.new('success', 'message')
+
+      log_entry = described_class.new(details: response.to_yaml)
+
+      expect { log_entry.parsed_details }.not_to raise_error
+    end
+
+    it 'can parse ActiveSupport::TimeWithZone instances' do
+      time = Time.zone.now
+
+      log_entry = described_class.new(details: time.to_yaml)
+
+      expect { log_entry.parsed_details }.not_to raise_error
+    end
+
+    it 'can parse user specified classes instances' do
+      stub_spree_preferences(log_entry_permitted_classes: ['Date'])
+
+      log_entry = described_class.new(details: Date.today)
+
+      expect { log_entry.parsed_details }.not_to raise_error
+    end
+
+    it 'raises a meaningful exception when a disallowed class is found' do
+      log_entry = described_class.new(details: Date.today)
+
+      expect { log_entry.parsed_details }.to raise_error(described_class::DisallowedClass, /log_entry_permitted_classes/)
+    end
+  end
+end


### PR DESCRIPTION
`Spree::LogEntry` loads details from a YAML string that can potentially
contain any serialized Ruby object if users have overridden some part of
the codebase.

New Psych (YAML parser) version packed with Ruby 3.1 requires that, by
default, users are explicit about which type of classes are allowed to
be loaded (see ruby/psych@cb50aa8 and ruby/psych@1764942).

On 008168c, we updated our code to allow instances of
`ActiveMerchant::Billing::Response`. However, as [noted in a
comment](https://github.com/solidusio/solidus/commit/008168c962bb75370b70c12315515710f35fe1bc#r73483078),
it seems we're missing, at least, instances of
`ActiveSupport::TimeWithZone`.

We need to add all classes used internally and leave a door open for
users to add their own classes (via a new `log_entry_permitted_classes`
preference).

On top of that, by default, `YAML.safe_load` won't allow YAML aliases to be parsed.
However, we need them at least for older versions of serialized
`ActiveSupport::TimeWithZone`.

We add a configuration option so that users can still disable it.
Depending on the source of the YAML, parsing aliases could open gates to
entity expansion attacks (a DoS created by nesting self-references).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
