### PR TITLE
Improve Spree::Order::NumberGenerator speed

### DIFF
--- a/core/app/models/spree/order/number_generator.rb
+++ b/core/app/models/spree/order/number_generator.rb
@@ -35,11 +35,17 @@ module Spree
         # Use the random number if no other order exists with it.
         if Spree::Order.exists?(number: random)
           # If over half of all possible options are taken add another digit.
-          @length += 1 if Spree::Order.count > (10**@length / 2)
+          @length += 1 if order_count > (10**@length / 2)
         else
           break random
         end
       end
+    end
+
+    private
+
+    def order_count
+      @order_count ||= Spree::Order.count
     end
   end
 end

--- a/core/spec/models/spree/order/number_generator_spec.rb
+++ b/core/spec/models/spree/order/number_generator_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe Spree::Order::NumberGenerator do
         expect(subject.length).to eq option_length
       end
     end
+
+    context "when the first generated number already exists" do
+      before do
+        allow(Spree::Order).to receive(:exists?).and_return(true, false)
+      end
+
+      it "regenerates a new number" do
+        expect(subject).to be_a(String)
+        expect(subject.length).to eq(default_length)
+      end
+
+      context "when over half the possible order numbers already exist" do
+        before do
+          allow(Spree::Order).to receive(:count).and_return(10 ** Spree::Order::ORDER_NUMBER_LENGTH / 2 + 1)
+        end
+
+        it "regenerates a new number with an increased length" do
+          expect(subject).to be_a(String)
+          expect(subject.length).to eq(default_length + 1)
+        end
+      end
+    end
   end
 
   context "when letters option is true" do


### PR DESCRIPTION
## Summary

When generating a number, if it already exists, the length of numbers will be increased if over half of the possible options are already taken. Calculating the count of orders is very expensive when having millions of records. Upon multiple number collisions, this SQL becomes a bottleneck.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the README to account for my changes.~~
