### PR TITLE
Remove typo from warning about solidus migration check

### DIFF
--- a/core/lib/spree/migrations.rb
+++ b/core/lib/spree/migrations.rb
@@ -33,7 +33,7 @@ module Spree
         #{missing_migrations.map {|m| "#{prefix} - #{m}"}.join("\n")}
         #{prefix}
         #{prefix} Run `bin/rails railties:install:migrations` to get them.
-        #{prefix} You can silence thi warning by setting the `SOLIDUS_SKIP_MIGRATIONS_CHECK` environment variable.
+        #{prefix} You can silence this warning by setting the `SOLIDUS_SKIP_MIGRATIONS_CHECK` environment variable.
       WARN
     end
 


### PR DESCRIPTION
## Summary

Fixing a typo that I noticed while trying to recreate a bug!

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
~- [ ] I have updated the readme to account for my changes.~
