### PR TITLE
Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.3
   codecov: codecov/codecov@3.2.3
+  slack: circleci/slack@4.9.3
 
 executors:
   base:
@@ -83,6 +84,13 @@ commands:
           key: solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+
+  notify:
+    steps:
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: master, v[0-9]+\.[0-9]+
 
   test:
     steps:
@@ -233,6 +241,7 @@ jobs:
             bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
             export LIB_NAME=set # dummy requireable file
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
+      - notify
 
   test_solidus:
     parameters:
@@ -274,6 +283,7 @@ jobs:
           steps:
             - imagemagick
       - test
+      - notify
 
   test_with_coverage:
     parameters:
@@ -295,14 +305,17 @@ jobs:
       - setup
       - libvips
       - test_with_coverage
+      - notify
 
 workflows:
   build:
     jobs:
-      - solidus_installer
+      - solidus_installer:
+          context: slack-secrets
 
       # Only test with coverage support with the default versions
       - test_with_coverage:
+          context: slack-secrets
           post-steps:
             - codecov/upload:
                 file: $COVERAGE_FILE
@@ -310,14 +323,18 @@ workflows:
       # Based on supported versions for the current Solidus release and recommended versions from
       # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
       - test_solidus:
+          context: slack-secrets
           name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
           matrix: { parameters: { rails: ['7.0'], ruby: ['3.0', '3.1'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false] } }
       - test_solidus:
+          context: slack-secrets
           name: *name
           matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0'], database: ['sqlite'], paperclip: [false] } }
       - test_solidus:
+          context: slack-secrets
           name: *name
           matrix: { parameters: { rails: ['6.0'], ruby: ['2.6'], database: ['sqlite'], paperclip: [true] } }
       - test_solidus:
+          context: slack-secrets
           name: *name
           matrix: { parameters: { rails: ['5.2'], ruby: ['2.5'], database: ['sqlite'], paperclip: [true] } }


### PR DESCRIPTION
## Summary

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. We only track builds on master and branches tracking old Solidus minor releases. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2) channel on [Solidus' Slack workspace](https://solidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

We're using the default template for the notification:

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202616804-dafaad37-3989-43bf-ac1d-6c1680a691c5.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
