### PR TITLE
Remove link to unmaintained docker demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,18 +88,6 @@ You can also try out Solidus with one-click on Heroku:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/solidusio/solidus-example-app)
 
-Additionally, you can use Docker to run a demo on your local machine. Run the
-following command to download the image and run it at
-[http://localhost:3000](http://localhost:3000).
-
-```
-docker run --rm -it -p 3000:3000 solidusio/solidus-demo:latest
-```
-
-The admin interface can be accessed at
-[http://localhost:3000/admin/](http://localhost:3000/admin/), the default
-credentials are `admin@example.com` and `test123`.
-
 ## Getting started
 
 Begin by making sure you have


### PR DESCRIPTION
## Summary

We already have https://demo.solidus.io for a visual presentation, and
the development environment is dockerized. We don't want to spend time
maintaining it.

Closes #3944 & #4631

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [x] I have updated the readme to account for my changes.
