### PR TITLE
Do not pass arrays to can?

### DIFF
--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -36,7 +36,7 @@
       </tbody>
     </table>
 
-    <% if can?([:create, :update], Spree::ProductProperty) %>
+    <% if can?(:create, Spree::ProductProperty) && can?(:update, Spree::ProductProperty) %>
       <%= render 'spree/admin/shared/edit_resource_links' %>
     <% end %>
 
@@ -95,7 +95,7 @@
             <% end %>
           </tbody>
         </table>
-        <% if can?([:create, :update], Spree::VariantPropertyRule) %>
+        <% if can?(:create, Spree::VariantPropertyRule) && can?(:update, Spree::VariantPropertyRule) %>
           <%= render 'spree/admin/shared/edit_resource_links' %>
         <% end %>
       </fieldset>

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_actions do %>
-  <% if can?([:admin, :create], Spree::Order) %>
+  <% if can?(:admin, Spree::Order) && can?(:create, Spree::Order) %>
     <li>
       <%= link_to t(".create_order"), spree.new_admin_order_path(user_id: @user.id), class: 'btn btn-primary' %>
     </li>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -60,7 +60,7 @@
                 </span>
               </td>
               <td class="order-number">
-                <% if can?([:admin, :edit], order) %>
+                <% if can?(:admin, order) && can?(:edit, order) %>
                   <%= link_to order.number, edit_admin_order_url(order) %>
                 <% else %>
                   <%= order.number %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -38,7 +38,7 @@
         <tr data-hook="admin_orders_index_rows">
           <td class="order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
           <td class="order-number">
-            <% if can?([:admin, :edit], order) %>
+            <% if can?(:admin, order) && can?(:edit, order) %>
               <%= link_to order.number, edit_admin_order_path(order) %>
             <% else %>
               <%= order.number %>


### PR DESCRIPTION
## Summary

#4433 notes that we are, in several places, passing arrays to the `can?` method. According to the documentation, that's not supported, so this low touch change doesn't do that and behaves more like what we might expect.

@spaghetticode you mentioned that checking for `:admin` might be redundant; should I include removing that check in this change? Should we rely only on the controller level permissions?

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~- [ ] I have added automated tests to cover my changes.~ (maybe we need tests for this?)
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
~- [ ] I have updated the readme to account for my changes.~
