### PR TITLE
Cleanup Gemfile groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
       SOLIDUS_RAISE_DEPRECATIONS: true
       CIRCLE_TEST_REPORTS: /tmp/test-results
       CIRCLE_ARTIFACTS: /tmp/test-artifacts
+      BUNDLE_WITHOUT: "utils"
     docker:
       - image: &image cimg/ruby:2.7-browsers
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,8 @@ commands:
       - store_test_results:
           path: /tmp/test-results
 
-# TODO: Integrate with `setup` when we deprecate support for Rails 6.1 (vips is the default from Rails 7)
+  # TODO: Integrate with `setup` when we deprecate support
+  # for Rails 6.1 (vips is the default from Rails 7)
   libvips:
     steps:
       - run:

--- a/Gemfile
+++ b/Gemfile
@@ -17,16 +17,10 @@ end
 # and https://github.com/rails/sprockets-rails/issues/369
 gem 'sprockets', '~> 3'
 
-if /mysql/.match?(ENV['DB']) || ENV['DB_ALL']
-  gem 'mysql2', '~> 0.5.0', require: false
-end
-if /postgres/.match?(ENV['DB']) || ENV['DB_ALL']
-  gem 'pg', '~> 1.0', require: false
-end
-if ENV['DB_ALL'] || !/mysql|postgres/.match?(ENV['DB'])
-  gem 'sqlite3', require: false
-  gem 'fast_sqlite', require: false
-end
+dbs = ENV['DB_ALL'] ? 'all' : ENV.fetch('DB', 'sqlite')
+gem 'mysql2', '~> 0.5.0', require: false if dbs.match?(/all|mysql/)
+gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
+gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
 
 gem 'database_cleaner', '~> 1.3', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,52 +2,50 @@
 
 source 'https://rubygems.org'
 
-group :backend, :frontend, :core, :api do
-  gemspec require: false
+gemspec require: false
 
-  # rubocop:disable Bundler/DuplicatedGem
-  if ENV['RAILS_VERSION'] == 'master'
-    gem 'rails', github: 'rails', require: false
-  else
-    gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0.2', require: false
+# rubocop:disable Bundler/DuplicatedGem
+if ENV['RAILS_VERSION'] == 'master'
+  gem 'rails', github: 'rails', require: false
+else
+  gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0.2', require: false
+end
+# rubocop:enable Bundler/DuplicatedGem
+
+# Temporarily locking sprockets to v3.x
+# see https://github.com/solidusio/solidus/issues/3374
+# and https://github.com/rails/sprockets-rails/issues/369
+gem 'sprockets', '~> 3'
+
+platforms :ruby do
+  if /mysql/.match?(ENV['DB']) || ENV['DB_ALL']
+    gem 'mysql2', '~> 0.5.0', require: false
   end
-  # rubocop:enable Bundler/DuplicatedGem
-
-  # Temporarily locking sprockets to v3.x
-  # see https://github.com/solidusio/solidus/issues/3374
-  # and https://github.com/rails/sprockets-rails/issues/369
-  gem 'sprockets', '~> 3'
-
-  platforms :ruby do
-    if /mysql/.match?(ENV['DB']) || ENV['DB_ALL']
-      gem 'mysql2', '~> 0.5.0', require: false
-    end
-    if /postgres/.match?(ENV['DB']) || ENV['DB_ALL']
-      gem 'pg', '~> 1.0', require: false
-    end
-    if ENV['DB_ALL'] || !/mysql|postgres/.match?(ENV['DB'])
-      gem 'sqlite3', require: false
-      gem 'fast_sqlite', require: false
-    end
+  if /postgres/.match?(ENV['DB']) || ENV['DB_ALL']
+    gem 'pg', '~> 1.0', require: false
   end
-
-  platforms :jruby do
-    gem 'jruby-openssl', require: false
-    gem 'activerecord-jdbcsqlite3-adapter', require: false
+  if ENV['DB_ALL'] || !/mysql|postgres/.match?(ENV['DB'])
+    gem 'sqlite3', require: false
+    gem 'fast_sqlite', require: false
   end
-
-  gem 'database_cleaner', '~> 1.3', require: false
-  gem 'rspec-activemodel-mocks', '~> 1.1', require: false
-  gem 'rspec-rails', '~> 4.0.1', require: false
-  gem 'simplecov', require: false
-  gem 'rails-controller-testing', require: false
-  gem 'puma', require: false
-
-  # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
-  gem 'factory_bot_rails', '>= 4.8', require: false
 end
 
