### PR TITLE
Configure GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Solidus Core
+      labels:
+        - Solidus Core
+    - title: Solidus Admin
+      labels:
+        - Solidus Admin
+    - title: Solidus API
+      labels:
+        - Solidus API


### PR DESCRIPTION
## Summary

We're grouping changes by the solidus component they belong to. E.g. (PR
numbers and full changelog range would be linkable):

---
## What's Changed

### Solidus Core
* Fix bug by @waiting-for-dev in #<!--  -->36
* Add cool feature by @waiting-for-dev in #<!--  -->37

### Solidus Admin
* Make something compatible by @waiting-for-dev in #<!--  -->35

### Solidus API
* Add endpoint by @waiting-for-dev in #<!--  -->34

**Full Changelog:** v3.2.0...v3.3.0
---

That configuration makes the release notes follow the same schema that we're using in the [Changelog file](https://github.com/solidusio/solidus/blob/master/CHANGELOG.md). Unfortunately, it's not possible to change the release or PR templates to make them identical.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the readme to account for my changes.~
