### PR TITLE
Add explicit information about DB_* env variables to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ data already loaded.
   bin/sandbox
   ```
 
-  Depending on your local environment, it may necessary for you to set environment variables for your RDBMS, namely:
+  Depending on your local environment, it may be necessary for you to set environment variables for your RDBMS, namely:
     - `DB_HOST`
     - `DB_USER`
     - `DB_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -307,6 +307,11 @@ data already loaded.
   bin/sandbox
   ```
 
+  Depending on your local environment, it may necessary for you to set environment variables for your RDBMS, namely:
+    - `DB_HOST`
+    - `DB_USER`
+    - `DB_PASSWORD`
+
   If you need to create a Rails 5.2 application for your sandbox, for example
   if you are still using Ruby 2.4 which is not supported by Rails 6, you can
   use the `RAILS_VERSION` environment variable.


### PR DESCRIPTION
## Summary

Just a small change to the README.
It may take some time to figure out what Is the correct name for env variables in some cases, e.g. when the local RDBMS is secured with password access, does not allow root access, etc.

## Checklist

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
