### PR TITLE
Add basic support for order-level taxes

### DIFF
--- a/core/app/models/spree/order_taxation.rb
+++ b/core/app/models/spree/order_taxation.rb
@@ -17,13 +17,15 @@ module Spree
 
     # Apply taxes to the order.
     #
-    # This method will create or update adjustments on all line items and
-    # shipments in the order to reflect the appropriate taxes passed in. It
-    # will also remove any now inapplicable tax adjustments.
+    # This method will create or update adjustments on the order and all line
+    # items and shipments in the order to reflect the appropriate taxes passed
+    # in. It will also remove any now inapplicable tax adjustments.
     #
     # @param [Spree::Tax::OrderTax] taxes the taxes to apply to the order
     # @return [void]
     def apply(taxes)
+      update_adjustments(@order, taxes.order_taxes) if taxes.order_taxes
+
       @order.line_items.each do |item|
         taxed_items = taxes.line_item_taxes.select { |element| element.item_id == item.id }
         update_adjustments(item, taxed_items)
@@ -70,7 +72,7 @@ module Spree
 
       tax_adjustment ||= item.adjustments.new(
         source: tax_item.tax_rate,
-        order_id: item.order_id,
+        order_id: item.is_a?(Spree::Order) ? item.id : item.order_id,
         label: tax_item.label,
         included: tax_item.included_in_price
       )

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -157,10 +157,11 @@ module Spree
       recalculate_adjustments
 
       all_items = line_items + shipments
+      order_tax_adjustments = adjustments.select(&:eligible?).select(&:tax?)
 
       order.adjustment_total = all_items.sum(&:adjustment_total) + adjustments.select(&:eligible?).sum(&:amount)
-      order.included_tax_total = all_items.sum(&:included_tax_total)
-      order.additional_tax_total = all_items.sum(&:additional_tax_total)
+      order.included_tax_total = all_items.sum(&:included_tax_total) + order_tax_adjustments.select(&:included?).sum(&:amount)
+      order.additional_tax_total = all_items.sum(&:additional_tax_total) + order_tax_adjustments.reject(&:included?).sum(&:amount)
 
       order.promo_total = all_items.sum(&:promo_total) + adjustments.select(&:eligible?).select(&:promotion?).sum(&:amount)
 

--- a/core/app/models/spree/tax/item_tax.rb
+++ b/core/app/models/spree/tax/item_tax.rb
@@ -5,9 +5,10 @@ module Spree
     # Simple object used to hold tax data for an item.
     #
     # This generic object will hold the amount of tax that should be applied to
-    # an item. (Either a {Spree::LineItem} or a {Spree::Shipment}.)
+    # an item. (Either a {Spree::Order}, a {Spree::LineItem} or a {Spree::Shipment}.)
     #
-    # @attr_reader [Integer] item_id the {Spree::LineItem} or {Spree::Shipment} ID
+    # @attr_reader [Integer] item_id the {Spree::LineItem} or {Spree::Shipment} ID.
+    #   Or blank if an order-level tax.
     # @attr_reader [String] label information about the taxes
     # @attr_reader [Spree::TaxRate] tax_rate will be used as the source for tax
     #   adjustments

--- a/core/app/models/spree/tax/order_tax.rb
+++ b/core/app/models/spree/tax/order_tax.rb
@@ -8,13 +8,15 @@ module Spree
     # adjustments on an order.
     #
     # @attr_reader [Integer] order_id the {Spree::Order} these taxes apply to
+    # @attr_reader [Array<Spree::Tax::ItemTax>] order_taxes an array of tax
+    #   data for the order
     # @attr_reader [Array<Spree::Tax::ItemTax>] line_item_taxes an array of
     #   tax data for order's line items
     # @attr_reader [Array<Spree::Tax::ItemTax>] shipment_taxes an array of
     #   tax data for the order's shipments
     class OrderTax
       include ActiveModel::Model
-      attr_accessor :order_id, :line_item_taxes, :shipment_taxes
+      attr_accessor :order_id, :order_taxes, :line_item_taxes, :shipment_taxes
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds in some basic support to `Spree::OrderTaxation` for order-level taxes. This should help make it easier for us to support things like the upcoming [Colorado Delivery Fee](https://github.com/solidusio/solidus/discussions/4452).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the readme to account for my changes.~
