### PR TITLE
Skip update of release notes at the job definition level

### DIFF
--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -15,7 +15,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
     needs: extract_pipeline_context
-    if: github.event.pull_request.merged == true
+    if: |
+      (github.event.pull_request.merged == true) &&
+        !contains(github.event.pull_request.labels.*.name, 'changelog:skip')
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary

We're already skipping adding entries for PRs merged with the `changelog:skip` label. However, we were doing it only from the [code](https://github.com/solidusio/solidus/blob/f8cb8517b6dae37a0e1a00eae72409ac0b54c37a/dev_tools/lib/solidus/release_drafter.rb#L37) called by the job definition. We're now optimizing by also checking it at the job definition level to skip the execution of previous slow steps (i.e., checking out the code).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
