### PR TITLE
Use consistent labels for automatic backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,19 +1,19 @@
+name: "Automatic backporting"
 on:
   pull_request_target:
     types: ["labeled", "closed"]
 
 jobs:
   backport:
-    name: Backport PR
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true
       && contains(
            join(github.event.pull_request.labels.*.name, '---'),
-           '---Needs Backport'
+           '---backport'
          )
       && (
-        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'Needs Backport')) ||
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport')) ||
           (github.event.action == 'closed')
       )
     steps:
@@ -21,7 +21,7 @@ jobs:
         uses: sqren/backport-github-action@v8.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          auto_backport_label_prefix: Needs Backport-
+          auto_backport_label_prefix: backport-
           add_original_reviewers: true
 
       - name: Info log


### PR DESCRIPTION
## Summary

We're [normalizing the labels](https://github.com/solidusio/solidus/issues/4752) used on GitHub. Here, we update what is expected for the [automatic backporting](https://github.com/sqren/backport-github-action).

**We need to update the label names on GitHub just before merging this PR.**

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
