### PR TITLE
Remove trailing zeroes in tax amount

### DIFF
--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -37,7 +37,7 @@ describe "Adjustments", type: :feature do
     context "admin managing adjustments" do
       it "should display the correct values for existing order adjustments" do
         within first('table tr', text: 'Tax') do
-          expect(column_text(2)).to match(/TaxCategory - \d+ 20\.000%/)
+          expect(column_text(2)).to match(/TaxCategory - \d+ 20\.0%/)
           expect(column_text(3)).to eq("$2.00")
         end
       end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -118,7 +118,8 @@ module Spree
     def amount_for_adjustment_label
       ActiveSupport::NumberHelper::NumberToPercentageConverter.convert(
         amount * 100,
-        locale: I18n.locale
+        locale: I18n.locale,
+        precision: nil
       )
     end
 

--- a/core/spec/models/spree/tax_calculator/default_spec.rb
+++ b/core/spec/models/spree/tax_calculator/default_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Spree::TaxCalculator::Default do
       expect(line_item_tax.amount).to eq 1
       expect(line_item_tax.included_in_price).to be false
       expect(line_item_tax.tax_rate).to eq book_tax_rate
-      expect(line_item_tax.label).to eq "New York Sales Tax 5.000%"
+      expect(line_item_tax.label).to eq "New York Sales Tax 5.0%"
     end
 
     it "has tax information for the shipments" do


### PR DESCRIPTION
## Summary

**Issue**
`amount_for_adjustment_label` uses `ActiveSupport::NumberHelper::NumberToPercentageConverter` which defaults to a precision of 3, leading to the tax amount displayed in the label in a way that isn't very pleasing:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/49295880/205011401-1ea5de63-49a2-4668-9d0b-1732ae28b746.png">

**Proposed Solution**
Use amount's default precision
<img width="300" alt="image" src="https://user-images.githubusercontent.com/49295880/205011047-5af9d652-b88d-4c86-8290-0693db774665.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the readme to account for my changes.~