### PR TITLE
Automatically update the release draft when merging PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,19 @@ jobs:
       - test_with_coverage
       - notify
 
+  dev_tools:
+    docker:
+      - image: cimg/ruby:3.1
+    steps:
+      - checkout
+      - run:
+          name: "Test development tools"
+          command: |
+            cd dev_tools
+            bundle
+            bundle exec rspec
+      - notify
+
 workflows:
   build:
     jobs:
@@ -337,3 +350,5 @@ workflows:
           context: slack-secrets
           name: *name
           matrix: { parameters: { rails: ['5.2'], ruby: ['2.5'], database: ['sqlite'], paperclip: [true] } }
+      - dev_tools:
+          context: slack-secrets

--- a/.github/workflows/extract_pipeline_context.yml
+++ b/.github/workflows/extract_pipeline_context.yml
@@ -1,0 +1,28 @@
+name: "Extract pipeline context"
+
+on:
+  workflow_call:
+    outputs:
+      current_tag:
+        description: "Current tag"
+        value: ${{ jobs.extract.outputs.current_tag }}
+      candidate_tag:
+        description: "Candidate tag"
+        value: ${{ jobs.extract.outputs.candidate_tag }}
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --tags origin
+      - id: extraction
+        name: "Extract context for the current pipeline"
+        run: |
+          cd dev_tools/ && bin/extract-pipeline-context \
+            $GITHUB_OUTPUT \
+            ${{ github.ref_name }} \
+            `git tag --list`
+    outputs:
+      current_tag: ${{ steps.extraction.outputs.current_tag }}
+      candidate_tag: ${{ steps.extraction.outputs.candidate_tag }}

--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -1,0 +1,35 @@
+name: "Update Release Draft on GitHub"
+
+on:
+  pull_request_target:
+    branches:
+      - master
+      - v*
+    types:
+      - closed
+
+jobs:
+  extract_pipeline_context:
+    uses: "./.github/workflows/extract_pipeline_context.yml"
+
+  update:
+    runs-on: ubuntu-latest
+    needs: extract_pipeline_context
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        env:
+          BUNDLE_GEMFILE: "dev_tools/Gemfile"
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - name: "Save Release Draft"
+        run: |
+          cd dev_tools/ && bin/update-release-draft \
+            ${{ github.token }} \
+            ${{ github.repository }} \
+            ${{ needs.extract_pipeline_context.outputs.current_tag }} \
+            ${{ needs.extract_pipeline_context.outputs.candidate_tag }} \
+            ${{ github.ref_name }} \
+            ${{ github.event.number }}

--- a/dev_tools/Gemfile
+++ b/dev_tools/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :release_drafter do
+  gem 'octokit', '~> 6.0'
+  gem 'faraday-retry', '~> 2.0'
+end
+
+group :test do
+  gem 'rspec', '~> 3.12'
+end

--- a/dev_tools/README.md
+++ b/dev_tools/README.md
@@ -1,0 +1,3 @@
+This folder contains development tools that the Solidus Core Team uses to speed
+up processes. They're not intended to be used by other contributors or app
+developers.

--- a/dev_tools/bin/extract-pipeline-context
+++ b/dev_tools/bin/extract-pipeline-context
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/solidus/pipeline_context'
+
+stream = ARGV[0]
+base_branch = ARGV[1]
+tags = ARGV[2..]
+
+context = Solidus::PipelineContext.new(
+  base_branch: base_branch,
+  tags: tags
+)
+
+puts <<~MSG
+
+  Pipeline context:
+    Base branch: #{base_branch}
+    Current tag: #{context.current_tag}
+    Candidate tag: #{context.candidate_tag}
+
+MSG
+
+open(stream, 'a') do |s|
+  s.puts "current_tag=#{context.current_tag}"
+  s.puts "candidate_tag=#{context.candidate_tag}"
+end

