### PR TITLE
Ensure puma 6 is not used in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'rspec-rails', '~> 4.0.1', require: false
 gem 'simplecov', require: false
 gem 'simplecov-cobertura', require: false
 gem 'rails-controller-testing', require: false
-gem 'puma', require: false
+gem 'puma', '< 6', require: false
 gem 'i18n-tasks', '~> 0.9', require: false
 
 # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb


### PR DESCRIPTION
## Summary

Puma 6 has a number of breaking changes and as of now the most recent version of rails is generating a gemfile requiring puma to be 5.

E.g.

```
              # NoMethodError:
              #   undefined method `strings' for Puma::Events:Class
              #   /home/circleci/solidus/vendor/bundle/ruby/2.7.0/gems/capybara-3.37.1/lib/capybara/registrations/servers.rb:32:in `block in <top (required)>'
```

_from https://app.circleci.com/pipelines/github/nebulab/solidus/486/workflows/209fb43e-26fb-4f2d-9e0f-b15189513fa1/jobs/5619/parallel-runs/1_

See also:
- https://github.com/teamcapybara/capybara/issues/2529#issuecomment-1052603632
- https://github.com/puma/puma/pull/2798
- https://github.com/teamcapybara/capybara/issues/2590

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
