### PR TITLE
[3.2 hotfix] Fix `nil` bundle_path while installing solidus_frontend

### DIFF
--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -22,12 +22,14 @@ module Solidus
 
       private
 
-      def bundle_command(command, env = {})
+      def bundle_command(command)
         @generator_context.say_status :run, "bundle #{command}"
+        bundle_path = Gem.bin_path("bundler", "bundle")
+
         BundlerContext.bundle_cleanly do
           system(
             Gem.ruby,
-            Gem.bin_path("bundler", "bundle"),
+            bundle_path,
             *command.shellsplit,
           )
         end


### PR DESCRIPTION
## Summary

Tested by doing `bin/sandbox --frontend=solidus_frontend`, it fails with:

```
  installing  solidus_frontend
         run  bundle add solidus_frontend
/Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator/install_frontend.rb:30:in `system': no implicit conversion of nil into String (TypeError)
	from /Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator/install_frontend.rb:30:in `block in bundle_command'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/site_ruby/3.0.0/bundler.rb:410:in `block in with_unbundled_env'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/site_ruby/3.0.0/bundler.rb:709:in `with_env'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/site_ruby/3.0.0/bundler.rb:410:in `with_unbundled_env'
	from /Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator/bundler_context.rb:48:in `bundle_cleanly'
	from /Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator/install_frontend.rb:28:in `bundle_command'
	from /Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator/install_frontend.rb:40:in `install_solidus_frontend'
	from /Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator/install_frontend.rb:17:in `call'
	from /Users/elia/Code/Nebulab/solidus/core/lib/generators/solidus/install/install_generator.rb:199:in `install_frontend'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:134:in `block in invoke_all'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:134:in `each'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:134:in `map'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:134:in `invoke_all'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/group.rb:232:in `dispatch'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/railties-7.0.4/lib/rails/generators.rb:263:in `invoke'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/generate/generate_command.rb:26:in `perform'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /Users/elia/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'

```

without the fix and goes smoothly when the fix is applied.


cc @waiting-for-dev @abhishekgupta5 
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the readme to account for my changes.
