### PR TITLE
Ensure "sqlite3" is supported in addition to "sqlite" for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ executors:
     working_directory: *workdir
     environment:
       <<: *environment
-      DB: sqlite
+      DB: sqlite3
     docker:
       - image: *image
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 # and https://github.com/rails/sprockets-rails/issues/369
 gem 'sprockets', '~> 3'
 
-dbs = ENV['DB_ALL'] ? 'all' : ENV.fetch('DB', 'sqlite')
+dbs = ENV['DB_ALL'] ? 'all' : ENV.fetch('DB', 'sqlite3')
 gem 'mysql2', '~> 0.5.0', require: false if dbs.match?(/all|mysql/)
 gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ createuser --superuser --echo postgres # only the first time
 bin/build
 ```
 
-The `bin/build` script runs using PostgreSQL by default, but it can be overridden by setting the DB environment variable to `DB=sqlite` or `DB=mysql`. For example:
+The `bin/build` script runs using PostgreSQL by default, but it can be overridden by setting the DB environment variable to `DB=sqlite3` or `DB=mysql`. For example:
 
 ```bash
 env DB=mysql bin/build

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 
 set -e
 
-# Target postgresql. Override with: `env DB=sqlite bin/build`
+# Target postgresql. Override with: `env DB=sqlite3 bin/build`
 export DB=${DB:-postgresql}
 
 if [ -n "$COVERAGE" ]; then

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -18,7 +18,7 @@ mysql)
   USERNAME=$DB_USERNAME
   PASSWORD=$DB_PASSWORD
   ;;
-sqlite|'')
+sqlite3|sqlite|'')
   RAILSDB="sqlite3"
   ;;
 *)

--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -1,113 +1,48 @@
-<% db = case ENV['DB']
-        when 'mysql'
-          'mysql'
-        when 'postgres', 'postgresql'
-          'postgres'
-        when 'sqlite', '', nil
-          'sqlite'
-        else
-          raise "Invalid DB specified: #{ENV['DB']}"
-        end %>
-<% db_host = case db
-             when 'mysql'
-               ENV['DB_MYSQL_HOST'] || ENV['DB_HOST']
-             when 'postgres'
-               ENV['DB_POSTGRES_HOST'] || ENV['DB_HOST']
-             else
-               ENV['DB_HOST']
-             end %>
-<% db_username = ENV['DB_USERNAME'] %>
-<% db_password = ENV['DB_PASSWORD'] %>
+<%=
+require 'yaml'
 
-<% case ENV['DB']
-  when 'mysql' %>
-development:
-  adapter: mysql2
-  database: <%= options[:lib_name] %>_solidus_development
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  encoding: utf8
-test:
-  adapter: mysql2
-  database: <%= options[:lib_name] %>_solidus_test
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  encoding: utf8
-production:
-  adapter: mysql2
-  database: <%= options[:lib_name] %>_solidus_production
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  encoding: utf8
-<% when 'postgres', 'postgresql' %>
-development:
-  adapter: postgresql
-  database: <%= options[:lib_name] %>_solidus_development
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  min_messages: warning
-test:
-  adapter: postgresql
-  database: <%= options[:lib_name] %>_solidus_test
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  min_messages: warning
-production:
-  adapter: postgresql
-  database: <%= options[:lib_name] %>_solidus_production
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  min_messages: warning
-<% when 'sqlite', '', nil %>
-development:
-  adapter: sqlite3
-  database: db/solidus_development.sqlite3
-test:
-  adapter: sqlite3
-  database: db/solidus_test.sqlite3
-production:
-  adapter: sqlite3
-  database: db/solidus_production.sqlite3
-<% end %>
+lib = "#{options[:lib_name]}_solidus"
+
+case ENV['DB'].presence
+when /mysql/
+  default = {
+    adapter: 'mysql2',
+    encoding: 'utf8',
+    host: (ENV['DB_MYSQL_HOST'] || ENV['DB_HOST']).presence,
+    username: ENV['DB_PASSWORD'].presence,
+    password: ENV['DB_USERNAME'].presence,
+  }.compact
+
+  config = {
+    development: default.merge(database: "#{lib}_development"),
+    production:  default.merge(database: "#{lib}_production"),
+    test:        default.merge(database: "#{lib}_test"),
+  }
+when /postgres/
+  default = {
+    adapter: 'postgresql',
+    encoding: 'utf8',
+    host: ENV['DB_POSTGRES_HOST'] || ENV['DB_HOST'],
+    username: ENV['DB_PASSWORD'].presence,
+    password: ENV['DB_USERNAME'].presence,
+  }.compact
+
+  config = {
+    development: default.merge(database: "#{lib}_development"),
+    production:  default.merge(database: "#{lib}_production"),
+    test:        default.merge(database: "#{lib}_test"),
+  }
+when /sqlite/, nil
+  default = {
+    adapter: sqlite3
+  }
+  config = {
+    development: default.merge(database: "db/#{lib}_development.sqlite3"),
+    production:  default.merge(database: "db/#{lib}_production.sqlite3"),
+    test:        default.merge(database: "db/#{lib}_test.sqlite3"),
+  }
+else raise "Invalid DB specified: #{ENV['DB'].inspect}"
+end
+
+config.deep_stringify_keys.to_yaml
+%>