-group :backend, :frontend do
+platforms :jruby do
+  gem 'jruby-openssl', require: false
+  gem 'activerecord-jdbcsqlite3-adapter', require: false
+end
+
+gem 'database_cleaner', '~> 1.3', require: false
+gem 'rspec-activemodel-mocks', '~> 1.1', require: false
+gem 'rspec-rails', '~> 4.0.1', require: false
+gem 'simplecov', require: false
+gem 'rails-controller-testing', require: false
+gem 'puma', require: false
+
+# Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
+gem 'factory_bot_rails', '>= 4.8', require: false
+
+group :backend do
   # 'net/http' is required by 'capybara/server', triggering
   # a few "already initialized constant" warnings when loaded
   # from default gems. See:
@@ -61,13 +59,8 @@ group :backend, :frontend do
   gem 'capybara-screenshot', '>= 1.0.18', require: false
   gem 'selenium-webdriver', require: false
   gem 'webdrivers', require: false
-end
 
-group :frontend do
-  gem 'generator_spec'
-end
-
-group :backend do
+  # JavaScript testing
   gem 'teaspoon', github: 'jejacks0n/teaspoon', require: false
   gem 'teaspoon-mocha', github: 'jejacks0n/teaspoon', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'rspec-rails', '~> 4.0.1', require: false
 gem 'simplecov', require: false
 gem 'rails-controller-testing', require: false
 gem 'puma', require: false
+gem 'i18n-tasks', '~> 0.9', require: false
 
 # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
 gem 'factory_bot_rails', '>= 4.8', require: false
@@ -68,7 +69,6 @@ end
 group :utils do
   gem 'pry'
   gem 'launchy', require: false
-  gem 'i18n-tasks', '~> 0.9', require: false
   gem 'rubocop', '~> 0.75.0', require: false
   gem 'rubocop-performance', '~> 1.4', require: false
   gem 'rubocop-rails', '~> 2.3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,22 +17,15 @@ end
 # and https://github.com/rails/sprockets-rails/issues/369
 gem 'sprockets', '~> 3'
 
-platforms :ruby do
-  if /mysql/.match?(ENV['DB']) || ENV['DB_ALL']
-    gem 'mysql2', '~> 0.5.0', require: false
-  end
-  if /postgres/.match?(ENV['DB']) || ENV['DB_ALL']
-    gem 'pg', '~> 1.0', require: false
-  end
-  if ENV['DB_ALL'] || !/mysql|postgres/.match?(ENV['DB'])
-    gem 'sqlite3', require: false
-    gem 'fast_sqlite', require: false
-  end
+if /mysql/.match?(ENV['DB']) || ENV['DB_ALL']
+  gem 'mysql2', '~> 0.5.0', require: false
 end
-
-platforms :jruby do
-  gem 'jruby-openssl', require: false
-  gem 'activerecord-jdbcsqlite3-adapter', require: false
+if /postgres/.match?(ENV['DB']) || ENV['DB_ALL']
+  gem 'pg', '~> 1.0', require: false
+end
+if ENV['DB_ALL'] || !/mysql|postgres/.match?(ENV['DB'])
+  gem 'sqlite3', require: false
+  gem 'fast_sqlite', require: false
 end
 
 gem 'database_cleaner', '~> 1.3', require: false

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -14,8 +14,12 @@ DummyApp::RakeTasks.new(
   lib_name: 'solidus_core'
 )
 
-require 'yard'
-YARD::Rake::YardocTask.new
+require 'yard/rake/yardoc_task'
+YARD::Rake::YardocTask.new(:yard)
+# The following workaround can be removed
+# once https://github.com/lsegal/yard/pull/1457 is merged.
+task('yard:require') { require 'yard' }
+task yard: 'yard:require'
 
 namespace :spec do
   task :isolated do


### PR DESCRIPTION
## Summary

The `:frontend` group was still present in the Gemfile, also we can skip a few gems in the CI.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~~I have added automated tests to cover my changes.~~
- [ ] ~~I have attached screenshots to demo visual changes.~~
- [ ] ~~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [ ] ~~I have updated the readme to account for my changes.~~
