### PR TITLE
Make more stock classes configurable

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -502,7 +502,8 @@ module Spree
     end
 
     def create_shipments_for_line_item(line_item)
-      units = Spree::Stock::InventoryUnitBuilder.new(self).missing_units_for_line_item(line_item)
+      units = Spree::Config.stock.inventory_unit_builder_class.new(self).missing_units_for_line_item(line_item)
+
       Spree::Config.stock.coordinator_class.new(self, units).shipments.each do |shipment|
         shipments << shipment
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -810,8 +810,15 @@ module Spree
     end
 
     def validate_line_item_availability
-      availability_validator = Spree::Stock::AvailabilityValidator.new
-      raise InsufficientStock unless line_items.all? { |line_item| availability_validator.validate(line_item) }
+      availability_validator = Spree::Config.stock.availability_validator_class.new
+
+      # NOTE: This code assumes that the availability validator will return
+      # true for success and false for failure. This is not normally the
+      # behaviour of validators, as the framework only cares about the
+      # population of the errors, not the return value of the validate method.
+      raise InsufficientStock unless line_items.all? { |line_item|
+        availability_validator.validate(line_item)
+      }
     end
 
     def ensure_line_items_present

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -790,9 +790,12 @@ module Spree
 
     def ensure_inventory_units
       if has_checkout_step?("delivery")
-        inventory_validator = Spree::Stock::InventoryValidator.new
+        inventory_validator = Spree::Config.stock.inventory_validator_class.new
 
-        errors = line_items.map { |line_item| inventory_validator.validate(line_item) }.compact
+        errors = line_items.map { |line_item|
+          inventory_validator.validate(line_item)
+        }.compact
+
         raise InsufficientStock if errors.any?
       end
     end

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -24,7 +24,8 @@ module Spree
 
       def initialize(order, inventory_units = nil)
         @order = order
-        @inventory_units = inventory_units || InventoryUnitBuilder.new(order).units
+        @inventory_units =
+          inventory_units || Spree::Config.stock.inventory_unit_builder_class.new(order).units
         @splitters = Spree::Config.environment.stock_splitters
 
         filtered_stock_locations = Spree::Config.stock.location_filter_class.new(Spree::StockLocation.all, @order).filter

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -10,6 +10,7 @@ module Spree
       attr_writer :allocator_class
       attr_writer :inventory_unit_builder_class
       attr_writer :availability_validator_class
+      attr_writer :inventory_validator_class
 
       def coordinator_class
         @coordinator_class ||= '::Spree::Stock::SimpleCoordinator'
@@ -44,6 +45,11 @@ module Spree
       def availability_validator_class
         @availability_validator_class ||= '::Spree::Stock::AvailabilityValidator'
         @availability_validator_class.constantize
+      end
+ 
+      def inventory_validator_class
+        @inventory_validator_class ||= '::Spree::Stock::InventoryValidator'
+        @inventory_validator_class.constantize
       end
     end
   end

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -9,6 +9,7 @@ module Spree
       attr_writer :location_sorter_class
       attr_writer :allocator_class
       attr_writer :inventory_unit_builder_class
+      attr_writer :availability_validator_class
 
       def coordinator_class
         @coordinator_class ||= '::Spree::Stock::SimpleCoordinator'
@@ -38,6 +39,11 @@ module Spree
       def inventory_unit_builder_class
         @inventory_unit_builder_class ||= '::Spree::Stock::InventoryUnitBuilder'
         @inventory_unit_builder_class.constantize
+      end
+
+      def availability_validator_class
+        @availability_validator_class ||= '::Spree::Stock::AvailabilityValidator'
+        @availability_validator_class.constantize
       end
     end
   end

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -8,6 +8,7 @@ module Spree
       attr_writer :location_filter_class
       attr_writer :location_sorter_class
       attr_writer :allocator_class
+      attr_writer :inventory_unit_builder_class
 
       def coordinator_class
         @coordinator_class ||= '::Spree::Stock::SimpleCoordinator'
@@ -32,6 +33,11 @@ module Spree
       def allocator_class
         @allocator_class ||= '::Spree::Stock::Allocator::OnHandFirst'
         @allocator_class.constantize
+      end
+
+      def inventory_unit_builder_class
+        @inventory_unit_builder_class ||= '::Spree::Stock::InventoryUnitBuilder'
+        @inventory_unit_builder_class.constantize
       end
     end
   end

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -125,4 +125,23 @@ RSpec.describe Spree::Core::StockConfiguration do
       Object.send(:remove_const, :MyAvailabilityValidator)
     end
   end
