### PR TITLE
Improve ransackable attribute class method names

### DIFF
--- a/api/spec/requests/ransackable_attributes_spec.rb
+++ b/api/spec/requests/ransackable_attributes_spec.rb
@@ -64,8 +64,8 @@ describe "Ransackable Attributes" do
     end
   end
 
-  context "filtering by whitelisted attributes" do
-    it "filtering is supported for whitelisted attributes" do
+  context "filtering by allowed attributes" do
+    it "filtering is supported for allowed attributes" do
       product = create(:product, name: "Fritos")
       other_product = create(:product)
 

--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -3,8 +3,28 @@
 module Spree::RansackableAttributes
   extend ActiveSupport::Concern
   included do
-    class_attribute :whitelisted_ransackable_associations
-    class_attribute :whitelisted_ransackable_attributes
+    class_attribute :allowed_ransackable_associations
+    class_attribute :allowed_ransackable_attributes
+
+    def self.whitelisted_ransackable_associations
+      Spree::Deprecation.deprecation_warning(:whitelisted_ransackable_associations, 'use allowed_ransackable_associations instead')
+      allowed_ransackable_associations
+    end
+
+    def self.whitelisted_ransackable_associations=(new_value)
+      Spree::Deprecation.deprecation_warning(:whitelisted_ransackable_associations=, 'use allowed_ransackable_associations= instead')
+      self.allowed_ransackable_associations = new_value
+    end
+
+    def self.whitelisted_ransackable_attributes
+      Spree::Deprecation.deprecation_warning(:whitelisted_ransackable_attributes, 'use allowed_ransackable_attributes instead')
+      allowed_ransackable_attributes
+    end
+
+    def self.whitelisted_ransackable_attributes=(new_value)
+      Spree::Deprecation.deprecation_warning(:whitelisted_ransackable_attributes=, 'use allowed_ransackable_attributes= instead')
+      self.allowed_ransackable_attributes = new_value
+    end
 
     class_attribute :default_ransackable_attributes
     self.default_ransackable_attributes = %w[id]
@@ -12,11 +32,11 @@ module Spree::RansackableAttributes
 
   class_methods do
     def ransackable_associations(*_args)
-      whitelisted_ransackable_associations || []
+      allowed_ransackable_associations || []
     end
 
     def ransackable_attributes(*_args)
-      default_ransackable_attributes | (whitelisted_ransackable_attributes || [])
+      default_ransackable_attributes | (allowed_ransackable_attributes || [])
     end
   end
 end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -32,8 +32,8 @@ module Spree
       include Spree::RansackableAttributes unless included_modules.include?(Spree::RansackableAttributes)
 
       ransack_alias :name, :addresses_name
-      self.whitelisted_ransackable_associations = %w[addresses spree_roles]
-      self.whitelisted_ransackable_attributes = %w[name id email created_at]
+      self.allowed_ransackable_associations = %w[addresses spree_roles]
+      self.allowed_ransackable_attributes = %w[name id email created_at]
     end
 
     def wallet

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -26,7 +26,7 @@ module Spree
     DB_ONLY_ATTRS = %w(id updated_at created_at).freeze
     TAXATION_ATTRS = %w(state_id country_id zipcode).freeze
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     scope :with_values, ->(attributes) do
       where(value_attributes(attributes))

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -8,7 +8,7 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     def self.default
       find_by!(iso: Spree::Config.default_country_iso)

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -17,7 +17,7 @@ module Spree
 
     accepts_nested_attributes_for :return_items
 
-    self.whitelisted_ransackable_attributes = ['number']
+    self.allowed_ransackable_attributes = ['number']
 
     extend DisplayMoney
     money_methods :total, :total_excluding_vat, :amount

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -43,8 +43,8 @@ module Spree
 
     attr_accessor :target_shipment, :price_currency
 
-    self.whitelisted_ransackable_associations = ['variant']
-    self.whitelisted_ransackable_attributes = ['variant_id']
+    self.allowed_ransackable_associations = ['variant']
+    self.allowed_ransackable_attributes = ['variant_id']
 
     # @return [BigDecimal] the amount of this line item, which is the line
     #   item's price multiplied by its quantity.

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -25,7 +25,7 @@ module Spree
     after_touch :touch_all_products
     after_save :touch_all_products
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     def touch_all_products
       products.find_each(&:touch)

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -25,7 +25,7 @@ module Spree
     # TODO: Remove allow_nil once option_type is required on Solidus v4.0
     delegate :name, :presentation, to: :option_type, prefix: :option_type, allow_nil: true
 
-    self.whitelisted_ransackable_attributes = %w[name presentation]
+    self.allowed_ransackable_attributes = %w[name presentation]
 
     # Updates the updated_at column on all the variants associated with this
     # option value.

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -62,8 +62,8 @@ module Spree
       go_to_state :confirm
     end
 
-    self.whitelisted_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
-    self.whitelisted_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total store_id]
+    self.allowed_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
+    self.allowed_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total store_id]
 
     attr_reader :coupon_code
     attr_accessor :temporary_address

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -16,7 +16,7 @@ module Spree
     validates :promotion, presence: true
     validates :promotion_code, presence: true, if: :require_promotion_code?
 
