### PR TITLE
Paginate variant autocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -32,7 +32,8 @@
         data: function(term, page) {
           var searchData = {
             variant_search_term: term,
-            token: Spree.api_key
+            token: Spree.api_key,
+            page: page
           };
           return _.extend(searchData, searchOptions);
         },
@@ -40,7 +41,8 @@
         results: function(data, page) {
           window.variants = data["variants"];
           return {
-            results: data["variants"]
+            results: data["variants"],
+            more: data.current_page * data.per_page < data.total_count
           };
         }
       },

--- a/backend/vendor/assets/stylesheets/solidus_admin/select2.scss
+++ b/backend/vendor/assets/stylesheets/solidus_admin/select2.scss
@@ -439,7 +439,7 @@ disabled look for disabled choices in the results dropdown
 }
 
 .select2-more-results.select2-active {
-    background: #f4f4f4 image-url('solidus_admin/select2-spinner.gif') no-repeat 100%;
+    background: #f4f4f4 image-url('solidus_admin/select2-spinner.gif') no-repeat 95% center;
 }
 
 .select2-results .select2-ajax-error {
@@ -449,6 +449,7 @@ disabled look for disabled choices in the results dropdown
 .select2-more-results {
     background: #f4f4f4;
     display: list-item;
+    padding: 0.5em 1em
 }
 
 /* disabled styles */


### PR DESCRIPTION
## Summary

The variants API paginates results, but we never enabled the select2 "load more" feature in the variant autocomplete.

---

Also formatted the select2 "load more" indicator for some visual pleasure.

<img width="" alt="Spotify Premium 2022-10-06 14-57-36" src="https://user-images.githubusercontent.com/42868/194319098-a1cc9fdc-de76-41b4-8701-54bb0c0d44a3.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
