### PR TITLE
Be explicit about the solidus_frontend gemspec dependency

### DIFF
--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version
-  s.add_dependency 'solidus_frontend', s.version
   s.add_dependency 'solidus_sample', s.version
+
+  s.add_dependency 'solidus_frontend', '~> 3.3.0.alpha'
 end


### PR DESCRIPTION
Partial "Backport" of #4815 in master

## Summary

We need to avoid being too strict on the frontend dependency because otherwise we need to release a new solidus_frontend .dev version everytime we release a new solidus 3.3.x patch level version.

With this change, whenever the solidus main gem is used, Bundler will compute the frontend dependency less strictly and will pick the last version released on RubyGems.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
