### PR TITLE
Improve Ransackable attribute class methods usage

### DIFF
--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -3,8 +3,8 @@
 module Spree::RansackableAttributes
   extend ActiveSupport::Concern
   included do
-    class_attribute :allowed_ransackable_associations
-    class_attribute :allowed_ransackable_attributes
+    class_attribute :allowed_ransackable_associations, default: []
+    class_attribute :allowed_ransackable_attributes, default: []
 
     def self.whitelisted_ransackable_associations
       Spree::Deprecation.deprecation_warning(:whitelisted_ransackable_associations, 'use allowed_ransackable_associations instead')
@@ -32,11 +32,11 @@ module Spree::RansackableAttributes
 
   class_methods do
     def ransackable_associations(*_args)
-      allowed_ransackable_associations || []
+      allowed_ransackable_associations
     end
 
     def ransackable_attributes(*_args)
-      default_ransackable_attributes | (allowed_ransackable_attributes || [])
+      default_ransackable_attributes | allowed_ransackable_attributes
     end
   end
 end


### PR DESCRIPTION
## Summary
Having a default of `[]` seems more appropriate than `nil`. This will also
allow stores to concatenate onto the default value and get automatic
future additions in Solidus, whereas before, stores would have to define
the array in their decorator if the core model did not set any values.
    
This also applies to the deprecated whitelisted_ransackable_* as it
delegates to allowed_ransackable_*.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [] I have added automated tests to cover my changes.
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the README to account for my changes.~~
