### PR TITLE
[v3.1] Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@4.9.3
+
 executors:
   base:
     working_directory: &workdir ~/solidus
@@ -59,6 +62,13 @@ commands:
           paths:
             - vendor/bundle
 
+  notify:
+    steps:
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: master, v[0-9]+\.[0-9]+
+
   test:
     steps:
       - run:
@@ -99,6 +109,7 @@ jobs:
     steps:
       - setup
       - test
+      - notify
 
   mysql:
     executor: mysql
@@ -106,6 +117,7 @@ jobs:
     steps:
       - setup
       - test
+      - notify
 
   postgres_rails60:
     executor: postgres
@@ -116,6 +128,7 @@ jobs:
     steps:
       - setup
       - test
+      - notify
 
   postgres_rails52:
     executor: postgres
@@ -126,6 +139,7 @@ jobs:
     steps:
       - setup
       - test
+      - notify
 
 workflows:
   build:
@@ -134,7 +148,11 @@ workflows:
           filters:
             branches:
               only: /master|v\d\.\d+/
-      - postgres
-      - mysql
-      - postgres_rails60
-      - postgres_rails52
+      - postgres:
+          context: slack-secrets
+      - mysql:
+          context: slack-secrets
+      - postgres_rails60:
+          context: slack-secrets
+      - postgres_rails52:
+          context: slack-secrets


### PR DESCRIPTION
## Summary

Backports https://github.com/solidusio/solidus/pull/4726 to v3.1

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. We only track builds on master and branches tracking old Solidus minor releases. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2) channel on [Solidus' Slack workspace](https://solidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

We're using the default template for the notification:

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202616804-dafaad37-3989-43bf-ac1d-6c1680a691c5.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
