### PR TITLE
Stop using RSpec is_expected with block expectations

### DIFF
--- a/core/spec/models/spree/address/state_validator_spec.rb
+++ b/core/spec/models/spree/address/state_validator_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe Spree::Address::StateValidator do
   let(:state) { create :state, name: 'maryland', abbr: 'md', country: country }
   let(:address) { build(:address, country: country) }
 
-  subject do
-    -> { described_class.new(address).perform }
-  end
+  subject { described_class.new(address).perform }
 
   describe 'state attributes normalization' do
     context "having a country with no states" do
@@ -21,7 +19,7 @@ RSpec.describe Spree::Address::StateValidator do
 
       it "nullifies the state attr" do
         address.state = state
-        expect(subject).to change(address, :state).from(state).to(nil)
+        expect { subject }.to change(address, :state).from(state).to(nil)
       end
     end
 
@@ -39,8 +37,8 @@ RSpec.describe Spree::Address::StateValidator do
         end
 
         it "nullifies the state_name if the state attr belongs to the country" do
-          expect(subject).to change(address, :state_name).from(state_name).to(nil)
-          expect(subject).to_not change(address, :state).from(state)
+          expect { subject }.to change(address, :state_name).from(state_name).to(nil)
+          expect { subject }.to_not change(address, :state).from(state)
         end
 
         context "belonging to a different country" do
@@ -49,7 +47,7 @@ RSpec.describe Spree::Address::StateValidator do
           end
 
           it "doesn't nullify the state name" do
-            expect(subject).to_not change(address, :state_name).from(state_name)
+            expect { subject }.to_not change(address, :state_name).from(state_name)
           end
         end
       end
@@ -62,7 +60,7 @@ RSpec.describe Spree::Address::StateValidator do
         end
 
         it "sets the state having the specified state name" do
-          expect(subject).
+          expect { subject }.
             to change{ [address.state, address.state_name] }.
             from([nil, state.name]).
             to([state, nil])
@@ -76,7 +74,7 @@ RSpec.describe Spree::Address::StateValidator do
       it "doesn't validate the state presence" do
         address.state = nil
         address.state_name = nil
-        subject.call
+        subject
 
         expect(address.errors).to be_empty
       end
@@ -107,14 +105,18 @@ RSpec.describe Spree::Address::StateValidator do
     it "state_name is not nil and country does not have any states" do
       address.state = nil
       address.state_name = 'alabama'
-      subject.call
+
+      subject
+
       expect(address.errors).to be_empty
     end
 
     it "errors when state_name is nil" do
       address.state_name = nil
       address.state = nil
-      subject.call
+
+      subject
+
       expect(address.errors.messages).to eq({ state: ["can't be blank"] })
     end
 
@@ -127,7 +129,9 @@ RSpec.describe Spree::Address::StateValidator do
         it 'is invalid' do
           address.country = italy
           address.state = us_state
-          subject.call
+
+          subject
+
           expect(address.errors["state"]).to eq(['does not match the country'])
         end
       end

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -8,9 +8,9 @@ module Spree
     it "cannot link the same taxon to the same product more than once" do
       product = create(:product)
       taxon = create(:taxon)
-      add_taxon = lambda { product.taxons << taxon }
-      add_taxon.call
-      expect(add_taxon).to raise_error(ActiveRecord::RecordInvalid)
+      product.taxons << taxon
+
+      expect { product.taxons << taxon }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     let(:taxon_with_5_products) do

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -14,23 +14,22 @@ module Spree
       context "saving a default shipping address" do
         let(:user_address) { user.user_addresses.find_first_by_address_values(address.attributes) }
         let(:force_default) { true }
-        subject do
-          -> { user.save_in_address_book(address.attributes, force_default) }
-        end
+        subject { user.save_in_address_book(address.attributes, force_default) }
 
         context "the address is a new record" do
           let(:address) { build(:address) }
 
           it "creates a new Address" do
-            is_expected.to change { Spree::Address.count }.by(1)
+            expect { subject }.to change { Spree::Address.count }.by(1)
           end
 
           it "creates a UserAddress" do
