### PR TITLE
Deprecate unused `Spree::Config#mails_from`

### DIFF
--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -919,8 +919,6 @@ module Spree::Api
 
       context "can cancel an order" do
         before do
-          stub_spree_preferences(mails_from: "solidus@example.com")
-
           order.completed_at = Time.current
           order.state = 'complete'
           order.shipment_state = 'ready'

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -9,9 +9,6 @@ Spree.config do |config|
   # Default currency for new sites
   config.currency = "USD"
 
-  # from address for transactional emails
-  config.mails_from = "store@example.com"
-
   # Uncomment to stop tracking inventory levels in the application
   # config.track_inventory_levels = false
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -193,7 +193,17 @@ module Spree
 
     # @!attribute [rw] mails_from
     #   @return [String] Email address used as +From:+ field in transactional emails.
+    #   @deprecated Spree::Store#mail_from_address is used instead
     preference :mails_from, :string, default: 'solidus@example.com'
+    def mails_from=(value)
+      Spree::Deprecation.warn(<<~MSG) && preferences[:mail_from] = value
+        Solidus doesn't use `Spree::Config.mails_from` preference and it'll
+        removed on the next major release. Please, remove its definition in
+        `config/initializers/spree.rb`. Use the `Spree::Store#mail_from_address`
+        attribute for the default email address used as the 'From:' field in
+        transactional emails.
+      MSG
+    end
 
     # @!attribute [rw] max_level_in_taxons_menu
     #   @return [Integer] maximum nesting level in taxons menu (default: +1+)

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -138,7 +138,6 @@ end
 Spree.user_class = 'Spree::LegacyUser'
 Spree.load_defaults(Spree.solidus_version)
 Spree.config do |config|
-  config.mails_from = "store@example.com"
   config.use_legacy_events = ENV['USE_LEGACY_EVENTS'].present?
 
   if ENV['DISABLE_ACTIVE_STORAGE']

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -161,4 +161,20 @@ RSpec.describe Spree::AppConfiguration do
   it 'has default Event adapter' do
     expect(prefs.events.adapter).to eq Spree::Event::Adapters::ActiveSupportNotifications
   end
+
+  context 'mails_from' do
+    it 'is deprecated' do
+      expect(Spree::Deprecation).to receive(:warn).with(/Solidus doesn't use `Spree::Config.mails_from`/)
+
+      prefs.mails_from=('solidus@example.com')
+    end
+
+    it "still sets the value so that consumers aren't broken" do
+      Spree::Deprecation.silence do
+        prefs.mails_from=('solidus@example.com')
+      end
+
+      expect(prefs.mails_from).to eq('solidus@example.com')
+    end
+  end
 end

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Spree::TestingSupport::Preferences do
   describe '#with_unfrozen_spree_preference_store' do
     it 'changes the original settings, but returns them to original values at exit' do
       with_unfrozen_spree_preference_store do
-        Spree::Config.mails_from = 'override@example.com'
-        expect(Spree::Config.mails_from).to eq 'override@example.com'
-        expect(Spree::Config.preference_store[:mails_from]).to eq 'override@example.com'
+        Spree::Config.currency = 'EUR'
+        expect(Spree::Config.currency).to eq 'EUR'
+        expect(Spree::Config.preference_store[:currency]).to eq 'EUR'
       end
 
       # both the original frozen store and the unfrozen store are unaffected by changes above:
-      expect(Spree::Config.mails_from).to eq 'store@example.com'
+      expect(Spree::Config.currency).to eq 'USD'
       with_unfrozen_spree_preference_store do
-        expect(Spree::Config.mails_from).to eq 'store@example.com'
+        expect(Spree::Config.currency).to eq 'USD'
       end
     end
   end


### PR DESCRIPTION
## Summary

`Spree::Config#mails_from` setting is not used as the default `From:` field in transactional emails [since 2016](https://github.com/solidusio/solidus/commit/54d12c2cd0d0dd4870ad52c687d4f60bab995ff7). However, the preference still existed albeit being unused. It was also included in the generated `spree.rb`, something that could mislead users.

After this one is accepted, we need to update the [solidus demo](https://github.com/solidusio/solidus-demo/blob/cad75e15f3bc3dc693236295d01952ffcd3eb969/config/initializers/spree.rb#L11) & [solidus example](https://github.com/solidusio/solidus-example-app/blob/49409add13ad60816f2c36c2290726c1b9be6968/config/initializers/spree.rb#L13) apps.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the readme to account for my changes.~
