### PR TITLE
Hide soft deleted prices from admin product view

### DIFF
--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -8,7 +8,7 @@ module Spree
       def index
         params[:q] ||= {}
 
-        @search = @product.prices.accessible_by(current_ability, :index).ransack(params[:q])
+        @search = @product.prices.kept.accessible_by(current_ability, :index).ransack(params[:q])
         @master_prices = @search.result
           .currently_valid
           .for_master

--- a/backend/spec/controllers/spree/admin/prices_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/prices_controller_spec.rb
@@ -11,6 +11,8 @@ describe Spree::Admin::PricesController do
     context "when only given a product" do
       let(:product) { create(:product) }
 
+      let!(:deleted_master_price) { create(:price, variant: product.master).tap(&:discard!) }
+
       subject { get :index, params: { product_id: product.slug } }
 
       it { is_expected.to be_successful }
@@ -18,8 +20,9 @@ describe Spree::Admin::PricesController do
       it 'assigns usable instance variables' do
         subject
         expect(assigns(:search)).to be_a(Ransack::Search)
-        expect(assigns(:variant_prices)).to eq(product.prices.for_variant)
-        expect(assigns(:master_prices)).to eq(product.prices.for_master)
+        expect(assigns(:variant_prices)).to be_empty
+        expect(assigns(:master_prices)).to eq(product.prices.kept.for_master)
+        expect(assigns(:master_prices)).to_not include(deleted_master_price)
         expect(assigns(:product)).to eq(product)
       end
     end
@@ -28,6 +31,8 @@ describe Spree::Admin::PricesController do
       let(:variant) { create(:variant) }
       let(:product) { variant.product }
 
+      let!(:deleted_variant_price) { create(:price, variant: variant).tap(&:discard!) }
+
       subject { get :index, params: { product_id: product.slug, variant_id: variant.id } }
 
       it { is_expected.to be_successful }
@@ -35,9 +40,10 @@ describe Spree::Admin::PricesController do
       it 'assigns usable instance variables' do
         subject
         expect(assigns(:search)).to be_a(Ransack::Search)
-        expect(assigns(:variant_prices)).to eq(product.prices.for_variant)
+        expect(assigns(:variant_prices)).to eq(product.prices.kept.for_variant)
         expect(assigns(:master_prices)).to eq(product.prices.for_master)
         expect(assigns(:variant_prices)).to include(variant.default_price)
+        expect(assigns(:variant_prices)).to_not include(deleted_variant_price)
         expect(assigns(:product)).to eq(product)
       end
     end


### PR DESCRIPTION
## Summary

The `product.prices` relation has been changed in 3f4578aba47fbfdebcba7cbdcb84507f142ae93d to make eager loading possible, but this now shows soft deleted prices in the admin product prices tab.

Hiding them again to restore previous behavior.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.

## Before

![deleted prices shown](https://user-images.githubusercontent.com/42868/210389544-4e5b7529-6049-406c-a184-5c4b9bed4717.png)

## After

![deleted prices hidden](https://user-images.githubusercontent.com/42868/210391233-ff15fac3-b257-4dbb-8ce2-05b4e87199a1.png)
