### PR TITLE
Add back PayPal as a payment method for the starter frontend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,12 +220,22 @@ jobs:
 
       - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }
       - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
+      - run:
+          name: Ensure the correct PayPal is installed for SSF
+          command: |
+            cd /tmp/my_app
+            bundle list | grep 'solidus_paypal_commerce_platform (1.'
 
       - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
       - test_page: { expected_text: "<title>Ruby on Rails" }
 
       - install_solidus: { flags: "--sample=false --frontend=classic --authentication=custom" }
       - test_page: { expected_text: "data-hook=" }
+      - run:
+          name: Ensure the correct PayPal is installed for SSF
+          command: |
+            cd /tmp/my_app
+            bundle list | grep 'solidus_paypal_commerce_platform (0.'
 
       - run:
           name: "Test `rake task: extensions:test_app`"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,11 +224,8 @@ jobs:
       - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
       - test_page: { expected_text: "<title>Ruby on Rails" }
 
-      - install_solidus: { flags: "--sample=false --frontend=solidus_frontend --authentication=custom" }
+      - install_solidus: { flags: "--sample=false --frontend=classic --authentication=custom" }
       - test_page: { expected_text: "data-hook=" }
-
-      - install_solidus: { flags: "--sample=false --frontend=solidus_starter_frontend --authentication=devise" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
 
       - run:
           name: "Test `rake task: extensions:test_app`"

--- a/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
+++ b/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
@@ -3,7 +3,8 @@ unless Bundler.locked_gems.dependencies['solidus_frontend']
 end
 
 unless Bundler.locked_gems.dependencies['solidus_paypal_commerce_platform']
-  bundle_command 'add solidus_paypal_commerce_platform'
+  version = @selected_frontend == 'classic' ? '< 1' : '>= 1.a'
+  bundle_command "add solidus_paypal_commerce_platform --version='#{version}'"
 end
 
 generate 'solidus_paypal_commerce_platform:install'

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -16,6 +16,7 @@ module Solidus
       classic
       starter
     ]
+
     LEGACY_FRONTENDS = %w[
       solidus_starter_frontend
       solidus_frontend
@@ -322,18 +323,27 @@ module Solidus
       return 'paypal' if Bundler.locked_gems.dependencies['solidus_paypal_commerce_platform']
       return 'bolt' if Bundler.locked_gems.dependencies['solidus_bolt']
 
-      options[:payment_method] ||
-        (options[:auto_accept] && @selected_frontend == 'classic' ? 'paypal' : 'none') ||
-        (@selected_frontend != 'classic' && 'none') || # bail out if it's not classic
+      descriptions = {
+        paypal: "- [#{set_color 'paypal', :bold}] Install `solidus_paypal_commerce_platform` (#{set_color :default, :bold}).",
+        bolt: "- [#{set_color 'bolt', :bold}] Install `solidus_bolt`.",
+        none: "- [#{set_color 'none', :bold}] Skip installing a payment method.",
+      }
+
+      payment_methods = PAYMENT_METHODS
+
+      if @selected_frontend != 'classic'
+        payment_methods -= ['bolt']
+        descriptions.delete(:bolt)
+      end
+
+      selected = options[:payment_method] || (options[:auto_accept] && 'paypal') ||
         ask_with_description(
           default: 'paypal',
-          limited_to: PAYMENT_METHODS,
+          limited_to: payment_methods,
           desc: <<~TEXT
             Which payment method would you like to use?
 
-            - [#{set_color 'paypal', :bold}] Install `solidus_paypal_commerce_platform` (#{set_color :default, :bold}).
-            - [#{set_color 'bolt', :bold}] Install `solidus_bolt`.
-            - [#{set_color 'none', :bold}] Skip installing a payment method.
+            #{descriptions.values.join("\n")}
           TEXT
         )
     end

--- a/core/spec/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/generators/solidus/install/install_generator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Solidus::InstallGenerator do
       aggregate_failures do
         expect(generator.instance_variable_get(:@selected_frontend)).to eq("starter")
         expect(generator.instance_variable_get(:@selected_authentication)).to eq("devise")
-        expect(generator.instance_variable_get(:@selected_payment_method)).to eq("none")
+        expect(generator.instance_variable_get(:@selected_payment_method)).to eq("paypal")
         expect(generator.instance_variable_get(:@run_migrations)).to eq(true)
         expect(generator.instance_variable_get(:@load_seed_data)).to eq(true)
         expect(generator.instance_variable_get(:@load_sample_data)).to eq(true)
@@ -96,5 +96,43 @@ RSpec.describe Solidus::InstallGenerator do
         expect(generator.instance_variable_get(:@selected_frontend)).to eq('starter')
       end
     end
+
+    context 'when asked interactively' do
+      it 'presents different options for the "classic"' do
+        questions = []
+        generator = described_class.new([], ['--frontend=classic', '--authentication=devise'])
+        allow(generator).to receive(:ask_with_description) { |**args| questions << args }
+
+        generator.prepare_options
+
+        expect(questions.size).to eq(1)
+        expect(questions.first[:limited_to]).to eq(['paypal', 'bolt', 'none'])
+        expect(questions.first[:default]).to eq('paypal')
+        expect(strip_ansi questions.first[:desc]).to include('[paypal]')
+        expect(strip_ansi questions.first[:desc]).to include('[bolt]')
+        expect(strip_ansi questions.first[:desc]).to include('[none]')
+      end
+
+      it 'presents different options for the "classic"' do
+        questions = []
+        generator = described_class.new([], ['--frontend=starter', '--authentication=devise'])
+        allow(generator).to receive(:ask_with_description) { |**args| questions << args }
+
+        generator.prepare_options
+
+        expect(questions.size).to eq(1)
+        expect(questions.first[:limited_to]).to eq(['paypal', 'none'])
+        expect(questions.first[:default]).to eq('paypal')
+        expect(strip_ansi questions.first[:desc]).to include('[paypal]')
+        expect(strip_ansi questions.first[:desc]).not_to include('[bolt]')
+        expect(strip_ansi questions.first[:desc]).to include('[none]')
+      end
+    end
+  end
+
+  private
+
+  def strip_ansi(string)
+    string.gsub(/\u001b\[.*?m/, '')
   end
 end


### PR DESCRIPTION
## Summary

Restore `paypal` as a payment method option for when SSF is used as a frontend. Given the SSF has no versioning that we can use to connect it to the right version via dependencies we need to store the knowledge of which is the right version inside the installer itself. The installer will use v0.x for the _classic frontend_ and v1.x for the _starter frontend_.

- Fixes #4742 
- Blocked by https://github.com/solidusio/solidus_paypal_commerce_platform/issues/169
- Blocked by https://github.com/solidusio/solidus_paypal_commerce_platform/issues/170




<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
