### PR TITLE
Update product_option_types Seed File

### DIFF
--- a/sample/db/samples/assets.rb
+++ b/sample/db/samples/assets.rb
@@ -81,7 +81,7 @@ images = {
 }
 
 products[:solidus_tshirt].variants.each do |variant|
-  color = variant.option_value("tshirt-color").downcase
+  color = variant.option_value("clothing-color").downcase
   main_image = image["solidus_tshirt_#{color}", "png"]
   File.open(main_image) do |f|
     variant.images.create!(attachment: f)
@@ -96,7 +96,7 @@ products[:solidus_tshirt].variants.each do |variant|
 end
 
 products[:solidus_long].variants.each do |variant|
-  color = variant.option_value("tshirt-color").downcase
+  color = variant.option_value("clothing-color").downcase
   main_image = image["solidus_long_#{color}", "png"]
   File.open(main_image) do |f|
     variant.images.create!(attachment: f)
@@ -111,7 +111,7 @@ products[:solidus_long].variants.each do |variant|
 end
 
 products[:solidus_womens_tshirt].reload.variants.each do |variant|
-  color = variant.option_value("tshirt-color").downcase
+  color = variant.option_value("clothing-color").downcase
   main_image = image["solidus_womens_tshirt_#{color}", "png"]
   File.open(main_image) do |f|
     variant.images.create!(attachment: f)

--- a/sample/db/samples/option_types.rb
+++ b/sample/db/samples/option_types.rb
@@ -2,12 +2,12 @@
 
 Spree::OptionType.create!([
   {
-    name: "tshirt-size",
+    name: "clothing-size",
     presentation: "Size",
     position: 1
   },
   {
-    name: "tshirt-color",
+    name: "clothing-color",
     presentation: "Color",
     position: 2
   }

--- a/sample/db/samples/product_option_types.rb
+++ b/sample/db/samples/product_option_types.rb
@@ -5,6 +5,12 @@ Spree::Sample.load_sample("products")
 size = Spree::OptionType.find_by!(presentation: "Size")
 color = Spree::OptionType.find_by!(presentation: "Color")
 
-solidus_tshirt = Spree::Product.find_by!(name: "Solidus T-Shirt")
-solidus_tshirt.option_types = [size, color]
-solidus_tshirt.save!
+colored_clothes = [
+  "Solidus T-Shirt", "Solidus Long Sleeve", "Solidus Women's T-Shirt"
+]
+
+Spree::Product.all.each do |product|
+  product.option_types = [size]
+  product.option_types << color if colored_clothes.include?(product.name)
+  product.save!
+end

--- a/sample/db/samples/variants.rb
+++ b/sample/db/samples/variants.rb
@@ -157,6 +157,96 @@ variants = [
     option_values: [medium, black],
     sku: "SOL-WM006",
     cost_price: 17
+  },
+  {
+    product: solidus_snapback_cap,
+    option_values: [small],
+    sku: "SOL-SNC02",
+    cost_price: 17
+  },
+  {
+    product: solidus_snapback_cap,
+    option_values: [medium],
+    sku: "SOL-SNC03",
+    cost_price: 17
+  },
+  {
+    product: solidus_snapback_cap,
+    option_values: [large],
+    sku: "SOL-SNC04",
+    cost_price: 17
+  },
+  {
+    product: solidus_hoodie,
+    option_values: [small],
+    sku: "SOL-HD02",
+    cost_price: 27
+  },
+  {
+    product: solidus_hoodie,
+    option_values: [medium],
+    sku: "SOL-HD03",
+    cost_price: 27
+  },
+  {
+    product: solidus_hoodie,
+    option_values: [large],
+    sku: "SOL-HD04",
+    cost_price: 27
+  },
+  {
+    product: ruby_hoodie,
+    option_values: [small],
+    sku: "RUB-HD02",
+    cost_price: 27
+  },
+  {
+    product: ruby_hoodie,
+    option_values: [medium],
+    sku: "RUB-HD03",
+    cost_price: 27
+  },
+  {
+    product: ruby_hoodie,
+    option_values: [large],
+    sku: "RUB-HD04",
+    cost_price: 27
+  },
+  {
+    product: ruby_hoodie_zip,
+    option_values: [small],
+    sku: "RUB-HD05",
+    cost_price: 27
+  },
+  {
+    product: ruby_hoodie_zip,
+    option_values: [medium],
+    sku: "RUB-HD06",
+    cost_price: 27
+  },
+  {
+    product: ruby_hoodie_zip,
+    option_values: [large],
+    sku: "RUB-HD07",
+    cost_price: 27
+  },
+  {
+    product: ruby_polo,
+    option_values: [small],
+    sku: "RUB-PL02",
+    cost_price: 23
+  },
+  {
+    product: ruby_polo,
+    option_values: [medium],
+    sku: "RUB-PL03",
+    cost_price: 23
+  },
+  {
+    product: ruby_polo,
+    option_values: [large],
+    sku: "RUB-PL04",
+    cost_price: 23
   }
 ]
 


### PR DESCRIPTION
## Summary

When tinkering with a freshly created solidus app, I was surprised to see that Solidus Women's T-Shirt was missing an option to add variants.

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/49295880/196869832-0e9e53da-eeb4-4b20-8b35-903075598971.png">

Further investigation revealed that this due to Spree::ProductOptionType not being created when running seeds and that it impacts all clothing objects. I understand that this might have been done due to lack of images for the other variants, but one would expect to see the option to manually add the variants (and related images) through the admin panel.

With this commit all clothing options are assigned variants and the `New Variant` button i made visible in the admin panel:

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/49295880/196870405-bde0927e-e832-4849-b774-fab877ef8abc.png">

It also brings the option types in line with the ones displayed in demo.solidus.io

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/49295880/196871855-83999598-0089-4147-8974-2f13fb6e50d0.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~~I have added automated tests to cover my changes.~~
- [x] I have attached screenshots to demo visual changes.
- [ ] ~~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [ ] ~~I have updated the readme to account for my changes.~~
