### PR TITLE
Deprecate Rails 5.2

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -94,6 +94,15 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
   HEREDOC
 end
 
+if Gem::Version.new(Rails.version) < Gem::Version.new('6.0')
+  Spree::Deprecation.warn <<~HEREDOC
+    Rails 5.2 (EOL) is deprecated and will not be supported anymore from the next Solidus version.
+    Please, upgrade to a more recent Rails version.
+    Read more on upgrading from Rails 5.2 to Rails 6.0 here:
+    https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-5-2-to-rails-6-0
+  HEREDOC
+end
+
 require 'spree/core/version'
 
 require 'spree/core/active_merchant_dependencies'


### PR DESCRIPTION
[Rails 5.2 reached EOL](https://guides.rubyonrails.org/maintenance_policy.html) on June 1st, 2022 [1]. We're going to deprecate it
on Solidus v3.2, and remove support on the next major.
