### PR TITLE
Pre-add the default store to new payment methods

### DIFF
--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -69,6 +69,12 @@ module Spree
       def payment_method_params
         params.require(:payment_method).permit!
       end
+
+      def build_resource
+        model_class.new(
+          store_ids: [Spree::Store.default.id].compact
+        )
+      end
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -52,6 +52,21 @@ module Spree
       expect(response).to redirect_to spree.new_admin_payment_method_path
     end
 
+    describe "#new" do
+      subject { get :new }
+
+      it "adds the default store to the list of stores" do
+        default_store = create(:store, default: true)
+        subject
+        expect(assigns(:payment_method).store_ids).to eql([default_store.id])
+      end
+
+      it "does not add a store if there's no default store" do
+        subject
+        expect(assigns(:payment_method).store_ids).to eql([])
+      end
+    end
+
     describe "#index" do
       subject { get :index }
 


### PR DESCRIPTION
## Summary

This is a sensible default that won't be to be touched most of the time. Previously it was required to be added manually.

<img width="609" alt="image" src="https://user-images.githubusercontent.com/1051/210223909-6cedabdd-cfe3-49f4-b241-a635b8133c59.png">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.

<del>
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
</del>