+
+  describe '#inventory_validator_class' do
+    subject { stock_configuration.inventory_validator_class }
+
+    let(:stock_configuration) { described_class.new }
+
+    it "returns Spree::Stock::InventoryValidator" do
+      is_expected.to be ::Spree::Stock::InventoryValidator
+    end
+
+    it "can be reassigned" do
+      MyInventoryValidator = Class.new
+      stock_configuration.inventory_validator_class = MyInventoryValidator.to_s
+
+      expect(subject).to be MyInventoryValidator
+
+      Object.send(:remove_const, :MyInventoryValidator)
+    end
+  end
 end

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -106,4 +106,23 @@ RSpec.describe Spree::Core::StockConfiguration do
       Object.send(:remove_const, :MyInventoryUnitBuilder)
     end
   end
+
+  describe '#availability_validator_class' do
+    subject { stock_configuration.availability_validator_class }
+
+    let(:stock_configuration) { described_class.new }
+
+    it "returns Spree::Stock::AvailabilityValidator" do
+      is_expected.to be ::Spree::Stock::AvailabilityValidator
+    end
+
+    it "can be reassigned" do
+      MyAvailabilityValidator = Class.new
+      stock_configuration.availability_validator_class = MyAvailabilityValidator.to_s
+
+      expect(subject).to be MyAvailabilityValidator
+
+      Object.send(:remove_const, :MyAvailabilityValidator)
+    end
+  end
 end

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -3,93 +3,107 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Core::StockConfiguration do
+  let(:stock_configuration) { described_class.new }
+
   describe '#coordinator_class' do
-    let(:stock_configuration) { described_class.new }
     subject { stock_configuration.coordinator_class }
 
-    it "returns Spree::Stock::Coordinator" do
-      is_expected.to be ::Spree::Stock::SimpleCoordinator
+    it "returns Spree::Stock::Coordinator by default" do
+      expect(subject).to be ::Spree::Stock::SimpleCoordinator
     end
 
-    context "with another constant name assiged" do
+    it "can be reassigned" do
       MyCoordinator = Class.new
-      before { stock_configuration.coordinator_class = MyCoordinator.to_s }
+      stock_configuration.coordinator_class = MyCoordinator.to_s
 
-      it "returns the constant" do
-        is_expected.to be MyCoordinator
-      end
+      expect(subject).to be MyCoordinator
+
+      Object.send(:remove_const, :MyCoordinator)
     end
   end
 
   describe '#estimator_class' do
-    let(:stock_configuration) { described_class.new }
     subject { stock_configuration.estimator_class }
 
     it "returns Spree::Stock::Estimator" do
-      is_expected.to be ::Spree::Stock::Estimator
+      expect(subject).to be ::Spree::Stock::Estimator
     end
 
-    context "with another constant name assiged" do
+    it "can be reassigned" do
       MyEstimator = Class.new
-      before { stock_configuration.estimator_class = MyEstimator.to_s }
+      stock_configuration.estimator_class = MyEstimator.to_s
 
-      it "returns the constant" do
-        is_expected.to be MyEstimator
-      end
+      expect(subject).to be MyEstimator
+
+      Object.send(:remove_const, :MyEstimator)
     end
   end
 
   describe '#location_filter_class' do
-    let(:stock_configuration) { described_class.new }
     subject { stock_configuration.location_filter_class }
 
-    it "returns Spree::Stock::LocationFilter::Active" do
-      is_expected.to be ::Spree::Stock::LocationFilter::Active
+    it "returns Spree::Stock::LocationFilter::Active by default" do
+      expect(subject).to be ::Spree::Stock::LocationFilter::Active
     end
 
-    context "with another constant name assiged" do
+    it "can be reassigned" do
       MyFilter = Class.new
-      before { stock_configuration.location_filter_class = MyFilter.to_s }
+      stock_configuration.location_filter_class = MyFilter.to_s
 
-      it "returns the constant" do
-        is_expected.to be MyFilter
-      end
+      expect(subject).to be MyFilter
+
+      Object.send(:remove_const, :MyFilter)
     end
   end
 
   describe '#location_sorter_class' do
-    let(:stock_configuration) { described_class.new }
     subject { stock_configuration.location_sorter_class }
 
-    it "returns Spree::Stock::LocationSorter::Unsorted" do
-      is_expected.to be ::Spree::Stock::LocationSorter::Unsorted
+    it "returns Spree::Stock::LocationSorter::Unsorted by default" do
+      expect(subject).to be ::Spree::Stock::LocationSorter::Unsorted
     end
 
-    context "with another constant name assiged" do
+    it "can be reassigned" do
       MySorter = Class.new
-      before { stock_configuration.location_sorter_class = MySorter.to_s }
+      stock_configuration.location_sorter_class = MySorter.to_s
 
-      it "returns the constant" do
-        is_expected.to be MySorter
-      end
+      expect(subject).to be MySorter
+
+      Object.send(:remove_const, :MySorter)
     end
   end
 
   describe '#allocator_class' do
-    let(:stock_configuration) { described_class.new }
     subject { stock_configuration.allocator_class }
 
