### PR TITLE
Support code reloading when configuring static preferences sources

### DIFF
--- a/core/lib/spree/preferences/static_model_preferences.rb
+++ b/core/lib/spree/preferences/static_model_preferences.rb
@@ -36,8 +36,6 @@ module Spree
       end
 
       def add(klass, name, preferences)
-        # We use class name instead of class to allow reloading in dev
-        raise "Static model preference '#{name}' on #{klass} is already defined" if @store[klass.to_s][name]
         @store[klass.to_s][name] = Definition.new(klass, preferences)
       end
 

--- a/core/spec/models/spree/preferences/static_model_preferences_spec.rb
+++ b/core/spec/models/spree/preferences/static_model_preferences_spec.rb
@@ -23,6 +23,14 @@ module Spree
       expect(definitions).to have_key('my_definition')
     end
 
+    it "can replace preferences" do
+      subject.add(preference_class, 'my_definition', { color: "red" })
+
+      subject.add(preference_class, 'my_definition', { color: "blue" })
+
+      expect(definitions['my_definition'].fetch(:color)).to eq("blue")
+    end
+
     it "errors assigning invalid preferences" do
       expect {
         subject.add(preference_class, 'my_definition', { ice_cream: 'chocolate' })


### PR DESCRIPTION
This is how [we usually recommend configuring sources](https://github.com/solidusio/solidus_stripe/blob/3fab36511a9d02ebd64d03571704ac5a9031b63b/README.md#usage) for static
preferences:

```ruby
Spree.config do |config|
  config.static_model_preferences.add(
    AmazingStore::AmazingPaymentMethod,
    'amazing_payment_method_credentials',
    credentials: ENV['AMAZING_PAYMENT_METHOD_CREDENTIALS'],
    server: Rails.env.production? ? 'production' : 'test',
    test_mode: !Rails.env.production?
  )
end
```

However, it's no longer possible to directly [reference an autoloadable](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-and-on-each-reload)
class from an initializer.

In this case, we can't change the `#add` method to take the class name
instead. The reason is that it ends up [invoking a sanitization check](https://github.com/solidusio/solidus/blob/df51df62fa9b829216958b21b20514b7a3d87b30/core/lib/spree/preferences/static_model_preferences.rb#L13) on
the given preferences against the defined preferences, and that, of
course, needs access to the actual class.

Therefore, it's better to start recommending nesting the configuration
within a `.to_prepare` block, as they [run every time](https://guides.rubyonrails.org/configuring.html#initialization-events
) the code is
reloaded:

```ruby
Rails.application.config.to_prepare do
  Spree::Config.static_model_preferences.add(
    AmazingStore::AmazingPaymentMethod,
    'amazing_payment_method_credentials',
    credentials: ENV['AMAZING_PAYMENT_METHOD_CREDENTIALS'],
    server: Rails.env.production? ? 'production' : 'test',
    test_mode: !Rails.env.production?
  )
end
```

However, that means running the `#add` method multiple times, so we need
to change it to replace the definition instead of raising an error.

Closes #4070 & #4040