### PR TITLE
Allow Symbol as value in serialized preferences column for newly generated apps

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -112,7 +112,7 @@ module Solidus
       end
       application <<~RUBY
         # Allow Symbol as value in serialized preferences column of Solidus models
-        config.active_record.yaml_column_permitted_classes = [Symbol]
+        config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal]
       RUBY
     end
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -110,6 +110,10 @@ module Solidus
     I18n.enforce_available_locales = #{options[:enforce_available_locales]}
         RUBY
       end
+      application <<~RUBY
+        # Allow Symbol as value in serialized preferences column of Solidus models
+        config.active_record.yaml_column_permitted_classes = [Symbol]
+      RUBY
     end
 
     def plugin_install_preparation

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -78,7 +78,7 @@ module Spree
         inject_into_file("config/application.rb", after: /config.generators.system_tests = nil\n/, verbose: true) do
           <<-RUBY
             # Allow Symbol as value in serialized preferences column of Solidus models
-            config.active_record.yaml_column_permitted_classes = [Symbol]
+            config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal]
           RUBY
         end
       end

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -73,6 +73,17 @@ module Spree
       end
     end
 
+    def test_dummy_inject_yaml_safe_load_classes
+      inside dummy_path do
+        inject_into_file("config/application.rb", after: /config.generators.system_tests = nil\n/, verbose: true) do
+          <<-RUBY
+            # Allow Symbol as value in serialized preferences column of Solidus models
+            config.active_record.yaml_column_permitted_classes = [Symbol]
+          RUBY
+        end
+      end
+    end
+
     def test_dummy_clean
       inside dummy_path do
         remove_file ".gitignore"


### PR DESCRIPTION
Fixes an issue with latest Rails update for newly generated apps.

https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017#releases-2

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change

