### PR TITLE
Add display shipment total before tax

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -204,6 +204,10 @@ module Spree
       line_items.to_a.sum(&:total_before_tax)
     end
 
+    def shipment_total_before_tax
+      shipments.to_a.sum(&:total_before_tax)
+    end
+
     # Sum of all line item amounts pre-tax
     def item_total_excluding_vat
       line_items.to_a.sum(&:total_excluding_vat)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -38,9 +38,18 @@ module Spree
     class CannotRebuildShipments < StandardError; end
 
     extend Spree::DisplayMoney
-    money_methods :outstanding_balance, :item_total, :adjustment_total,
-      :included_tax_total, :additional_tax_total, :tax_total,
-      :shipment_total, :total, :order_total_after_store_credit, :total_available_store_credit
+    money_methods(
+      :outstanding_balance,
+      :item_total,
+      :adjustment_total,
+      :included_tax_total,
+      :additional_tax_total,
+      :tax_total,
+      :shipment_total,
+      :total,
+      :order_total_after_store_credit,
+      :total_available_store_credit
+    )
     alias :display_ship_total :display_shipment_total
 
     checkout_flow do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -48,7 +48,10 @@ module Spree
       :shipment_total,
       :total,
       :order_total_after_store_credit,
-      :total_available_store_credit
+      :total_available_store_credit,
+      :item_total_before_tax,
+      :shipment_total_before_tax,
+      :item_total_excluding_vat
     )
     alias :display_ship_total :display_shipment_total
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1004,6 +1004,7 @@ RSpec.describe Spree::Order, type: :model do
       ]
       # (2*10)-15 + 30-16 = 5 + 14 = 19
       expect(subject.item_total_excluding_vat).to eq 19.0
+      expect(subject.display_item_total_excluding_vat).to eq Spree::Money.new(19)
     end
   end
 
@@ -1019,6 +1020,7 @@ RSpec.describe Spree::Order, type: :model do
       ]
       # (2*10)-2 + 30-3 = 18 + 27 = 14
       expect(subject.item_total_before_tax).to eq 45.0
+      expect(subject.display_item_total_before_tax).to eq Spree::Money.new(45)
     end
   end
 
@@ -1034,6 +1036,7 @@ RSpec.describe Spree::Order, type: :model do
       ]
       # 20-2 + 30-3 = 18 + 27 = 14
       expect(subject.shipment_total_before_tax).to eq 45.0
+      expect(subject.display_shipment_total_before_tax).to eq Spree::Money.new(45)
     end
   end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1022,6 +1022,21 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
+  describe "#shipment_total_before_tax" do
+    it "sums all of the line items totals before tax" do
+      subject.shipments = [
+        Spree::Shipment.new(cost: 20, included_tax_total: 15.0).tap do |li|
+          li.adjustments.build(eligible: true, amount: -2)
+        end,
+        Spree::Shipment.new(cost: 30, included_tax_total: 16.0).tap do |li|
+          li.adjustments.build(eligible: true, amount: -3)
+        end
+      ]
+      # 20-2 + 30-3 = 18 + 27 = 14
+      expect(subject.shipment_total_before_tax).to eq 45.0
+    end
+  end
+
   context "#refund_total" do
     let(:order) { create(:order_with_line_items) }
     let!(:payment) { create(:payment_with_refund, order: order, amount: 5, refund_amount: 3) }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1007,6 +1007,21 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
+  describe "#item_total_before_tax" do
+    it "sums all of the line items totals before tax" do
+      subject.line_items = [
+        Spree::LineItem.new(price: 10, quantity: 2, included_tax_total: 15.0).tap do |li|
+          li.adjustments.build(eligible: true, amount: -2)
+        end,
+        Spree::LineItem.new(price: 30, quantity: 1, included_tax_total: 16.0).tap do |li|
+          li.adjustments.build(eligible: true, amount: -3)
+        end
+      ]
+      # (2*10)-2 + 30-3 = 18 + 27 = 14
+      expect(subject.item_total_before_tax).to eq 45.0
+    end
+  end
+
   context "#refund_total" do
     let(:order) { create(:order_with_line_items) }
     let!(:payment) { create(:payment_with_refund, order: order, amount: 5, refund_amount: 3) }


### PR DESCRIPTION
**Description**

This adds a few `money_methods` to the `Spree::Order` model. I expected these to be there, and they weren't, so I guess it's in everyone's best interest to add them. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
