### PR TITLE
Backport Solidus master Circle CI test scenarios to v3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,22 @@ orbs:
 
 executors:
   base:
+    parameters: &parameters
+      ruby:
+        type: string
+        default: "2.7"
     working_directory: &workdir ~/solidus
     environment: &environment
       DEFAULT_MAX_WAIT_TIME: 10
       SOLIDUS_RAISE_DEPRECATIONS: true
       CIRCLE_TEST_REPORTS: /tmp/test-results
       CIRCLE_ARTIFACTS: /tmp/test-artifacts
+      BUNDLE_WITHOUT: "utils"
     docker:
-      - image: &image cimg/ruby:2.7-browsers
+      - image: &image cimg/ruby:<< parameters.ruby >>-browsers
 
   postgres:
+    parameters: *parameters
     working_directory: *workdir
     environment:
       <<: *environment
@@ -27,6 +33,7 @@ executors:
           POSTGRES_USER: root
 
   mysql:
+    parameters: *parameters
     working_directory: *workdir
     environment:
       <<: *environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,103 @@ commands:
           name: Install libvips
           command: sudo apt-get install -y libvips
 
-jobs: {}
+  install_solidus:
+    parameters:
+      flags:
+        type: string
+        default: "# no options"
+        description: "flags to be passed to `bin/rails g solidus:install"
+    steps:
+      - run:
+          name: "Cleanup & check rails version"
+          command: |
+            gem environment path
+            rm -rf /tmp/my_app /tmp/.tool-versions # cleanup previous runs
+
+            ruby -v >> /tmp/.tool-versions
+            gem search -eq rails >> /tmp/.tool-versions # get the latest rails from rubygems
+            gem search -eq solidus >> /tmp/.tool-versions # get the latest solidus from rubygems
+
+            cat /tmp/.tool-versions
+      - restore_cache:
+          keys:
+            - solidus-installer-v5-{{ checksum "/tmp/.tool-versions" }}
+            - solidus-installer-v5-
+      - run:
+          name: "Prepare the rails application"
+          command: |
+            cd /tmp
+            test -d my_app || gem install rails solidus
+            test -d my_app || rails new my_app --skip-javascript --skip-git
+      - save_cache:
+          key: solidus-installer-v5-{{ checksum "/tmp/.tool-versions" }}
+          paths:
+            - /tmp/my_app
+            - /home/circleci/.rubygems
+      - run:
+          name: "Run `solidus:install` with `<<parameters.flags>>`"
+          command: |
+            cd /tmp/my_app
+            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+            unset RAILS_ENV # avoid doing everything on the test environment
+            bin/rails generate solidus:install --auto-accept <<parameters.flags>>
+
+  test_page:
+    parameters:
+      app_root:
+        type: string
+        default: '/tmp/my_app'
+      path:
+        type: string
+        default: '/'
+      expected_text:
+        type: string
+
+    steps:
+      - run:
+          name: "Check the contents of the <<parameters.path>> page"
+          command: |
+            cd <<parameters.app_root>>
+            unset RAILS_ENV # avoid doing everything on the test environment
+            bin/rails server -p 3000 &
+            wget --quiet --output-document - --tries=30 --retry-connrefused "http://localhost:3000<<parameters.path>>" | grep "<<parameters.expected_text>>"
+            echo "Exited with $?"
+            kill $(cat "tmp/pids/server.pid")
+
+jobs:
+  solidus_installer:
+    executor: sqlite
+    steps:
+      - checkout
+      - run:
+          name: "apt-get update, for libvips"
+          command: "sudo apt-get update"
+      - libvips
+
+      - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }
+      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
+
+      - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
+      - test_page: { expected_text: "<title>Ruby on Rails" }
+
+      - install_solidus: { flags: "--sample=false --frontend=solidus_frontend --authentication=custom" }
+      - test_page: { expected_text: "data-hook=" }
+
+      - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --authentication=devise" }
+      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
+
+      - run:
+          name: "Test `rake task: extensions:test_app`"
+          command: |
+            mkdir -p /tmp/dummy_extension
+            cd /tmp/dummy_extension
+            bundle init
+            bundle add rails sqlite3 --skip-install
+            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+            export LIB_NAME=set # dummy requireable file
+            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
 
 workflows:
   build:
-    jobs: []
+    jobs:
+      - solidus_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,15 @@ executors:
       - image: *image
       - image: cimg/mysql:5.7
 
+  sqlite:
+    parameters: *parameters
+    working_directory: *workdir
+    environment:
+      <<: *environment
+      DB: sqlite
+    docker:
+      - image: *image
+
 commands:
   setup:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,9 +176,6 @@ jobs:
           command: "sudo apt-get update"
       - libvips
 
