### PR TITLE
Deprecate Spree::Core::Searcher

### DIFF
--- a/core/app/controllers/spree/base_controller.rb
+++ b/core/app/controllers/spree/base_controller.rb
@@ -8,7 +8,10 @@ class Spree::BaseController < ApplicationController
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::PaymentParameters
+
+  # Deprecate with Spree::Core::Search::Base
   include Spree::Core::ControllerHelpers::Search
+
   include Spree::Core::ControllerHelpers::Store
   include Spree::Core::ControllerHelpers::StrongParameters
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -17,7 +17,9 @@
 # a.get :color
 # a.preferred_color
 #
+# Deprecate with Spree::Core::Search::Base
 require "spree/core/search/base"
+#
 require "spree/core/search/variant"
 require 'spree/preferences/configuration'
 require 'spree/core/environment'
@@ -272,6 +274,7 @@ module Spree
     # @!attribute [rw] show_products_without_price
     #   @return [Boolean] Whether products without a price are visible in the frontend (default: +false+)
     preference :show_products_without_price, :boolean, default: false
+    deprecate :show_products_without_price, deprecator: Spree::Deprecation
 
     # @!attribute [rw] show_raw_product_description
     #   @return [Boolean] Don't escape HTML of product descriptions. (default: +false+)
@@ -309,6 +312,7 @@ module Spree
 
     # searcher_class allows spree extension writers to provide their own Search class
     class_name_attribute :searcher_class, default: 'Spree::Core::Search::Base'
+    deprecate :searcher_class, deprecator: Spree::Deprecation
 
     # Allows implementing custom pricing for variants
     # @!attribute [rw] variant_price_selector_class

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -131,7 +131,10 @@ require 'spree/core/controller_helpers/current_host'
 require 'spree/core/controller_helpers/order'
 require 'spree/core/controller_helpers/payment_parameters'
 require 'spree/core/controller_helpers/pricing'
+
+## Deprecate with Spree::Core::Search::Base
 require 'spree/core/controller_helpers/search'
+
 require 'spree/core/controller_helpers/store'
 require 'spree/core/controller_helpers/strong_parameters'
 require 'spree/core/role_configuration'

--- a/core/lib/spree/core/controller_helpers/search.rb
+++ b/core/lib/spree/core/controller_helpers/search.rb
@@ -5,6 +5,12 @@ module Spree
     module ControllerHelpers
       module Search
         def build_searcher(params)
+          Spree::Deprecation.warn(
+            'This module will be moving the to solidus_frontend gem,
+            If you have not already done so, please update to the latest
+            solidus_frontend version which will remove this deprication flag'
+          )
+
           Spree::Config.searcher_class.new(params).tap do |searcher|
             searcher.current_user = spree_current_user
             searcher.pricing_options = current_pricing_options

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -9,6 +9,12 @@ module Spree
         attr_accessor :pricing_options
 
         def initialize(params)
+          Spree::Deprecation.warn(
+            'This class will be moving the to solidus_frontend gem,
+            If you have not already done so, please update to the latest
+            solidus_frontend version which will remove this deprication flag'
+          )
+
           self.pricing_options = Spree::Config.default_pricing_options
           @properties = {}
           prepare(params)

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -4,102 +4,10 @@ require 'rails_helper'
 require 'spree/core/product_filters'
 
 RSpec.describe Spree::Core::Search::Base do
-  include ImageSpecHelper
-  before do
-    include Spree::Core::ProductFilters
-    @taxon = create(:taxon, name: "Ruby on Rails")
+  it 'shows a deprecation warning when initialized' do
+    expect(Spree::Deprecation).to receive(:warn).with(/This class will be moving the to solidus_frontend gem/)
 
-    @product1 = create(:product, name: "RoR Mug", price: 9.00)
-    @product1.taxons << @taxon
-    @product2 = create(:product, name: "RoR Shirt", price: 11.00)
-    @product3 = create(:product, name: "RoR Pants", price: 16.00)
-  end
-
-  it "returns all products by default" do
     params = { per_page: "" }
     searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(3)
