### PR TITLE
Allow to extend user deletion logic

### DIFF
--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -89,7 +89,7 @@
           <% if can?(:edit, user) %>
             <%= link_to_edit user, no_text: true, url: spree.admin_user_path(user) %>
           <% end %>
-          <% if can?(:destroy, user) && user.orders.none? %>
+          <% if can?(:destroy, user) && user.can_be_deleted? %>
             <%= link_to_delete user, no_text: true, url: spree.admin_user_path(user) %>
           <% end %>
         </td>


### PR DESCRIPTION
## Summary

Currently we restrict to delete a user with an exception if
the user has any orders. Some businesses might want to
allow to delete users with incomplete orders.

This allows to override the can_be_deleted? method in the user
class.

Refs #3138

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- [x] I have added automated tests to cover my changes.
