### PR TITLE
Apply store credits before creating payments

### DIFF
--- a/core/lib/spree/core/controller_helpers/payment_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/payment_parameters.rb
@@ -120,9 +120,7 @@ module Spree
 
     # This is a strange thing to do since an order can have multiple payments
     # but we always assume that it only has a single payment and that its
-    # amount should be the current order total.  Also, this is pretty much
-    # overridden when the order transitions to confirm by the logic inside of
-    # Order#add_store_credit_payments.
+    # amount should be the current order total after store credit is applied.
     # We should reconsider this method and its usage at some point.
     #
     # This method expects a params hash in the format of:
@@ -147,7 +145,7 @@ module Spree
     #      payments_attributes: [
     #        {
     #          ...params...
-    #          amount: <the order total>,
+    #          amount: <the order total after store credit>,
     #        },
     #      ],
     #      ...other params...
@@ -159,7 +157,7 @@ module Spree
       return params if params[:order].blank?
       return params if params[:order][:payments_attributes].blank?
 
-      params[:order][:payments_attributes].first[:amount] = order.total
+      params[:order][:payments_attributes].first[:amount] = order.order_total_after_store_credit
 
       params
     end

--- a/core/spec/lib/spree/core/controller_helpers/payment_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/payment_parameters_spec.rb
@@ -191,5 +191,18 @@ RSpec.describe Spree::Core::ControllerHelpers::PaymentParameters, type: :control
         other_param: 2
       )
     end
+
+    context 'with store credit' do
+      let!(:credit) { create(:store_credit, user: order.user, amount: 10) }
+      it 'produces the expected hash' do
+        expect(params_hash).to eq(
+          order: {
+            payments_attributes: [{ amount: 91 }],
+            other_order_param: 1
+          },
+          other_param: 2
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is sponsored by [MagmaLabs](https://www.magmalabs.io/)

## Summary

fix #3050 

Currently we are using the order total when set payment amount. This PR update to use total after store credit

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [X] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
