### PR TITLE
Re-add and fix extension:test_app test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,17 @@ jobs:
       - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --with-authentication" }
       - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
 
+      - run:
+          name: "Test `rake task: extensions:test_app`"
+          command: |
+            mkdir -p /tmp/dummy_extension
+            cd /tmp/dummy_extension
+            bundle init
+            bundle add rails sqlite3 --skip-install
+            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+            export LIB_NAME=set # dummy requireable file
+            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
+
   test_solidus:
     parameters:
       database:

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails/generators'
+require 'rails/generators/app_base'
 require 'rails/version'
 require_relative 'install_generator/bundler_context'
 require_relative 'install_generator/support_solidus_frontend_extraction'
@@ -8,7 +9,9 @@ require_relative 'install_generator/install_frontend'
 
 module Solidus
   # @private
-  class InstallGenerator < Rails::Generators::Base
+  class InstallGenerator < Rails::Generators::AppBase
+    argument :app_path, type: :string, default: Rails.root
+
     CORE_MOUNT_ROUTE = "mount Spree::Core::Engine"
 
     LEGACY_FRONTEND = 'solidus_frontend'

--- a/core/lib/generators/solidus/install/install_generator/bundler_context.rb
+++ b/core/lib/generators/solidus/install/install_generator/bundler_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Solidus
-  class InstallGenerator < Rails::Generators::Base
+  class InstallGenerator < Rails::Generators::AppBase
     # Bundler context during the install process.
     #
     # This class gives access to information about the bundler context in which

--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Solidus
-  class InstallGenerator < Rails::Generators::Base
+  class InstallGenerator < Rails::Generators::AppBase
     class InstallFrontend
       attr_reader :bundler_context,
                   :generator_context

--- a/core/lib/generators/solidus/install/install_generator/support_solidus_frontend_extraction.rb
+++ b/core/lib/generators/solidus/install/install_generator/support_solidus_frontend_extraction.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Solidus
-  class InstallGenerator < Rails::Generators::Base
+  class InstallGenerator < Rails::Generators::AppBase
     # Helper for extracting solidus_frontend from solidus meta-gem
     #
     # We're recommending users use newer solidus_starter_frontend. However,


### PR DESCRIPTION
This reverts and applies a fix to commit e1928bc36c6edc529210b45a24cabdf4abc4a522.

Bug description
---------------

Given my working Solidus branch is v3.2

When I run the following test script from master in CI:

```
mkdir -p /tmp/dummy_extension
cd /tmp/dummy_extension
bundle init
bundle add rails sqlite3 --skip-install
bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
export LIB_NAME=set # dummy requireable file
bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
```

I get the following error:

```
NoMethodError: undefined method `join' for nil:NilClass
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb:61:in `block in apply'
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb:5:in `block in apply'
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb:46:in `apply'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/generators/solidus/install/install_generator/install_frontend.rb:55:in `install_solidus_starter_frontend'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/generators/solidus/install/install_generator/install_frontend.rb:19:in `call'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/generators/solidus/install/install_generator.rb:200:in `install_frontend'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/spree/testing_support/common_rake.rb:21:in `block (2 levels) in initialize'
/home/circleci/.rubygems/bundler/gems/solidus-80ccfeda8438/core/lib/spree/testing_support/extension_rake.rb:9:in `block (2 levels) in <top (required)>'
(eval):1:in `block in standard_rake_options'
/home/circleci/.rubygems/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
Tasks: TOP => common:test_app
```

See
https://app.circleci.com/pipelines/github/nebulab/solidus/564/workflows/7f01bce7-fc69-496c-9b2b-b96aaa10da8a/jobs/6680 for an actual instance of this error.

Investigation
-------------

This is the line from
https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/v3.2/template.rb that is failing:

```
repo_dir = Rails.root.join("tmp/solidus_starter_frontend-#{SecureRandom.hex}").tap(&:mkpath).to_s
```

Based on further investigations, we found that `Rails.root` was returning nil because `Rails.app_class` was also nil (See https://api.rubyonrails.org/classes/Rails.html for the definitions of these Rails methods).

Cause
-----

In 5fbcb90db312a350cac3971d0662c7fa52d033b4,
`Solidus::InstallGenerator::::InstallFrontend#install_solidus_starter_frontend` was updated to use the generator context to apply the SolidusStarterFrontend template to the app. However, unlike 0bd55c7da2f from master, the change was made without changing InstallGenerator's superclass from `Rails::Generators::Base` to `Rails::Generators::AppBase`.

Because InstallGenerator was inheriting from `Rails::Generators::Base`, the `Rails.app_class` it was passing to the SolidusStarterFrontend template was nil, causing `Rails.root` to be nil.

Related PR
----------

The issue was encountered while implementing #4717.

## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