--- a/dev_tools/bin/update-release-draft
+++ b/dev_tools/bin/update-release-draft
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler'
+
+Bundler.setup(:release_drafter)
+require_relative '../lib/solidus/release_drafter'
+
+github_token = ARGV[0]
+repository = ARGV[1]
+current_tag = ARGV[2]
+candidate_tag = ARGV[3]
+branch = ARGV[4]
+pr_number = ARGV[5]
+
+drafter = Solidus::ReleaseDrafter.new(
+  github_token: github_token,
+  repository: repository
+)
+
+puts <<~MSG
+
+  Saving release draft on GitHub for:
+    Repository: #{repository}
+    Branch: #{branch}
+
+MSG
+
+draft = drafter.call(
+  pr_number: pr_number,
+  current_tag: current_tag,
+  candidate_tag: candidate_tag,
+  branch: branch
+)
+
+if draft
+  puts <<~MSG
+
+    Generated release draft:
+
+    #{draft.content}
+
+  MSG
+else
+  puts <<~MSG
+
+    Release draft generation was skipped
+
+  MSG
+end

--- a/dev_tools/lib/solidus/pipeline_context.rb
+++ b/dev_tools/lib/solidus/pipeline_context.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative '../../../core/lib/spree/core/version'
+
+module Solidus
+  # Provides context for the pipeline in which a PR is being submitted.
+  #
+  # @api private
+  class PipelineContext
+    MAIN_BRANCH = 'master'
+
+    VERSION_PREFIX = 'v'
+
+    VERSION_SEPARATOR = '.'
+
+    STABLE_VERSION_REGEXP = /^#{VERSION_PREFIX}(\d+)#{VERSION_SEPARATOR}(\d+)#{VERSION_SEPARATOR}(\d+)$/.freeze
+
+    attr_reader :tags,
+                :base_branch,
+                :tracking_major
+
+    def self.tracking_major?
+      Spree::VERSION.split('.')[1..2] == ['0', '0']
+    end
+
+    def initialize(tags:, base_branch:, tracking_major: self.class.tracking_major?)
+      @tags = tags.select { |tag| tag.match?(STABLE_VERSION_REGEXP) }
+      raise ArgumentError, 'tags cannot be empty' unless tags.any?
+
+      @base_branch = base_branch
+      @tracking_major = tracking_major
+      raise ArgumentError, "branch #{base_branch} cannot track major version" if tracking_major && !main_branch?
+    end
+
+    def current_tag
+      @current_tag ||=
+        begin
+          if main_branch?
+            highest_tag_between(tags)
+          else
+            highest_tag_between(tags.select { |tag| tag.start_with?(base_branch) })
+          end
+        end
+    end
+
+    def candidate_tag
+      @candidate_tag ||=
+        begin
+          current_tag
+            .delete_prefix(VERSION_PREFIX)
+            .split(VERSION_SEPARATOR)
+            .map(&:to_i)
+            .then { |version_numbers| bump(version_numbers) }
+            .join(VERSION_SEPARATOR)
+            .prepend(VERSION_PREFIX)
+        end
+    end
+
+    private
+
+    def main_branch?
+      base_branch == MAIN_BRANCH
+    end
+
+    def highest_tag_between(tags)
+      tags
+        .map { |tag| tag.delete_prefix(VERSION_PREFIX) }
+        .max_by { |version_number| Gem::Version.new(version_number) }
+        .prepend(VERSION_PREFIX)
+    end
+
+    def bump(version_numbers)
+      main_branch? ? bump_for_main(*version_numbers) : bump_for_patch(*version_numbers)
+    end
+
+    def bump_for_main(major, minor, patch)
+      tracking_major ? [major + 1, 0, 0] : [major, minor + 1, 0]
+    end
+
+    def bump_for_patch(major, minor, patch)
+      [major, minor, patch + 1]
+    end
+  end
+end

