### PR TITLE
Update deprecated jQuery methods (Backport #4625 to v3.2)

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -56,7 +56,7 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
       processData: false,  // tell jQuery not to process the data
       contentType: false,  // tell jQuery not to set contentType
       xhr: function () {
-        var xhr = $.ajaxSettings.xhr();
+        var xhr = $.ajaxSetup.xhr(); // Using default ajax builder but inputting upload settings
         if (xhr.upload) {
           xhr.upload.onprogress = function (event) {
             if (event.lengthComputable) {

--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -67,9 +67,9 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
         }
         return xhr;
       }
-    }).done(function() {
+    }).then(function() {
       that.set({progress: 100})
-    }).error(function(jqXHR, textStatus, errorThrown) {
+    }).fail(function() {
       that.set({serverError: true});
     });
   }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -100,30 +100,26 @@ var ShipmentSplitItemView = Backbone.View.extend({
       variant_id: this.variant.id,
       quantity: quantity
     };
-    var jqXHR;
+    var path;
     if (target_type == 'stock_location') {
       // transfer to a new location
       split_attr.stock_location_id = target_id;
-      jqXHR = Spree.ajax({
-        type: "POST",
-        url: Spree.pathFor('api/shipments/transfer_to_location'),
-        data: split_attr
-      });
+      path = Spree.pathFor("api/shipments/transfer_to_location");
     } else if (target_type == 'shipment') {
       // transfer to an existing shipment
       split_attr.target_shipment_number = target_id;
-      jqXHR = Spree.ajax({
-        type: "POST",
-        url: Spree.pathFor('api/shipments/transfer_to_shipment'),
-        data: split_attr
-      });
+      path = Spree.pathFor('api/shipments/transfer_to_shipment');
     } else {
       alert('Please select the split destination.');
       return false;
     }
-    jqXHR.error(function(msg) {
+    Spree.ajax({
+      type: "POST",
+      url: path,
+      data: split_attr
+    }).fail(function(msg) {
       alert(Spree.t("split_failed"));
-    }).done(function(response) {
+    }).then(function(response) {
       if (response.success) {
         window.Spree.advanceOrder();
       } else {

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -155,8 +155,12 @@ describe "Shipments", type: :feature do
         alert_text = page.driver.browser.switch_to.alert.text
         expect(alert_text).to include 'Please select the split destination'
         page.driver.browser.switch_to.alert.accept
+        find('#item_quantity').fill_in(with: 'text')
         find('.select2-container').click
         find(:xpath, '//body').all('.select2-drop li.select2-result', text: "#{location_name} (0 on hand)")[1].click
+        find('.save-split').click
+        accept_alert 'Quantity must be greater than 0' # Test Ajax error handling
+        find('#item_quantity').fill_in(with: '1')
         find('.save-split').click
       end
       expect(page).to have_content /Pending package from '#{location_name}'/i


### PR DESCRIPTION
## Summary

Backport #4625 to v3.2 in order to solve JS errors in the backend.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
