### PR TITLE
Remove unutilized coffee-rails dependency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ tab_width = 2
 [**.rb]
 max_line_length = 80
 
-[**.js, **.coffee]
+[**.js]
 max_line_length = 120
 
 [*.md]

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,12 +8,7 @@ Backend contains the controllers, views, and assets making up the admin interfac
 
 Can be found in [app/assets/javascripts/spree/backend/](./app/assets/javascripts/spree/backend/)
 
-Our scripts are written in a mix of CoffeeScript and JavaScript (ES5). We can't
-easily use a transpiler for ECMAScript >= 6 without adding additional steps for
-applications using solidus\_admin.
-
-Though we have existing CoffeeScript files, any new files should be in
-JavaScript (ES5).
+Any new files should be in JavaScript (ES5).
 
 ### Stylesheets
 

--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -4,7 +4,6 @@ require 'spree_core'
 require 'spree_api'
 
 require 'jquery-rails'
-require 'coffee-rails'
 require 'sassc-rails'
 require 'handlebars_assets'
 require 'font-awesome-rails'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
-  s.add_dependency 'coffee-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'jbuilder', '~> 2.8'
   s.add_dependency 'jquery-rails'

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -31,7 +31,7 @@ if defined?(DummyApp)
 
     config.suite do |suite|
       suite.use_framework :mocha, "2.3.3"
-      suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
+      suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.js"
       suite.helper = "spec_helper"
       suite.boot_partial = "/boot"
       suite.expand_assets = true

--- a/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/backend/all.js
+++ b/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/backend/all.js
@@ -1,5 +1,5 @@
 // This is a manifest file that'll be compiled into including all the files listed below.
-// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// Add new JavaScript code in separate files in this directory and they'll automatically
 // be included in the compiled file accessible from http://example.com/assets/application.js
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.

--- a/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -1,5 +1,5 @@
 // This is a manifest file that'll be compiled into including all the files listed below.
-// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// Add new JavaScript code in separate files in this directory and they'll automatically
 // be included in the compiled file accessible from http://example.com/assets/application.js
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.

--- a/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/backend/all.js
+++ b/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/backend/all.js
@@ -1,5 +1,5 @@
 // This is a manifest file that'll be compiled into including all the files listed below.
-// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// Add new JavaScript code in separate files in this directory and they'll automatically
 // be included in the compiled file accessible from http://example.com/assets/application.js
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.

--- a/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/frontend/all.js
@@ -1,5 +1,5 @@
 // This is a manifest file that'll be compiled into including all the files listed below.
-// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// Add new JavaScript code in separate files in this directory and they'll automatically
 // be included in the compiled file accessible from http://example.com/assets/application.js
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.


### PR DESCRIPTION
All coffee script has been translated into vanilla javascript and no longer
requires the gem coffee-rails. This PR removes the dependency and
all associated language associated with the utilization of the gem.
Ref #4401 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