--- a/dev_tools/lib/solidus/release_drafter.rb
+++ b/dev_tools/lib/solidus/release_drafter.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative 'release_drafter/client'
+require_relative 'release_drafter/builder'
+
+module Solidus
+  # Coordinates updating the release draft on GitHub when a PR is merged.
+  #
+  # @api private
+  class ReleaseDrafter
+    LABEL_PREFIX = 'changelog:'
+
+    LABELS = {
+      "#{LABEL_PREFIX}solidus_core" => 'Solidus Core',
+      "#{LABEL_PREFIX}solidus_backend" => 'Solidus Backend',
+      "#{LABEL_PREFIX}solidus_api" => 'Solidus API',
+      "#{LABEL_PREFIX}solidus_sample" => 'Solidus Sample',
+      "#{LABEL_PREFIX}solidus" => 'Solidus'
+    }.freeze
+
+    SKIP_LABEL = "#{LABEL_PREFIX}skip"
+
+    NO_EDIT_WARNING = <<~TXT
+      <!-- Please, don't edit manually. The content is automatically generated. -->
+    TXT
+
+    def initialize(github_token:, repository:,
+                   client: Client.new(github_token: github_token, repository: repository))
+      @repository = repository
+      @client = client
+    end
+
+    def call(pr_number:, current_tag:, candidate_tag:, branch:)
+      pr = @client.fetch_pr(pr_number: pr_number)
+      pr_labels = pr.labels.map(&:name)
+      matching_labels = LABELS.keys & pr_labels
+      return if pr_labels.include?(SKIP_LABEL) || matching_labels.empty?
+
+      draft = @client.fetch_draft(tag: candidate_tag)
+      Builder.new(draft: draft, categories: LABELS.values, prepend: NO_EDIT_WARNING, append: full_changelog(current_tag, candidate_tag))
+        .then { |builder| add_pr(builder, pr, matching_labels) }
+        .then { |draft| save_release(draft, candidate_tag, branch) }
+    end
+
+    private
+
+    def builder(draft, current_tag, candidate_tag)
+      Builder.new(draft: draft, categories: LABELS.values, prepend: NO_EDIT_WARNING, append: full_changelog(current_tag, candidate_tag))
+    end
+
+    def add_pr(builder, pr, labels)
+      builder.add(
+        number: pr.number,
+        categories: LABELS.values_at(*labels),
+        title: pr.title,
+        user: pr.user.login
+      )
+    end
+
+    def save_release(draft, candidate_tag, branch)
+      if draft.new?
+        @client.create_draft(draft: draft, tag: candidate_tag, branch: branch)
+      else
+        @client.update_draft(draft: draft, tag: candidate_tag, branch: branch)
+      end
+    end
+
+    def full_changelog(current_tag, candidate_tag)
+      <<~TXT
+
+
+        **Full Changelog**: https://github.com/#{@repository}/compare/#{current_tag}...#{candidate_tag}
+      TXT
+    end
+  end
+end

