### PR TITLE
Deprecate creating new shipment with an item via API

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -61,9 +61,10 @@ module Spree
           variant = Spree::Variant.unscoped.find(params[:variant_id])
           @order.contents.add(variant, quantity, { shipment: @shipment })
           @shipment.save!
+          @shipment.reload
         end
 
-        respond_with(@shipment.reload, default_template: :show)
+        respond_with(@shipment, default_template: :show)
       end
 
       def update

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -41,6 +41,8 @@ module Spree
       def create
         authorize! :create, Shipment
         quantity = params[:quantity].to_i
+        variant = Spree::Variant.unscoped.find(params[:variant_id])
+
         @shipment = @order.shipments.create(stock_location_id: params.fetch(:stock_location_id))
         @order.contents.add(variant, quantity, { shipment: @shipment })
 

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -40,13 +40,28 @@ module Spree
 
       def create
         authorize! :create, Shipment
-        quantity = params[:quantity].to_i
-        variant = Spree::Variant.unscoped.find(params[:variant_id])
 
         @shipment = @order.shipments.create(stock_location_id: params.fetch(:stock_location_id))
-        @order.contents.add(variant, quantity, { shipment: @shipment })
 
-        @shipment.save!
+        if passing_deprecated_params_on_create?
+          Spree::Deprecation.warn <<~MSG
+          Passing `quantity` or `variant_id` to
+
+              POST /api/shipments
+
+          is deprecated and won't be allowed anymore starting from Solidus 4.0.
+          Instead, create an empty shipment and add items to it subsequently using
+          the dedicated endpoint:
+
+              PUT /api/shipments/{shipment_number}/add
+
+          MSG
+
+          quantity = params[:quantity].to_i
+          variant = Spree::Variant.unscoped.find(params[:variant_id])
+          @order.contents.add(variant, quantity, { shipment: @shipment })
+          @shipment.save!
+        end
 
         respond_with(@shipment.reload, default_template: :show)
       end
@@ -130,6 +145,10 @@ module Spree
         @quantity                  = params[:quantity].to_i
         authorize! [:update, :destroy], @original_shipment
         authorize! :create, Shipment
+      end
+
+      def passing_deprecated_params_on_create?
+        params[:variant_id] || params[:quantity]
       end
 
       def find_order_on_create

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -5579,6 +5579,10 @@ paths:
         Creates a shipment.
 
         Please note that this request can be only performed by users with the `create` permission on the shipment.
+
+        **Deprecation Warning**: Adding items to the shipment via this endpoint
+        is deprecated. Instead, create an empty shipment and populate it with
+        the dedicated endpoint [to add items to the shipment](/docs/solidus/7078dbcf415ac-add-shipment-item).
       operationId: create-shipment
       tags:
         - Shipments
@@ -5594,8 +5598,10 @@ paths:
                   type: integer
                 variant_id:
                   type: integer
+                  deprecated: true
                 quantity:
                   type: integer
+                  deprecated: true
             examples:
               Example:
                 value:

--- a/api/spec/requests/spree/api/shipments_spec.rb
+++ b/api/spec/requests/spree/api/shipments_spec.rb
@@ -63,17 +63,15 @@ module Spree::Api
           post spree.api_shipments_path, params: params
         end
 
-        [:variant_id, :stock_location_id].each do |field|
-          context "when #{field} is missing" do
-            before do
-              params.delete(field)
-            end
+        context "when stock_location_id is missing" do
+          before do
+            params.delete(:stock_location_id)
+          end
 
-            it 'should return proper error' do
-              subject
-              expect(response.status).to eq(422)
-              expect(json_response['exception']).to eq("param is missing or the value is empty: #{field}")
-            end
+          it 'should return proper error' do
+            subject
+            expect(response.status).to eq(422)
+            expect(json_response['exception']).to eq("param is missing or the value is empty: stock_location_id")
           end
         end
 

--- a/api/spec/requests/spree/api/shipments_spec.rb
+++ b/api/spec/requests/spree/api/shipments_spec.rb
@@ -96,6 +96,43 @@ module Spree::Api
             expect(json_response).to have_attributes(attributes)
           end
         end
