### PR TITLE
Fix delete response in admin users controller

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -121,7 +121,7 @@ module Spree
       # handling raise from Spree::Admin::ResourceController#destroy
       def user_destroy_with_orders_error
         invoke_callbacks(:destroy, :fails)
-        render status: :forbidden, text: t('spree.error_user_destroy_with_orders')
+        render status: :forbidden, plain: t("spree.error_user_destroy_with_orders")
       end
 
       def sign_in_if_change_own_password

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -473,6 +473,35 @@ describe Spree::Admin::UsersController, type: :controller do
     end
   end
 
+  describe "#destroy" do
+    stub_authorization! do |_user|
+      can :manage, Spree.user_class
+    end
+
+    subject do
+      delete :destroy, params: { id: user.id }
+      response
+    end
+
+    context "with user having no orders" do
+      let(:user) { create(:user) }
+
+      it "can be destroyed" do
+        is_expected.to be_redirect
+        expect(flash[:success]).to eq("User has been successfully removed!")
+      end
+    end
+
+    context "with user having orders" do
+      let(:user) { create(:user, :with_orders) }
+
+      it "cannot be destroyed" do
+        is_expected.to be_forbidden
+        expect(subject.body).to eq I18n.t("spree.error_user_destroy_with_orders")
+      end
+    end
+  end
+
   describe "#orders" do
     stub_authorization! do |_user|
       can :manage, Spree.user_class

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -21,6 +21,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_orders do
+      after(:create) do |user, _|
+        create(:order, user: user)
+      end
+    end
+
     factory :admin_user do
       after(:create) do |user, _|
         admin_role = Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')


### PR DESCRIPTION
**Description**

If a user with orders gets deleted in the admin an exception is raised. This exception is handled by the `user_destroy_with_orders_error method`.

This method uses the deprecated (and later removed) `text` response. Instead we need to use `plain`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