-      - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-
       - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
       - test_page: { expected_text: "<title>Ruby on Rails" }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,13 +176,13 @@ jobs:
           command: "sudo apt-get update"
       - libvips
 
-      - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
+      - install_solidus: { flags: "--sample=false --frontend=none --with-authentication=false" }
       - test_page: { expected_text: "<title>Ruby on Rails" }
 
-      - install_solidus: { flags: "--sample=false --frontend=solidus_frontend --authentication=custom" }
+      - install_solidus: { flags: "--sample=false --frontend=solidus_frontend --with-authentication" }
       - test_page: { expected_text: "data-hook=" }
 
-      - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --authentication=devise" }
+      - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --with-authentication" }
       - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,17 +185,6 @@ jobs:
       - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --with-authentication" }
       - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
 
-      - run:
-          name: "Test `rake task: extensions:test_app`"
-          command: |
-            mkdir -p /tmp/dummy_extension
-            cd /tmp/dummy_extension
-            bundle init
-            bundle add rails sqlite3 --skip-install
-            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
-            export LIB_NAME=set # dummy requireable file
-            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
-
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,12 @@ commands:
           name: Install libvips
           command: sudo apt-get install -y libvips
 
+  imagemagick:
+    steps:
+      - run:
+          name: Install imagemagick
+          command: sudo apt-get install -y imagemagick
+
   install_solidus:
     parameters:
       flags:
@@ -185,7 +191,63 @@ jobs:
       - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --with-authentication" }
       - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
 
+  test_solidus:
+    parameters:
+      database:
+        type: string
+        default: postgres
+      ruby:
+        type: string
+        default: '3.1'
+      rails:
+        type: string
+        default: "7.0"
+      paperclip:
+        type: boolean
+        default: true
+      legacy:
+        type: string
+        default: "0"
+    executor:
+      name: << parameters.database >>
+      ruby: << parameters.ruby >>
+    parallelism: &parallelism 3
+    environment:
+      DISABLE_ACTIVE_STORAGE: << parameters.paperclip >>
+      RAILS_VERSION: "~> << parameters.rails >>"
+      USE_LEGACY_EVENTS: << parameters.legacy >>
+      BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX: "(<< parameters.ruby >>:<< parameters.rails >>:<< parameters.database >>:<< parameters.paperclip >>)"
+    steps:
+      - setup
+      - when:
+          condition:
+            not:
+              equal: [<<parameters.ruby>>, '2.5']
+          steps:
+            - libvips
+      - when:
+          condition:
+            equal: [<<parameters.ruby>>, '2.5']
+          steps:
+            - imagemagick
+      - test
+
 workflows:
   build:
     jobs:
       - solidus_installer
