### PR TITLE
Make the inventory unit builder configurable

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -486,7 +486,8 @@ module Spree
     end
 
     def create_shipments_for_line_item(line_item)
-      units = Spree::Stock::InventoryUnitBuilder.new(self).missing_units_for_line_item(line_item)
+      units = Spree::Config.stock.inventory_unit_builder_class.new(self).missing_units_for_line_item(line_item)
+
       Spree::Config.stock.coordinator_class.new(self, units).shipments.each do |shipment|
         shipments << shipment
       end

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -24,7 +24,8 @@ module Spree
 
       def initialize(order, inventory_units = nil)
         @order = order
-        @inventory_units = inventory_units || InventoryUnitBuilder.new(order).units
+        @inventory_units =
+          inventory_units || Spree::Config.stock.inventory_unit_builder_class.new(order).units
         @splitters = Spree::Config.environment.stock_splitters
 
         filtered_stock_locations = Spree::Config.stock.location_filter_class.new(Spree::StockLocation.all, @order).filter

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -8,6 +8,7 @@ module Spree
       attr_writer :location_filter_class
       attr_writer :location_sorter_class
       attr_writer :allocator_class
+      attr_writer :inventory_unit_builder_class
 
       def coordinator_class
         @coordinator_class ||= '::Spree::Stock::SimpleCoordinator'
@@ -32,6 +33,11 @@ module Spree
       def allocator_class
         @allocator_class ||= '::Spree::Stock::Allocator::OnHandFirst'
         @allocator_class.constantize
+      end
+
+      def inventory_unit_builder_class
+        @inventory_unit_builder_class ||= '::Spree::Stock::InventoryUnitBuilder'
+        @inventory_unit_builder_class.constantize
       end
     end
   end

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -92,4 +92,26 @@ RSpec.describe Spree::Core::StockConfiguration do
       end
     end
   end
+
+  describe '#inventory_unit_builder_class' do
+    subject { stock_configuration.inventory_unit_builder_class }
+
+    let(:stock_configuration) { described_class.new }
+
+    it "returns Spree::Stock::InventoryUnitBuilder" do
+      is_expected.to be ::Spree::Stock::InventoryUnitBuilder
+    end
+
+    context "with another constant name assigned" do
+      MyInventoryUnitBuilder = Class.new
+
+      before do
+        stock_configuration.inventory_unit_builder_class = MyInventoryUnitBuilder.to_s
+      end
+
+      it "returns the constant" do
+        expect(subject).to be MyInventoryUnitBuilder
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -38,6 +38,14 @@ module Spree
           subject.shipments.count == StockLocation.count
         end
 
+        it 'uses the pluggable inventory unit builder class' do
+          expect(Spree::Config.stock)
+            .to receive(:inventory_unit_builder_class)
+            .and_call_original
+
+          subject.shipments
+        end
+
         context "missing stock items in active stock location" do
           let!(:another_location) { create(:stock_location, propagate_all_variants: false) }
 


### PR DESCRIPTION
**Description**

This adds the inventory unit builder (`Spree::Stock::InventoryUnitBuilder` by default) to the `Spree::Config.stock` configuration, so that it can be overridden.

This is desirable for any store that doesn't have a one-to-one mapping between purchased variants and the fulfilled inventory units. The extension `solidus_product_assembly` heavily overrides this class to accomplish this, so with this change it will be able to stop decorating `Spree::Stock::InventoryUnitBuilder` and instead provide its own.

I'll admit that I'm not a huge fan of how I tested the functionality in the order class, but there's a reason for stubbing the preference like that. `Spree::Config.stock` isn't a normal config object, so it doesn't support our test helpers for stubbing preferences within the context of only a single test.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
