### PR TITLE
Fix publishing events responding to #to_hash on Ruby 2.7

### DIFF
--- a/core/lib/spree/bus.rb
+++ b/core/lib/spree/bus.rb
@@ -9,12 +9,12 @@ module Spree
   # It has some modifications to support internal usage of the legacy event
   # system {see Spree::AppConfiguration#use_legacy_events}.
   Bus = Omnes::Bus.new
-  Bus.define_singleton_method(:publish) do |*args, **kwargs, &block|
+  def Bus.publish(event, **kwargs)
     if Spree::Config.use_legacy_events
-      Spree::Event.fire(*args, **kwargs, &block)
+      Spree::Event.fire(event, **kwargs)
     else
       # Override caller_location to point to the actual event publisher
-      super(*args, **kwargs, caller_location: caller_locations(1)[0], &block)
+      super(event, **kwargs, caller_location: caller_locations(1)[0])
     end
   end
 end

--- a/core/spec/lib/spree/bus_spec.rb
+++ b/core/spec/lib/spree/bus_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Bus do
+  describe '.publish' do
+    it "doesn't coerce events responding to #to_hash",
+      if: (Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")) && !Spree::Config.use_legacy_events do
+      described_class.register(:foo)
+      event = Class.new do
+        def omnes_event_name
+          :foo
+        end
+
+        def to_hash
+          { foo: 'bar' }
+        end
+      end.new
+
+      expect { described_class.publish(event) }.not_to raise_error
+    ensure
+      described_class.registry.unregister(:foo)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a method accepts both splatted positional & keyword parameters and
a single argument responding to `#to_hash` is given, the argument is
coerced to hash and assigned to the keyword arguments.

E.g.:

```ruby
class Hashable
  def to_hash
    { im: :a_hash }
  end
end

def method_with_splat_on_the_positional_argument(*args, **kwargs) # method_with_splat_on_the_positional_argument(Hashable.new)
  puts args.inspect # =>  []
  puts kwargs.inspect # => {:im=>:a_hash}
end
```

However,

```ruby
def method_without_splat_on_the_positional_argument(args, **kwargs) # method_without_splat_on_the_positional_argument(Hashable.new)
  puts args.inspect # => #<Hashable:0x000055cfe8b072b0>
  puts kwargs.inspect # => {}
end
```

We fix the problem on the Spree::Bus override by being explicit about
the expected parameters.

References https://github.com/solidusio/solidus_stripe/pull/157#issuecomment-1400648000

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
