### PR TITLE
Fix styling of table rows for deleted records

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -1,3 +1,5 @@
+@import "spree/backend/components/actions";
+
 table {
   // Extend all tables with Bootstrap's default table style
   @extend .table;
@@ -114,8 +116,8 @@ table {
   tbody {
     tr {
       &.deleted td {
-        background-color: lighten(theme-color("danger"), 6);
-        border-color: lighten(theme-color("danger"), 15);
+        background-color: $color-action-remove-bg;
+        text-decoration: line-through;
       }
     }
 


### PR DESCRIPTION
## Summary

The current styling is brutal and not nice. Using the remove action hover style for deleted records in tables.

### Before

![deleted-records-before](https://user-images.githubusercontent.com/42868/210389544-4e5b7529-6049-406c-a184-5c4b9bed4717.png)

### After

![deleted-records-after](https://user-images.githubusercontent.com/42868/210401593-9ec3b682-045a-4cd1-88f7-ffff78f8e320.png)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
