### PR TITLE
Provide support to fix locale selection in admin login page

### DIFF
--- a/backend/app/concerns/spree/admin/sets_user_language_locale_key.rb
+++ b/backend/app/concerns/spree/admin/sets_user_language_locale_key.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Admin
+    module SetsUserLanguageLocaleKey
+      def set_user_language_locale_key
+        :admin_locale
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -12,9 +12,7 @@ module Spree
 
       # Overrides ControllerHelpers::Common
       # We want the admin's locale selection to be different than that on the frontend
-      def set_user_language_locale_key
-        :admin_locale
-      end
+      include SetsUserLanguageLocaleKey
 
       def action
         params[:action].to_sym

--- a/backend/app/controllers/spree/admin/locale_controller.rb
+++ b/backend/app/controllers/spree/admin/locale_controller.rb
@@ -3,6 +3,8 @@
 module Spree
   module Admin
     class LocaleController < Spree::Admin::BaseController
+      skip_before_action :authorize_admin, only: [:set]
+
       def set
         requested_locale = params[:switch_to_locale].to_s.presence
 


### PR DESCRIPTION
## Expected behavior

Given I am running a Solidus app with Solidus I18n (see https://github.com/gsmendoza/rails_7_store/tree/solidus_30253731078c_3_2_0_alpha_solidus_i18n)

And I am in the admin login page

When I change the locale in the locale selector (e.g. to Espanol MX)

Then I should see the locale change on the login page

## Actual behavior

The "Loading" popup window appears but nothing happens.

In the backend, a PUT request is submitted to "/admin/locale/set" but the request is redirected to the login page, e.g.

```
Started PUT "/admin/locale/set" for ::1 at 2022-08-04 17:24:49 +0800
Processing by Spree::Admin::LocaleController#set as JSON
Parameters: {"switch_to_locale"=>"es-MX"}
Redirected to http://localhost:3000/admin/login
Completed 200 OK in 11ms (ActiveRecord: 0.0ms | Allocations: 4703)
```

If you try to log in afterwards, you are redirected to http://localhost:3000/admin/locale/set with the following error:

```
Routing Error: No route matches [GET] "/admin/locale/set"
```

## Causes

1. Non-logged in users are not authorized to change the admin locale.
2. When the language is changed on the admin, SolidusAuthDevise's admin controllers do not react to this, because their `set_user_language_locale_key` is not set to `:admin_locale`.

## Background

https://github.com/solidusio/solidus_auth_devise/pull/224 was submitted to fix the second cause of the bug: `set_user_language_locale_key` not being set to `:admin_locale`. Based on the discussions in the PR, we decided to update Solidus in two ways:

1. Fix the first cause of the bug: Non-logged in users are not authorized to change the admin locale.
2. Extract `SetsUserLanguageLocaleKey` so that https://github.com/solidusio/solidus_auth_devise/pull/224 won't have to refer to `:admin_locale` key directly.

## Fix Demo

Tested manually with this Rails app: https://github.com/gsmendoza/rails_7_store/tree/gsmendoza/eng-436-changing-the-locale-in-the-admin-login.

The Rails app includes this corresponding fix for SolidusAuthDevise: https://github.com/gsmendoza/solidus_auth_devise/tree/gsmendoza/eng-436-changing-the-locale-in-the-admin-login.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the readme to account for my changes.~
