### PR TITLE
Use labeler action to mark all kind of changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,22 @@
-Solidus Core: core/**/*
-Solidus Admin: backend/**/*
-Solidus API: api/**/*
+"changelog:solidus_core":
+  - "core/**/*"
+"changelog:solidus_backend":
+  - "backend/**/*"
+"changelog:solidus_api":
+  - "api/**/*"
+"changelog:solidus_sample":
+  - "sample/**/*"
+"changelog:solidus":
+  - "lib/**/*"
+  - "README.md"
+  - "solidus.gemspec"
+"changelog:repository":
+  - any:
+    - "**/*"
+    - "!core/**/*"
+    - "!backend/**/*"
+    - "!api/**/*"
+    - "!sample/**/*"
+    - "!lib/**/*"
+    - "!README.md"
+    - "!solidus.gemspec"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,15 +1,14 @@
 name: "Pull Request Labeler"
-on:
-- pull_request_target
+on: pull_request_target
 
 jobs:
-  triage:
+  triage_changelog_label:
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
## Summary

We leverage the [labeler action](https://github.com/actions/labeler) to mark all kinds of changes done in the repository. We will reach the end goal with future work that will comprise:

- Ensuring that at least one changelog label is set before merging a PR.
- Leveraging the changelog labels to build both the GH release draft and the Changelog automatically.

The expected labels are:

- `changelog:solidus_core` for changes relative to the `solidus_core` gem.
- `changelog:solidus_backend` for changes relative to the `solidus_backend` gem.
- `changelog:solidus_api` for changes relative to the `solidus_api` gem.
- `changelog:solidus_sample` for changes relative to the `solidus_sample` gem.
- `changelog:solidus` for changes relative to the `solidus` gem.
- `changelog:repository` for changes done to code that doesn't belong to any gem.

We'll also manually add a `changelog:skip` label that we will use to override the automatic inclusion of a change. We'll also probably skip entries relative to `changelog:repository`.

References #4752 

**Before merging this PR, I'll  rename the `Solidus *` labels to `changelog:solidus_*` and add the missing labels**

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
