### PR TITLE
Include discarded prices in delete_prices_with_nil_amount task

### DIFF
--- a/core/lib/tasks/solidus/delete_prices_with_nil_amount.rake
+++ b/core/lib/tasks/solidus/delete_prices_with_nil_amount.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 namespace :solidus do
-  desc "Delete Spree::Price records which amount field is NULL"
+  desc "Delete Spree::Price records (including discarded) which amount field is NULL"
   task delete_prices_with_nil_amount: :environment do
-    Spree::Price.where(amount: nil).delete_all
+    Spree::Price.with_discarded.where(amount: nil).delete_all
   end
 end

--- a/core/spec/lib/tasks/solidus/delete_prices_with_nil_amount_spec.rb
+++ b/core/spec/lib/tasks/solidus/delete_prices_with_nil_amount_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe 'solidus' do
 
     it 'removes all prices which amount column is NULL' do
       price = create(:price)
-      expect(Spree::Price).to receive(:where).with(amount: nil).and_return(Spree::Price.where(id: price))
+      with_discarded = instance_double("Spree::Price::ActiveRecord_Relation", where: Spree::Price.where(id: price))
+
+      expect(Spree::Price).to receive(:with_discarded) { with_discarded }
 
       task.invoke
 


### PR DESCRIPTION

## Summary

The task [`delete_prices_with_nil_amount`](https://github.com/solidusio/solidus/blob/master/core/lib/tasks/solidus/delete_prices_with_nil_amount.rake) is currently removing only non-discarded prices. We should remove discarded prices as well, otherwise the migration path from https://github.com/solidusio/solidus/blob/master/CHANGELOG.md#solidus-310-v31-2021-09-10
may fail. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
