### PR TITLE
Tweaks for the Solidus installer

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -170,7 +170,7 @@ module Solidus
 
       frontend = detect_frontend_to_install(bundler_context)
 
-      support_solidus_frontend_extraction(bundler_context)
+      support_solidus_frontend_extraction(bundler_context) unless frontend == LEGACY_FRONTEND
 
       say_status :installing, frontend
 

--- a/core/lib/generators/solidus/install/install_generator/bundler_context.rb
+++ b/core/lib/generators/solidus/install/install_generator/bundler_context.rb
@@ -35,13 +35,9 @@ module Solidus
                             ", #{d.requirement.as_list.map(&:dump).join(", ")}"
                           end
 
-            if d.groups != Array(:default)
-              group = d.groups.size == 1 ? ", :group => #{d.groups.first.inspect}" : ", :groups => #{d.groups.inspect}"
-            end
-
             source = ", :source => \"#{d.source.remotes.join(",")}\"" unless is_local || is_git || d.source.nil?
 
-            %(gem #{name}#{requirement}#{group}#{source})
+            %(gem #{name}#{requirement}#{source})
           end.join("\n")
         end
       end
@@ -86,11 +82,9 @@ module Solidus
           "solidus_#{component}",
           solidus_dependency.requirement,
           {
-            "groups" => solidus_dependency.groups,
             "source" => solidus_dependency.source,
             "git" => solidus_dependency.source.try(:uri),
-            "ref" => solidus_dependency.source.try(:ref),
-            "autorequire" => solidus_dependency.autorequire
+            "ref" => solidus_dependency.source.try(:ref)
           }
         )
       end

--- a/core/lib/generators/solidus/install/install_generator/bundler_context.rb
+++ b/core/lib/generators/solidus/install/install_generator/bundler_context.rb
@@ -11,10 +11,11 @@ module Solidus
     #
     # @api private
     class BundlerContext
-      # Write and remove into a Gemfile, supporting the `path: ` option.
+      # Write and remove into and from a Gemfile
       #
-      # This custom injector adds support for path sources, which is missing in
-      # bundler's upstream injector.
+      # This custom injector fixes support for path and custom sources, which is
+      # missing in bundler's upstream injector for a dependency fetched with
+      # `Bundled.locked_gems.dependencies`.
       #
       # @api private
       class InjectorWithPathSupport < Bundler::Injector
@@ -35,7 +36,7 @@ module Solidus
               group = d.groups.size == 1 ? ", :group => #{d.groups.first.inspect}" : ", :groups => #{d.groups.inspect}"
             end
 
-            source = ", :source => \"#{d.source}\"" unless local || d.source.nil?
+            source = ", :source => \"#{d.source.remotes.join(",")}\"" unless local || d.source.nil?
             git = ", :git => \"#{d.git}\"" unless d.git.nil?
             branch = ", :branch => \"#{d.branch}\"" unless d.branch.nil?
 

--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -25,7 +25,7 @@ module Solidus
       def install_solidus_frontend
         unless @bundler_context.component_in_gemfile?(:frontend)
           BundlerContext.bundle_cleanly do
-            `bundle add solidus_frontend --source=https://rubygems.org`
+            `bundle add solidus_frontend`
             `bundle install`
           end
         end


### PR DESCRIPTION
## Summary

We're tweaking the installer with some fixes and optimizations. Please, see the individual commits for better comprehension and review:

- Fix for when a private gem server is used.
- Fix for when a git source is used.
- Remove unhandled groups and autorequire options.
- Do not break down the solidus meta-gem when solidus_frontend is used.
- Do not add `source:` when installing solidus_frontend

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
~- [ ] I have updated the readme to account for my changes.~
