### PR TITLE
Use valid jQuery3 methods on ajax calls

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -56,7 +56,7 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
       processData: false,  // tell jQuery not to process the data
       contentType: false,  // tell jQuery not to set contentType
       xhr: function () {
-        var xhr = $.ajaxSettings.xhr();
+        var xhr = $.ajaxSetup.xhr(); // Using default ajax builder but inputting upload settings
         if (xhr.upload) {
           xhr.upload.onprogress = function (event) {
             if (event.lengthComputable) {

--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -67,9 +67,9 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
         }
         return xhr;
       }
-    }).done(function() {
+    }).then(function() {
       that.set({progress: 100})
-    }).error(function(jqXHR, textStatus, errorThrown) {
+    }).catch(function() {
       that.set({serverError: true});
     });
   }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -100,36 +100,29 @@ var ShipmentSplitItemView = Backbone.View.extend({
       variant_id: this.variant.id,
       quantity: quantity
     };
-    var jqXHR;
     if (target_type == 'stock_location') {
       // transfer to a new location
       split_attr.stock_location_id = target_id;
-      jqXHR = Spree.ajax({
-        type: "POST",
-        url: Spree.pathFor('api/shipments/transfer_to_location'),
-        data: split_attr
-      });
     } else if (target_type == 'shipment') {
       // transfer to an existing shipment
       split_attr.target_shipment_number = target_id;
-      jqXHR = Spree.ajax({
-        type: "POST",
-        url: Spree.pathFor('api/shipments/transfer_to_shipment'),
-        data: split_attr
-      });
     } else {
       alert('Please select the split destination.');
       return false;
     }
-    jqXHR.error(function(msg) {
+    Spree.ajax({
+      type: "POST",
+      url: Spree.pathFor('api/shipments/transfer_to_location'),
+      data: split_attr,
+    }).catch(function(msg) {
       alert(Spree.t("split_failed"));
-    }).done(function(response) {
+    }).then(function(response) {
       if (response.success) {
         window.Spree.advanceOrder();
       } else {
         alert(response.message);
-      };
-    });
+      }
+    })
   },
 
   template: HandlebarsTemplates['variants/split'],


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->
After the inclusion of https://github.com/solidusio/solidus/pull/4167, it was discovered that some of the extensions (specifically solidus_product_assembly) specs are failing on master with no changes to the code. It was discovered that after moving to jQuery3, some methods no longer existed including one being utilized in ajax calls for splitting shipments and image uploads.

This PR corrects these issues by updating the deprecated methods to utilize those available in jQuery3.
TODO: Build a test to cover this script.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
