### PR TITLE
Don't install solidus_auth_devise if it's already in the Gemfile

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -187,14 +187,12 @@ module Solidus
     end
 
     def install_frontend
-      bundler_context = BundlerContext.new
-
       if options[:frontend] == 'none'
-        support_solidus_frontend_extraction(bundler_context)
+        support_solidus_frontend_extraction
       else
-        frontend = detect_frontend_to_install(bundler_context)
+        frontend = detect_frontend_to_install
 
-        support_solidus_frontend_extraction(bundler_context) unless frontend == LEGACY_FRONTEND
+        support_solidus_frontend_extraction unless frontend == LEGACY_FRONTEND
 
         say_status :installing, frontend
 
@@ -285,7 +283,7 @@ module Solidus
 
     private
 
-    def detect_frontend_to_install(bundler_context)
+    def detect_frontend_to_install
       ENV['FRONTEND'] ||
         options[:frontend] ||
         (bundler_context.component_in_gemfile?(:frontend) && LEGACY_FRONTEND) ||
@@ -299,12 +297,16 @@ module Solidus
         MSG
     end
 
-    def support_solidus_frontend_extraction(bundler_context)
+    def support_solidus_frontend_extraction
       say_status "break down", "solidus"
 
       SupportSolidusFrontendExtraction.
         new(bundler_context: bundler_context).
         call
+    end
+
+    def bundler_context
+      @bundler_context ||= BundlerContext.new
     end
   end
 end

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -126,14 +126,9 @@ module Solidus
       end
     end
 
