### PR TITLE
Restore `--payment-method=` for `solidus:install` on v3.2

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -92,7 +92,8 @@ unbundled bin/rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
-  --with_authentication=false
+  --with_authentication=false \
+  --payment-method=none
   $@
 
 unbundled bin/rails generate solidus:auth:install \

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -52,17 +52,8 @@ fi
 
 cd ./sandbox
 cat <<RUBY >> Gemfile
-
 gem 'solidus', path: '..'
-gem 'solidus_auth_devise', '>= 2.1.0'
-gem 'rails-i18n'
-gem 'solidus_i18n'
-
-group :test, :development do
-  platforms :mri do
-    gem 'pry-byebug'
-  end
-end
+gem 'pry-byebug', group: [:test, :development], platforms: :mri
 RUBY
 
 replace_in_database_yml() {
@@ -88,13 +79,7 @@ fi
 
 unbundled bundle install --gemfile Gemfile
 unbundled bin/rails db:drop db:create
-unbundled bin/rails generate solidus:install \
-  --auto-accept \
-  --user_class=Spree::User \
-  --enforce_available_locales=true \
-  --with_authentication=false \
-  --payment-method=none
-  $@
+unbundled bin/rails generate solidus:install --auto-accept $@
 
 unbundled bin/rails generate solidus:auth:install \
   --auto_run_migrations=true

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -21,6 +21,7 @@ module Solidus
 
     PAYMENT_METHODS = {
       'paypal' => 'solidus_paypal_commerce_platform',
+      'bolt' => 'solidus_bolt',
       'none' => nil,
     }
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -183,19 +183,6 @@ module Solidus
       rake 'db:create'
     end
 
-    def run_bundle_install_if_needed_by_plugins
-      @plugins_to_be_installed.each do |plugin_name|
-        gem plugin_name
-      end
-
-      BundlerContext.bundle_cleanly { run "bundle install" } if @plugins_to_be_installed.any?
-      run "spring stop" if defined?(Spring)
-
-      @plugin_generators_to_run.each do |plugin_generator_name|
-        generate "#{plugin_generator_name} --skip_migrations=true"
-      end
-    end
-
     def install_frontend
       return if options[:frontend] == 'none'
 
@@ -210,6 +197,19 @@ module Solidus
       InstallFrontend.
         new(bundler_context: bundler_context, generator_context: self).
         call(frontend, installer_adds_auth: @plugins_to_be_installed.include?('solidus_auth_devise'))
+    end
+
+    def run_bundle_install_if_needed_by_plugins
+      @plugins_to_be_installed.each do |plugin_name|
+        gem plugin_name
+      end
+
+      BundlerContext.bundle_cleanly { run "bundle install" } if @plugins_to_be_installed.any?
+      run "spring stop" if defined?(Spring)
+
+      @plugin_generators_to_run.each do |plugin_generator_name|
+        generate "#{plugin_generator_name} --skip_migrations=true"
+      end
     end
 
     def run_migrations

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -143,6 +143,11 @@ module Solidus
     end
 
     def install_payment_method
+      say_status :warning, set_color(
+        "Selecting a payment along with `solidus_starter_frontend` that might require manual integration.",
+        :yellow
+      ), :yellow
+
       name = options[:payment_method]
 
       unless options[:auto_accept]

--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -30,7 +30,14 @@ module Solidus
           end
         end
 
-        @generator_context.generate("solidus_frontend:install #{@generator_context.options[:auto_accept] ? '--auto-accept' : ''}")
+        # Solidus bolt will be handled in the installer as a payment method.
+        begin
+          skip_solidus_bolt = ENV['SKIP_SOLIDUS_BOLT']
+          ENV['SKIP_SOLIDUS_BOLT'] = 'true'
+          @generator_context.generate("solidus_frontend:install #{@generator_context.options[:auto_accept] ? '--auto-accept' : ''}")
+        ensure
+          ENV['SKIP_SOLIDUS_BOLT'] = skip_solidus_bolt
+        end
       end
 
       def install_solidus_starter_frontend(installer_adds_auth)


### PR DESCRIPTION
## Summary

Solidus PCP is now compatible with Ruby 3 and can be re-enabled, since the CLI flag has been restored we can also attach bolt to it and let user select the payment method with CLI flags.

I included the minimum required to make the installer work, since we don't have tests for it I tried with:

```
bin/sandbox --frontend=solidus_frontend --payment-method=bolt --with-authentication 
bin/sandbox --frontend=solidus_frontend --payment-method=none --with-authentication 
```

and variations, also including the same options but interactively.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~~[ ] I have added automated tests to cover my changes.~~
- ~~[ ] I have attached screenshots to demo visual changes.~~
- ~~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- ~~[ ] I have updated the readme to account for my changes.~~