### PR TITLE
Delegate `--auto-accept` installer option to solidus_frontend

### DIFF
--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -30,7 +30,7 @@ module Solidus
           end
         end
 
-        @generator_context.generate('solidus_frontend:install')
+        @generator_context.generate("solidus_frontend:install #{@generator_context.options[:auto_accept] ? '--auto-accept' : ''}")
       end
 
       def install_solidus_starter_frontend(installer_adds_auth)


### PR DESCRIPTION
## Summary

When Solidus is installed unattended, we also want the solidus_frontend installer to be silent. That's used, for example, in the sandbox application.

References https://github.com/solidusio/solidus_frontend/pull/14.

It's safe to be merged now although the installation will use the released version of solidus_frontend, which doesn't contain the `--auto-accept` option yet. That's because Thor (Rails generators) will ignore unknown options.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
~- [ ] I have updated the readme to account for my changes.~