-    self.whitelisted_ransackable_associations = %w[promotion_code]
+    self.allowed_ransackable_associations = %w[promotion_code]
 
     private
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -30,7 +30,7 @@ module Spree
     money_methods :amount, :price
     alias_method :money, :display_amount
 
-    self.whitelisted_ransackable_attributes = %w(amount variant_id currency country_iso)
+    self.allowed_ransackable_attributes = %w(amount variant_id currency country_iso)
 
     # An alias for #amount
     def price

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -131,8 +131,8 @@ module Spree
 
     alias :options :product_option_types
 
-    self.whitelisted_ransackable_associations = %w[stores variants_including_master master variants]
-    self.whitelisted_ransackable_attributes = %w[name slug]
+    self.allowed_ransackable_associations = %w[stores variants_including_master master variants]
+    self.allowed_ransackable_attributes = %w[name slug]
 
     def self.ransackable_scopes(_auth_object = nil)
       %i(with_discarded with_variant_sku_cont with_all_variant_sku_cont with_kept_variant_sku_cont)

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -9,6 +9,6 @@ module Spree
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties, optional: true
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties, optional: true
 
-    self.whitelisted_ransackable_attributes = ['value']
+    self.allowed_ransackable_attributes = ['value']
   end
 end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -52,8 +52,8 @@ module Spree
     end
     scope :applied, -> { joins(:order_promotions).distinct }
 
-    self.whitelisted_ransackable_associations = ['codes']
-    self.whitelisted_ransackable_attributes = %w[name path promotion_category_id]
+    self.allowed_ransackable_associations = ['codes']
+    self.allowed_ransackable_attributes = %w[name path promotion_category_id]
     def self.ransackable_scopes(*)
       %i(active)
     end

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -11,7 +11,7 @@ class Spree::PromotionCode < Spree::Base
   validates :promotion, presence: true
   validate :promotion_not_apply_automatically, on: :create
 
-  self.whitelisted_ransackable_attributes = ['value']
+  self.allowed_ransackable_attributes = ['value']
 
   # Whether the promotion code has exceeded its usage restrictions
   #

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -11,7 +11,7 @@ module Spree
 
     after_touch :touch_all_products
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     private
 

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -27,7 +27,7 @@ module Spree
     extend DisplayMoney
     money_methods :amount, :total_excluding_vat
 
-    self.whitelisted_ransackable_attributes = ['memo']
+    self.allowed_ransackable_attributes = ['memo']
 
     def total_excluding_vat
       return_items.sum(&:total_excluding_vat)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -41,8 +41,8 @@ module Spree
 
     include ::Spree::Config.state_machines.shipment
 
-    self.whitelisted_ransackable_associations = ['order']
-    self.whitelisted_ransackable_attributes = ['number']
+    self.allowed_ransackable_associations = ['order']
+    self.allowed_ransackable_attributes = ['number']
 
     delegate :tax_category, :tax_category_id, to: :selected_shipping_rate, allow_nil: true
 

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -15,7 +15,7 @@ module Spree
       )
     end
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     # table of { country.id => [ state.id , state.name ] }, arrays sorted by name
     # blank is added elsewhere, if needed

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -20,7 +20,7 @@ module Spree
     after_save :conditional_variant_touch, if: :saved_changes?
     after_touch { variant.touch }
 
-    self.whitelisted_ransackable_attributes = ['count_on_hand', 'stock_location_id']
+    self.allowed_ransackable_attributes = ['count_on_hand', 'stock_location_id']
 
     # @return [Array<Spree::InventoryUnit>] the backordered inventory units
     #   associated with this stock item

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -31,7 +31,7 @@ module Spree
     after_create :create_stock_items, if: :propagate_all_variants?
     after_save :ensure_one_default
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     def state_text
       state.try(:abbr) || state.try(:name) || state_name

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -13,8 +13,8 @@ module Spree
 
     scope :recent, -> { order(created_at: :desc) }
 
-    self.whitelisted_ransackable_associations = %w[variant]
-    self.whitelisted_ransackable_attributes = ['quantity']
+    self.allowed_ransackable_associations = %w[variant]
+    self.allowed_ransackable_attributes = ['quantity']
 
     def readonly?
       !new_record?

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -32,7 +32,7 @@ module Spree
 
     validates :amount, presence: true, numericality: true
 
-    self.whitelisted_ransackable_associations = %w[tax_categories zone]
+    self.allowed_ransackable_associations = %w[tax_categories zone]
 
     # Finds all tax rates whose zones match a given address
     scope :for_address, ->(address) { joins(:zone).merge(Spree::Zone.for_address(address)) }

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -27,7 +27,7 @@ module Spree
 
     include ::Spree::Config.taxon_attachment_module
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     # @return [String] meta_title if set otherwise a string containing the
     #   root name and taxon name

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -13,7 +13,7 @@ module Spree
 
     default_scope -> { order(position: :asc) }
 
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.allowed_ransackable_attributes = %w[name]
 
     private
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -113,8 +113,8 @@ module Spree
       joins(:stock_items).where(arel_conditions.inject(:or)).distinct
     end
 
