### PR TITLE
Duplication of gem when execute rails generate solidus:install

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -123,7 +123,10 @@ module Solidus
 
         Would you like to install it? (Y/n)"))
 
-        @plugins_to_be_installed << 'solidus_auth_devise'
+        unless gem list "^solidus_auth_devise$" -i
+          @plugins_to_be_installed << 'solidus_auth_devise'
+        end
+
         @plugin_generators_to_run << 'solidus:auth:install'
       end
     end


### PR DESCRIPTION
**Description**
 This  Pull Request aims to consider gem `solidus_auth_devise` when installed, avoiding duplicity during the `rails generate solidus:install`

  If needed you can reference another PR or issue here, e.g.:
  [Ref #ISSUE](https://github.com/solidusio/solidus/issues/4289)

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
