### PR TITLE
[v3.0] Only install ActiveStorage adapter on supported Rails versions

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails/generators'
+require 'rails/version'
 
 module Solidus
   # @private
@@ -15,7 +16,7 @@ module Solidus
     class_option :migrate, type: :boolean, default: true, banner: 'Run Solidus migrations'
     class_option :seed, type: :boolean, default: true, banner: 'Load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations must be run)'
-    class_option :active_storage, type: :boolean, default: true, banner: 'Install ActiveStorage as image attachments handler for products and taxons'
+    class_option :active_storage, type: :boolean, default: Rails.gem_version >= Gem::Version.new("6.1.0"), banner: 'Install ActiveStorage as image attachments handler for products and taxons'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string


### PR DESCRIPTION
**Description**
We only support the ActiveStorage adapter for Rails >= 6.1,
but we install it for any supported Rails versions by default.

If generating a dummy test app for an extension this leads to
failing test runs, because Solidus quits oif the Rails version
is not Rails 6.1 if using the ActiveStorage adapter.

Solving by installing the ActiveStorage adapter only if the Rails
version is >= 6.1.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