-    self.whitelisted_ransackable_associations = %w[option_values product prices default_price]
-    self.whitelisted_ransackable_attributes = %w[weight sku]
+    self.allowed_ransackable_associations = %w[option_values product prices default_price]
+    self.allowed_ransackable_attributes = %w[weight sku]
 
     # Returns variants that have a price for the given pricing options
     # If you have modified the pricing options class, you might want to modify this scope too.

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -42,7 +42,7 @@ module Spree
     alias :members :zone_members
     accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |member| member['zoneable_id'].blank? }
 
-    self.whitelisted_ransackable_attributes = %w[name description]
+    self.allowed_ransackable_attributes = %w[name description]
 
     # Returns all zones that contain any of the zone members of the zone passed
     # in. This also includes any country zones that contain the state of the

--- a/core/spec/models/spree/concerns/ransackable_attributes_spec.rb
+++ b/core/spec/models/spree/concerns/ransackable_attributes_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::RansackableAttributes do
+  let(:test_class) { Class.new(Spree::Base) }
+
+  context "class attributes" do
+    context "whitelisted_ransackable_associations" do
+      it "is deprecated but working" do
+        expect(Spree::Deprecation).to receive(:warn)
+        test_class.allowed_ransackable_associations = ["test"]
+
+        result = test_class.whitelisted_ransackable_associations
+
+        expect(result).to match_array(["test"])
+        expect(test_class.ransackable_associations).to match_array(["test"])
+      end
+    end
+
+    context "whitelisted_ransackable_associations=" do
+      it "is deprecated but working" do
+        expect(Spree::Deprecation).to receive(:warn)
+
+        test_class.whitelisted_ransackable_associations = ["new_value"]
+
+        expect(test_class.allowed_ransackable_associations).to match_array(["new_value"])
+        expect(test_class.ransackable_associations).to match_array(["new_value"])
+      end
+    end
+
+    context "whitelisted_ransackable_associations.concat" do
+      it "is deprecated but working" do
+        expect(Spree::Deprecation).to receive(:warn)
+        test_class.allowed_ransackable_associations = ["test"]
+
+        test_class.whitelisted_ransackable_associations.concat(["new_value"])
+
+        expect(test_class.allowed_ransackable_associations).to match_array(["test", "new_value"])
+        expect(test_class.ransackable_associations).to match_array(["test", "new_value"])
+      end
+    end
+
+    context "whitelisted_ransackable_attributes" do
+      it "is deprecated but working" do
+        expect(Spree::Deprecation).to receive(:warn)
+        test_class.allowed_ransackable_attributes = []
+
+        result = test_class.whitelisted_ransackable_attributes
+
+        expect(result).to be_empty
+        expect(test_class.ransackable_attributes).to match_array(["id"])
+      end
+    end
+
+    context "whitelisted_ransackable_attributes=" do
+      it "is deprecated but working" do
+        expect(Spree::Deprecation).to receive(:warn)
+
+        test_class.whitelisted_ransackable_attributes = ["new_value"]
+
+        expect(test_class.allowed_ransackable_attributes).to match_array(["new_value"])
+        expect(test_class.ransackable_attributes).to match_array(["id", "new_value"])
+      end
+    end
+
+    context "whitelisted_ransackable_attributes.concat" do
+      it "is deprecated but working" do
+        expect(Spree::Deprecation).to receive(:warn)
+        test_class.allowed_ransackable_attributes = ["test"]
+
+        test_class.whitelisted_ransackable_attributes.concat(["new_value"])
+
+        expect(test_class.allowed_ransackable_attributes).to match_array(["test", "new_value"])
+        expect(test_class.ransackable_attributes).to match_array(["id", "test", "new_value"])
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Spree::Price, type: :model do
   describe 'searchable columns' do
-    subject { described_class.whitelisted_ransackable_attributes }
+    subject { described_class.allowed_ransackable_attributes }
     it 'allows searching by variant_id' do
       expect(subject).to include("variant_id")
     end


### PR DESCRIPTION
## Summary

Using allow and disallow or similar naming is generally more favourable than
whitelist and blacklist respectively. To some it has a clear meaning,
but also, the replaced names have racial connotations [1], and are not
recommended by some style guides [2].

Partial continuation of:
- https://github.com/solidusio/solidus/pull/3656

(I will make fix the other areas in separate PRs)

[1] https://www.selfdefined.app/definitions/blacklist-whitelist/#:~:text=A%20%22blacklist%22%20often%20refers%20to,want%20to%20receive%2C%20etc.
[2] https://developers.google.com/style/word-list

For now, these `whitelisted_ransackable_*` methods are deprecated for their `allowed_ransackable_*` counterparts. Note, using Rails' `:deprecate` shorthand method doesn't work for class methods so it was done manually.

Stores will be able to use the replaced methods and can change to the new ones before the next major with the same behavior. A temporary rough spec was added to ensure this.

## Checklist
Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes. **(Yes. but the new methods are tested indirectly)**
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the README to account for my changes.~~
