### PR TITLE
Support for Colorado Delivery Fee (flat fee and order-level taxes)

### DIFF
--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -19,6 +19,20 @@
               <%= t('spree.included_in_price') %>
             </label>
           </div>
+          <div data-hook="level" class="field">
+            <%= f.label :level, t('spree.tax_rate_level') %>
+            <%= admin_hint t('spree.tax_rate_level'), t(:tax_rate_level, scope: [:spree, :hints, "spree/tax_rate"]) %>
+            <ul>
+              <% Spree::TaxRate.levels.keys.each do |level| %>
+                <li>
+                  <label>
+                    <%= f.radio_button :level, level %>
+                    <%= t("spree.#{level}_level") %>
+                  </label>
+                </li>
+              <% end %>
+            </ul>
+          </div>
         </div>
 
         <div class="col-5">

--- a/core/app/models/spree/calculator/flat_fee.rb
+++ b/core/app/models/spree/calculator/flat_fee.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_dependency 'spree/calculator'
+
+module Spree
+  # Very simple tax rate calculator. Can be used to apply a flat fee to any
+  # type of item, including an order.
+  class Calculator::FlatFee < Calculator
+    alias_method :rate, :calculable
+
+    # Amount is fixed regardles of what it's being applied to.
+    def compute(_object)
+      rate.active? ? rate.amount : 0
+    end
+
+    alias_method :compute_order, :compute
+    alias_method :compute_shipment, :compute
+    alias_method :compute_line_item, :compute
+    alias_method :compute_shipping_rate, :compute
+  end
+end

--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -6,9 +6,9 @@ module Spree
       private
 
       def rates_for_item(item)
-        @rates_for_order ||= Spree::TaxRate.for_address(item.order.tax_address)
+        @rates_for_item ||= Spree::TaxRate.item_level.for_address(item.order.tax_address)
 
-        @rates_for_order.select do |rate|
+        @rates_for_item.select do |rate|
           rate.active? && rate.tax_categories.map(&:id).include?(item.tax_category_id)
         end
       end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -11,6 +11,11 @@ module Spree
     include Spree::CalculatedAdjustments
     include Spree::AdjustmentSource
 
+    enum level: {
+      item: 0,
+      order: 1
+    }, _suffix: true
+
     belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates, optional: true
 
     has_many :tax_rate_tax_categories,

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -123,6 +123,8 @@ module Spree
     end
 
     def translation_key(_amount)
+      return "flat_fee" if calculator.is_a?(Spree::Calculator::FlatFee)
+
       key = included_in_price? ? "vat" : "sales_tax"
       key += "_with_rate" if show_rate_in_label?
       key.to_sym

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1631,6 +1631,7 @@ en:
       spree/tax_category:
         is_default: When checked, this tax category will be selected by default when creating new products or variants.
       spree/tax_rate:
+        tax_rate_level: Item-level taxes will be applied as adjustments on line items and shipments. Order-level taxes will create an adjustment on the order. Care should be taken when chosing order-level adjustments as they aren't considered in refunds or in discounts. The default is item-level.
         validity_period: This determines the validity period within which the tax rate is valid and will be applied to eligible items. <br /> If no start date value is specified, the tax rate will be immediately available. <br /> If no expiration date value is specified, the tax rate will never expire
       spree/variant:
         deleted: Deleted Variant
@@ -1694,6 +1695,7 @@ en:
     iso_name: Iso Name
     item: Item
     item_description: Item Description
+    item_level: Item-level
     item_total: Item Total
     item_total_rule:
       operators:
@@ -1872,6 +1874,7 @@ en:
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information
+    order_level: Order-level
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,
@@ -2289,6 +2292,7 @@ en:
     tax_code: Tax Code
     tax_included: Tax (incl.)
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
+    tax_rate_level: Tax Rate Level
     tax_rates: Tax Rates
     taxon: Taxon
     taxon_attachment_removal_error: There was an error removing the attachment

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -527,6 +527,9 @@ en:
       spree/calculator/distributed_amount:
         one: Distributed Amount
         other: Distributed Amount
+      spree/calculator/flat_fee:
+        one: Flat Fee
+        other: Flat Fee
       spree/calculator/flat_percent_item_total:
         one: Flat Percent
         other: Flat Percent
@@ -1600,7 +1603,7 @@ en:
       spree/calculator:
         promotions: This is used to determine the promotional discount to be applied to an order, an item, or shipping charges.
         shipping_methods: This is used to calculate the shipping rates on a per order or per package rate.
-        tax_rates: This is used to calculate both sales tax (United States-style taxes) and value-added tax (VAT). Typically this calculator should be the only tax calculator required by your store.
+        tax_rates: The "Default Tax" calculator is used for both sales tax (United States-style taxes) and value-added tax (VAT). Typically this calculator should be the only tax calculator required by your store. "Flat Fee" can be used for any taxes that require a flat fee be charged to the customer.
       spree/price:
         country: 'This determines in what country the price is valid.<br/>Default: Any Country'
         master_variant: Changing master variant prices will not change variant prices below, but will be used to populate all new variants

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2294,7 +2294,7 @@ en:
     tax_category: Tax Category
     tax_code: Tax Code
     tax_included: Tax (incl.)
-    tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
+    tax_rate_amount_explanation: When using the "Default Tax" calculator, the amount is treated as a decimal amount to aid in calculations. (i.e. If the tax rate is 5% then enter 0.05) If using the "Flat Fee" calculator, the amount is used for the static fee.
     tax_rate_level: Tax Rate Level
     tax_rates: Tax Rates
     taxon: Taxon

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -816,6 +816,7 @@ en:
       line_item: "%{promotion} (%{promotion_name})"
       order: "%{promotion} (%{promotion_name})"
       tax_rates:
