### PR TITLE
Fix Order#tax_address method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -255,7 +255,7 @@ module Spree
         ship_address
       else
         bill_address
-      end || store.default_cart_tax_location
+      end || store&.default_cart_tax_location
     end
 
     def updater

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -467,16 +467,32 @@ RSpec.describe Spree::Order, type: :model do
       context "when tax_using_ship_address is true" do
         let(:tax_using_ship_address) { true }
 
-        it 'returns the stores default cart tax location' do
-          expect(subject).to eq(store.default_cart_tax_location)
+        context "when the order is associated with a store" do
+          it 'returns the stores default cart tax location' do
+            expect(subject).to eq(store.default_cart_tax_location)
+          end
+        end
+
+        context "when the order is not associated with a store" do
+          let(:store) { nil }
+
+          it { is_expected.to be_nil }
         end
       end
 
       context "when tax_using_ship_address is not true" do
         let(:tax_using_ship_address) { false }
 
-        it 'returns the stores default cart tax location' do
-          expect(subject).to eq(store.default_cart_tax_location)
+        context "when the order is associated with a store" do
+          it 'returns the stores default cart tax location' do
+            expect(subject).to eq(store.default_cart_tax_location)
+          end
+        end
+
+        context "when the order is not associated with a store" do
+          let(:store) { nil }
+
+          it { is_expected.to be_nil }
         end
       end
     end


### PR DESCRIPTION
**Description**

Calling `#tax_address` on an order that has no address but also no store associated raises the following error:

    undefined method `default_cart_tax_location' for nil:NilClass

Given that the `store` association is optional, and/or it may not have been already set on the `Spree::Order` instance, we should avoid raising an error.

A simple way to expose the issue is by entering the following command in the rails console:

    Spree::Order.new.tax_address



**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
