### PR TITLE
Fix CircleCI errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,9 @@ commands:
     steps:
       - run:
           name: Install libvips
-          command: sudo apt-get install -y libvips
+          command: |
+            sudo apt-get update
+            sudo apt-get install -yq libvips-dev
 
   imagemagick:
     steps:
@@ -214,9 +216,6 @@ jobs:
     executor: sqlite
     steps:
       - checkout
-      - run:
-          name: "apt-get update, for libvips"
-          command: "sudo apt-get update"
       - libvips
 
       - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,8 @@ commands:
             cat /tmp/.tool-versions
       - restore_cache:
           keys:
-            - solidus-installer-v5-{{ checksum "/tmp/.tool-versions" }}
-            - solidus-installer-v5-
+            - solidus-installer-v6-{{ checksum "/tmp/.tool-versions" }}
+            - solidus-installer-v6-
       - run:
           name: "Prepare the rails application"
           command: |


### PR DESCRIPTION
## Summary

This PR fixes two errors on CircleCI.

### 1. Fix CircleCI errors due to libvips not being found

CircleCI jobs started to [fail](https://app.circleci.com/pipelines/github/solidusio/solidus/3824/workflows/04890df9-effb-47ad-92cc-a44010684c80/jobs/34141) due to the package `libvips` no longer being available. Previously, `libvips` was [resolved to `libvips42`](https://app.circleci.com/pipelines/github/nebulab/solidus/613/workflows/a5746325-db19-49ba-bb18-29ef7b5d8ae4/jobs/7383/parallel-runs/0/steps/0-108). However, only using `libvips42` will make [some tests fail](https://app.circleci.com/pipelines/github/solidusio/solidus/3847/workflows/2f4730ee-2443-41b0-b675-98cdd5f3e37c/jobs/34422). To get rid of the errors, we need to add `libvips-dev` (which also relies on the latter).

### 2. Invalidate cache for solidus installer CircleCI job

That's to fix an [issue with non-matching ruby versions](https://app.circleci.com/pipelines/github/solidusio/solidus/3838/workflows/2b5f5731-1c8c-4589-bfc0-6206156cd364/jobs/34317?invite=true#step-108-130).

An alternative solution to reset cache that won't require code changes is also currently discussed in #4759.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