-  end
-
-  context "when include_images is included in the initialization params" do
-    let(:params) { { include_images: true, keyword: @product1.name, taxon: @taxon.id } }
-    let(:image_file) { open_image('blank.jpg') }
-    subject { described_class.new(params).retrieve_products }
-
-    before do
-      @product1.master.images.create(attachment_file_name: 'test', attachment: image_file, position: 2)
-      @product1.master.images.create(attachment_file_name: 'test1', attachment: image_file, position: 1)
-      @product1.reload
-    end
-
-    it "returns images in correct order" do
-      expect(subject.first).to eq @product1
-      expect(subject.first.images).to eq @product1.master.images
-    end
-  end
-
-  context "when ascend_by_master_price scope is included in the initialization params" do
-    let(:params) { { search: { ascend_by_master_price: nil } } }
-
-    subject { described_class.new(params).retrieve_products }
-
-    it "returns products in ascending order" do
-      expect(subject.map { |product| product.price.to_i }).to eq [9, 11, 16]
-    end
-  end
-
-  context "when descend_by_master_price scope is included in the initialization params" do
-    let(:params) { { search: { descend_by_master_price: nil } } }
-
-    subject { described_class.new(params).retrieve_products }
-
-    it "returns products in descending order" do
-      expect(subject.map { |product| product.price.to_i }).to eq [16, 11, 9]
-    end
-  end
-
-  it "switches to next page according to the page parameter" do
-    params = { per_page: "2" }
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(2)
-
-    params[:page] = "2"
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(1)
-  end
-
-  it "maps search params to named scopes" do
-    params = { per_page: "",
-               search: { "price_range_any" => ["Under $10.00"] } }
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(1)
-  end
-
-  it "maps multiple price_range_any filters" do
-    params = { per_page: "",
-               search: { "price_range_any" => ["Under $10.00", "$10.00 - $15.00"] } }
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(2)
-  end
-
-  it "uses ransack if scope not found" do
-    params = { per_page: "",
-               search: { "name_not_cont" => "Shirt" } }
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(2)
-  end
-
-  it "accepts a current user" do
-    user = double
-    searcher = Spree::Core::Search::Base.new({})
-    searcher.current_user = user
-    expect(searcher.current_user).to eql(user)
-  end
-
-  it "finds products in alternate currencies" do
-    create(:price, currency: 'EUR', variant: @product1.master)
-    searcher = Spree::Core::Search::Base.new({})
-    searcher.pricing_options = Spree::Config.pricing_options_class.new(currency: 'EUR')
-    expect(searcher.retrieve_products).to eq([@product1])
   end
 end

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Spree::AppConfiguration do
   end
 
   it "uses base searcher class by default" do
+    expect(Spree::Deprecation).to receive(:warn)
     expect(prefs.searcher_class).to eq Spree::Core::Search::Base
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/search_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/search_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Spree::Core::ControllerHelpers::Search, type: :controller do
 
   describe '#build_searcher' do
     it 'returns Spree::Core::Search::Base instance' do
+      expect(Spree::Deprecation).to receive(:warn).exactly(3).times
+
       allow(controller).to receive_messages(
         spree_current_user: create(:user),
         current_pricing_options: Spree::Config.pricing_options_class.new(currency: 'USD')


### PR DESCRIPTION
## Summary
Solidus' Search Base is currently only utilized by the front end. Additionally, eager loading is tuned for the FE implementation. Therefore it would make sense to move the related class, preferences, and module into this gem. This PR is part 2 of 3 steps:

1. [Move related class/preferences/modules to solidus_frontend](https://github.com/solidusio/solidus_frontend/pull/7)
2. [Deprecate Solidus::Core::Search::Base, Solidus::Core::ControllerHelpers::Search, and related preferences on the solidus gem](https://github.com/solidusio/solidus/pull/4527)
3. Remove Solidus::Core::Search::Base, Solidus::Core::ControllerHelpers::Search, and related preferences from solidus

The deprecation warnings are meant to remind users utilizing the solidus_frontend gem just to update it - This deprecation warning would not show for anyone not utilizing the frontend gem. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~~I have attached screenshots to demo visual changes.~~
- [ ] ~~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [ ] ~~I have updated the readme to account for my changes.~~
