### PR TITLE
Add support for sorting store credits with different algorithms

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -596,8 +596,9 @@ module Spree
 
       if matching_store_credits.any?
         payment_method = Spree::PaymentMethod::StoreCredit.first
+        sorter = Spree::Config.store_credit_prioritizer_class.new(matching_store_credits, self)
 
-        matching_store_credits.order_by_priority.each do |credit|
+        sorter.call.each do |credit|
           break if remaining_total.zero?
           next if credit.amount_remaining.zero?
 

--- a/core/app/models/spree/store_credit_prioritizer.rb
+++ b/core/app/models/spree/store_credit_prioritizer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spree
+  class StoreCreditPrioritizer
+    def initialize(credits, _order)
+      @credits = credits
+    end
+
+    def call
+      credits.order_by_priority
+    end
+
+    private
+
+    attr_reader :credits
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -532,6 +532,15 @@ module Spree
                                                           small: '400x400>',
                                                           product: '680x680>',
                                                           large: '1200x1200>' }
+
+    # Allows providing your own class for prioritizing store credit application
+    # to an order.
+    #
+    # @!attribute [rw] store_credit_prioritizer_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::StoreCreditPrioritizer.
+    class_name_attribute :store_credit_prioritizer_class, default: 'Spree::StoreCreditPrioritizer'
+
     # @!attribute [rw] taxon_image_style_default
     #
     # Defines which style to default to when style is not provided

--- a/core/spec/models/spree/store_credit_prioritizer_spec.rb
+++ b/core/spec/models/spree/store_credit_prioritizer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::StoreCreditPrioritizer, type: :model do
+  let(:order) { create(:order) }
+  let(:credits) { Spree::StoreCredit.all }
+  let(:sorter) { described_class.new(credits, order) }
+
+  describe '#call' do
+    subject { sorter.call }
+
+    let(:credit_type_1) { create(:primary_credit_type, priority: '30') }
+    let!(:credit_1) { create(:store_credit, credit_type: credit_type_1) }
+    let(:credit_type_2) { create(:primary_credit_type, priority: '20') }
+    let!(:credit_2) { create(:store_credit, credit_type: credit_type_2) }
+    let(:credit_type_3) { create(:primary_credit_type, priority: '10') }
+    let!(:credit_3) { create(:store_credit, credit_type: credit_type_3) }
+
+    it 'returns the credits ordered by their priority' do
+      expect(subject.to_a).to eq([credit_3, credit_2, credit_1])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

In our store, we have a set of custom eligibility rules for store credits based on the contents of the order. So we need a hook to inject a different way to prioritize store credits, as opposed to simply the type priority. While it might be possible to monkey patch the `in_priority_order` scope, that feels somewhat wrong - and the `add_store_credit_payment` method of `Spree::Order` does a *lot* that we would prefer not to monkey patch.

This PR adds a very simple configuration hook in the middle of this method to allow stores to inject some new behavior. By default, this simply does what the existing method did - sort by credit priority.

## Checklist

- [ X ] I have written a thorough PR description.
- [ X ] I have kept my commits small and atomic.
- [ X ] I have used clear, explanatory commit messages.
- [ X ] I have added automated tests to cover my changes.
