### PR TITLE
Ignore big reformatting commits in GitHub blame UI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# rubocop -a (Jan 26, 2016)
+989ba2e74e49332d2281187d09a2dc7aad75922a
+# Rubocop auto (Mar 8, 2018)
+b3007bb0973dcb987b0328b4e59306cd2549148d


### PR DESCRIPTION
## Summary

By adding a `.git-blame-ignore-revs` file that contains the commits that git blame will ignore, we are able to remove them from the blame view when using this feature.

See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view for extra details.

From that link it's worth mentioning that:

>If the blame view for a file shows Ignoring revisions in .git-blame-ignore-revs, you can still bypass .git-blame-ignore-revs and see the normal blame view. In the URL, append a ~ to the SHA and the Ignoring revisions in .git-blame-ignore-revs will disappear.

For now, I added just a couple of big commits, but we can add more with time.

This same behavior can be enabled locally with:

	git config blame.ignoreRevsFile .git-blame-ignore-revs

This config is not suitable as a global config though, because it will fail on repositories that do not have the file set.



Other resources:

- https://blog.testdouble.com/posts/2022-11-21-rubocop-git-blame/


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the README to account for my changes.
