### PR TITLE
Update README: update Frontend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Solidus consists of several gems. When you require the `solidus` gem in your
 `Gemfile`, Bundler will install all of the following gems:
 
 - [`solidus_api`](https://github.com/solidusio/solidus/tree/master/api) (RESTful API)
-- [`solidus_frontend`](https://github.com/solidusio/solidus/tree/master/frontend) (Cart and storefront)
 - [`solidus_backend`](https://github.com/solidusio/solidus/tree/master/backend) (Admin area)
 - [`solidus_core`](https://github.com/solidusio/solidus/tree/master/core) (Essential models, mailers, and classes)
 - [`solidus_sample`](https://github.com/solidusio/solidus/tree/master/sample) (Sample data)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Solidus consists of several gems. When you require the `solidus` gem in your
 `Gemfile`, Bundler will install all of the following gems:
 
 - [`solidus_api`](https://github.com/solidusio/solidus/tree/master/api) (RESTful API)
+- [`solidus_frontend`](https://github.com/solidusio/solidus_frontend) (Cart and storefront)
 - [`solidus_backend`](https://github.com/solidusio/solidus/tree/master/backend) (Admin area)
 - [`solidus_core`](https://github.com/solidusio/solidus/tree/master/core) (Essential models, mailers, and classes)
 - [`solidus_sample`](https://github.com/solidusio/solidus/tree/master/sample) (Sample data)


### PR DESCRIPTION
## Summary
The frontend has been removed in #4497 and moved to https://github.com/solidusio/solidus_frontend
Removing the frontend from the list of the default included gems.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [x] I have updated the readme to account for my changes.
