### PR TITLE
Only default to activestorage adapter if Rails version is supported

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -21,6 +21,7 @@ require "spree/core/search/base"
 require "spree/core/search/variant"
 require 'spree/preferences/configuration'
 require 'spree/core/environment'
+require 'spree/rails_compatibility'
 
 module Spree
   class AppConfiguration < Preferences::Configuration
@@ -497,7 +498,7 @@ module Spree
     # @!attribute [rw] image_attachment_module
     # @return [Module] a module that can be included into Spree::Image to allow attachments
     # Enumerable of images adhering to the present_image_class interface
-    class_name_attribute :image_attachment_module, default: 'Spree::Image::ActiveStorageAttachment'
+    class_name_attribute :image_attachment_module, default: Spree::RailsCompatibility.default_image_attachment_module
 
     # @!attribute [rw] allowed_image_mime_types
     #
@@ -555,7 +556,7 @@ module Spree
     # @!attribute [rw] taxon_attachment_module
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface
-    class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::ActiveStorageAttachment'
+    class_name_attribute :taxon_attachment_module, default: Spree::RailsCompatibility.default_taxon_attachment_module
 
     # Configures the absolute path that contains the Solidus engine
     # migrations. This will be checked at app boot to confirm that all Solidus

--- a/core/lib/spree/rails_compatibility.rb
+++ b/core/lib/spree/rails_compatibility.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails/gem_version'
+
 module Spree
   # Supported Rails versions compatibility
   #
@@ -45,6 +47,28 @@ module Spree
         Rails.application.config.i18n.raise_on_missing_translations = value
       else
         Rails.application.config.action_view.raise_on_missing_translations = value
+      end
+    end
+
+    # Set default image attachment adapter
+    #
+    # TODO: Remove when deprecating Rails 6.0
+    def self.default_image_attachment_module
+      if version_gte?("6.1")
+        "Spree::Image::ActiveStorageAttachment"
+      else
+        "Spree::Image::PaperclipAttachment"
+      end
+    end
+
+    # Set default taxon attachment adapter
+    #
+    # TODO: Remove when deprecating Rails 6.0
+    def self.default_taxon_attachment_module
+      if version_gte?("6.1")
+        "Spree::Taxon::ActiveStorageAttachment"
+      else
+        "Spree::Taxon::PaperclipAttachment"
       end
     end
 


### PR DESCRIPTION
## Summary

We only support the activestorage adapter with Rails 6.1 and above,
but we default to it, even if the Rails version is 6.0 and below.
Since we still support Rails 5.2 and 6.0, we cannot default to
the active storage adapter. The app won't boot unless we also
change the adapter in the spree initializer.

If the initializer, though, is nested in a `config.to_prepare` hook
(as recommended from Rails new autoloader zeitwerk [1]) the app
refuses to start anyhow, because the config is then taken from
the `app_configuration` defaults.

[1](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#use-case-1-during-boot-load-reloadable-code)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
