### PR TITLE
Remove N+1 from admin users

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -92,7 +92,7 @@ module Spree
 
         @search = super.ransack(params[:q])
         @collection = @search.result.includes(:spree_roles)
-        @collection = @collection.includes(:spree_orders)
+        @collection = @collection.includes(:orders)
         @collection = @collection.page(params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -89,7 +89,7 @@
           <% if can?(:edit, user) %>
             <%= link_to_edit user, no_text: true, url: spree.admin_user_path(user) %>
           <% end %>
-          <% if can?(:destroy, user) && user.orders.count.zero? %>
+          <% if can?(:destroy, user) && user.orders.none? %>
             <%= link_to_delete user, no_text: true, url: spree.admin_user_path(user) %>
           <% end %>
         </td>


### PR DESCRIPTION
**Description**

First fixing the preloading by using the correct relation name and then remove an explicit query by using a enumerable method to check if a user has orders in the admin users table.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
