### PR TITLE
[v3.1] Test with Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       CIRCLE_TEST_REPORTS: /tmp/test-results
       CIRCLE_ARTIFACTS: /tmp/test-artifacts
     docker:
-      - image: &image circleci/ruby:2.5-node-browsers
+      - image: &image circleci/ruby:2.7-node-browsers
 
   postgres:
     working_directory: *workdir


### PR DESCRIPTION
## Summary

The latest Bundler version (2.4) that automatically installs on CI does not support Ruby 2.5 anymore, also Ruby 2.5 is not receiving any updates from the Ruby team anymore.

We still support using Ruby 2.5 with Solidus 3.1, but we do not test it with later versions. We should test with Ruby 2.7 instead.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
