### PR TITLE
Add eligibility check to free shipping action

### DIFF
--- a/core/app/models/spree/promotion/actions/free_shipping.rb
+++ b/core/app/models/spree/promotion/actions/free_shipping.rb
@@ -7,6 +7,7 @@ module Spree
         def perform(payload = {})
           order = payload[:order]
           promotion_code = payload[:promotion_code]
+          return false unless promotion.eligible? order
 
           created_adjustments = order.shipments.map do |shipment|
             next if promotion_credit_exists?(shipment)

--- a/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe Spree::Promotion::Actions::FreeShipping, type: :model do
       end
     end
 
+    context "when given order is ineligible for promotion" do
+      it "does not create any discounts" do
+        allow(promotion).to receive(:eligible?).with(order).and_return false
+
+        expect(action.perform(payload)).to be false
+        expect(promotion.usage_count).to eq(0)
+        expect(order.shipment_adjustments.count).to eq(0)
+        expect(order.shipment_adjustments.map(&:promotion_code)).to eq []
+      end
+    end
+
     context "when a number of the orders shipments already have free shipping" do
       let(:shipments) { order.shipments }
 


### PR DESCRIPTION
## Summary

Ref: #4505 

Prevents free shipping from wrongly being added to orders in some cases