### PR TITLE
Allow user stock locations to be deleted

### DIFF
--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -40,6 +40,7 @@
         <%= label_tag nil, plural_resource_name(Spree::StockLocation) %>
         <ul>
           <% if can?(:manage, Spree::UserStockLocation) %>
+            <%= hidden_field_tag('user[stock_location_ids][]', nil) %>
             <% @stock_locations.each do |stock_location| %>
               <li>
                 <label>

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -433,6 +433,13 @@ describe Spree::Admin::UsersController, type: :controller do
         put :update, params: { id: user.id, user: { stock_location_ids: [location2.id] } }
         expect(user.reload.stock_locations).to eq([location2])
       end
+
+      it "can clear stock locations" do
+        user.stock_locations << Spree::StockLocation.create(name: "my_location")
+        expect {
+          put :update, params: { id: user.id, user: { name: "Bob Bloggs", stock_location_ids: [""] } }
+        }.to change { user.reload.stock_locations.to_a }.to([])
+      end
     end
 
     context "when the user cannot manage stock locations" do

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -348,7 +348,7 @@ describe Spree::Admin::UsersController, type: :controller do
       end
     end
 
-    context "when the user can manage only some stock locations" do
+    context "when the user can manage only some roles" do
       stub_authorization! do |_user|
         can :manage, Spree.user_class
         can :manage, Spree::Role

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -229,6 +229,41 @@ describe 'Users', type: :feature do
       expect(page).to have_text 'Account updated'
     end
 
+    context 'when :can_restrict_stock_management is true' do
+      custom_authorization! do |_user|
+        can [:show], Spree::StockLocation
+      end
+
+      before do
+        stub_spree_preferences(Spree::Config, can_restrict_stock_management: true)
+      end
+
+      let!(:stock_location) { create(:stock_location, name: "location_1") }
+
+      it 'can edit user stock locations' do
+        click_link 'Account'
+
+        check 'user_spree_stock_locations_location_1'
+        click_button 'Update'
+        expect(page).to have_text 'Account updated'
+        expect(find_field('user_spree_stock_locations_location_1')).to be_checked
+      end
+
+      it 'can delete user stock locations' do
+        user_a.stock_locations << Spree::StockLocation.create(name: "dummy")
+        click_link 'Account'
+
+        user_a.stock_locations.each do |location|
+          uncheck "user_spree_stock_locations_#{location.name}"
+        end
+
+        click_button 'Update'
+        expect(page).to have_text 'Account updated'
+        expect(find_field('user_spree_stock_locations_dummy')).not_to be_checked
+        expect(user_a.reload.stock_locations).to be_empty
+      end
+    end
+
     context 'without password permissions' do
       custom_authorization! do |_user|
         cannot [:update_password], Spree.user_class


### PR DESCRIPTION
**Description**
Currently, if using `Spree::UserStockLocation` associations, once a user has an associated stock location, it is impossible to remove all associated stock locations. This is because the template is missing a hidden field for `user[:stock_location_ids]`.

This PR remedies the problem by mirroring the conventions used for the user's roles. It also adds coverage around the expected behavior in the controller, which was missing.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
