### PR TITLE
Fix stores with no authentication

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -54,6 +54,11 @@ module Spree
           Spree::UserLastUrlStorer.new(self).store_location
         end
 
+        # Auth extensions are expected to define it, otherwise it's a no-op
+        def spree_current_user
+          defined?(super) ? super : nil
+        end
+
         # proxy method to *possible* spree_current_user method
         # Authentication extensions (such as spree_auth_devise) are meant to provide spree_current_user
         def try_spree_current_user

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -18,9 +18,6 @@ RAILS_6_OR_ABOVE = Rails.gem_version >= Gem::Version.new('6.0')
 # @private
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-
-  def spree_current_user
-  end
 end
 
 # @private

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -114,4 +114,27 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       expect(response).to redirect_to('/unauthorized')
     end
   end
+
+  describe "#spree_current_user" do
+    context "when an ancestor defines it" do
+      it "delegates" do
+        controller = Class.new(ApplicationController) do
+          include (Module.new do
+            def spree_current_user
+              :user
+            end
+          end)
+          include Spree::Core::ControllerHelpers::Auth
+        end.new
+
+        expect(controller.spree_current_user).to eq :user
+      end
+    end
+
+    context "when no ancestor defines it" do
+      it "returns nil" do
+        expect(controller.spree_current_user).to eq nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
We deprecated `#try_spree_current_user` in favor of
`#spree_current_user` in #3923. The former defaulted to `nil` when
no authentication library was present, but the latter was simply not
defined under those circumstances.

This commit restores the old behavior, as the code base works with the
assumption that current user is `nil` when no extension has defined it
(see [one example](https://github.com/solidusio/solidus/blob/fee8a860c068b6ad050f9b2ff9052aadf9d56174/backend/app/controllers/spree/admin/base_controller.rb#L36) or [another](https://github.com/solidusio/solidus/blob/fee8a860c068b6ad050f9b2ff9052aadf9d56174/backend/app/controllers/spree/admin/cancellations_controller.rb#L33)).

The issue was [raised in the support channel](https://solidusio.slack.com/archives/C0JBKDF35/p1657030519259159?thread_ts=1657019907.668419&cid=C0JBKDF35
).
