### PR TITLE
Make Promotion factory adjustment trait more flexible

### DIFF
--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -27,6 +27,22 @@ FactoryBot.define do
       end
     end
 
+    trait :with_adjustable_action do
+      transient do
+        preferred_amount { 10 }
+        calculator_class { Spree::Calculator::FlatRate }
+        promotion_action_class { Spree::Promotion::Actions::CreateItemAdjustments }
+      end
+
+      after(:create) do |promotion, evaluator|
+        calculator = evaluator.calculator_class.new
+        calculator.preferred_amount = evaluator.preferred_amount
+        evaluator.promotion_action_class.create!(calculator: calculator, promotion: promotion)
+      end
+    end
+
+    factory :promotion_with_action_adjustment, traits: [:with_adjustable_action]
+
     trait :with_line_item_adjustment do
       transient do
         adjustment_rate { 10 }

--- a/core/spec/lib/spree/core/testing_support/factories/promotion_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/promotion_factory_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe 'promotion code factory' do
     it_behaves_like 'a working factory'
   end
 
+  describe 'promotion with action adjustment' do
+    let(:factory) { :promotion_with_action_adjustment }
+
+    it_behaves_like 'a working factory'
+  end
+
   describe 'promotion with item adjustment' do
     let(:factory) { :promotion_with_item_adjustment }
 


### PR DESCRIPTION
## Summary
Currently, we do not have a factory for Promotion Actions, and so this trait is used instead. Add more flexibility on the action and calculator class used is useful for when making new Promotion Actions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):
~~- [ ] I have added automated tests to cover my changes.~~
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the readme to account for my changes.~~
