### PR TITLE
Test matrix of ruby/rails versions on different Databases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,15 +60,19 @@ commands:
       - checkout
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      - run: |
-          gem install bundler -v"~> 2.1" --conservative
-          bundle lock
+      - run:
+          name: "Lock dependencies"
+          command: |
+            sudo gem update --system
+            gem install bundler -v"~> 2.3" --conservative
+            bundle lock
+            ruby -v > .ruby-version
       - restore_cache:
           keys:
-            - solidus-gems-v3-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - solidus-gems-v3-{{ .Branch }}
-            - solidus-gems-v3-master
-            - solidus-gems-v3
+            - solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}
+            - solidus-gems-v3-{{checksum ".ruby-version"}}-master
+            - solidus-gems-v3-{{checksum ".ruby-version"}}
 
       - run: |
           bundle config set path 'vendor/bundle'
@@ -76,7 +80,7 @@ commands:
           bundle clean
 
       - save_cache:
-          key: solidus-gems-v3-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ orbs:
 
 executors:
   base:
+    parameters: &parameters
+      ruby:
+        type: string
+        default: "2.7"
     working_directory: &workdir ~/solidus
     environment: &environment
       DEFAULT_MAX_WAIT_TIME: 10
@@ -14,9 +18,10 @@ executors:
       CIRCLE_ARTIFACTS: /tmp/test-artifacts
       BUNDLE_WITHOUT: "utils"
     docker:
-      - image: &image cimg/ruby:2.7-browsers
+      - image: &image cimg/ruby:<< parameters.ruby >>-browsers
 
   postgres:
+    parameters: *parameters
     working_directory: *workdir
     environment:
       <<: *environment
@@ -29,6 +34,7 @@ executors:
           POSTGRES_USER: root
 
   mysql:
+    parameters: *parameters
     working_directory: *workdir
     environment:
       <<: *environment
@@ -40,6 +46,7 @@ executors:
       - image: cimg/mysql:5.7
 
   sqlite:
+    parameters: *parameters
     working_directory: *workdir
     environment:
       <<: *environment
@@ -219,83 +226,71 @@ jobs:
             export LIB_NAME=set # dummy requireable file
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
 
-  postgres:
-    executor: postgres
+  test_solidus:
+    parameters:
+      database:
+        type: string
+        default: postgres
+      ruby:
+        type: string
+        default: '3.1'
+      rails:
+        type: string
+        default: "7.0"
+      paperclip:
+        type: boolean
+        default: true
+      legacy:
+        type: string
+        default: "0"
+    executor:
+      name: << parameters.database >>
+      ruby: << parameters.ruby >>
+    parallelism: &parallelism 3
+    environment:
+      DISABLE_ACTIVE_STORAGE: << parameters.paperclip >>
+      RAILS_VERSION: "~> << parameters.rails >>"
+      USE_LEGACY_EVENTS: << parameters.legacy >>
+    steps:
+      - setup
+      - libvips
+      - test
+
+  test_with_coverage:
+    parameters:
+      database:
+        type: string
+        default: postgres
+      ruby:
+        type: string
+        default: '3.1'
+    executor:
+      name: << parameters.database >>
+      ruby: << parameters.ruby >>
     parallelism: &parallelism 3
     environment:
       COVERAGE: 'true'
       COVERAGE_DIR: /tmp/coverage
+      DISABLE_ACTIVE_STORAGE: false
     steps:
       - setup
       - libvips
       - test_with_coverage
 
-  legacy_events:
-    executor: postgres
-    parallelism: &parallelism
-    environment:
-      USE_LEGACY_EVENTS: '1'
-    steps:
-      - setup
-      - libvips
-      - test
-
-  mysql:
-    executor: mysql
-    parallelism: *parallelism
-    steps:
-      - setup
-      - libvips
-      - test
-
-  postgres_rails61:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 6.1.0'
-    steps:
-      - setup
-      - test
-
-  sqlite:
-    executor: sqlite
-    parallelism: *parallelism
-    steps:
-      - setup
-      - libvips
-      - test
-
-  postgres_rails60:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 6.0.0'
-      DISABLE_ACTIVE_STORAGE: true
-    steps:
-      - setup
-      - test
-
-  postgres_rails52:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 5.2.0'
-      DISABLE_ACTIVE_STORAGE: true
-    steps:
-      - setup
-      - test
-
 workflows:
   build:
     jobs:
-      - postgres:
+      - test_with_coverage:
           post-steps:
             - codecov/upload:
                 file: $COVERAGE_FILE
-      - mysql
-      - sqlite
-      - postgres_rails61
-      - postgres_rails60
-      - postgres_rails52
-      - legacy_events
+      - test_solidus:
+          name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
+          matrix: { parameters: { rails: ['7.0'], ruby: ['3.0', '3.1'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false] } }
+      - test_solidus:
+          name: *name
+          matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0'], database: ['sqlite'], paperclip: [false] } }
+      - test_solidus:
+          name: *name
+          matrix: { parameters: { rails: ['5.2', '6.0'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true] } }
       - solidus_installer

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,16 @@ group :backend do
     gem 'net-http', require: false
   end
 
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
+    # Need to explicitly declare gems when using ruby 3.0 with older versions of rails. Can be removed when mail 2.8.0 is released.
+    # - https://bugs.ruby-lang.org/issues/17873
+    # - https://stackoverflow.com/a/72474475
+    gem 'net-smtp', require: false
+    gem 'net-imap', require: false
+    gem 'net-pop', require: false
+  end
+
   gem 'capybara', '~> 3.13', require: false
   gem 'capybara-screenshot', '>= 1.0.18', require: false
   gem 'selenium-webdriver', require: false


### PR DESCRIPTION
## Summary

_Continuing from #4652, most of the work done by @cpfergus1, I'm just taking this through the finish line_

- parameterize the main job
- add matrixes to better cover what we officially support
- try to be efficient and avoid combinatorial explosion (i.e. skip combos sufficiently covered by other jobs)
- this doesn't consider ruby versions older than 2.7 although the gemspec allows installing solidus with 2.5

Probably @solidusio/core-team should decide on how to interpret semver with regards to EOL dependencies such as Ruby and Rails, my suggestion would be to automatically drop support for versions that are no longer maintained.

Open to suggestions on how to streamline the matrixes 👂 

_ℹ️ The higher amount of runs increases the chance to incur into a flakey, this is not a fault of more coverage per-se but something to be aware of, and possibly motivation to fix them_

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
