### PR TITLE
Run auth generator when starter frontend installs the gem

### DIFF
--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -38,7 +38,10 @@ module Solidus
 
         # TODO: Move installation of solidus_auth_devise to the
         # solidus_starter_frontend template
-        BundlerContext.bundle_cleanly { `bundle add solidus_auth_devise` } unless auth_present?(installer_adds_auth)
+        unless auth_present?(installer_adds_auth)
+          BundlerContext.bundle_cleanly { `bundle add solidus_auth_devise` }
+          @generator_context.generate('solidus:auth:install --auto-run-migrations')
+        end
         `LOCATION="https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/main/template.rb" bin/rails app:template`
       end
 


### PR DESCRIPTION
## Summary

When the installation of solidus_auth_devise is performed by the
installation of solidus_starter_frontend, we also need to run
solidus_auth_devise' install generator. This responsibility needs to be
eventually moved to the solidus_starter_frontend repository.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the readme to account for my changes.~
