### PR TITLE
[v2.9] Fix bug in Order#deliver_order_confirmation_email

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -456,8 +456,8 @@ module Spree
         "Spree::MailerSubscriber#order_finalized.",
         caller(1)
 
-      Spree::Config.order_mailer_class.confirm_email(order).deliver_later
-      order.update_column(:confirmation_delivered, true)
+      Spree::Config.order_mailer_class.confirm_email(self).deliver_later
+      update_column(:confirmation_delivered, true)
     end
 
     # Helper methods for checkout steps

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -62,6 +62,19 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
+  describe '#deliver_order_confirmation_mailer' do
+    it 'sends an email' do
+      expect(Spree::Config.order_mailer_class).to receive(:confirm_email).and_call_original
+      order.deliver_order_confirmation_email
+    end
+
+    it 'marks the order as confirmation_delivered' do
+      expect do
+        order.deliver_order_confirmation_email
+      end.to change(order, :confirmation_delivered).to true
+    end
+  end
+
   context '#store' do
     it { is_expected.to respond_to(:store) }
 


### PR DESCRIPTION
## Summary
When this method was re-introduced in solidusio/solidus#3485 with the purpose of adding a deprecation warning, the reintroduced method had a bug where `order` was being called on the order (instead of self).

There is a similar fix applied to `v2.11` here: solidusio/solidus#4339

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the readme to account for my changes.~
