### PR TITLE
[v3.1 backport] Ensure puma 6 is not used in development 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :backend, :frontend, :core, :api do
   gem 'simplecov', require: false
   gem 'with_model', require: false
   gem 'rails-controller-testing', require: false
-  gem 'puma', require: false
+  gem 'puma', '< 6', require: false
 
   # Ensure the requirement is also updated in core/lib/spree/testing_support.rb
   gem 'factory_bot_rails', '~> 4.8', require: false


### PR DESCRIPTION
## Summary

Puma 6 has a number of breaking changes and as of now the most recent version of rails is generating a gemfile requiring puma to be 5.

Backport of https://github.com/solidusio/solidus/pull/4676.

cc @mamhoff 

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