--- a/dev_tools/lib/solidus/release_drafter/builder.rb
+++ b/dev_tools/lib/solidus/release_drafter/builder.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Solidus
+  class ReleaseDrafter
+    # Defines the template for releases and adds entries to it.
+    #
+    # @api private
+    class Builder
+      TITLE_PREFIX = '## '
+
+      TITLE_TEMPLATE = lambda do |category|
+        TITLE_PREFIX + category
+      end.freeze
+
+      SEPARATOR = "\n"
+
+      TITLE_SEPARATOR = SEPARATOR
+
+      ENTRY_TEMPLATE = lambda do |title, number, user|
+        "- #{title} ##{number} (@#{user})"
+      end.freeze
+
+      ENTRY_SEPARATOR = SEPARATOR
+
+      SECTION_SEPARATOR = SEPARATOR + SEPARATOR
+
+      def initialize(draft:, categories:, prepend: '', append: '')
+        @categories = Set[*categories]
+        @prepend = prepend
+        @prepend_pattern = /^#{Regexp.quote(@prepend)}/m
+        @append = append
+        @append_pattern = /#{Regexp.quote(@append)}$/m
+        @draft = draft.new? ? draft.with(content: initial_content) : draft
+        sanitize_prepend_append
+        @ast = build_ast
+        sanitize_categories
+      end
+
+      def add(title:, number:, user:, categories:)
+        ENTRY_TEMPLATE.(title, number, user)
+          .then { |entry| add_to_ast(entry, categories) }
+          .then { |ast| @draft.with(content: unparse(ast)) }
+      end
+
+      private
+
+      def initial_content
+        @prepend + @categories.map do |category|
+          TITLE_TEMPLATE.(category)
+        end.join(SECTION_SEPARATOR) + @append
+      end
+
+      def build_ast
+        generated_lines.reduce([nil, {}]) do |(current_category, ast), line|
+          maybe_next_category = line.match(/^#{TITLE_PREFIX}(.*)$/)&.[](1)
+          if line.strip.empty?
+            [current_category, ast]
+          elsif maybe_next_category
+            [maybe_next_category, ast.merge(maybe_next_category => [])]
+          elsif current_category
+            [current_category, ast.merge(current_category => ast[current_category] + [line])]
+          else
+            [current_category, ast]
+          end
+        end[1]
+      end
+
+      def add_to_ast(entry, categories)
+        (@categories & categories).each_with_object(@ast.dup) do |category, ast|
+          ast[category] << entry
+        end
+      end
+
+      def unparse(ast)
+        @prepend + ast.map do |(category, entries)|
+          "#{TITLE_TEMPLATE.(category)}#{TITLE_SEPARATOR}#{entries.join(ENTRY_SEPARATOR)}"
+        end.join(SECTION_SEPARATOR) + @append
+      end
+
+      def generated_lines
+        @draft
+          .content
+          .gsub(@prepend_pattern, '')
+          .gsub(@append_pattern, '')
+          .lines(SEPARATOR, chomp: true)
+      end
+
+      def sanitize_prepend_append
+        raise <<~MSG unless @draft.content.match(@prepend_pattern)
+          Prepended text is not present in the draft.
+
+          We expected to find
+
+          ---
+          #{@prepend}
+          ---
+
+          at the beginning of
+
+          ---
+          #{@draft.content}
+          ---
+        MSG
+
+        raise <<~MSG unless @draft.content.match(@append_pattern)
+          Appended text is not present in the draft.
+
+          We expected to find
+
+          ---
+          #{@append}
+          ---
+
+          at the end of
+
+          ---
+          #{@draft.content}
+          ---
+        MSG
+      end
+
+      def sanitize_categories
+        raise <<~MSG unless @categories == Set[*@ast.keys]
+          Given categories don't match those found in the draft.
+
+          Given categories:
+
+          #{@categories.join(', ')}
+
+          Found categories:
+
+          #{@ast.keys.join(', ')}
+        MSG
+      end
+    end
+  end
+end

--- a/dev_tools/lib/solidus/release_drafter/client.rb
+++ b/dev_tools/lib/solidus/release_drafter/client.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'octokit'
+require 'faraday'
+require_relative 'draft'
+
+module Solidus
+  class ReleaseDrafter
+    # Octokit wrapper for the network calls we need to work with GH releases.
+    #
+    # @api private
+    class Client
+      def initialize(github_token:, repository:)
+        @repository = repository
+        @client = Octokit::Client.new(access_token: github_token).tap { |c| c.auto_paginate }
+      end
+
+      def fetch_draft(tag:)
+        release = @client.releases(@repository).find do |release|
+          release.name == tag
+        end
+        release ? Draft.new(url: release.url, content: release.body) : Draft.empty
+      end
+
+      def fetch_pr(pr_number:)
+        @client.pull(@repository, pr_number)
+      end
+
+      def create_draft(draft:, tag:, branch:)
+        @client.create_release(
+          @repository,
+          tag,
+          name: tag,
+          target_commitish: branch,
+          body: draft.content,
+          draft: true
+        ) && draft
+      end
+
+      def update_draft(draft:, tag:, branch:)
+        @client.update_release(
+          draft.url,
+          name: tag,
+          body: draft.content,
+          draft: true,
+          tag_name: tag,
+          target_commitish: branch
+        ) && draft
+      end
+    end
+  end
+end

--- a/dev_tools/lib/solidus/release_drafter/draft.rb
+++ b/dev_tools/lib/solidus/release_drafter/draft.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Solidus
+  class ReleaseDrafter
+    # Simple data structure wrapping what we need to save GH release drafts.
+    #
+    # @api private
+    class Draft
+      attr_reader :url, :content
+
+      def self.empty
+        new(url: nil, content: nil)
+      end
+
+      def initialize(url:, content:)
+        @url = url
+        @content = content&.encode(universal_newline: true)
+      end
+
+      def new?
+        @url.nil?
+      end
+
+      def with(content:)
+        self.class.new(content: content, url: @url)
+      end
+    end
+  end
+end

--- a/dev_tools/spec/lib/solidus/pipeline_context_spec.rb
+++ b/dev_tools/spec/lib/solidus/pipeline_context_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'solidus/pipeline_context'
+
+RSpec.describe Solidus::PipelineContext do
+  describe '#initialize' do
+    it 'ignores tags that do not match a full stable version number' do
+      context = described_class.new(
+        tags: %w[v3.0.0 v3.0 v3.0 v3 v3.0.0.beta invalid v.3.0.0],
+        base_branch: 'master'
+      )
+
+      expect(context.tags).to eq(['v3.0.0'])
+    end
+
+    it 'raises when tags is empty' do
+      expect {
+        described_class.new(tags: [], base_branch: 'master')
+      }.to raise_error(ArgumentError, 'tags cannot be empty')
+    end
+
+    it 'raises when branch is not the main one and tracks major is true' do
+      expect {
+        described_class.new(tags: %w[v3.0.0], base_branch: 'v3.1', tracking_major: true)
+      }.to raise_error(ArgumentError, 'branch v3.1 cannot track major version')
+    end
+  end
+
+  describe '#current_tag' do
+    context 'when the base branch is the main branch' do
+      it 'returns the highest tag' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0],
+          base_branch: 'master'
+        )
+
+        expect(context.current_tag).to eq('v3.0.0')
+      end
+
+      it 'compares tags as versions' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v3.0.0.alpha v3.0.0],
+          base_branch: 'master'
+        )
+
+        expect(context.current_tag).to eq('v3.0.0')
+      end
+    end
+
+    context 'when the base branch is a patch branch' do
+      it 'returns the highest tag matching the base branch' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0],
+          base_branch: 'v2.0'
+        )
+
+        expect(context.current_tag).to eq('v2.0.2')
+      end
+
+      it 'compares tags as versions' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0.alpha v2.0.0 v3.0.0],
+          base_branch: 'v2.0'
+        )
+
+        expect(context.current_tag).to eq('v2.0.0')
+      end
+    end
+  end
+
+  describe '#candidate_tag' do
+    context 'when the base branch is a patch branch' do
+      it 'returns the next patch level tag on the base branch' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
+          base_branch: 'v2.0'
+        )
+
+        expect(context.candidate_tag).to eq('v2.0.3')
+      end
+    end
+
+    context 'when the base branch is the main branch' do
+      it "returns the next minor level tag when not tracking a major release" do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
+          base_branch: 'master',
+          tracking_major: false
+        )
+
+        expect(context.candidate_tag).to eq('v2.1.0')
+      end
+
+      it "returns the next major level tag when tracking a major release" do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
+          base_branch: 'master',
+          tracking_major: true
+        )
+
+        expect(context.candidate_tag).to eq('v3.0.0')
+      end
+    end
+  end
+
+  describe '.tracking_major?' do
+    context 'when Spree::VERSION points to the next major release' do
+      it 'returns true' do
+        stub_const('Spree::VERSION', '4.0.0.alpha')
+
+        expect(described_class.tracking_major?).to be(true)
+      end
+    end
+
+    context "when Spree::VERSION doesn't point to the next major release" do
+      it 'returns false' do
+        stub_const('Spree::VERSION', '3.3.0.alpha')
+
+        expect(described_class.tracking_major?).to be(false)
+      end
+    end
+  end
+end

