### PR TITLE
Improve variant and product autocomplete functions flexibility with Ransack

### DIFF
--- a/api/spec/requests/spree/api/variants_spec.rb
+++ b/api/spec/requests/spree/api/variants_spec.rb
@@ -47,7 +47,7 @@ module Spree::Api
 
       it 'can query the results through ransack' do
         expected_result = create(:variant, sku: 'FOOBAR')
-        get spree.api_variants_path, params: { q: { sku_cont: 'FOO' } }
+        get spree.api_variants_path, params: { variant_search_term: nil, q: { sku_cont: 'FOO' } }
         expect(json_response['count']).to eq(1)
         expect(json_response['variants'].first['sku']).to eq expected_result.sku
       end

--- a/backend/app/assets/javascripts/spree/backend/orders/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit.js
@@ -1,6 +1,8 @@
 Spree.ready(function () {
   'use strict';
 
-  $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({ suppliable_only: true });
+  $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({
+    searchParameters: function (_term) { return { suppliable_only: true } }
+  });
   $("[data-hook='admin_orders_index_search']").find(".variant_autocomplete").variantAutocomplete();
 });

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -10,16 +10,30 @@
   /**
     * Make the element a select2 dropdown used for finding Variants. By default, the search term will be
     * passed to the defined Spree::Config.variant_search_class by the controller with its defined scope.
-    * @param  {Object} options Options
+    * @param  {Object|undefined|null} options Options
     * @param  {Function|undefined} options.searchParameters Returns a hash object for params to merge on the select2 ajax request
     *                                                       Accepts an argument of the select2 search term. To use Ransack, define
     *                                                       variant_search_term as a falsy value, and q as the Ransack query. Note,
     *                                                       you need to ensure that the attributes are allowed to be Ransacked.
     */
-  $.fn.variantAutocomplete = function(options = {}) {
+  $.fn.variantAutocomplete = function(options) {
     function extraParameters(term) {
-      if (typeof(options['searchParameters']) === 'function') {
-        return options['searchParameters'](term)
+      if (typeof(options) === 'object') {
+        if (typeof(options['searchParameters']) === 'function') {
+          return options['searchParameters'](term)
+        } else {
+          console.warn(
+            "Solidus deprecation: Passing an object of parameters to variantAutocomplete is deprecated. Instead, on the options object, please declare `searchParameters` as a function returning the parameters.\n\n",
+            "Deprecated usage:\n",
+            "$('#id').variantAutocomplete({\n",
+            "  suppliable_only: true\n",
+            "})",
+            "\n\nNew usage:\n",
+            "$('#id').variantAutocomplete({\n",
+            "  searchParameters: function (_selectSearchTerm) { return { suppliable_only: true  } }\n",
+            "})"
+          )
+        }
       }
 
       return {}

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -7,10 +7,24 @@
     });
   };
 
-  $.fn.variantAutocomplete = function(searchOptions) {
-    if (searchOptions == null) {
-      searchOptions = {};
+  /**
+    * Make the element a select2 dropdown used for finding Variants. By default, the search term will be
+    * passed to the defined Spree::Config.variant_search_class by the controller with its defined scope.
+    * @param  {Object} options Options
+    * @param  {Function|undefined} options.searchParameters Returns a hash object for params to merge on the select2 ajax request
+    *                                                       Accepts an argument of the select2 search term. To use Ransack, define
+    *                                                       variant_search_term as a falsy value, and q as the Ransack query. Note,
+    *                                                       you need to ensure that the attributes are allowed to be Ransacked.
+    */
+  $.fn.variantAutocomplete = function(options = {}) {
+    function extraParameters(term) {
+      if (typeof(options['searchParameters']) === 'function') {
+        return options['searchParameters'](term)
+      }
+
+      return {}
     }
+
     this.select2({
       placeholder: Spree.translations.variant_placeholder,
       minimumInputLength: 3,
@@ -35,7 +49,7 @@
             token: Spree.api_key,
             page: page
           };
-          return _.extend(searchData, searchOptions);
+          return _.extend(searchData, extraParameters(term));
         },
 
         results: function(data, page) {

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
@@ -84,6 +84,8 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
       noCancel: this.model.isNew() && this.model.collection.length == 1
     });
     this.$el.html(html);
-    this.$("[name=variant_id]").variantAutocomplete({ suppliable_only: true });
+    this.$("[name=variant_id]").variantAutocomplete({
+      searchParameters: function (_term) { return { suppliable_only: true  } }
+    });
   }
 });

--- a/backend/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/search_controller_spec.rb
@@ -88,10 +88,20 @@ describe Spree::Admin::SearchController, type: :controller do
     end
 
     context 'when ids param is not present' do
-      let(:params) { { q: { name_cont: 'jersey' } } }
+      context "when the default ransack is used" do
+        let(:params) { { q: { name_cont: 'jersey' } } }
 
-      it_should_behave_like 'product search' do
-        let(:expected_products) { [product_one, product_two] }
+        it_should_behave_like 'product search' do
+          let(:expected_products) { [product_one, product_two] }
+        end
+      end
+
+      context "when a custom ransack query is used" do
+        let(:params) { { q: { slug_eq: 'better-jersey' } } }
+
+        it_should_behave_like 'product search' do
+          let(:expected_products) { [product_two] }
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
From this change, when initializing a productAutocomplete, a callback can be given to the searchCallback option. This callback should return a hash object that will be used to merge onto the existing parameters in the select2 ajax function. The callback also allows for one argument, which is the string typed in the select2 (term). Custom Ransack can be achieved by defining this option with the Ransack query on the `q` key.

```JavaScript
$('#product-dropdown').productAutocomplete({
  multiple: false,
  searchCallback: (searchString) => ({
    q: {
      name_cont: searchString,
      available_on_not_null: true
    })
  }
})
```

Similar behavior was already existing on the `variantAutocomplete`, however accepted a simple `hash` object instead of a function, and so one didn't have access to the select2 search term, so this was improved.

```JavaScript
$('#variant-dropdown).variantAutocomplete({
  searchCallback: (searchString) => ({
    q: {
      variant_search_term: null,
      sku_cont: searchString
    })
  }
})
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):
- [ ] I have added automated tests to cover my changes.
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the README to account for my changes.~~

----
Autocompletes are still working:

## Variant
### Orders#index
<img width="1728" alt="Screenshot 2022-11-28 at 14 10 33" src="https://user-images.githubusercontent.com/76776099/204292078-8c00336f-00a9-4139-bf78-778dc21af990.png">

### Orders#edit
<img width="1728" alt="Screenshot 2022-11-28 at 14 10 45" src="https://user-images.githubusercontent.com/76776099/204292104-17697d23-44d7-4b67-a526-53093c49eb6b.png">

## Product
### Promotion Rules - Product
<img width="1728" alt="Screenshot 2022-11-28 at 14 12 10" src="https://user-images.githubusercontent.com/76776099/204292159-1b1ced64-8f17-43a7-a1e9-cfecb80afa65.png">

### Promotion Rules - Option Values
<img width="1728" alt="Screenshot 2022-11-28 at 14 12 47" src="https://user-images.githubusercontent.com/76776099/204292221-f36b3406-6655-4d70-82d7-0391386d2097.png">
