### PR TITLE
Add Bolt as a Payment Method Option (Solidus 3.1)

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -10,6 +10,7 @@ module Solidus
 
     PAYMENT_METHODS = {
       'paypal' => 'solidus_paypal_commerce_platform',
+      'bolt' => 'solidus_bolt',
       'none' => nil,
     }
 


### PR DESCRIPTION
This PR adds bolt as a payment method option during solidus installation.

The `install_generator.rb` file has been updated to add Bolt as an optional payment method during solidus installation.
The Bolt option in the payment method installs the `solidus_bolt` gem.

Ref https://github.com/nebulab/solidus_bolt/issues/109

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
