### PR TITLE
Ensure the presence of a changelog label before merging a PR

### DIFF
--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -1,0 +1,21 @@
+name: "Ensure Changelog label"
+
+on:
+  pull_request_target:
+    types: ["labeled", "unlabeled"]
+  workflow_call:
+
+jobs:
+  ensure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Check for the presence of a changelog label"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view \
+            ${{ github.event.pull_request.number }} \
+            --json labels \
+            --jq 'any(.labels[].name; startswith("changelog:"))' \
+            | jq -e

--- a/.github/workflows/triage_for_changelog.yml
+++ b/.github/workflows/triage_for_changelog.yml
@@ -1,8 +1,9 @@
-name: "Pull Request Labeler"
+name: "Triage for Changelog"
+
 on: pull_request_target
 
 jobs:
-  triage_changelog_label:
+  triage:
     permissions:
       contents: read
       pull-requests: write
@@ -12,3 +13,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
+  ensure:
+    uses: "./.github/workflows/ensure_changelog_label.yml"
+    needs: "triage"


### PR DESCRIPTION
## Summary

With #4756, we created a set of labels prefixed with `changelog:`. They cover all possible changes in the repository. We're now adding a check to ensure that at least one is present.

The action runs in two contexts:

- When labels on a PR change.
- Just after the automatic labeler has done its work, which is a
  safeguard in case we add new files to the repo that don't meet the
  current rules.

We need to query the API with the `gh` command as `${{ github.event.pull_request.labels }}` won't contain the updated information after the `triage` step on the "Triage for Changelog" workflow. For simplicity, we keep the same for "Ensure Changelog label" standalone workflow.

Closes #4765

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