+
+        context 'when passing a variant and a quantity along' do
+          let(:params) do
+            {
+              variant_id: stock_location.stock_items.first.variant.to_param,
+              quantity: 2,
+              shipment: { order_id: order.number },
+              stock_location_id: stock_location.to_param
+            }
+          end
+
+          it 'creates a new shipment with a deprecation message' do
+            expect(Spree::Deprecation).to receive(:warn).with(/variant_id/)
+
+            subject
+            expect(response).to be_ok
+            expect(json_response).to have_attributes(attributes)
+          end
+        end
+
+        context 'when passing a quantity along (without a variant_id)' do
+          let(:params) do
+            {
+              quantity: 1,
+              shipment: { order_id: order.number },
+              stock_location_id: stock_location.to_param
+            }
+          end
+
+          it 'returns proper error with a deprecation warning' do
+            expect(Spree::Deprecation).to receive(:warn).with(/variant_id/)
+
+            subject
+            expect(response.status).to eq(404)
+            expect(json_response['error']).to eq("The resource you were looking for could not be found.")
+          end
+        end
       end
 
       it 'can update a shipment' do

--- a/api/spec/requests/spree/api/shipments_spec.rb
+++ b/api/spec/requests/spree/api/shipments_spec.rb
@@ -49,8 +49,36 @@ module Spree::Api
 
       sign_in_as_admin!
 
-      # Start writing this spec a bit differently than before....
       describe 'POST #create' do
+        let(:params) do
+          {
+            shipment: { order_id: order.number },
+            stock_location_id: stock_location.to_param
+          }
+        end
+
+        subject do
+          post spree.api_shipments_path, params: params
+        end
+
+        it 'creates a new shipment' do
+          subject
+          expect(response).to be_ok
+          expect(json_response).to have_attributes(attributes)
+        end
+
+        context "when stock_location_id is missing" do
+          before do
+            params.delete(:stock_location_id)
+          end
+
+          it 'returns proper error' do
+            subject
+            expect(response.status).to eq(422)
+            expect(json_response['exception']).to eq("param is missing or the value is empty: stock_location_id")
+          end
+        end
+
         context 'when passing a variant along' do
           let(:params) do
             {
@@ -60,27 +88,9 @@ module Spree::Api
             }
           end
 
-          subject do
-            post spree.api_shipments_path, params: params
-          end
-
-          before do
+          it 'creates a new shipment with a deprecation message' do
             expect(Spree::Deprecation).to receive(:warn).with(/variant_id/)
-          end
 
-          context "when stock_location_id is missing" do
-            before do
-              params.delete(:stock_location_id)
-            end
-
-            it 'returns proper error' do
-              subject
-              expect(response.status).to eq(422)
-              expect(json_response['exception']).to eq("param is missing or the value is empty: stock_location_id")
-            end
-          end
-
-          it 'creates a new shipment' do
             subject
             expect(response).to be_ok
             expect(json_response).to have_attributes(attributes)

--- a/api/spec/requests/spree/api/shipments_spec.rb
+++ b/api/spec/requests/spree/api/shipments_spec.rb
@@ -224,6 +224,17 @@ module Spree::Api
         end
       end
 
+      context 'for empty shipments' do
+        let(:order) { create :completed_order_with_totals }
+        let(:shipment) { order.shipments.create(stock_location: stock_location) }
+
+        it 'adds a variant to a shipment' do
+          put spree.add_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 2 }
+          expect(response.status).to eq(200)
+          expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(2)
+        end
+      end
+
       describe '#mine' do
         subject do
           get spree.mine_api_shipments_path, params: params


### PR DESCRIPTION
**Description**

There's no known reason why we need to force creating a shipment with exactly one variant into it.

There's a dedicated endpoint for that:

```
PUT /api/shipments/{shipment_number}/add
```

This feature is not used anymore in our backend UI and, if someone is using this endpoint, they will receive a deprecation warning with the instructions on how to adjust their flow to be compatible with the next major version.


TODO:

- [x] deprecate fields in [the related API documentation endpoint](https://solidus.stoplight.io/docs/solidus/6e41c2d519a2b-create-shipment)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- ~I have attached screenshots to this PR for visual changes (if needed)~
