### PR TITLE
Add a default implementation for PaymentMethod#try_void

### DIFF
--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -116,13 +116,15 @@ RSpec.describe Spree::PaymentMethod, type: :model do
   end
 
   describe '#auto_capture?' do
-    class TestGateway < Spree::PaymentMethod::CreditCard
-      def gateway_class
-        Provider
+    let(:gateway) do
+      gateway_class = Class.new(Spree::PaymentMethod::CreditCard) do
+        def gateway_class
+          Provider
+        end
       end
-    end
 
-    let(:gateway) { TestGateway.new }
+      gateway_class.new
+    end
 
     subject { gateway.auto_capture? }
 
@@ -174,28 +176,28 @@ RSpec.describe Spree::PaymentMethod, type: :model do
   end
 
   describe 'ActiveMerchant methods' do
-    class PaymentGateway
-      def initialize(options)
+    let(:payment_method) do
+      payment_method_class = Class.new(Spree::PaymentMethod) do
+        def gateway_class
+          Class.new do
+            def initialize(options)
+            end
+
+            def authorize; 'authorize'; end
+
+            def purchase; 'purchase'; end
+
+            def capture; 'capture'; end
+
+            def void; 'void'; end
+
+            def credit; 'credit'; end
+          end
+        end
       end
 
-      def authorize; 'authorize'; end
-
-      def purchase; 'purchase'; end
-
-      def capture; 'capture'; end
-
-      def void; 'void'; end
-
-      def credit; 'credit'; end
+      payment_method_class.new
     end
-
-    class TestPaymentMethod < Spree::PaymentMethod
-      def gateway_class
-        PaymentGateway
-      end
-    end
-
-    let(:payment_method) { TestPaymentMethod.new }
 
     it "passes through authorize" do
       expect(payment_method.authorize).to eq 'authorize'


### PR DESCRIPTION
## Summary

We use to replicate this behavior on all the payment extensions that add a payment integration. Still, the logic is pretty similar all the times.

By adding this default behavior we can save some time integrating new payment methods, unelss something special is needed.

The default try_void method added will just check if the void attempt is successful, otherwise it will return false. This will determine if Solidus will emit a refund along with an order cancellation.

The method is a bit complex because void can have different arity, based on if the payment method support payment profiles or not. See [payment processing] for more information.

[payment processing]: https://github.com/solidusio/solidus/blob/16d1e3704fbbe630a584c919de1a640a6ab6c6f8/core/app/models/spree/payment/processing.rb#L74-L81

This PR comes from [this conversation](https://github.com/solidusio/solidus_paypal_commerce_platform/pull/180#discussion_r1060830180) on PayPal Commerce Platform.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
