### PR TITLE
Switch orders name search to use contains instead of starts with

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -70,8 +70,8 @@
 
             <div class="col-12 col-xl-6">
               <div class="field">
-                <%= label_tag :q_bill_address_name_start, t('spree.name_contains') %>
-                <%= f.text_field :bill_address_name_start, size: 25 %>
+                <%= label_tag :q_bill_address_name_cont, t('spree.name_contains') %>
+                <%= f.text_field :bill_address_name_cont, size: 25 %>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

This updates the bill address name search in the backend orders to use _contains_ instead of _starts_with_. The label for this name field is "Name Contains", which makes the user assume they can search anywhere in the name. This is especially important after the change to relying on one address name field instead of separate first and last (which we finally just got to at my organization).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
~- [ ] I have updated the readme to account for my changes.~
