### PR TITLE
Make split_promotions_with_any_match_policy task faster

### DIFF
--- a/core/lib/tasks/solidus/split_promotions_with_any_match_policy.rake
+++ b/core/lib/tasks/solidus/split_promotions_with_any_match_policy.rake
@@ -3,7 +3,8 @@
 namespace :solidus do
   desc "Split Promotions with 'any' match policy"
   task split_promotions_with_any_match_policy: :environment do
-    Spree::Promotion.where(match_policy: :any).includes(:promotion_rules).all.each do |promotion|
+    promotions = Spree::Promotion.where(match_policy: :any)
+    promotions.includes(:promotion_rules, :promotion_actions).find_each do |promotion|
       if promotion.promotion_rules.length <= 1
         promotion.update!(match_policy: :all)
       elsif promotion.active?
@@ -28,6 +29,8 @@ namespace :solidus do
       end
     end
 
-    Spree::Order.where(completed_at: nil).each { |order| Spree::PromotionHandler::Cart.new(order).activate }
+    if promotions.any?
+      Spree::Order.where(completed_at: nil).each { |order| Spree::PromotionHandler::Cart.new(order).activate }
+    end
   end
 end


### PR DESCRIPTION
## Summary

Do not re-apply promotions to incomplete orders if there are no promotions effected. This is not necessary and speeds up the task for shop with lots of incomplete orders (this could easily be in the thousands).

Also make the effected promotions update faster by using find_each and include actions as well.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
