### PR TITLE
Add missing sprockets-rails dependency

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
   s.add_dependency 'ransack', '~> 2.0'
+  s.add_dependency 'sprockets-rails'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
 
   s.post_install_message = <<-MSG


### PR DESCRIPTION
Rails 7 doesn't have sprockets-rails as a dependency anymore [1].
However, it's a dependency on solidus_core [2].

We hadn't caught it because our test suite depends transitively on it
through sassc-rails [3] in solidus_backend [4] & solidus_frontend [5].

However, we had an incompatibility when using standalone solidus_core
(like in the dummy app for extensions) with Rails 7.

[1] - https://guides.rubyonrails.org/7_0_release_notes.html#railties-notable-changes

[2]
https://github.com/solidusio/solidus/blob/35d43a17124b92651ab43a36ae91f68b7f00f0c5/core/lib/spree/core.rb#L10

[3] - https://github.com/sass/sassc-rails/blob/8d0462d54b5b5dd84cb1df31823c3afaebb64534/sassc-rails.gemspec#L31

[4]
https://github.com/solidusio/solidus/blob/455754bee7a8c58489ef4b913b42c4168212929c/backend/solidus_backend.gemspec#L35

[5]
https://github.com/solidusio/solidus/blob/455754bee7a8c58489ef4b913b42c4168212929c/frontend/solidus_frontend.gemspec#L34