-            is_expected.to change { Spree::UserAddress.count }.by(1)
+            expect { subject }.to change { Spree::UserAddress.count }.by(1)
           end
 
           it "sets the UserAddress default flag to true" do
-            subject.call
+            subject
+
             expect(user_address.default).to eq true
             expect(user_address.default_billing).to be_falsey
           end
@@ -46,7 +45,7 @@ module Spree
           end
 
           it "adds the address to the user's associated addresses" do
-            is_expected.to change { user.reload.addresses.count }.by(1)
+            expect { subject }.to change { user.reload.addresses.count }.by(1)
           end
         end
 
@@ -65,8 +64,8 @@ module Spree
 
           context "saving a shipping address" do
             context "makes all the other associated shipping addresses not be the default and ignores the billing ones" do
-              it { is_expected.not_to change { original_user_address.reload.default }.from(true) }
-              it { is_expected.not_to change { original_user_bill_address.reload.default_billing } }
+              it { expect { subject }.not_to change { original_user_address.reload.default }.from(true) }
+              it { expect { subject }.not_to change { original_user_bill_address.reload.default_billing } }
             end
 
             context "an odd flip-flop corner case discovered running backfill rake task" do
@@ -85,11 +84,11 @@ module Spree
           end
 
           context "saving a billing address" do
-            subject { -> { user.save_in_address_book(address.attributes, true, :billing) } }
+            subject { user.save_in_address_book(address.attributes, true, :billing) }
 
             context "makes all the other associated billing addresses not be the default and ignores the shipping ones" do
-              it { is_expected.not_to change { original_user_address.reload.default } }
-              it { is_expected.to change { original_user_bill_address.reload.default_billing }.from(true).to(false) }
+              it { expect { subject }.not_to change { original_user_address.reload.default } }
+              it { expect { subject }.to change { original_user_bill_address.reload.default_billing }.from(true).to(false) }
             end
 
             context "an odd flip-flop corner case discovered running backfill rake task" do
@@ -117,12 +116,12 @@ module Spree
 
           context "properly sets the default flag" do
             context "shipping address" do
-              it { expect(subject.call).to eq user.ship_address }
+              it { expect(subject).to eq user.ship_address }
             end
 
             context "billing address" do
               subject { user.save_in_address_book(address.attributes, true, :billing) }
-              it { is_expected.to eq user.bill_address }
+              it { expect(subject).to eq user.bill_address }
             end
           end
 
@@ -145,12 +144,12 @@ module Spree
 
             context "is the new default" do
               context "shipping address" do
-                it { is_expected.to eq user.ship_address }
+                it { expect(subject).to eq user.ship_address }
               end
 
               context "billing address" do
                 subject { user.save_in_address_book(address.attributes, true, :billing) }
-                it { is_expected.to eq user.bill_address }
+                it { expect(subject).to eq user.bill_address }
               end
             end
           end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Spree::Order, type: :model do
           end
           specify do
             transition = lambda { order.next! }