--- a/dev_tools/spec/lib/solidus/release_drafter/builder_spec.rb
+++ b/dev_tools/spec/lib/solidus/release_drafter/builder_spec.rb
@@ -1,0 +1,386 @@
+# frozen_string_literal: true
+
+require 'solidus/release_drafter/builder'
+require 'solidus/release_drafter/draft'
+
+RSpec.describe Solidus::ReleaseDrafter::Builder do
+  let(:core) { 'Solidus Core' }
+  let(:backend) { 'Solidus Backend' }
+  let(:api) { 'Solidus API' }
+  let(:categories) { [core, backend, api] }
+
+  describe '#initialize' do
+    context 'for an existing draft' do
+      it "raises when categories doesn't match" do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+
+        expect {
+          described_class.new(draft: draft, categories: categories)
+        }.to raise_error(/Given categories don't match those found in the draft/)
+      end
+
+      it 'raises when prepended text is not present' do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+
+        expect {
+          described_class.new(draft: draft, categories: categories, prepend: "## List of changes\n\n")
+        }.to raise_error(/Prepended text is not present in the draft/)
+      end
+
+      it 'raises when appended text is not present' do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+
+        expect {
+          described_class.new(draft: draft, categories: categories, append: "\n\n That's been everything!")
+        }.to raise_error(/Appended text is not present in the draft/)
+      end
+    end
+  end
+
+  describe '#add' do
+    context 'empty draft' do
+      let(:draft) { Solidus::ReleaseDrafter::Draft.empty }
+
+      it 'adds entry under all matching categories' do
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core, api]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - New entry #10 (@alice)
+        TXT
+      end
+
+      it "returns the initial draft when categories don't match" do
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: ['unknown']).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+
+        TXT
+      end
+
+      it "returns the same when categories are empty" do
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: []).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+
+        TXT
+      end
+
+      it 'prepends given text' do
+        builder = described_class.new(draft: draft, categories: categories, prepend: "## List of changes\n\n")
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core, api]).content
+        ).to eq <<~TXT.chomp
+          ## List of changes
+
+          ## Solidus Core
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - New entry #10 (@alice)
+        TXT
+      end
+
+      it 'appends given text' do
+        builder = described_class.new(draft: draft, categories: categories, append: "\n\nThat's been everything!")
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core, backend]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+          - New entry #10 (@alice)
+
+          ## Solidus API
+
+
+          That's been everything!
+        TXT
+      end
+    end
+
+    context 'existing draft' do
+      it 'adds entry under all matching categories' do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core, backend]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+          - New entry #10 (@alice)
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+      end
+
+      it "returns the same when categories don't match" do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: ['unknown']).content
+        ).to eq(content)
+      end
+
+      it "returns the same when categories are empty" do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: []).content
+        ).to eq(content)
+      end
+
+      it 'removes extra lines with only space characters' do
+        content = <<~TXT.chomp
+
+          ## Solidus Core
+
+          - Old entry 1 #9 (@bob)
+
+          - Old entry 2 #10 (@alice)
+          \t
+          ## Solidus Backend
+
+
+          ## Solidus API
+
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 11, user: 'alice', categories: [core, backend]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+          - Old entry 2 #10 (@alice)
+          - New entry #11 (@alice)
+
+          ## Solidus Backend
+          - New entry #11 (@alice)
+
+          ## Solidus API
+
+        TXT
+      end
+
+      it 'removes unknown content before categories' do
+        content = <<~TXT.chomp
+          Outlier
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+      end
+
+      it 'keeps unknown content within a category' do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+          Outlier
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories)
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+          Outlier
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+      end
+
+      it 'keeps prepended text in place' do
+        content = <<~TXT.chomp
+          ## List of changes
+
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories, prepend: "## List of changes\n\n")
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [core, api]).content
+        ).to eq <<~TXT.chomp
+          ## List of changes
+
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+          - New entry #10 (@alice)
+
+          ## Solidus Backend
+
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+          - New entry #10 (@alice)
+        TXT
+      end
+
+      it 'keeps appended text in place' do
+        content = <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+
+          That's been everything!
+        TXT
+        draft = Solidus::ReleaseDrafter::Draft.new(url: 'https://release.com', content: content)
+        builder = described_class.new(draft: draft, categories: categories, append: "\n\nThat's been everything!")
+
+        expect(
+          builder.add(title: 'New entry', number: 10, user: 'alice', categories: [backend]).content
+        ).to eq <<~TXT.chomp
+          ## Solidus Core
+          - Old entry 1 #9 (@bob)
+
+          ## Solidus Backend
+          - New entry #10 (@alice)
+
+          ## Solidus API
+          - Old entry 2 #8 (@alice)
+
+          That's been everything!
+        TXT
+      end
+    end
+  end
+end

