### PR TITLE
Fix the dummy app usage of the generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,16 @@ jobs:
       - install_solidus:
           flags: "--sample=false --frontend=solidus_starter_frontend"
           home_page_text: "The only eCommerce platform you’ll ever need."
+      - run:
+          name: "rake task: extensions:test_app"
+          command: |
+            mkdir -p /tmp/dummy_extension
+            cd /tmp/dummy_extension
+            bundle init
+            bundle add rails sqlite3 --skip-install
+            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+            export LIB_NAME=set # dummy requireable file
+            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
 
   postgres:
     executor: postgres

--- a/core/lib/generators/solidus/install/frontend_templates/solidus_frontend.rb
+++ b/core/lib/generators/solidus/install/frontend_templates/solidus_frontend.rb
@@ -1,7 +1,12 @@
 solidus = Bundler.locked_gems.dependencies['solidus']
 
-# `solidus_frontend` is not sourced from rubygems if the solidus gem was not.
-github_solidus_frontend = '--github solidusio/solidus_frontend' unless solidus.nil? || solidus.source.is_a?(Bundler::Source::Rubygems)
+if Bundler.locked_gems.dependencies['solidus_frontend']
+  say_status :skipping, "solidus_frontend is already in the bundle", :blue
+else
+  # `solidus_frontend` is not sourced from rubygems if the solidus gem was not.
+  github_solidus_frontend = '--github solidusio/solidus_frontend' unless solidus.nil? || solidus.source.is_a?(Bundler::Source::Rubygems)
 
-bundle_command("add solidus_frontend #{github_solidus_frontend}")
+  bundle_command("add solidus_frontend #{github_solidus_frontend}")
+end
+
 generate 'solidus_frontend:install'

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -168,7 +168,7 @@ module Solidus
     end
 
     def install_routes
-      if Rails.root.join('config', 'routes.rb').read.include? CORE_MOUNT_ROUTE
+      if Pathname(app_path).join('config', 'routes.rb').read.include? CORE_MOUNT_ROUTE
         say_status :route_exist, CORE_MOUNT_ROUTE, :blue
       else
         route <<~RUBY

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -42,6 +42,10 @@ module Solidus
       paths.flatten
     end
 
+    def self.exit_on_failure?
+      true
+    end
+
     def prepare_options
       @run_migrations = options[:migrate]
       @load_seed_data = options[:seed]

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -9,12 +9,15 @@ class CommonRakeTasks
     namespace :common do
       task :test_app, :user_class do |_t, args|
         args.with_defaults(user_class: "Spree::LegacyUser")
-        require ENV['LIB_NAME']
+        lib_name = ENV['LIB_NAME'] or
+          raise "Please provide a library name via the LIB_NAME environment variable."
+
+        require lib_name
 
         force_rails_environment_to_test
 
         Spree::DummyGenerator.start [
-          "--lib-name=#{ENV['LIB_NAME']}",
+          "--lib-name=#{lib_name}",
           "--quiet",
         ]
 
@@ -28,7 +31,7 @@ class CommonRakeTasks
           'generate',
           'solidus:install',
           Dir.pwd, # use the current dir as Rails.root
-          "--lib-name=#{ENV['LIB_NAME']}",
+          "--lib-name=#{lib_name}",
           "--auto-accept",
           "--with-authentication=false",
           "--payment-method=none",

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -34,7 +34,6 @@ class CommonRakeTasks
           "--lib-name=#{lib_name}",
           "--auto-accept",
           "--with-authentication=false",
-          "--payment-method=none",
           "--migrate=false",
           "--seed=false",
           "--sample=false",

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -25,7 +25,7 @@ class CommonRakeTasks
         # within ruby is changed to that of the dummy app.
         sh({
           'SKIP_SOLIDUS_BOLT' => '1',
-          'FRONTEND' => 'solidus_frontend',
+          'FRONTEND' => ENV['FRONTEND'] || 'solidus_frontend',
         }, [
           'bin/rails',
           'generate',

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-unless defined?(Solidus::InstallGenerator)
-  require 'generators/solidus/install/install_generator'
-end
-
 require 'generators/spree/dummy/dummy_generator'
 
 class CommonRakeTasks
@@ -17,8 +13,31 @@ class CommonRakeTasks
 
         force_rails_environment_to_test
 
-        Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-        Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+        Spree::DummyGenerator.start [
+          "--lib-name=#{ENV['LIB_NAME']}",
+          "--quiet",
+        ]
+
+        # While the dummy app is generated the current directory
+        # within ruby is changed to that of the dummy app.
+        sh({
+          'SKIP_SOLIDUS_BOLT' => '1',
+          'FRONTEND' => 'solidus_frontend',
+        }, [
+          'bin/rails',
+          'generate',
+          'solidus:install',
+          Dir.pwd, # use the current dir as Rails.root
+          "--lib-name=#{ENV['LIB_NAME']}",
+          "--auto-accept",
+          "--with-authentication=false",
+          "--payment-method=none",
+          "--migrate=false",
+          "--seed=false",
+          "--sample=false",
+          "--user-class=#{args[:user_class]}",
+          "--quiet",
+        ].shelljoin)
 
         puts "Setting up dummy database..."
 


### PR DESCRIPTION
## Summary

Currently the installer generator relies on `Rails.root` which is not available when running it on the dummy app from extensions. 

- CI coverage was added
- It skips solidus_bolt
- Uses solidus_frontend by default, can be overridden setting `ENV['FRONTEND']`
- Sets the generator to `exit(false)` if an error occurs while running it

Example of a broken CI from one extension: https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_paypal_commerce_platform/545/workflows/05ea9623-3caa-45bb-9724-99ad3ca91dfe/jobs/1417

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
