### PR TITLE
Improve Bogus (test) Credit Card voiding

### DIFF
--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -57,8 +57,12 @@ module Spree
       end
     end
 
-    def void(_response_code, _credit_card, _options = {})
-      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+    def void(_response_code, _credit_card, options = {})
+      if options[:originator].completed?
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+      else
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+      end
     end
 
     # @see Spree::PaymentMethod#try_void

--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -65,11 +65,6 @@ module Spree
       end
     end
 
-    # @see Spree::PaymentMethod#try_void
-    def try_void(_payment)
-      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
-    end
-
     def test?
       # Test mode is not really relevant with bogus gateway (no such thing as live server)
       true

--- a/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
@@ -22,5 +22,13 @@ module Spree
         ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
       end
     end
+
+    def void(_response_code, options = {})
+      if options[:originator].completed?
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+      else
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -47,8 +47,12 @@ RSpec.describe Spree::Order, type: :model do
       let(:order) { create(:order_ready_to_ship) }
       let(:payment) { order.payments.first }
 
-      it 'voids the payment' do
-        expect { subject }.to change { payment.reload.state }.from('completed').to('void')
+      it 'does not change the payment state' do
+        expect { subject }.not_to change { payment.reload.state }
+      end
+
+      it 'refunds the payment' do
+        expect { subject }.to change { Spree::Refund.count }.by(1)
       end
 
       it "cancels the order" do

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -224,44 +224,7 @@ RSpec.describe Spree::PaymentMethod, type: :model do
     let(:payment) { create(:payment, payment_method: payment_method) }
 
     context "when the payment method supports payment profiles" do
-      let(:payment_method) do
-        payment_method_class = Class.new(Spree::PaymentMethod) do
-          # We are intentionally not defining try_void on this payment method.
-          # In this way the following specs will use the default implementation
-          # on Spree::PaymentMethod.
-
-          def self.name
-            "PaymentMethodWithPaymentProfiles"
-          end
-
-          def payment_profiles_supported?
-            true
-          end
-
-          def create_profile(payment)
-            # Noop
-          end
-
-          def gateway_class
-            Class.new do
-              def initialize(_options)
-              end
-
-              def void(_response_code, _source, gateway_options = {})
-                payment = gateway_options[:originator]
-
-                if payment.completed?
-                  ActiveMerchant::Billing::Response.new(false, "Can't void a completed payment", {}, test: true)
-                else
-                  ActiveMerchant::Billing::Response.new(true, "Payment correctly voided", {}, test: true)
-                end
-              end
-            end
-          end
-        end
-
-        payment_method_class.new
-      end
+      let(:payment_method) { create(:credit_card_payment_method) }
 
       context "when the payment is already captured" do
         it "returns false" do
@@ -278,40 +241,7 @@ RSpec.describe Spree::PaymentMethod, type: :model do
     end
 
     context "when the payment method doesn't support payment profiles" do
-      let(:payment_method) do
-        payment_method_class = Class.new(Spree::PaymentMethod) do
-          # We are intentionally not defining try_void on this payment method.
-          # In this way the following specs will use the default implementation
-          # on Spree::PaymentMethod.
-
-          def self.name
-            "PaymentMethodWithoutPaymentProfiles"
-          end
-
-          def payment_profiles_supported?
-            false
-          end
-
-          def gateway_class
-            Class.new do
-              def initialize(_options)
-              end
-
-              def void(_response_code, gateway_options = {})
-                payment = gateway_options[:originator]
-
-                if payment.completed?
-                  ActiveMerchant::Billing::Response.new(false, "Can't void a completed payment", {}, test: true)
-                else
-                  ActiveMerchant::Billing::Response.new(true, "Payment correctly voided", {}, test: true)
-                end
-              end
-            end
-          end
-        end
-
-        payment_method_class.new
-      end
+      let(:payment_method) { create(:simple_credit_card_payment_method) }
 
       context "when the payment is already captured" do
         it "returns false" do


### PR DESCRIPTION
Follow up for #4843 and #4859.

⚠️ This doesn't change any behavior of real credit card processing. This change has been made to improve DX, when someone is trying to simulate a realistic order flow (create order, capture payment, cancel order) with the provided BogusCreditCard placeholder, which we use in our demo and sandbox.

## Summary

Before this change, all the attempts to void a payment in the admin panel would be succeeding. This is not realistic because, in real life, you can't void captured credit card payments. 

With this change, we can simulate a failure (by trying to cancel an order with captured payment). This will leave the payment in the complete state and will create a refund for that payment. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