--- a/core/lib/spree/testing_support/dummy_app/database.yml
+++ b/core/lib/spree/testing_support/dummy_app/database.yml
@@ -1,54 +1,48 @@
-<% db = case ENV['DB']
-        when 'mysql'
-          'mysql'
-        when 'postgres', 'postgresql'
-          'postgres'
-        when 'sqlite', '', nil
-          'sqlite'
-        else
-          raise "Invalid DB specified: #{ENV['DB']}"
-        end %>
-<% db_host = case db
-             when 'mysql'
-               ENV['DB_MYSQL_HOST'] || ENV['DB_HOST']
-             when 'postgres'
-               ENV['DB_POSTGRES_HOST'] || ENV['DB_HOST']
-             else
-               ENV['DB_HOST']
-             end %>
-<% db_prefix = ENV['LIB_NAME'].presence || "solidus" %>
-<% db_username = ENV['DB_USERNAME'] %>
-<% db_password = ENV['DB_PASSWORD'] %>
-<% case db
-when 'mysql' %>
-test:
-  adapter: mysql2
-  database: <%= db_prefix %>_test
-  <% unless db_username.blank? %>
-  username: <%= db_username %>
-  <% end %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  encoding: utf8
-<% when 'postgres' %>
-test:
-  adapter: postgresql
-  database: <%= db_prefix %>_test
-  username: <%= db_username.presence || "postgres" %>
-  <% unless db_password.blank? %>
-  password: <%= db_password %>
-  <% end %>
-  <% unless db_host.blank? %>
-  host: <%= db_host %>
-  <% end %>
-  min_messages: warning
-<% when 'sqlite' %>
-test:
-  adapter: sqlite3
-  database: db/<%= db_prefix %>_test.sqlite3
-  timeout: 10000
-<% end %>
+<%=
+require 'yaml'
+
+lib = "#{ENV['LIB_NAME']}_solidus"
+
+case ENV['DB'].presence
+when /mysql/
+  default = {
+    adapter: 'mysql2',
+    encoding: 'utf8',
+    host: (ENV['DB_MYSQL_HOST'] || ENV['DB_HOST']).presence,
+    username: ENV['DB_PASSWORD'].presence,
+    password: ENV['DB_USERNAME'].presence,
+  }.compact
+
+  config = {
+    development: default.merge(database: "#{lib}_development"),
+    production:  default.merge(database: "#{lib}_production"),
+    test:        default.merge(database: "#{lib}_test"),
+  }
+when /postgres/
+  default = {
+    adapter: 'postgresql',
+    encoding: 'utf8',
+    host: ENV['DB_POSTGRES_HOST'] || ENV['DB_HOST'],
+    username: ENV['DB_PASSWORD'].presence,
+    password: ENV['DB_USERNAME'].presence,
+  }.compact
+
+  config = {
+    development: default.merge(database: "#{lib}_development"),
+    production:  default.merge(database: "#{lib}_production"),
+    test:        default.merge(database: "#{lib}_test"),
+  }
+when /sqlite/, nil
+  default = {
+    adapter: sqlite3
+  }
+  config = {
+    development: default.merge(database: "db/#{lib}_development.sqlite3"),
+    production:  default.merge(database: "db/#{lib}_production.sqlite3"),
+    test:        default.merge(database: "db/#{lib}_test.sqlite3"),
+  }
+else raise "Invalid DB specified: #{ENV['DB'].inspect}"
+end
+
+config.deep_stringify_keys.to_yaml
+%>


### PR DESCRIPTION
## Summary

The current name is legacy and rails now uses "sqlite3", starting to move in that direction simplifies some setups (e.g. sandbox creation inside extensions).

Matching PR in the extensions ORB: https://github.com/solidusio/circleci-orbs-extensions/pull/66
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