--- a/dev_tools/spec/lib/solidus/release_drafter/draft_spec.rb
+++ b/dev_tools/spec/lib/solidus/release_drafter/draft_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'solidus/release_drafter/draft'
+
+RSpec.describe Solidus::ReleaseDrafter::Draft do
+  describe '#initialize' do
+    it "encodes all line breaks in content as LF" do
+      draft = described_class.new(url: nil, content: "\r\n\n\r")
+
+      expect(draft.content).to eq("\n\n\n")
+    end
+
+    it 'allows content to be nil' do
+      draft = described_class.new(url: nil, content: nil)
+
+      expect(draft.content).to be(nil)
+    end
+  end
+end

--- a/dev_tools/spec/lib/solidus/release_drafter_spec.rb
+++ b/dev_tools/spec/lib/solidus/release_drafter_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+require 'solidus/release_drafter'
+
+RSpec.describe Solidus::ReleaseDrafter do
+  describe '#call' do
+    let(:client) do
+      Class.new do
+        def initialize(prs: {})
+          @prs = prs
+        end
+
+        def fetch_draft(tag:)
+          Solidus::ReleaseDrafter::Draft.empty
+        end
+
+        def fetch_pr(pr_number:)
+          @prs[pr_number]
+        end
+
+        def create_draft(draft:, tag:, branch:)
+          draft
+        end
+
+        def update_draft(draft:, tag:, branch:)
+          draft
+        end
+
+        def add_pr(pr_number:, labels: [])
+          @prs[pr_number] = OpenStruct.new(
+            number: pr_number,
+            title: "PR number #{pr_number}",
+            labels: labels.map { |name| OpenStruct.new(name: name) },
+            user: OpenStruct.new(login: 'alice')
+          )
+        end
+      end.new
+    end
+
+    subject do
+      described_class.new(
+        client: client,
+        github_token: 'dummy',
+        repository: 'fake/solidus'
+      )
+    end
+
+    it 'adds the PR under a single matching label' do
+      client.add_pr(pr_number: 1, labels: ['changelog:solidus_core'])
+
+      expect(
+        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+      ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 #1 (@alice)")}/)
+    end
+
+    it 'adds the PR under more than one matching label' do
+      client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
+
+      expect(
+        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+      ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 #1 (@alice)")}.*#{Regexp.escape("## Solidus API\n- PR number 1 #1 (@alice)")}/m)
+    end
+
+    it 'ignores if no matching label is present' do
+      client.add_pr(pr_number: 1, labels: %w[other])
+
+      expect(
+        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
+      ).to be(nil)
+    end
+
+    it 'ignores if the skipping label is present' do
+      client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:skip])
+
+      expect(
+        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
+      ).to be(nil)
+    end
+
+    it 'adds a non-edit warning' do
+      client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
+
+      expect(
+        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+      ).to include("don't edit manually")
+    end
+
+    it 'adds a link to the full Changelog' do
+      client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
+
+      expect(
+        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+      ).to include("**Full Changelog**: https://github.com/fake/solidus/compare/v3.0.0...v3.1.0")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We add a GitHub action to automatically update the next [release draft](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) whenever a PR is merged.

A PR is categorized under at least one of the changelog categories [according to its labels](https://github.com/solidusio/solidus/pull/4756). Labels are already automatically added by the [labeler GitHub action](https://github.com/actions/labeler). A PR can be skipped when the `changelog:skip` label is added.

The chosen format mimics what we've done in the [Changelog](https://github.com/solidusio/solidus/blob/0cae150e4f347cd9f232001bb945ecc9974abb29/CHANGELOG.md), so we can leverage this work further to automate its generation.

We prepend the draft content with a comment warning about its automatic generation and append a link to the list of new commits since the previous tag.

The following tag is computed like this:

- We take the current tag in the base branch thanks to a custom callable workflow that extracts the information from the pipeline.
- For PRs to master, the following tag is the subsequent minor or major version depending on the value of `Spree::VERSION`.
- The following tag is the next patch version for PRs to branches corresponding to supported versions.

We considered using [Release Drafter action](https://github.com/marketplace/actions/release-drafter) as an alternative, but it reaches GitHub API abuse limit in our repo.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
