### PR TITLE
Fail with `raise` when the storage adapter is not supported

### DIFF
--- a/core/app/models/concerns/spree/active_storage_adapter.rb
+++ b/core/app/models/concerns/spree/active_storage_adapter.rb
@@ -10,7 +10,7 @@ module Spree
     included do
       next if Rails.gem_version >= Gem::Version.new('6.1.0.alpha')
 
-      abort <<~MESSAGE
+      raise <<~MESSAGE
         Configuration Error: Solidus ActiveStorage attachment adpater requires Rails >= 6.1.0.
 
         Spree::Config.image_attachment_module preference is set to #{Spree::Config.image_attachment_module}


### PR DESCRIPTION
When `abort` is raised on a CI test, it's skipped, but it's not counted
as a failure, giving an obscure error result on the corresponding job.

See f1f9ca1a01c46ceaaec9d2ba5d9d7c7982742aa8 for an example.