### PR TITLE
Fix source tag used to create the diff for the release notes on master

### DIFF
--- a/.github/workflows/extract_pipeline_context.yml
+++ b/.github/workflows/extract_pipeline_context.yml
@@ -12,6 +12,9 @@ on:
       current_tag:
         description: "Current tag"
         value: ${{ jobs.extract.outputs.current_tag }}
+      current_diff_source_tag:
+        description: "Current diff source tag"
+        value: ${{ jobs.extract.outputs.current_diff_source_tag }}
       candidate_tag:
         description: "Candidate tag"
         value: ${{ jobs.extract.outputs.candidate_tag }}
@@ -47,6 +50,7 @@ jobs:
             `git tag --list`
     outputs:
       current_tag: ${{ steps.extraction.outputs.current_tag }}
+      current_diff_source_tag: ${{ steps.extraction.outputs.current_diff_source_tag }}
       candidate_tag: ${{ steps.extraction.outputs.candidate_tag }}
       candidate_version: ${{ steps.extraction.outputs.candidate_version }}
       candidate_minor_version: ${{ steps.extraction.outputs.candidate_minor_version }}

--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -29,7 +29,7 @@ jobs:
           cd dev_tools/ && bin/update-release-draft \
             ${{ github.token }} \
             ${{ github.repository }} \
-            ${{ needs.extract_pipeline_context.outputs.current_tag }} \
+            ${{ needs.extract_pipeline_context.outputs.current_diff_source_tag }} \
             ${{ needs.extract_pipeline_context.outputs.candidate_tag }} \
             ${{ github.ref_name }} \
             ${{ github.event.number }}

--- a/dev_tools/bin/extract-pipeline-context
+++ b/dev_tools/bin/extract-pipeline-context
@@ -19,6 +19,7 @@ puts <<~MSG
   Pipeline context:
     Base branch: #{base_branch}
     Current tag: #{context.current_tag}
+    Current diff source tag: #{context.current_diff_source_tag}
     Candidate tag: #{context.candidate_tag}
     Candidate version: #{context.candidate_version}
     Candidate minor version: #{context.candidate_minor_version}
@@ -30,6 +31,7 @@ MSG
 
 open(stream, 'a') do |s|
   s.puts "current_tag=#{context.current_tag}"
+  s.puts "current_diff_source_tag=#{context.current_diff_source_tag}"
   s.puts "candidate_tag=#{context.candidate_tag}"
   s.puts "candidate_version=#{context.candidate_version}"
   s.puts "candidate_minor_version=#{context.candidate_minor_version}"

--- a/dev_tools/bin/update-release-draft
+++ b/dev_tools/bin/update-release-draft
@@ -8,7 +8,7 @@ require_relative '../lib/solidus/release_drafter'
 
 github_token = ARGV[0]
 repository = ARGV[1]
-current_tag = ARGV[2]
+current_diff_source_tag = ARGV[2]
 candidate_tag = ARGV[3]
 branch = ARGV[4]
 pr_number = ARGV[5]
@@ -28,7 +28,7 @@ MSG
 
 draft = drafter.call(
   pr_number: pr_number,
-  current_tag: current_tag,
+  current_diff_source_tag: current_diff_source_tag,
   candidate_tag: candidate_tag,
   branch: branch
 )

--- a/dev_tools/lib/solidus/pipeline_context.rb
+++ b/dev_tools/lib/solidus/pipeline_context.rb
@@ -48,6 +48,15 @@ module Solidus
         end
     end
 
+    def current_diff_source_tag
+      return current_tag unless main_branch?
+
+      current_tag
+        .split(VERSION_SEPARATOR)
+        .then { |(major, minor, patch)| [major, minor, '0'] }
+        .join(VERSION_SEPARATOR)
+    end
+
     def candidate_tag
       @candidate_tag ||= next_tag(current_tag, @tracking_major)
     end

--- a/dev_tools/spec/lib/solidus/pipeline_context_spec.rb
+++ b/dev_tools/spec/lib/solidus/pipeline_context_spec.rb
@@ -74,6 +74,30 @@ RSpec.describe Solidus::PipelineContext do
     end
   end
 
+  describe '#current_diff_source_tag' do
+    context 'when the base branch is the main branch' do
+      it 'returns the current tag adjusted to its first patch version' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0 v3.0.1],
+          base_branch: 'master'
+        )
+
+        expect(context.current_diff_source_tag).to eq('v3.0.0')
+      end
+    end
+
+    context 'when the base branch is a patch branch' do
+      it 'returns the current tag' do
+        context = described_class.new(
+          tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0 v3.0.1],
+          base_branch: 'v3.0'
+        )
+
+        expect(context.current_diff_source_tag).to eq('v3.0.1')
+      end
+    end
+  end
+
   describe '#candidate_tag' do
     context 'when the base branch is a patch branch' do
       it 'returns the next patch level tag on the base branch' do

--- a/dev_tools/spec/lib/solidus/release_drafter_spec.rb
+++ b/dev_tools/spec/lib/solidus/release_drafter_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: ['changelog:solidus_core'])
 
       expect(
-        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
       ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 #1 (@alice)")}/)
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
 
       expect(
-        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
       ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 #1 (@alice)")}.*#{Regexp.escape("## Solidus API\n- PR number 1 #1 (@alice)")}/m)
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[other])
 
       expect(
-        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
       ).to be(nil)
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:skip])
 
       expect(
-        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
       ).to be(nil)
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
 
       expect(
-        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
       ).to include("don't edit manually")
     end
 
@@ -90,7 +90,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
 
       expect(
-        subject.call(pr_number: 1, current_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
       ).to include("**Full Changelog**: https://github.com/fake/solidus/compare/v3.0.0...v3.1.0")
     end
   end


### PR DESCRIPTION
## Summary

On the automatic generation of the release notes (see #4719), we append them with a link to the diff of commits after the new release. E.g.:

```md
**Full Changelog**: https://github.com/solidusio/solidus/compare/v3.2.1...v3.2.2
```

Using the current tag in the series as the diff source works for patch-level releases. However, in minor and major releases, we need to use the first patch level of the previous version (e.g., `v3.2.0`) for a couple of reasons:

- That's what it really will show all the changes done in master since the last release.
- Otherwise, whenever a new patch version is released, the automatic generation of the release notes will break, as the expected appended will have changed.

Fixes #4795

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
