### PR TITLE
Skip failing test because of unsupported feature on Rails < 6.1

### DIFF
--- a/core/spec/models/spree/image/preferences_spec.rb
+++ b/core/spec/models/spree/image/preferences_spec.rb
@@ -12,20 +12,22 @@ RSpec.describe Spree::Image, type: :model do
   }
   custom_style_default = :other
 
-  it 'correctly sets the image styles ActiveStorage' do
-    stub_spree_preferences(
-      product_image_styles: custom_styles,
-      product_image_style_default: custom_style_default
-    )
+  if Rails.gem_version >= Gem::Version.new('6.1.0.alpha')
+    it 'correctly sets the image styles ActiveStorage' do
+      stub_spree_preferences(
+        product_image_styles: custom_styles,
+        product_image_style_default: custom_style_default
+      )
 
-    # We make use of a custom class, such that the preferences loaded
-    # are the mocked ones.
-    active_storage_asset = Class.new(Spree::Asset) do
-      include Spree::Image::ActiveStorageAttachment
+      # We make use of a custom class, such that the preferences loaded
+      # are the mocked ones.
+      active_storage_asset = Class.new(Spree::Asset) do
+        include Spree::Image::ActiveStorageAttachment
+      end
+
+      expect(active_storage_asset.attachment_definitions[:attachment][:styles]).to eq(custom_styles)
+      expect(active_storage_asset.attachment_definitions[:attachment][:default_style]).to eq(custom_style_default)
     end
-
-    expect(active_storage_asset.attachment_definitions[:attachment][:styles]).to eq(custom_styles)
-    expect(active_storage_asset.attachment_definitions[:attachment][:default_style]).to eq(custom_style_default)
   end
 
   it 'correctly sets the image styles Paperclip' do


### PR DESCRIPTION
`ActiveStorageAdapter` is only supposed to work on Rails versions
greater than 6.1.

CI was silently failing on Rails 5.2 because of [calling `abort` on our
code](https://github.com/solidusio/solidus/blob/aa77140e8c5b07ab597126ba76524a3931bbb449/core/app/models/concerns/spree/active_storage_adapter.rb#L13).

I'll create a follow-up PR using `raise` instead of `abort`.