### PR TITLE
Raise a custom extension passing invalid search params

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -4,6 +4,12 @@ module Spree
   module Core
     module Search
       class Base
+        class InvalidOptions < ArgumentError
+          def initialize(option)
+            super("Invalid option passed to the searcher: '#{option}'")
+          end
+        end
+
         attr_accessor :properties
         attr_accessor :current_user
         attr_accessor :pricing_options
@@ -57,16 +63,19 @@ module Spree
         end
 
         def add_search_scopes(base_scope)
-          if @properties[:search]
-            @properties[:search].each do |name, scope_attribute|
-              scope_name = name.to_sym
-              if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
-                base_scope = base_scope.send(scope_name, *scope_attribute)
-              else
-                base_scope = base_scope.merge(Spree::Product.ransack({ scope_name => scope_attribute }).result)
-              end
+          return base_scope unless @properties[:search].present?
+          raise InvalidOptions.new(:search) unless @properties[:search].respond_to?(:each_pair)
+
+          @properties[:search].each_pair do |name, scope_attribute|
+            scope_name = name.to_sym
+
+            if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
+              base_scope = base_scope.send(scope_name, *scope_attribute)
+            else
+              base_scope = base_scope.merge(Spree::Product.ransack({ scope_name => scope_attribute }).result)
             end
           end
+
           base_scope
         end
 

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe Spree::Core::Search::Base do
     expect(searcher.retrieve_products.count).to eq(2)
   end
 
+  it "raises a proper exception when search param is invalid" do
+    params = { per_page: "",
+               search: "blub" }
+    searcher = Spree::Core::Search::Base.new(params)
+    expect { searcher.retrieve_products }.to raise_error(described_class::InvalidOptions, "Invalid option passed to the searcher: 'search'")
+  end
+
   it "accepts a current user" do
     user = double
     searcher = Spree::Core::Search::Base.new({})


### PR DESCRIPTION
## Summary

Right now, passing a string (or any other thing that is not a Hash) to the searcher in the `:search` parameter will raise a `NoMethodError`.

For example: `/products?per_page=&keywords=&search=blub` would raise a NoMethodError.

This commit avoids that a generic NoMethodError is raised and instead raises a very specific exception that serves two purposes:

1. Helps debugging: the error message contains the name of the param that is invalid, making it easier to spot eventual issues.
2. Allows to rescue the error safely at the storefront level. For example, to respond with a 400, one can easily do:

       rescue_from Spree::Core::Search::Base::InvalidOptions do |error|
         raise ActionController::BadRequest.new, error.message
       end

### Backward compatibility impact

If a store was rescuing from NoMethodError trying to catch this extension, their rescuing will fail. There's nothing to do about that. 

--- 

🙏  This issue was originally reported in HackerOne by our friends at @renuo, but we agreed to treat this as a regular bug because of the low security impact this might have.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