-            expect(transition).to raise_error(StateMachines::InvalidTransition, /#{I18n.t('spree.items_cannot_be_shipped')}/)
+            expect { transition.call }.to raise_error(StateMachines::InvalidTransition, /#{I18n.t('spree.items_cannot_be_shipped')}/)
           end
         end
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1541,10 +1541,10 @@ RSpec.describe Spree::Order, type: :model do
     describe "#record_ip_address" do
       let(:ip_address) { "127.0.0.1" }
 
-      subject { -> { order.record_ip_address(ip_address) } }
+      subject { order.record_ip_address(ip_address) }
 
       it "updates the last used IP address" do
-        expect(subject).to change(order, :last_ip_address).to(ip_address)
+        expect { subject }.to change(order, :last_ip_address).to(ip_address)
       end
 
       # IP address tracking should not raise validation exceptions
@@ -1552,7 +1552,7 @@ RSpec.describe Spree::Order, type: :model do
         before { allow(order).to receive(:valid?).and_return(false) }
 
         it "updates the IP address" do
-          expect(subject).to change(order, :last_ip_address).to(ip_address)
+          expect { subject }.to change(order, :last_ip_address).to(ip_address)
         end
       end
 
@@ -1560,7 +1560,7 @@ RSpec.describe Spree::Order, type: :model do
         let(:order) { build(:order) }
 
         it "updates the IP address" do
-          expect(subject).to change(order, :last_ip_address).to(ip_address)
+          expect { subject }.to change(order, :last_ip_address).to(ip_address)
         end
       end
     end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -115,72 +115,62 @@ RSpec.describe Spree::Taxon, type: :model do
     let(:taxon2_child) { create(:taxon, name: 't2_child', taxonomy: taxonomy, parent: taxon2) }
 
     context "changing parent" do
-      subject do
-        -> { taxon2.update!(parent: taxon1) }
-      end
+      subject { taxon2.update!(parent: taxon1) }
 
       it "changes own permalink" do
-        is_expected.to change{ taxon2.reload.permalink }.from('t/t2').to('t/t1/t2')
+        expect { subject }.to change{ taxon2.reload.permalink }.from('t/t2').to('t/t1/t2')
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/t2/t2_child')
+        expect { subject }.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/t2/t2_child')
       end
     end
 
     context "changing own permalink" do
-      subject do
-        -> { taxon2.update!(permalink: 'foo') }
-      end
+      subject { taxon2.update!(permalink: 'foo') }
 
       it "changes own permalink" do
-        is_expected.to change{ taxon2.reload.permalink }.from('t/t2').to('t/foo')
+        expect { subject }.to change{ taxon2.reload.permalink }.from('t/t2').to('t/foo')
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/foo/t2_child')
+        expect { subject }.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/foo/t2_child')
       end
     end
 
     context "changing own permalink part" do
-      subject do
-        -> { taxon2.update!(permalink_part: 'foo') }
-      end
+      subject { taxon2.update!(permalink_part: 'foo') }
 
       it "changes own permalink" do
-        is_expected.to change{ taxon2.reload.permalink }.from('t/t2').to('t/foo')
+        expect { subject }.to change{ taxon2.reload.permalink }.from('t/t2').to('t/foo')
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/foo/t2_child')
+        expect { subject }.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/foo/t2_child')
       end
     end
 
     context "changing parent and own permalink" do
-      subject do
-        -> { taxon2.update!(parent: taxon1, permalink: 'foo') }
-      end
+      subject { taxon2.update!(parent: taxon1, permalink: 'foo') }
 
       it "changes own permalink" do
-        is_expected.to change{ taxon2.reload.permalink }.from('t/t2').to('t/t1/foo')
+        expect { subject }.to change{ taxon2.reload.permalink }.from('t/t2').to('t/t1/foo')
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/foo/t2_child')
+        expect { subject }.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/foo/t2_child')
       end
     end
 
     context 'changing parent permalink with special characters ' do
-      subject do
-        -> { taxon2.update!(permalink: 'spécial&charactèrs') }
-      end
+      subject { taxon2.update!(permalink: 'spécial&charactèrs') }
 
       it 'changes own permalink with parameterized characters' do
-        is_expected.to change{ taxon2.reload.permalink }.from('t/t2').to('t/special-characters')
+        expect { subject }.to change{ taxon2.reload.permalink }.from('t/t2').to('t/special-characters')
       end
 
       it 'changes child permalink with parameterized characters' do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/special-characters/t2_child')
+        expect { subject }.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/special-characters/t2_child')
       end
     end
   end


### PR DESCRIPTION
## Summary

This syntax support is ending and it was printing a number of deprecation messages in our test suite output.

From [One-line syntax documentation](https://relishapp.com/rspec/rspec-core/docs/subject/one-liner-syntax):

> The one-liner syntax only works with non-block expectations
> (e.g. expect(obj).to eq, etc) and it cannot be used with block
> expectations (e.g. expect { object }).


<details>

<summary>List of related deprecation warnings removed</summary>

```
Deprecation Warnings:

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::Address#state_name` from "A State Name" to nil` not `expect(value).to change `Spree::Address#state_name` from "A State Name" to nil`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::Address#state` from #<Spree::State id: 1311, name: "maryland", abbr: "md", country_id:...at: "2023-01-24 05:57:48.394225000 +0000", created_at: "2023-01-24 05:57:48.394225000 +0000"> to nil` not `expect(value).to change `Spree::Address#state` from #<Spree::State id: 1311, name: "maryland", abbr: "md", country_id:...at: "2023-01-24 05:57:48.394225000 +0000", created_at: "2023-01-24 05:57:48.394225000 +0000"> to nil`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::Address.count` by 1` not `expect(value).to change `Spree::Address.count` by 1`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::Order#last_ip_address` to "127.0.0.1"` not `expect(value).to change `Spree::Order#last_ip_address` to "127.0.0.1"`
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::Order#last_ip_address` to "127.0.0.1"` not `expect(value).to change `Spree::Order#last_ip_address` to "127.0.0.1"`
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::Order#last_ip_address` to "127.0.0.1"` not `expect(value).to change `Spree::Order#last_ip_address` to "127.0.0.1"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `Spree::UserAddress.count` by 1` not `expect(value).to change `Spree::UserAddress.count` by 1`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `[address.state, address.state_name]` from [nil, "maryland"] to [#<Spree::State id: 1317, name..._at: "2023-01-24 05:57:48.428391000 +0000", created_at: "2023-01-24 05:57:48.428391000 +0000">, nil]` not `expect(value).to change `[address.state, address.state_name]` from [nil, "maryland"] to [#<Spree::State id: 1317, name..._at: "2023-01-24 05:57:48.428391000 +0000", created_at: "2023-01-24 05:57:48.428391000 +0000">, nil]`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `original_user_address.reload.default` from true` not `expect(value).to change `original_user_address.reload.default` from true`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `original_user_address.reload.default`` not `expect(value).to change `original_user_address.reload.default``

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `original_user_bill_address.reload.default_billing` from true to false` not `expect(value).to change `original_user_bill_address.reload.default_billing` from true to false`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `original_user_bill_address.reload.default_billing`` not `expect(value).to change `original_user_bill_address.reload.default_billing``

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2.reload.permalink` from "t/t2" to "t/foo"` not `expect(value).to change `taxon2.reload.permalink` from "t/t2" to "t/foo"`
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2.reload.permalink` from "t/t2" to "t/foo"` not `expect(value).to change `taxon2.reload.permalink` from "t/t2" to "t/foo"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2.reload.permalink` from "t/t2" to "t/special-characters"` not `expect(value).to change `taxon2.reload.permalink` from "t/t2" to "t/special-characters"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2.reload.permalink` from "t/t2" to "t/t1/foo"` not `expect(value).to change `taxon2.reload.permalink` from "t/t2" to "t/t1/foo"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2.reload.permalink` from "t/t2" to "t/t1/t2"` not `expect(value).to change `taxon2.reload.permalink` from "t/t2" to "t/t1/t2"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/foo/t2_child"` not `expect(value).to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/foo/t2_child"`
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/foo/t2_child"` not `expect(value).to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/foo/t2_child"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/special-characters/t2_child"` not `expect(value).to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/special-characters/t2_child"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/t1/foo/t2_child"` not `expect(value).to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/t1/foo/t2_child"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/t1/t2/t2_child"` not `expect(value).to change `taxon2_child.reload.permalink` from "t/t2/t2_child" to "t/t1/t2/t2_child"`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `user.reload.addresses.count` by 1` not `expect(value).to change `user.reload.addresses.count` by 1`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise ActiveRecord::RecordInvalid` not `expect(value).to raise ActiveRecord::RecordInvalid`

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise StateMachines::InvalidTransition with message matching /We are unable to calculate shipping rates for the selected items./` not `expect(value).to raise StateMachines::InvalidTransition with message matching /We are unable to calculate shipping rates for the selected items./`
```
</details>

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
