### PR TITLE
Use `call` in the adjustments recalculator's interface

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -197,7 +197,7 @@ module Spree
     end
 
     def update_promotions
-      Spree::Config.promotion_adjuster_class.new(order).adjust!
+      Spree::Config.promotion_adjuster_class.new(order).call
     end
 
     # DEPRECATED; this functionality is handled in #update_promotions

--- a/core/app/models/spree/promotion/order_adjustments_recalculator.rb
+++ b/core/app/models/spree/promotion/order_adjustments_recalculator.rb
@@ -14,7 +14,7 @@ module Spree
         @order = order
       end
 
-      def adjust!
+      def call
         all_items = line_items + shipments
         all_items.each do |item|
           promotion_adjustments = item.adjustments.select(&:promotion?)

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -85,9 +85,9 @@ module Spree
     describe '#recalculate_adjustments ' do
       describe 'promotion recalculation' do
         it "calls the Promotion Adjustments Recalculator" do
-          adjuster = double(:adjust!)
+          adjuster = double(:call)
           expect(Spree::Promotion::OrderAdjustmentsRecalculator).to receive(:new).and_return(adjuster)
-          expect(adjuster).to receive(:adjust!)
+          expect(adjuster).to receive(:call)
           order.recalculate
         end
       end

--- a/core/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
+++ b/core/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Promotion::OrderAdjustmentsRecalculator do
-  subject { described_class.new(order).adjust! }
+  subject { described_class.new(order).call }
 
-  describe '#adjust! ' do
+  describe '#call ' do
     describe 'promotion recalculation' do
       let(:order) { create(:order_with_line_items, line_items_count: 1, line_items_price: 10) }
       let(:line_item) { order.line_items[0] }


### PR DESCRIPTION
## Summary

We introduced an extension point for promotion adjustments in #4460.

We change the expected interface from `#adjust!` to `#call` for consistency, as that's the new standard we want to follow (see #4677 for an example). That's going to ease the adoption of a service layer if we eventually introduce it.

Ref. #4846 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
