### PR TITLE
Depend on solidus_frontend in GH for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :backend, :frontend do
 end
 
 group :frontend do
+  gem 'solidus_frontend', github: 'solidusio/solidus_frontend', branch: 'v3.2'
   gem 'generator_spec'
 end
 

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version
-  s.add_dependency 'solidus_frontend', s.version
   s.add_dependency 'solidus_sample', s.version
+
+  s.add_dependency 'solidus_frontend', '~> 3.2.5'
 end


### PR DESCRIPTION
## Summary

In development, we don't want Bundler to use solidus_frontend from RubyGems. That's because we don't always have a development version released for any version of Solidus.

This will allow us to always use the last development code, without the need of releasing a new `.dev` version on RubyGems.

The outlined issue is especially true when we release a new patch version. See [these CI failures](https://app.circleci.com/pipelines/github/solidusio/solidus/3916/workflows/9a770641-fcde-424e-a3ce-a5ee5194e76b/jobs/35477); with this change, we can still have solidus tests running against the last development version (exactly as we were doing before moving `solidus_frontend` out of the repository), without releasing `v3.2.6 alpha` on RubyGems.


The second commit updates the gemspec dependency as well, because we need it to work when the gem is used as well ( (see https://app.circleci.com/pipelines/github/nebulab/solidus/684/workflows/b04c3f41-a5c4-425c-98f1-e98bbb0e8ac8/jobs/8630). It will work at the infrastructure level, even before we release this change, because for solidus core and extensions, we are still using the branch and not RubyGems to retrieve the gem.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
