### PR TITLE
Fix deprecation of active payment methods

### DIFF
--- a/core/lib/tasks/payment_method.rake
+++ b/core/lib/tasks/payment_method.rake
@@ -5,7 +5,7 @@ namespace :payment_method do
   "which happens after switching Payment Service Provider."
   task deactivate_unsupported_payment_methods: :environment do
     Spree::PaymentMethod.pluck(:id, :type).select do |id, type|
-      ActiveSupport::Dependencies.constantize(type)
+      type.constantize
     rescue NameError
       fix_payment_method_record(id, type)
     end


### PR DESCRIPTION
PR #3837 added a rake task to deactivate payment method records that are
no longer valid because of removing a payment method class.

The task iterates over all payment method records and tries to
constantize from its polymorphic type column. When that process returns
a `NameError`, it assumes that the class is no longer present and
proceeds to deactivate the record.

Before this commit, `ActiveSupport::Dependencies.constantize` was used.
However, the method was removed on Rails 7 [1], so our code raised a
`NoMethodError`. As `NoMethodError` is a subclass of `NameError` [2],
the deactivation logic was called for every record.

As Rails recommends, we update the code to use `String#constantize`
instead.

[1] - https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#activesupport-dependencies-private-api-has-been-deleted
[2] - https://ruby-doc.org/core-3.1.0/NoMethodError.html

This fixes CI on master.

cc @luca-landa.