### PR TITLE
Revert the deprecation of `#redirect_back_or_default` method

### DIFF
--- a/core/app/models/spree/user_last_url_storer.rb
+++ b/core/app/models/spree/user_last_url_storer.rb
@@ -26,7 +26,6 @@ module Spree
     #  or its subclasses. The controller will be passed to each rule for matching.
     def initialize(controller)
       @controller = controller
-      Spree::Deprecation.warn("This class will be removed without replacement on the release of Solidus 4.0")
     end
 
     # Stores into session[:spree_user_return_to] the request full path for

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -37,12 +37,6 @@ module Spree
         end
 
         def redirect_back_or_default(default)
-          Spree::Deprecation.warn <<~MSG
-            'Please use #stored_spree_user_location_or when using solidus_auth_devise.
-            Otherwise, please utilize #redirect_back provided in Rails 5+ or
-            #redirect_back_or_to in Rails 7+ instead'
-          MSG
-
           redirect_to(session["spree_user_return_to"] || default)
           session["spree_user_return_to"] = nil
         end
@@ -57,11 +51,6 @@ module Spree
         end
 
         def store_location
-          Spree::Deprecation.warn <<~MSG
-            store_location is being deprecated in solidus 4.0
-            without replacement
-          MSG
-
           Spree::UserLastUrlStorer.new(self).store_location
         end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
   describe '#redirect_back_or_default' do
     before do
       def controller.index
-        Spree::Deprecation.silence { redirect_back_or_default('/') }
+        redirect_back_or_default('/')
       end
     end
 
@@ -29,11 +29,6 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     it 'redirects to default page' do
       get :index
       expect(response).to redirect_to('/')
-    end
-
-    it 'is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn)
-      get :index
     end
   end
 
@@ -74,7 +69,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
   describe '#store_location' do
     it 'sets session return url' do
       allow(controller).to receive_messages(request: double(fullpath: '/redirect'))
-      Spree::Deprecation.silence { controller.store_location }
+      controller.store_location
       expect(session[:spree_user_return_to]).to eq '/redirect'
     end
   end

--- a/core/spec/models/spree/user_last_url_storer_spec.rb
+++ b/core/spec/models/spree/user_last_url_storer_spec.rb
@@ -27,11 +27,6 @@ RSpec.describe Spree::UserLastUrlStorer do
     described_class.rules.delete('CustomRule')
   end
 
-  it 'is deprecated' do
-    expect(Spree::Deprecation).to receive(:warn)
-    described_class.new(controller)
-  end
-
   describe '::rules' do
     it 'includes default rules' do
       rule = Spree::UserLastUrlStorer::Rules::AuthenticationRule
@@ -48,7 +43,7 @@ RSpec.describe Spree::UserLastUrlStorer do
     context 'when at least one rule matches' do
       it 'does not set the path value into the session' do
         described_class.rules << CustomRule
-        Spree::Deprecation.silence { subject.store_location }
+        subject.store_location
         expect(session[:spree_user_return_to]).to be_nil
       end
     end
@@ -57,7 +52,7 @@ RSpec.describe Spree::UserLastUrlStorer do
       it 'sets the path value into the session' do
         described_class.rules << CustomRule
         described_class.rules.delete('CustomRule')
-        Spree::Deprecation.silence { subject.store_location }
+        subject.store_location
         expect(session[:spree_user_return_to]).to eql fullpath
       end
     end


### PR DESCRIPTION
## Summary

We deprecated `#redirect_back_or_default` method in #4533. However, the original plan was halted because of auth problems in solidus_auth_devise. See solidusio/solidus_auth_devise#232 for details.

Ref. #4846 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
