### PR TITLE
Add ruby 2.5 and 2.6 to the CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,10 +283,16 @@ jobs:
 workflows:
   build:
     jobs:
+      - solidus_installer
+
+      # Only test with coverage support with the default versions
       - test_with_coverage:
           post-steps:
             - codecov/upload:
                 file: $COVERAGE_FILE
+
+      # Based on supported versions for the current Solidus release and recommended versions from
+      # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
       - test_solidus:
           name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
           matrix: { parameters: { rails: ['7.0'], ruby: ['3.0', '3.1'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false] } }
@@ -295,5 +301,7 @@ workflows:
           matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0'], database: ['sqlite'], paperclip: [false] } }
       - test_solidus:
           name: *name
-          matrix: { parameters: { rails: ['5.2', '6.0'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true] } }
-      - solidus_installer
+          matrix: { parameters: { rails: ['6.0'], ruby: ['2.6'], database: ['sqlite'], paperclip: [true] } }
+      - test_solidus:
+          name: *name
+          matrix: { parameters: { rails: ['5.2'], ruby: ['2.5'], database: ['sqlite'], paperclip: [true] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,12 @@ commands:
           name: Install libvips
           command: sudo apt-get install -y libvips
 
+  imagemagick:
+    steps:
+      - run:
+          name: Install imagemagick
+          command: sudo apt-get install -y imagemagick
+
   install_solidus:
     parameters:
       flags:
@@ -256,7 +262,17 @@ jobs:
       USE_LEGACY_EVENTS: << parameters.legacy >>
     steps:
       - setup
-      - libvips
+      - when:
+          condition:
+            not:
+              equal: [<<parameters.ruby>>, '2.5']
+          steps:
+            - libvips
+      - when:
+          condition:
+            equal: [<<parameters.ruby>>, '2.5']
+          steps:
+            - imagemagick
       - test
 
   test_with_coverage:

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ group :backend do
   # from default gems. See:
   # - https://github.com/ruby/net-protocol/issues/10
   # - https://stackoverflow.com/a/72474475
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
+  v = ->(string) { Gem::Version.new(string) }
+  if Gem::Requirement.new(['>= 2.6', '< 3']) === Gem::Version.new(RUBY_VERSION)
     gem 'net-http', require: false
   end
 


### PR DESCRIPTION
## Summary

Since we officially still support ruby 2.5 and 2.6 we should ensure no code is committed that would break on those versions.

We're trying to keep the number of jobs at bay, running each rails version with its recommended ruby version, as listed in:

- https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
- https://www.ruby-lang.org/en/downloads/releases/

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
