### PR TITLE
Remove deprecated_address_id column from shipments

### DIFF
--- a/core/db/migrate/20230427095534_drop_deprecated_address_id_from_shipments.rb
+++ b/core/db/migrate/20230427095534_drop_deprecated_address_id_from_shipments.rb
@@ -1,0 +1,11 @@
+class DropDeprecatedAddressIdFromShipments < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :spree_shipments, column: [:deprecated_address_id], name: :index_spree_shipments_on_deprecated_address_id
+    remove_column :spree_shipments, :deprecated_address_id
+  end
+
+  def down
+    add_column :spree_shipments, :deprecated_address_id
+    add_index :spree_shipments, :deprecated_address_id, name: :index_spree_shipments_on_deprecated_address_id
+  end
+end


### PR DESCRIPTION
We have not used this column since we removed all references to it in
2016.

It was reverted on 039f3ce83834d38d00de1bf17c99987a76587b92 because of
being backward incompatible. We re-add it now targeting next major
(v4.0).

Ref #4377.

Thanks again for your understanding, @mamhoff.