### PR TITLE
Remove Ruby v2.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,10 +342,10 @@ workflows:
       - test_solidus:
           context: slack-secrets
           name: *name
-          matrix: { parameters: { rails: ['6.0'], ruby: ['2.6'], database: ['sqlite'], paperclip: [true] } }
+          matrix: { parameters: { rails: ['6.0'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true] } }
       - test_solidus:
           context: slack-secrets
           name: *name
-          matrix: { parameters: { rails: ['5.2'], ruby: ['2.6'], database: ['sqlite'], paperclip: [true] } }
+          matrix: { parameters: { rails: ['5.2'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true] } }
       - dev_tools:
           context: slack-secrets

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :backend do
   # - https://github.com/ruby/net-protocol/issues/10
   # - https://stackoverflow.com/a/72474475
   v = ->(string) { Gem::Version.new(string) }
-  if Gem::Requirement.new(['>= 2.6', '< 3']) === Gem::Version.new(RUBY_VERSION)
+  if Gem::Requirement.new(['>= 2.7', '< 3']) === Gem::Version.new(RUBY_VERSION)
     gem 'net-http', require: false
   end
 

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'jbuilder', '~> 2.8'

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -12,7 +12,7 @@
         <% if @taxon.parent %>
           <div class="input-group-prepend">
             <span class="input-group-text">
-              <%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %>
+              <%= @taxon.permalink.split('/')[...-1].join('/') + '/' %>
             </span>
           </div>
         <% end %>

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -84,15 +84,6 @@ module Spree
   end
 end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
-  Spree::Deprecation.warn <<~HEREDOC
-    Ruby 2.6, which reached EOL, is deprecated and will not be supported anymore from the next Solidus version.
-    Please, upgrade to a more recent Ruby version.
-    Read more on the release notes for different Ruby versions here:
-    https://www.ruby-lang.org/en/downloads/releases/
-  HEREDOC
-end
-
 if Gem::Version.new(Rails.version) < Gem::Version.new('6.0')
   Spree::Deprecation.warn <<~HEREDOC
     Rails 5.2 (EOL) is deprecated and will not be supported anymore from the next Solidus version.

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -34,7 +34,7 @@ module Spree
                               states
                             else
                               end_state_position = states.index(state.to_sym)
-                              states[0..end_state_position]
+                              states[..end_state_position]
                             end
 
         states_to_process.each do |state_to_process|

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   %w[

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_core', s.version

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['README.md', 'lib/**/*']
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version


### PR DESCRIPTION
## Summary

Remove support for ruby v2.6

[Ruby v2.6 is EOL](https://www.ruby-lang.org/en/downloads/branches/) since 12 Apr 2022.

Our [new release policy](https://solidus.io/release_policy/) makes it clear that we don't support Ruby versions that are no longer maintained.

We also make a basic sanitization check in our code base to update to newer standards:

1 - Use [beginless ranges](https://ruby-doc.org/core-2.7.0/Range.html#class-Range-label-Beginless-2FEndless+Ranges) when possible.

Fixes #4841 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