+
+      # Based on supported versions for the current Solidus release and recommended versions from
+      # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
+      - test_solidus:
+          name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
+          matrix: { parameters: { rails: ['7.0'], ruby: ['3.0', '3.1'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false] } }
+      - test_solidus:
+          name: *name
+          matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0'], database: ['sqlite'], paperclip: [false] } }
+      - test_solidus:
+          name: *name
+          matrix: { parameters: { rails: ['6.0'], ruby: ['2.6'], database: ['sqlite'], paperclip: [true] } }
+      - test_solidus:
+          name: *name
+          matrix: { parameters: { rails: ['5.2'], ruby: ['2.5'], database: ['sqlite'], paperclip: [true] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,22 +88,6 @@ commands:
           command: sudo apt-get install -y libvips
 
 jobs:
-  persist_version:
-    executor: base
-    steps:
-      - setup
-
-      - run:
-          name: Persist Solidus version
-          command: |
-            mkdir -p workspace
-            bundle exec ruby -e "puts Spree.solidus_gem_version.segments[0..1].join('.')" > workspace/solidus-version
-
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - solidus-version
-
   postgres:
     executor: postgres
     parallelism: &parallelism 3
@@ -162,10 +146,6 @@ jobs:
 workflows:
   build:
     jobs:
-      - persist_version:
-          filters:
-            branches:
-              only: /master|v\d\.\d+/
       - postgres
       - mysql
       - postgres_rails61

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,68 +87,8 @@ commands:
           name: Install libvips
           command: sudo apt-get install -y libvips
 
-jobs:
-  postgres:
-    executor: postgres
-    parallelism: &parallelism 3
-    steps:
-      - setup
-      - libvips
-      - test
-
-  legacy_events:
-    executor: postgres
-    parallelism: &parallelism
-    environment:
-      USE_LEGACY_EVENTS: '1'
-    steps:
-      - setup
-      - libvips
-      - test
-
-  mysql:
-    executor: mysql
-    parallelism: *parallelism
-    steps:
-      - setup
-      - libvips
-      - test
-
-  postgres_rails61:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 6.1.0'
-    steps:
-      - setup
-      - test
-
-  postgres_rails60:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 6.0.0'
-      DISABLE_ACTIVE_STORAGE: true
-    steps:
-      - setup
-      - test
-
-  postgres_rails52:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 5.2.0'
-      DISABLE_ACTIVE_STORAGE: true
-    steps:
-      - setup
-      - test
+jobs: {}
 
 workflows:
   build:
-    jobs:
-      - postgres
-      - mysql
-      - postgres_rails61
-      - postgres_rails60
-      - postgres_rails52
-      - legacy_events
+    jobs: []

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :backend, :frontend, :core, :api do
   gem 'simplecov', require: false
   gem 'rails-controller-testing', require: false
   gem 'puma', '< 6', require: false
+  gem 'i18n-tasks', '~> 0.9', require: false
 
   # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
   gem 'factory_bot_rails', '>= 4.8', require: false
@@ -66,7 +67,6 @@ end
 group :utils do
   gem 'pry'
   gem 'launchy', require: false
-  gem 'i18n-tasks', '~> 0.9', require: false
   gem 'rubocop', '~> 0.75.0', require: false
   gem 'rubocop-performance', '~> 1.4', require: false
   gem 'rubocop-rails', '~> 2.3', require: false

--- a/api/spec/requests/spree/api/checkouts_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_spec.rb
@@ -82,8 +82,6 @@ module Spree::Api
         end
 
         it "can update addresses and transition from address to delivery" do
-          pending "SQLite adapter fails to provide a unique index" if ActiveRecord::Base.connection.adapter_name == "SQLite"
-
           put spree.api_checkout_path(order),
             params: { order_token: order.guest_token, order: {
               bill_address_attributes: address,
@@ -109,8 +107,6 @@ module Spree::Api
 
         # Regression test for https://github.com/spree/spree/issues/4498
         it "does not contain duplicate variant data in delivery return" do
-          pending "SQLite adapter fails to provide a unique index" if ActiveRecord::Base.connection.adapter_name == "SQLite"
-
           put spree.api_checkout_path(order),
             params: { order_token: order.guest_token, order: {
               bill_address_attributes: address,

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -184,19 +184,21 @@ module Solidus
     end
 
     def install_frontend
-      return if options[:frontend] == 'none'
-
       bundler_context = BundlerContext.new
 
-      frontend = detect_frontend_to_install(bundler_context)
+      if options[:frontend] == 'none'
+        support_solidus_frontend_extraction(bundler_context)
+      else
+        frontend = detect_frontend_to_install(bundler_context)
 
-      support_solidus_frontend_extraction(bundler_context) unless frontend == LEGACY_FRONTEND
+        support_solidus_frontend_extraction(bundler_context) unless frontend == LEGACY_FRONTEND
 
-      say_status :installing, frontend
+        say_status :installing, frontend
 
-      InstallFrontend
-        .new(bundler_context: bundler_context, generator_context: self)
-        .call(frontend)
+        InstallFrontend
+          .new(bundler_context: bundler_context, generator_context: self)
+          .call(frontend)
+      end
     end
 
     def run_bundle_install_if_needed_by_plugins


### PR DESCRIPTION
## Goal

We want to backport the Solidus master CircleCI config to v3.2
So that we can test various Solidus installation scenarios on v3.2

## Known issues

The `extension:test_app` smoke test from master currently fails in v3.2. 

Given my working Solidus branch is v3.2, when I run the following test script from master in CI:

```
mkdir -p /tmp/dummy_extension
cd /tmp/dummy_extension
bundle init
bundle add rails sqlite3 --skip-install
bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
export LIB_NAME=set # dummy requireable file
bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
```

I get the following error:

```
NoMethodError: undefined method `join' for nil:NilClass
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb:61:in `block in apply'
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb:5:in `block in apply'
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb:46:in `apply'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/generators/solidus/install/install_generator/install_frontend.rb:55:in `install_solidus_starter_frontend'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/generators/solidus/install/install_generator/install_frontend.rb:19:in `call'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/generators/solidus/install/install_generator.rb:200:in `install_frontend'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/spree/testing_support/common_rake.rb:21:in `block (2 levels) in initialize'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/spree/testing_support/extension_rake.rb:9:in `block (2 levels) in <top (required)>'
(eval):1:in `block in standard_rake_options'
/home/circleci/.rubygems/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
Tasks: TOP => common:test_app
```

This is the line from https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb that is failing:

```ruby
repo_dir = Rails.root.join("tmp/solidus_starter_frontend-#{SecureRandom.hex}").tap(&:mkpath).to_s
```

Based on the error, `Rails.root` appears to be returning nil.

See https://app.circleci.com/pipelines/github/nebulab/solidus/564/workflows/7f01bce7-fc69-496c-9b2b-b96aaa10da8a/jobs/6680 for a sample of the failure.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