-    def plugin_install_preparation
-      @plugins_to_be_installed = []
-      @plugin_generators_to_run = []
-    end
-
-    def install_auth_plugin
-      with_authentication = options[:with_authentication]
-      with_authentication.nil? and with_authentication = (options[:auto_accept] || !no?("
+    def select_auth_plugin
+      @with_authentication = options[:with_authentication]
+      @with_authentication.nil? and @with_authentication = (options[:auto_accept] || !no?("
         Solidus has a default authentication extension that uses Devise.
         You can find more info at https://github.com/solidusio/solidus_auth_devise.
 
@@ -141,14 +136,9 @@ module Solidus
         solidus_starter_frontend as your storefront in a later step.
 
         Would you like to install it? (Y/n)"))
-
-      if with_authentication
-        @plugins_to_be_installed << 'solidus_auth_devise'
-        @plugin_generators_to_run << 'solidus:auth:install'
-      end
     end
 
-    def install_payment_method
+    def select_payment_method
       say_status :warning, set_color(
         "Selecting a payment along with `solidus_starter_frontend` might require manual integration.",
         :yellow
@@ -160,12 +150,7 @@ module Solidus
   You can select a payment method to be included in the installation process.
   Please select a payment method name:", limited_to: PAYMENT_METHODS.keys, default: PAYMENT_METHODS.keys.first)
 
-      gem_name = PAYMENT_METHODS.fetch(name)
-
-      if gem_name
-        @plugins_to_be_installed << gem_name
-        @plugin_generators_to_run << "#{gem_name}:install"
-      end
+      @payment_method_gem_name = PAYMENT_METHODS.fetch(name)
     end
 
     def include_seed_data
@@ -202,17 +187,16 @@ module Solidus
       end
     end
 
-    def run_bundle_install_if_needed_by_plugins
-      @plugins_to_be_installed.each do |plugin_name|
-        gem plugin_name
-      end
+    def install_authentication_plugin
+      return unless @with_authentication
 
-      BundlerContext.bundle_cleanly { run "bundle install" } if @plugins_to_be_installed.any?
-      run "spring stop" if defined?(Spring)
+      install_plugin(plugin_name: 'solidus_auth_devise', plugin_generator_name: 'solidus:auth:install')
+    end
 
-      @plugin_generators_to_run.each do |plugin_generator_name|
-        generate "#{plugin_generator_name} --skip_migrations=true"
-      end
+    def install_payment_method_plugin
+      return unless @payment_method_gem_name
+
+      install_plugin(plugin_name: @payment_method_gem_name, plugin_generator_name: "#{@payment_method_gem_name}:install")
     end
 
     def run_migrations
@@ -303,6 +287,13 @@ module Solidus
       SupportSolidusFrontendExtraction.
         new(bundler_context: bundler_context).
         call
+    end
+
+    def install_plugin(plugin_name:, plugin_generator_name:)
+      gem plugin_name
+      BundlerContext.bundle_cleanly { run "bundle install" }
+      run "spring stop" if defined?(Spring)
+      generate "#{plugin_generator_name} --skip_migrations=true"
     end
 
     def bundler_context

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -302,7 +302,7 @@ module Solidus
       end
 
       gem plugin_name
-      BundlerContext.bundle_cleanly { run "bundle install" }
+      run_bundle
       run "spring stop" if defined?(Spring)
       generate "#{plugin_generator_name} --skip_migrations=true"
     end

--- a/core/lib/generators/solidus/install/install_generator/bundler_context.rb
+++ b/core/lib/generators/solidus/install/install_generator/bundler_context.rb
@@ -49,7 +49,7 @@ module Solidus
       end
 
       def initialize
-        @dependencies = Bundler.locked_gems.dependencies
+        @dependencies = uncached_dependencies
         @injector = InjectorWithPathSupport
       end
 
@@ -91,6 +91,14 @@ module Solidus
 
       def solidus_dependency
         @dependencies['solidus']
+      end
+
+      # We want to get the locked gems from `Bundler.definition.locked_gems`
+      # instead of `Bundler.locked_gems` so that the locked gems won't be
+      # memoized. See
+      # https://rubydoc.info/gems/bundler/2.3.22/Bundler.locked_gems.
+      def uncached_dependencies
+        Bundler.definition.locked_gems.dependencies
       end
     end
   end

--- a/core/lib/generators/solidus/install/install_generator/install_frontend.rb
+++ b/core/lib/generators/solidus/install/install_generator/install_frontend.rb
@@ -24,22 +24,11 @@ module Solidus
 
       private
 
-      def bundle_command(command)
-        @generator_context.say_status :run, "bundle #{command}"
-        bundle_path = Gem.bin_path("bundler", "bundle")
-
-        BundlerContext.bundle_cleanly do
-          system(
-            Gem.ruby,
-            bundle_path,
-            *command.shellsplit,
-          )
-        end
-      end
-
       def install_solidus_frontend
         unless @bundler_context.component_in_gemfile?(:frontend)
-          bundle_command 'add solidus_frontend'
+          # `Rails::Generator::AppBase#bundle_command` is protected so have to `send` it.
+          # See https://api.rubyonrails.org/v3.2.16/classes/Rails/Generators/AppBase.html#method-i-run_bundle
+          @generator_context.send :bundle_command, 'add solidus_frontend'
         end
 
         # Solidus bolt will be handled in the installer as a payment method.


### PR DESCRIPTION
Fixes #4766.

Goal
----

Given I have a Rails app
When I add Solidus 3.2.4 to the Gemfile
And I install Solidus with Solidus Starter Frontend and Solidus Auth Devise
Then I should see only one `solidus_auth_devise` line in the Gemfile.

Current behavior
----------------

The Gemfile has two lines for `solidus_auth_devise` :

```ruby
# FIXME: Please remove this line if `solidus_auth_devise` appears anywhere else in the gemfile
#        or replace it with a simple `gem 'solidus_auth_devise'` otherwise.
gem 'solidus_auth_devise' unless File.read(__FILE__).lines[__LINE__..-1].grep(/solidus_auth_devise/).any?

gem "solidus_auth_devise"
```

Cause
-----

This is a workaround to an issue where `Solidus#InstallGenerator` and SolidusStarterFrontend both add `solidus_auth_devise` to the Gemfile. From <https://github.com/solidusio/solidus_starter_frontend/pull/277/commits/b9e8a7fa04f05718b5953619d4a3b377f0e017e3>:

> ```
> Adding solidus_auth_devise to the Gemfile was conflicting with it
> being added by the solidus installer again unless
> `--with-authentication=false` was provided. But the auth extension
> is also required by SSF. This forced a workaround in which we skip
> the `gem` entry in the Gemfile if another entry for the same gem is
> present in any of the following lines. It's ugly but puts a bandaid
> that will at least allow the installation to succeed.
> ```

## Testing

I have confirmed manually that, in conjunction with the [SolidusStarterFrontend update](https://github.com/solidusio/solidus_starter_frontend/commits/gsmendoza/sol-547-fix-ensure-that-ssf-32-doesnt-add), installing Solidus in v3.2 now installs `solidus_auth_devise` only once. See

* https://github.com/solidusio/solidus_starter_frontend/commits/gsmendoza/sol-547-fix-ensure-that-ssf-32-doesnt-add
  - This update to SolidusStarterFrontend removes the SolidusAuthDevise workaround and FIXME comment.
* https://github.com/nebulab/solidus/tree/gsmendoza/sol-547-fix-ensure-that-ssf-32-doesnt-add--with-test-ssf-branch
  - A branch of this PR that ties InstallGenerator to a branch of SolidusStarterFrontend without the workaround.
* https://github.com/gsmendoza/solidus_store/tree/rails-7-0-4--solidus-3-2-4--sol-547-fix-ensure-that-ssf-32-doesnt-add
  - The app generated by the Solidus installation I did to test this fix.
* [solidus-install-log.txt](https://github.com/solidusio/solidus/files/10111919/solidus-install-log.txt)
  - The log of the Solidus installation. Note the "skipping  solidus_auth_devise is already in the gemfile" line.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
