### PR TITLE
Fix option_values nested attributes behavior on the API

### DIFF
--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -7185,10 +7185,6 @@ components:
           type: array
           items:
             type: integer
-        option_values_attributes:
-          type: array
-          items:
-            $ref: '#/components/schemas/option-value-input'
         options:
           type: object
           description: '`Name` will be the name/presentation of the option type and `Value` will be the name/presentation of the option value. They will be created if not exist.'

--- a/api/spec/requests/spree/api/option_types_spec.rb
+++ b/api/spec/requests/spree/api/option_types_spec.rb
@@ -89,6 +89,22 @@ module Spree::Api
         expect(response.status).to eq(201)
       end
 
+      it "can create an option type with nested option values" do
+        post spree.api_option_types_path, params: {
+          option_type: {
+            name: "Option Type",
+            presentation: "Option Type",
+            option_values_attributes: [
+              name: "foo", presentation: "Foo"
+            ]
+          }
+        }
+
+        option_value = Spree::OptionType.find(json_response["id"]).option_values.first
+        expect(option_value).not_to be(nil)
+        expect(option_value.name).to eq("foo")
+      end
+
       it "cannot create an option type with invalid attributes" do
         post spree.api_option_types_path, params: { option_type: {} }
         expect(response.status).to eq(422)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -131,7 +131,7 @@ module Spree
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,
       :position, :track_inventory,
-      :product_id, :product, :option_values_attributes, :price,
+      :product_id, :product, :price,
       :weight, :height, :width, :depth, :sku, :cost_currency, option_value_ids: [], options: [:name, :value]
     ]
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -65,9 +65,9 @@ module Spree
 
     @@line_item_attributes = [:id, :variant_id, :quantity]
 
-    @@option_type_attributes = [:name, :presentation, :option_values_attributes]
-
     @@option_value_attributes = [:name, :presentation]
+
+    @@option_type_attributes = [:name, :presentation, option_values_attributes: option_value_attributes]
 
     @@payment_attributes = [:amount, :payment_method_id, :payment_method]
 


### PR DESCRIPTION
**Description**

Both for option types and variants, `:option_values_attributes` was defined as a plain Symbol. As the [Rails documentation makes clear](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html), nested attributes must be explicitly defined. Otherwise, they default to an empty Hash. On top of that, there's not a nested attributes definition for option values in variants.

We fix it for option types and remove it altogether for variants. Variants already support [`:option_value_ids` array](https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/lib/spree/permitted_attributes.rb#L135), which covers the most common use case (adding option values to an already created variant), so there's no need to provide such a nested hierarchy.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
