### PR TITLE
[v3.2] Fix the dummy app usage of the generator

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-unless defined?(Solidus::InstallGenerator)
-  require 'generators/solidus/install/install_generator'
-end
-
 require 'generators/spree/dummy/dummy_generator'
 
 class CommonRakeTasks
@@ -17,8 +13,31 @@ class CommonRakeTasks
 
         force_rails_environment_to_test
 
-        Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-        Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+        Spree::DummyGenerator.start [
+          "--lib-name=#{ENV['LIB_NAME']}",
+          "--quiet",
+        ]
+
+        # While the dummy app is generated the current directory
+        # within ruby is changed to that of the dummy app.
+        sh({
+          'SKIP_SOLIDUS_BOLT' => '1',
+          'FRONTEND' => 'solidus_frontend',
+        }, [
+          'bin/rails',
+          'generate',
+          'solidus:install',
+          Dir.pwd, # use the current dir as Rails.root
+          "--lib-name=#{ENV['LIB_NAME']}",
+          "--auto-accept",
+          "--with-authentication=false",
+          "--payment-method=none",
+          "--migrate=false",
+          "--seed=false",
+          "--sample=false",
+          "--user-class=#{args[:user_class]}",
+          "--quiet",
+        ].shelljoin)
 
         puts "Setting up dummy database..."
 


### PR DESCRIPTION
## Summary

Backports part of #4646

We already shell-out for setting the environment and running migrations, this way we can avoid requiring the generator and we run it in a standard app environment instead of from within a library.

Before this change it was failing to set Rails.root as the app_path for the generator.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
