### PR TITLE
Promote orders with any `promotionable?` line-item

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -264,7 +264,8 @@ module Spree
       when Spree::LineItem
         !promotable.variant.product.promotionable?
       when Spree::Order
-        promotable.line_items.any? { |line_item| !line_item.variant.product.promotionable? }
+        promotable.line_items.present? &&
+          promotable.line_items.none? { |line_item| line_item.variant.product.promotionable? }
       end
     end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -693,12 +693,12 @@ RSpec.describe Spree::Promotion, type: :model do
         let!(:line_item) { create(:line_item) }
         let!(:line_item2) { create(:line_item) }
 
-        context "and at least one item is non-promotionable" do
+        context "and at least one item is promotionable" do
           before do
             line_item.variant.product.promotionable = false
           end
 
-          it { is_expected.to be false }
+          it { is_expected.to be true }
         end
 
         context "and the items are all non-promotionable" do
@@ -708,10 +708,6 @@ RSpec.describe Spree::Promotion, type: :model do
           end
 
           it { is_expected.to be false }
-        end
-
-        context "and at least one item is promotionable" do
-          it { is_expected.to be true }
         end
       end
     end


### PR DESCRIPTION
**Description**

Promote orders with any `promotionable?` line-item

The current behaviour seems incorrect, and also, there is a spec which is not clear about what the behaviour should be as the setup does not align with the test name.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
