### PR TITLE
Require mail >= 2.8.0.rc1 for Ruby 3.1 support

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'image_processing', '~> 1.10'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'mini_magick', '~> 4.10'
+  s.add_dependency 'mail', ['>= 2.8.0.rc1', '< 3.0']
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
   s.add_dependency 'psych', ['>= 3.1.0', '< 5.0']


### PR DESCRIPTION
## Summary

Ruby 3.1 removed net-smtp, net-imap and net-pop from standardlib and extracted them into independent gems.

The mail gem >= 2.8 added them to their dependencies. Since we require the mail gem in core.rb:17 we need to add the mail gem as dependency and need to make sure it is the Ruby 3.1 compatible version as we support Ruby 3.1

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
