### PR TITLE
Remove Ruby v2.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,17 +277,7 @@ jobs:
       BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX: "(<< parameters.ruby >>:<< parameters.rails >>:<< parameters.database >>:<< parameters.paperclip >>)"
     steps:
       - setup
-      - when:
-          condition:
-            not:
-              equal: [<<parameters.ruby>>, '2.5']
-          steps:
-            - libvips
-      - when:
-          condition:
-            equal: [<<parameters.ruby>>, '2.5']
-          steps:
-            - imagemagick
+      - libvips
       - test
       - notify
 
@@ -356,6 +346,6 @@ workflows:
       - test_solidus:
           context: slack-secrets
           name: *name
-          matrix: { parameters: { rails: ['5.2'], ruby: ['2.5'], database: ['sqlite'], paperclip: [true] } }
+          matrix: { parameters: { rails: ['5.2'], ruby: ['2.6'], database: ['sqlite'], paperclip: [true] } }
       - dev_tools:
           context: slack-secrets

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'jbuilder', '~> 2.8'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -97,7 +97,7 @@ module Spree
 
     # Sets the last digits field based on the assigned credit card number.
     def set_last_digits
-      self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
+      self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..)
     end
 
     # @return [String] the credit card type if it can be determined from the

--- a/core/lib/generators/solidus/install/app_templates/frontend/break_down_solidus_gem.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/break_down_solidus_gem.rb
@@ -18,7 +18,7 @@ bundler_injector = Class.new(Bundler::Injector) do
       requirement = if is_local
                       ", path: \"#{d.source.path}\""
                     elsif is_git
-                      ", git: \"#{d.git}\"".yield_self { |g| d.ref ? g + ", ref: \"#{d.ref}\"" : g }
+                      ", git: \"#{d.git}\"".then { |g| d.ref ? g + ", ref: \"#{d.ref}\"" : g }
                     elsif conservative_versioning
                       ", \"#{conservative_version(@definition.specs[d.name][0])}\""
                     else

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -120,7 +120,7 @@ module Spree
         dummy_application_path = File.expand_path("#{dummy_path}/config/application.rb", destination_root)
         unless options[:pretend] || !File.exist?(dummy_application_path)
           contents = File.read(dummy_application_path)
-          contents[(contents.index("module #{module_name}"))..-1]
+          contents[(contents.index("module #{module_name}"))..]
         end
       end
     end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -86,7 +86,7 @@ end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
   Spree::Deprecation.warn <<~HEREDOC
-    Ruby 2.5 & Ruby 2.6 (both EOL) are deprecated and will not be supported anymore from the next Solidus version.
+    Ruby 2.6, which reached EOL, is deprecated and will not be supported anymore from the next Solidus version.
     Please, upgrade to a more recent Ruby version.
     Read more on the release notes for different Ruby versions here:
     https://www.ruby-lang.org/en/downloads/releases/

--- a/core/lib/spree/testing_support/factory_bot.rb
+++ b/core/lib/spree/testing_support/factory_bot.rb
@@ -37,7 +37,7 @@ module Spree
         Spree::Deprecation.warn(
           "Please do not cherry-pick factories, this is not well supported by FactoryBot, " \
           'follow the changelog instructions on how to migrate your current setup.',
-          callsites[index..-1]
+          callsites[index..]
         )
       end
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   %w[

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_core', s.version

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['README.md', 'lib/**/*']
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version


### PR DESCRIPTION
## Summary

Ruby [v2.5 is EOL](https://www.ruby-lang.org/en/downloads/branches/) since 05 Apr 2021.

Our new [release policy](https://solidus.io/release_policy/) makes it clear that we don't support Ruby versions that are no longer maintained.

We also make a basic sanitization check in our code base to update to newer standards:

1. Use [endless ranges](https://ruby-doc.org/core-2.6/Range.html#class-Range-label-Endless+Ranges) when possible
2. Use more succint [#then](https://ruby-doc.org/core-2.6/Object.html#method-i-yield_self) alias instead of #yield_self

Closes #4840 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
