### PR TITLE
[v3.2] Only default to activestorage adapter if Rails version is supported

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -21,6 +21,7 @@ require "spree/core/search/base"
 require "spree/core/search/variant"
 require 'spree/preferences/configuration'
 require 'spree/core/environment'
+require 'spree/rails_compatibility'
 
 module Spree
   class AppConfiguration < Preferences::Configuration
@@ -497,7 +498,7 @@ module Spree
     # @!attribute [rw] image_attachment_module
     # @return [Module] a module that can be included into Spree::Image to allow attachments
     # Enumerable of images adhering to the present_image_class interface
-    class_name_attribute :image_attachment_module, default: 'Spree::Image::ActiveStorageAttachment'
+    class_name_attribute :image_attachment_module, default: Spree::RailsCompatibility.default_image_attachment_module
 
     # @!attribute [rw] allowed_image_mime_types
     #
@@ -555,7 +556,7 @@ module Spree
     # @!attribute [rw] taxon_attachment_module
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface
-    class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::ActiveStorageAttachment'
+    class_name_attribute :taxon_attachment_module, default: Spree::RailsCompatibility.default_taxon_attachment_module
 
     # Configures the absolute path that contains the Solidus engine
     # migrations. This will be checked at app boot to confirm that all Solidus

--- a/core/lib/spree/rails_compatibility.rb
+++ b/core/lib/spree/rails_compatibility.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails/gem_version'
+
 module Spree
   # Supported Rails versions compatibility
   #
@@ -45,6 +47,28 @@ module Spree
         Rails.application.config.i18n.raise_on_missing_translations = value
       else
         Rails.application.config.action_view.raise_on_missing_translations = value
+      end
+    end
+
+    # Set default image attachment adapter
+    #
+    # TODO: Remove when deprecating Rails 6.0
+    def self.default_image_attachment_module
+      if version_gte?("6.1")
+        "Spree::Image::ActiveStorageAttachment"
+      else
+        "Spree::Image::PaperclipAttachment"
+      end
+    end
+
+    # Set default taxon attachment adapter
+    #
+    # TODO: Remove when deprecating Rails 6.0
+    def self.default_taxon_attachment_module
+      if version_gte?("6.1")
+        "Spree::Taxon::ActiveStorageAttachment"
+      else
+        "Spree::Taxon::PaperclipAttachment"
       end
     end
 


### PR DESCRIPTION
Same as #4563 but for v3.2