### PR TITLE
Deprecate #redirect_back_or_default

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -41,6 +41,9 @@ module Spree
           session["spree_user_return_to"] = nil
         end
 
+        deprecate redirect_back_or_default: 'Please use redirect_back provided in Rails 5+ or redirect_back_or_to in Rails 7+ instead',
+                  deprecator: Spree::Deprecation
+
         def set_guest_token
           unless cookies.signed[:guest_token].present?
             cookies.permanent.signed[:guest_token] = Spree::Config[:guest_token_cookie_options].merge(

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -26,9 +26,15 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       get :index
       expect(response).to redirect_to('/redirect')
     end
+
     it 'redirects to default page' do
       get :index
       expect(response).to redirect_to('/')
+    end
+
+    it 'is deprecated' do
+      expect(Spree::Deprecation).to receive(:warn)
+      get :index
     end
   end
 


### PR DESCRIPTION
## Summary

Rails introduced [redirect_back](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back) in rails 5+ and [redirect_back_or_to](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back_or_to) in rails 7+. These included rails methods should be utilized in place of #redirect_back_or_default to eliminate redundancy. #redirect_back_or_default is utilized in the following extensions and will be updated as well:

solidus_frontend
solidus_starter_frontend
solidus_auth_devise
solidus_social
solidus_active_shipping
solidus_paypal_marketplace


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~~I have attached screenshots to demo visual changes.~~
- [ ] ~~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [ ] ~~I have updated the readme to account for my changes.~~