+        flat_fee: "%{name}"
         sales_tax: "%{name}"
         sales_tax_with_rate: "%{name} %{amount}"
         vat: "%{name} (Included in Price)"

--- a/core/db/migrate/20220805202442_add_level_to_spree_tax_rates.rb
+++ b/core/db/migrate/20220805202442_add_level_to_spree_tax_rates.rb
@@ -1,0 +1,5 @@
+class AddLevelToSpreeTaxRates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_tax_rates, :level, :integer, default: 0, null: false
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -645,6 +645,7 @@ module Spree
 
         env.calculators.tax_rates = %w[
           Spree::Calculator::DefaultTax
+          Spree::Calculator::FlatFee
         ]
 
         env.payment_methods = %w[

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -17,6 +17,9 @@ FactoryBot.define do
   factory :default_tax_calculator, class: 'Spree::Calculator::DefaultTax' do
   end
 
+  factory :flat_fee_calculator, class: 'Spree::Calculator::FlatFee' do
+  end
+
   factory :shipping_calculator, class: 'Spree::Calculator::Shipping::FlatRate' do
     preferred_amount { 10.0 }
   end

--- a/core/lib/tasks/colorado_delivery_fee.rake
+++ b/core/lib/tasks/colorado_delivery_fee.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :taxes do
+  desc "Creates all of the records necessary to start collecting the Colorado Delivery Fee"
+  task colorado_delivery_fee: :environment do
+    usa = Spree::Country.find_by!(iso: "US")
+    colorado = usa.states.find_by!(abbr: "CO")
+
+    ActiveRecord::Base.transaction do
+      zone = Spree::Zone.create!(
+        name: "Colorado",
+        description: "State-based zone containing only Colorado.",
+        states: [colorado]
+      )
+
+      calculator = Spree::Calculator::FlatFee.new
+      rate = Spree::TaxRate.create!(
+        name: "Colorado Delivery Fee",
+        calculator: calculator,
+        zone: zone,
+        amount: 0.27,
+        show_rate_in_label: false,
+        level: "order"
+      )
+      rate.tax_categories << Spree::TaxCategory.default if Spree::TaxCategory.default
+    end
+  end
+end

--- a/core/spec/models/spree/calculator/flat_fee_spec.rb
+++ b/core/spec/models/spree/calculator/flat_fee_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "shared_examples/calculator_shared_examples"
+
+RSpec.describe Spree::Calculator::FlatFee, type: :model do
+  let(:tax_rate) { build(:tax_rate, amount: 42) }
+  let(:calculator) { described_class.new(calculable: tax_rate) }
+
+  it_behaves_like "a calculator with a description"
+
+  let(:order) { build(:order) }
+
+  describe "#compute" do
+    subject { calculator.compute(order) }
+
+    context "when the calculator is active" do
+      it { is_expected.to eq 42 }
+    end
+
+    context "when the calculator is inactive" do
+      let(:tax_rate) { build(:tax_rate, expires_at: 2.days.ago) }
+      it { is_expected.to eq 0 }
+    end
+  end
+end

--- a/core/spec/models/spree/tax_calculator/default_spec.rb
+++ b/core/spec/models/spree/tax_calculator/default_spec.rb
@@ -52,5 +52,29 @@ RSpec.describe Spree::TaxCalculator::Default do
     it "has tax information for the shipments" do
       expect(calculated_taxes.shipment_taxes).to be_empty
     end
+
+    context "with a flat order-level fee" do
+      let!(:flat_fee_rate) do
+        FactoryBot.create(
+          :tax_rate,
+          name: "Flat Book Fee",
+          tax_categories: [books_category],
+          calculator: FactoryBot.build(:flat_fee_calculator),
+          zone: new_york_zone,
+          amount: 0.27,
+          show_rate_in_label: false,
+          level: "order"
+        )
+      end
+
+      it "has tax information for the order", aggregate_failures: true do
+        expect(calculated_taxes.order_taxes.count).to eq 1
+
+        order_tax = calculated_taxes.order_taxes.first
+        expect(order_tax.amount).to eq 0.27
+        expect(order_tax.tax_rate).to eq flat_fee_rate
+        expect(order_tax.label).to eq "Flat Book Fee"
+      end
+    end
   end
 end


### PR DESCRIPTION
## ❗ TODO
- [x] Add radio buttons for TaxRate#level enum to admin
- [x] Tweak descriptions for TaxRate#rate and TaxRate#calculator in admin
- [x] Add specs for order-level taxes
- [x] Rake task to automatically generate Colorado Delivery Fee stuff

## Summary
Add support for the new Colorado Delivery Fee. This is achieved by making two small changes to the existing tax system:
1. New `Spree::Calculator::FlatFee` calculator. Can be used to return a fixed amount that comes from an associated `Spree::TaxRate`.
2. `Spree::TaxRate#level` enum to distinguish between item- and order-level tax rates. Item-level taxes remain the default, since we very rarely if ever want to use order-level tax rates.

These changes in additional to the recent work to support order-level taxes in `Spree::OrderTaxation` (#4477), makes it possible to configure a tax rate for the Colorado Delivery Fee.

<img width="1000" alt="Screen Shot 2022-08-05 at 2 18 26 PM" src="https://user-images.githubusercontent.com/876067/183200886-ec65da5e-9d9e-4b7a-a7ce-519b4cea6e84.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [x] ~I have attached screenshots to demo visual changes.~
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [x] ~I have updated the readme to account for my changes.~
