### PR TITLE
Deprecate Ruby 2.5 & Ruby 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Wait for all the gems to be installed (progress can be checked through `docker-c
 You can provide the ruby version you want your image to use:
 
 ```bash
-docker-compose build --build-arg RUBY_VERSION=2.6 app
+docker-compose build --build-arg RUBY_VERSION=2.7 app
 docker-compose up -d
 ```
 

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -85,6 +85,15 @@ module Spree
   end
 end
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
+  Spree::Deprecation.warn <<~HEREDOC
+    Ruby 2.5 & Ruby 2.6 (both EOL) are deprecated and will not be supported anymore from the next Solidus version.
+    Please, upgrade to a more recent Ruby version.
+    Read more on the release notes for different Ruby versions here:
+    https://www.ruby-lang.org/en/downloads/releases/
+  HEREDOC
+end
+
 require 'spree/core/version'
 
 require 'spree/core/active_merchant_dependencies'

--- a/guides/source/developers/getting-started/develop-solidus.html.md
+++ b/guides/source/developers/getting-started/develop-solidus.html.md
@@ -161,7 +161,7 @@ docker-compose logs -f app
 The image can be built with other ruby versions through the `RUBY_VERSION` build argument:
 
 ```bash
-docker-compose build --build-arg RUBY_VERSION=2.6 app
+docker-compose build --build-arg RUBY_VERSION=2.7 app
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Ruby 2.5 [EOL](https://www.ruby-lang.org/en/downloads/branches/) date was 2021-04-05, while it was 2022-04-12 for Ruby 2.6.

We deprecate support and we'll remove it altogether on the next major
version.