### PR TITLE
Revert jQuery changes to xhr var in image upload

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -56,7 +56,7 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
       processData: false,  // tell jQuery not to process the data
       contentType: false,  // tell jQuery not to set contentType
       xhr: function () {
-        var xhr = $.ajaxSetup.xhr(); // Using default ajax builder but inputting upload settings
+        var xhr = $.ajaxSettings.xhr();
         if (xhr.upload) {
           xhr.upload.onprogress = function (event) {
             if (event.lengthComputable) {

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -40,33 +40,53 @@ describe "Product Images", type: :feature do
       end
     end
 
-    it "should allow an admin to upload and edit an image for a product" do
-      click_link "new_image_link"
-      within_fieldset 'New Image' do
-        attach_file('image_attachment', file_path)
-      end
-      click_button "Update"
-      expect(page).to have_content("successfully created!")
-
-      # Icons are hidden, so hover to have them pop-up
-      find('tbody > tr').hover
-      within_row(1) do
-        within ".actions" do
-          click_icon :edit
+    context 'Using the new image link' do
+      it "should allow an admin to upload and edit an image for a product" do
+        click_link "new_image_link"
+        within_fieldset 'New Image' do
+          attach_file('image_attachment', file_path)
         end
+        click_button "Update"
+        expect(page).to have_content("successfully created!")
+
+        # Icons are hidden, so hover to have them pop-up
+        find('tbody > tr').hover
+        within_row(1) do
+          within ".actions" do
+            click_icon :edit
+          end
+        end
+
+        fill_in "image_alt", with: "ruby on rails t-shirt"
+        click_button "Update"
+
+        expect(page).to have_content "successfully updated!"
+        expect(page).to have_field "image[alt]", with: "ruby on rails t-shirt"
+
+        find('tbody > tr').hover
+        accept_alert do
+          click_icon :trash
+        end
+        expect(page).not_to have_field "image[alt]", with: "ruby on rails t-shirt"
       end
+    end
 
-      fill_in "image_alt", with: "ruby on rails t-shirt"
-      click_button "Update"
+    context 'Using the drag and drop upload window' do
+      it "should allow an admin to upload an image and edit an image for a product" do
+        page.find(".upload").drop(file_path)
+        find('tbody > tr').hover
+        within_row(1) do
+          within ".actions" do
+            click_icon :edit
+          end
+        end
 
-      expect(page).to have_content "successfully updated!"
-      expect(page).to have_field "image[alt]", with: "ruby on rails t-shirt"
+        fill_in "image_alt", with: "ruby on rails t-shirt"
+        click_button "Update"
 
-      find('tbody > tr').hover
-      accept_alert do
-        click_icon :trash
+        expect(page).to have_content "successfully updated!"
+        expect(page).to have_field "image[alt]", with: "ruby on rails t-shirt"
       end
-      expect(page).not_to have_field "image[alt]", with: "ruby on rails t-shirt"
     end
 
     context 'Using Active Storage',


### PR DESCRIPTION
## Summary

This PR reverts 6ae4717 from https://github.com/solidusio/solidus/pull/4625. A set of parenthesis was missing in the call and should have been `$.ajaxSetup().xhr()`. An additional test was created covering the drop window for images and the change to `$.ajaxSetup().xhr()` was fully reverted because the reason cited for the change could not be verified (I cannot find a source that states the method is deprecated). 

Resolves #4706 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the readme to account for my changes.~
