### PR TITLE
fix: update_shipped_shipments now cancels properly

### DIFF
--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -112,15 +112,29 @@ class Spree::OrderCancellations
 
   # if any shipments are now fully shipped then mark them as such
   def update_shipped_shipments(inventory_units)
+    shipped_shippments_available_states.reduce({}) do |h,state_name|
+      h.merge({
+        state_name => updateable_shipped_shipments.select { |shipment| all_ius_match_state?(shipment, state_name) }
+      })
+    end.map {|state_name, shipments|} do
+      Spree::Shipment.update_all(shipments, state: state_name, shipped_at: Time.current)
+    end
+  end
+
+  def all_ius_match_state?(shipment, state_name)
+    shipment.inventory_units.all? do |iu|
+      iu.send "#{state_name}?".to_sym
+    end
+  end
+
+  def updateable_shipped_shipments
     shipments = Spree::Shipment.
       includes(:inventory_units).
       where(id: inventory_units.map(&:shipment_id)).
       to_a
+  end
 
-    shipments.each do |shipment|
-      if shipment.inventory_units.all? { |iu| iu.shipped? || iu.canceled? }
-        shipment.update!(state: 'shipped', shipped_at: Time.current)
-      end
-    end
+  def shipped_shippments_available_states
+    %w(shipped canceled)
   end
 end


### PR DESCRIPTION
also refactor method parts for easier overwriting,
in a way that also encourages the use of super for the main method

**Description**
[We](https://github.com/suvie-eng) were having this same issue, and I found the related issue when searching.

This solution may a fait bit more ruby algo gymnastics, but if it's acceptable I think it could make it easier to overwrite this pattern, again while still trying to encourage people to call `super` when overwriting the `update_shipped_shipments` method.  

I also use an `update_all` call, to avoid N+1 queries.

I can include other comments, tests, etc, if this code looks like it'd be acceptable, and if anyone has suggestions.  Until I confirmed receptiveness I didn't want to setup the test env.   This PR is basically WIP, pending feedback.

Ref: https://github.com/solidusio/solidus/issues/2947


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
