### PR TITLE
Fix: common:test_app should change Rails.env to test

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -16,6 +16,7 @@ class CommonRakeTasks
         require ENV['LIB_NAME']
 
         ENV["RAILS_ENV"] = 'test'
+        Rails.env = 'test'
 
         Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
         Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -15,8 +15,7 @@ class CommonRakeTasks
         args.with_defaults(user_class: "Spree::LegacyUser")
         require ENV['LIB_NAME']
 
-        ENV["RAILS_ENV"] = 'test'
-        Rails.env = 'test'
+        force_rails_environment_to_test
 
         Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
         Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
@@ -41,6 +40,11 @@ class CommonRakeTasks
   end
 
   private
+
+  def force_rails_environment_to_test
+    ENV["RAILS_ENV"] = 'test'
+    Rails.env = 'test'
+  end
 
   def extension_installation_generator_exists?
     require "generators/#{generator_namespace}/install/install_generator"


### PR DESCRIPTION
This fixes the following error when running `bundle exec rake` in SolidusPaypalCommercePlatform:

```
An error occurred in a `before(:suite)` hook.
Failure/Error: //= link spree/backend/all.js

Sprockets::FileNotFound:
  couldn't find file 'spree/backend/all.js'
  Checked in these paths:
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/config
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/images
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/stylesheets
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/javascripts
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/stylesheets
```

Cause
-----

`bundle exec rake` executes [`Solidus::InstallGenerator#setup_assets`](https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/lib/generators/solidus/install/install_generator.rb#L81),
which would only install the `all.*` frontend and backend assets if either

* `Spree::Frontend` and `Spree::Backend` are loaded, or
* The Rails environment is test.

Currently, when `bundle exec rake` executes [`common:test_app`](https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/lib/spree/testing_support/common_rake.rb) to build the dummy app, it assigns the `RAILS_ENV` environment variable to `'test'`. However, if `Rails.env` has already been called, for example, in the `require ENV['LIB_NAME']` statement before the `RAILS_ENV` assigment, then `Rails.env` would [retain its value](https://github.com/rails/rails/blob/3872bc0e54d32e8bf3a6299b0bfe173d94b072fc/railties/lib/rails.rb#L72), which would most likely be `'development'`.

Trigger
-------

This bug surfaced after we applied https://github.com/solidusio/solidus/pull/4251 (Fix: solidus:install adds the frontend assets even if the repo does not have `solidus_frontend`).

## Testing

Tested against

* https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/tree/gsmendoza/eng-340-fix-soliduspaypalcommerceplatform-bundle--debug
* https://github.com/gsmendoza/solidus_gdpr/tree/gsmendoza/eng-340-fix-soliduspaypalcommerceplatform-bundle--debug

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- N/A: I have updated Guides and README accordingly to this change (if needed)
- N/A: I have added tests to cover this change (if needed)
- N/A: I have attached screenshots to this PR for visual changes (if needed)
