### PR TITLE
Configurable cancelation adjuster

### DIFF
--- a/core/app/models/spree/order_cancellations/cancelled_items_adjuster.rb
+++ b/core/app/models/spree/order_cancellations/cancelled_items_adjuster.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Spree
+  class OrderCancellations
+    class CancelledItemsAdjuster
+      def initialize(order)
+        @order = order
+      end
+
+      def adjust!
+        order.line_items.each do |line_item|
+          line_item.adjustments.select(&:cancellation?).each do |adjustment|
+            adjustment.amount = adjustment.source.compute_amount(adjustment.adjustable)
+            adjustment.update_columns(amount: adjustment.amount )
+          end
+        end
+      end
+
+      private
+
+      attr_reader :order
+    end
+  end
+end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -238,9 +238,7 @@ module Spree
     end
 
     def update_cancellations
-      line_items.each do |line_item|
-        line_item.adjustments.select(&:cancellation?).each(&:recalculate)
-      end
+      Spree::Config.cancelled_items_adjuster.new(order).adjust!
     end
 
     def update_item_totals

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -105,6 +105,11 @@ module Spree
     # adjustment_total) on the item.
     # @return [void]
     def recalculate_adjustments
+      # Cancelations must be applied before promotions and taxes. If you get
+      # your order adjusted because of having ordered merchandise worth X, and
+      # and you then cancel have your order, the promotion should become ineligible.
+      # You should also not be taxes for short-shipped items.
+      update_cancellations
       # Promotion adjustments must be applied first, then tax adjustments.
       # This fits the criteria for VAT tax as outlined here:
       # http://www.hmrc.gov.uk/vat/managing/charging/discounts-etc.htm#1
@@ -113,7 +118,6 @@ module Spree
       update_item_promotions
       update_order_promotions
       update_taxes
-      update_cancellations
       update_item_totals
     end
 

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -34,6 +34,7 @@ class Spree::UnitCancel < Spree::Base
   # This method is used by Adjustment#update to recalculate the cost.
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
-    -line_item.price
+    rest = [line_item.total_before_tax, adjustment&.amount&.abs].compact.sum
+    -([line_item.price, rest].min)
   end
 end

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -34,20 +34,6 @@ class Spree::UnitCancel < Spree::Base
   # This method is used by Adjustment#update to recalculate the cost.
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
-
-    -weighted_line_item_amount(line_item)
-  end
-
-  private
-
-  def weighted_line_item_amount(line_item)
-    quantity_of_line_item = quantity_of_line_item(line_item)
-    raise ZeroDivisionError, "Line Item does not have any inventory units available to cancel" if quantity_of_line_item.zero?
-
-    line_item.total_before_tax / quantity_of_line_item
-  end
-
-  def quantity_of_line_item(line_item)
-    BigDecimal(line_item.inventory_units.not_canceled.reject(&:original_return_item).size)
+    -line_item.price
   end
 end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -426,6 +426,13 @@ module Spree
     #   Spree::OrderCancellations.
     class_name_attribute :order_cancellations_class, default: 'Spree::OrderCancellations'
 
+    # Allows providing your own class for adjusting items with cancellation adjustments
+    #
+    # @!attribute [rw] cancelled_items_adjuster
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::OrderCancellations::CancelledItemsAdjuster.
+    class_name_attribute :cancelled_items_adjuster, default: 'Spree::OrderCancellations::CancelledItemsAdjuster'
+
     # Allows providing your own class for canceling payments.
     #
     # @!attribute [rw] payment_canceller

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.pricing_options_class).to eq Spree::Variant::PriceSelector.pricing_options_class
   end
 
+  it "has a getter for the order cancellations and cancelled items adjuster" do
+    expect(prefs.order_cancellations_class).to eq(Spree::OrderCancellations)
+    expect(prefs.cancelled_items_adjuster).to eq(Spree::OrderCancellations::CancelledItemsAdjuster)
+  end
+
   describe '#stock' do
     subject { prefs.stock }
     it { is_expected.to be_a Spree::Core::StockConfiguration }