-    it "returns Spree::Stock::Allocator::OnHandFirst" do
-      is_expected.to be ::Spree::Stock::Allocator::OnHandFirst
+    it "returns Spree::Stock::Allocator::OnHandFirst by default" do
+      expect(subject).to be ::Spree::Stock::Allocator::OnHandFirst
     end
 
-    context "with another constant name assiged" do
+    it "can be reassigned" do
       MyAllocator = Class.new
-      before { stock_configuration.allocator_class = MyAllocator.to_s }
+      stock_configuration.allocator_class = MyAllocator.to_s
 
-      it "returns the constant" do
-        is_expected.to be MyAllocator
-      end
+      expect(subject).to be MyAllocator
+
+      Object.send(:remove_const, :MyAllocator)
+    end
+  end
+
+  describe '#inventory_unit_builder_class' do
+    subject { stock_configuration.inventory_unit_builder_class }
+
+    it "returns Spree::Stock::InventoryUnitBuilder by default" do
+      expect(subject).to be ::Spree::Stock::InventoryUnitBuilder
+    end
+
+    it "can be reassigned" do
+      MyInventoryUnitBuilder = Class.new
+      stock_configuration.inventory_unit_builder_class = MyInventoryUnitBuilder.to_s
+
+      expect(subject).to be MyInventoryUnitBuilder
+
+      Object.send(:remove_const, :MyInventoryUnitBuilder)
     end
   end
 end

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyCoordinator
 
+    ensure
       Object.send(:remove_const, :MyCoordinator)
     end
   end
@@ -35,6 +36,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyEstimator
 
+    ensure
       Object.send(:remove_const, :MyEstimator)
     end
   end
@@ -52,6 +54,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyFilter
 
+    ensure
       Object.send(:remove_const, :MyFilter)
     end
   end
@@ -69,6 +72,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MySorter
 
+    ensure
       Object.send(:remove_const, :MySorter)
     end
   end
@@ -86,6 +90,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyAllocator
 
+    ensure
       Object.send(:remove_const, :MyAllocator)
     end
   end
@@ -103,6 +108,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyInventoryUnitBuilder
 
+    ensure
       Object.send(:remove_const, :MyInventoryUnitBuilder)
     end
   end
@@ -122,6 +128,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyAvailabilityValidator
 
+    ensure
       Object.send(:remove_const, :MyAvailabilityValidator)
     end
   end
@@ -141,6 +148,7 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       expect(subject).to be MyInventoryValidator
 
+    ensure
       Object.send(:remove_const, :MyInventoryValidator)
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1701,4 +1701,43 @@ RSpec.describe Spree::Order, type: :model do
       expect(subject).to eq 40
     end
   end
+
+  describe "#validate_line_item_availability" do
+    subject { order.send(:validate_line_item_availability) }
+
+    before do
+      class TestValidator
+        def validate(line_item)
+          if line_item.variant.sku == "UNAVAILABLE"
+            line_item.errors.add(:quantity, ":(")
+            false
+          else
+            true
+          end
+        end
+      end
+
+      test_stock_config = Spree::Core::StockConfiguration.new
+      test_stock_config.availability_validator_class = TestValidator.to_s
+      stub_spree_preferences(stock: test_stock_config)
+    end
+
+    let(:order) { create :order_with_line_items, line_items_count: 2 }
+
+    context "when the line items are valid" do
+      it "doesn't raise an exception" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when the line items are not valid" do
+      before do
+        order.line_items.last.variant.sku = "UNAVAILABLE"
+      end
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(Spree::Order::InsufficientStock)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -38,6 +38,14 @@ module Spree
           subject.shipments.count == StockLocation.count
         end
 
+        it 'uses the pluggable inventory unit builder class' do
+          expect(Spree::Config.stock)
+            .to receive(:inventory_unit_builder_class)
+            .and_call_original
+
+          subject.shipments
+        end
+
         context "missing stock items in active stock location" do
           let!(:another_location) { create(:stock_location, propagate_all_variants: false) }
 

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -230,7 +230,7 @@ module Spree
         flash[:error] = I18n.t('spree.insufficient_stock_for_order')
         redirect_to cart_path
       else
-        availability_validator = Spree::Stock::AvailabilityValidator.new
+        availability_validator = Spree::Config.stock.availability_validator_class.new
         unavailable_items = @order.line_items.reject { |line_item| availability_validator.validate(line_item) }
         if unavailable_items.any?
           item_names = unavailable_items.map(&:name).to_sentence


### PR DESCRIPTION
**Description**

This makes three additional stock classes configurable, so that they can be overridden by extensions like `solidus_product_assembly` or any stores that need similar functionality:

- `Spree::Stock::InventoryUnitBuilder`
- `Spree::Stock::InventoryValidator`
- `Spree::Stock::AvailabilityValidator`

I think there's probably more (breaking) work to be done to improve how this system works and better support the use case of having line items that map to inventory units with different quantities or variants, but this is a good first step.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)

