### PR TITLE
Deprecate method #redirect_back_or_default

### DIFF
--- a/core/app/models/spree/user_last_url_storer.rb
+++ b/core/app/models/spree/user_last_url_storer.rb
@@ -26,6 +26,7 @@ module Spree
     #  or its subclasses. The controller will be passed to each rule for matching.
     def initialize(controller)
       @controller = controller
+      Spree::Deprecation.warn("This class will be removed without replacement on the release of Solidus 4.0")
     end
 
     # Stores into session[:spree_user_return_to] the request full path for

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -57,6 +57,11 @@ module Spree
         end
 
         def store_location
+          Spree::Deprecation.warn <<~MSG
+            store_location is being deprecated in solidus 4.0
+            without replacement
+          MSG
+
           Spree::UserLastUrlStorer.new(self).store_location
         end
 

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -37,6 +37,12 @@ module Spree
         end
 
         def redirect_back_or_default(default)
+          Spree::Deprecation.warn <<~MSG
+            'Please use #stored_spree_user_location_or when using solidus_auth_devise.
+            Otherwise, please utilize #redirect_back provided in Rails 5+ or
+            #redirect_back_or_to in Rails 7+ instead'
+          MSG
+
           redirect_to(session["spree_user_return_to"] || default)
           session["spree_user_return_to"] = nil
         end

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
   describe '#store_location' do
     it 'sets session return url' do
       allow(controller).to receive_messages(request: double(fullpath: '/redirect'))
-      controller.store_location
+      Spree::Deprecation.silence { controller.store_location }
       expect(session[:spree_user_return_to]).to eq '/redirect'
     end
   end

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
   describe '#redirect_back_or_default' do
     before do
       def controller.index
-        redirect_back_or_default('/')
+        Spree::Deprecation.silence { redirect_back_or_default('/') }
       end
     end
 
@@ -29,6 +29,11 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     it 'redirects to default page' do
       get :index
       expect(response).to redirect_to('/')
+    end
+
+    it 'is deprecated' do
+      expect(Spree::Deprecation).to receive(:warn)
+      get :index
     end
   end
 

--- a/core/spec/models/spree/user_last_url_storer_spec.rb
+++ b/core/spec/models/spree/user_last_url_storer_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Spree::UserLastUrlStorer do
     described_class.rules.delete('CustomRule')
   end
 
+  it 'is deprecated' do
+    expect(Spree::Deprecation).to receive(:warn)
+    described_class.new(controller)
+  end
+
   describe '::rules' do
     it 'includes default rules' do
       rule = Spree::UserLastUrlStorer::Rules::AuthenticationRule
@@ -43,7 +48,7 @@ RSpec.describe Spree::UserLastUrlStorer do
     context 'when at least one rule matches' do
       it 'does not set the path value into the session' do
         described_class.rules << CustomRule
-        subject.store_location
+        Spree::Deprecation.silence { subject.store_location }
         expect(session[:spree_user_return_to]).to be_nil
       end
     end
@@ -52,7 +57,7 @@ RSpec.describe Spree::UserLastUrlStorer do
       it 'sets the path value into the session' do
         described_class.rules << CustomRule
         described_class.rules.delete('CustomRule')
-        subject.store_location
+        Spree::Deprecation.silence { subject.store_location }
         expect(session[:spree_user_return_to]).to eql fullpath
       end
     end


### PR DESCRIPTION
## Summary

Rails introduced [redirect_back](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back) in rails 5+ and [redirect_back_or_to](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back_or_to) in rails 7+. The naming of Solidus method #redirect_back_or_default lead to some confusion between the two methods and it appeared that it could be replaced by the included Rails methods to eliminate redundancy and simplify the code. After further investigation, the two functions create different results and cannot be used interchangeably. Devise, however, already contains a similar function to #redirect_back_or_default, so the functionality would be best moved to solidus_auth_devise.

This will affect the following gems

solidus_frontend - https://github.com/solidusio/solidus_frontend/pull/9
solidus_starter_frontend - https://github.com/solidusio/solidus_starter_frontend/pull/241
solidus_auth_devise - https://github.com/solidusio/solidus_auth_devise/pull/228
solidus_social - https://github.com/solidusio-contrib/solidus_social/pull/109
solidus_active_shipping - archived, No plans to update
solidus_paypal_marketplace - https://github.com/solidusio-contrib/solidus_paypal_marketplace/pull/103


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~~I have attached screenshots to demo visual changes.~~
- [ ] ~~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [ ] ~~I have updated the readme to account for my changes.~~