--- a/core/spec/models/spree/order_cancellations/cancelled_items_adjuster_spec.rb
+++ b/core/spec/models/spree/order_cancellations/cancelled_items_adjuster_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::OrderCancellations::CancelledItemsAdjuster do
+  let(:order) { create(:order_ready_to_ship) }
+  subject { described_class.new(order).adjust! }
+
+  it "does not change anything on an order without canceled items" do
+    expect { subject }.not_to change { order.line_items.sum(&:total_before_tax) }
+  end
+
+  context "if there is a canceled item" do
+    before do
+      Spree::OrderCancellations.new(order).short_ship([order.inventory_units.first])
+      # manually update the value of the cancellation adjustment
+      order.line_items.first.adjustments.detect(&:cancellation?).update(amount: -2)
+    end
+
+    it "changes the line item's total before tax" do
+      expect { subject }.to change { order.reload.line_items.sum(&:total_before_tax) }
+    end
+  end
+end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Spree::OrderCancellations do
     end
 
     context "when rounding is required" do
-      let(:order) { create(:order_ready_to_ship, line_items_count: 1, line_items_price: 0.83) }
+      let(:order) { create(:order_ready_to_ship, line_items_attributes: [{ price: 0.83 }]) }
       let(:line_item) { order.line_items.to_a.first }
       let(:inventory_unit_1) { line_item.inventory_units[0] }
       let(:inventory_unit_2) { line_item.inventory_units[1] }
@@ -155,10 +155,10 @@ RSpec.describe Spree::OrderCancellations do
       before do
         order.contents.add(line_item.variant)
 
-        # make the total $1.67 so it divides unevenly
+        # make the total $1.65 so it divides unevenly
         line_item.adjustments.create!(
           order: order,
-          amount: 0.01,
+          amount: -0.01,
           label: 'some promo',
           source: promotion_action,
           finalized: true,
@@ -171,9 +171,9 @@ RSpec.describe Spree::OrderCancellations do
         order.cancellations.short_ship([inventory_unit_2])
         expect(line_item.adjustments.map(&:amount)).to match_array(
           [
-            0.01,  # promo adjustment
-            -0.84, # short ship 1
-            -0.83, # short ship 2
+            -0.83, # short ship 1
+            -0.82, # short ship 2
+            -0.01,  # promo adjustment
           ]
         )
         expect(line_item.total).to eq 0

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -38,20 +38,7 @@ RSpec.describe Spree::UnitCancel do
 
     context "all inventory on the line item are not canceled" do
       it "divides the line item total by the inventory units size" do
-        expect(subject).to eq(-5.0)
-      end
-    end
-
-    context "some inventory on the line item is canceled" do
-      before { inventory_unit2.cancel! }
-
-      it "divides the line item total by the uncanceled units size" do
         expect(subject).to eq(-10.0)
-      end
-
-      it "raises an error if dividing by 0" do
-        inventory_unit.cancel!
-        expect { subject }.to raise_error ZeroDivisionError, "Line Item does not have any inventory units available to cancel"
       end
     end
 
@@ -119,7 +106,9 @@ RSpec.describe Spree::UnitCancel do
 
       it 'does not include line item additional taxes' do
         expect(line_item.additional_tax_total).not_to eq 0
-        expect(subject).to eq(-5.0)
+        unit_cancel.adjust!
+        expect(subject).to eq(-10.0)
+        expect(line_item.additional_tax_total).to eq 0
       end
     end
   end


### PR DESCRIPTION
## Summary

While working on the promotion system, I realized that unit cancels use `Spree::Adjustment#recalculate`. This is unfortunate, as that method does not work well for the improved promotions system, but is still used for cancellation adjustments. 

Knowing how taxes work, I was surprised to see that cancellation adjustments are recalculated after taxes are applied. This PR fixes that, and can thus simplify the calculation of the unit cancellation amount significantly: Before taxes, the amount of a cancellation must be simply the line item's price, since an inventory unit always has a quantity of 1. 

Tax adjustments will recalculate regardless of their `finalized` state. I believe this should be the case for cancellation adjustments as well. While it is unlikely that unit cancels change in value, taxes might very well change between order completion and unit cancellation. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the readme to account for my changes.~
