### PR TITLE
Test Solidus on Ruby 3.0 and 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,22 @@ executors:
     docker:
       - image: *image
 
+  ruby30:
+    working_directory: *workdir
+    environment:
+      <<: *environment
+      DB: sqlite
+    docker:
+      - image: cimg/ruby:3.0-browsers
+
+  ruby31:
+    working_directory: *workdir
+    environment:
+      <<: *environment
+      DB: sqlite
+    docker:
+      - image: cimg/ruby:3.1-browsers
+
 commands:
   setup:
     steps:
@@ -263,6 +279,26 @@ jobs:
       - setup
       - test
 
+  ruby30:
+    executor: ruby30
+    parallelism: *parallelism
+    environment:
+      RAILS_VERSION: '>= 7.0.1'
+      DISABLE_ACTIVE_STORAGE: true
+    steps:
+      - setup
+      - test
+
+  ruby31:
+    executor: ruby31
+    parallelism: *parallelism
+    environment:
+      RAILS_VERSION: '>= 7.0.1'
+      DISABLE_ACTIVE_STORAGE: true
+    steps:
+      - setup
+      - test
+
 workflows:
   build:
     jobs:
@@ -275,5 +311,7 @@ workflows:
       - postgres_rails61
       - postgres_rails60
       - postgres_rails52
+      - ruby30
+      - ruby31
       - legacy_events
       - solidus_installer


### PR DESCRIPTION
## Summary
Adds CircleCI jobs that test Solidus on Ruby 3.0 and 3.1 with Rails 7.0

Solidus is currently supporting the latest releases of Ruby and Rails so it should be tested on these builds along with other supported versions.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
