### PR TITLE
Add Bolt as a Payment Method Option

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -10,6 +10,7 @@ module Solidus
 
     PAYMENT_METHODS = {
       'paypal' => 'solidus_paypal_commerce_platform',
+      'bolt' => 'solidus_bolt',
       'none' => nil,
     }
 


### PR DESCRIPTION
**This PR adds bolt as a payment method option during solidus installation.**
The `install_generator.rb` file has been updated to add `Bolt` as an optional payment method during solidus installation.

The `Bolt` option in the payment method installs the `solidus_bolt` gem.

Ref [solidus_bolt#109](https://github.com/nebulab/solidus_bolt/issues/109)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
