### PR TITLE
Deprecate `Admin::OrdersHelper#line_item_shipment_price`

### DIFF
--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -4,10 +4,13 @@ module Spree
   module Admin
     module OrdersHelper
       # Renders all the extension partials that may have been specified in the extensions
+      #
+      # @return [ActiveSupport::SafeBuffer] the string returned is already html-safe
       def event_links
         links = []
         @order_events.sort.each do |event|
           next unless @order.send("can_#{event}?")
+
           translated_event = t(event, scope: [:spree, :admin, :order, :events])
           links << button_to(
             translated_event,
@@ -19,12 +22,18 @@ module Spree
         safe_join(links, "&nbsp;".html_safe)
       end
 
+      # @deprecated use `Spree::LineItem#display_amount` instead
       def line_item_shipment_price(line_item, quantity)
         Spree::Money.new(line_item.price * quantity, { currency: line_item.currency })
       end
       deprecate deprecator: Spree::Deprecation,
         line_item_shipment_price: "use Spree::LineItem#display_amount instead"
 
+      # Addresss Verification System response code
+      #
+      # @see https://en.wikipedia.org/wiki/Address_verification_service
+      #
+      # @return [Hash] codes as keys, descriptions as values
       def avs_response_code
         {
           "A" => "Street address matches, but 5-digit and 9-digit postal code do not match.",
@@ -56,6 +65,13 @@ module Spree
         }
       end
 
+      # Addresss Verification System response code
+      #
+      # @see https://developer.visa.com/request_response_codes#card_verification2_results
+      # @see https://developer.paypal.com/api/nvp-soap/AVSResponseCodes/#cvv2-error-response-codes
+      # @see https://www.checkout.com/docs/resources/codes/cvv-response-codes
+      #
+      # @return [Hash] codes as keys, descriptions as values
       def cvv_response_code
         {
           "M" => "CVV2 Match",

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -22,6 +22,8 @@ module Spree
       def line_item_shipment_price(line_item, quantity)
         Spree::Money.new(line_item.price * quantity, { currency: line_item.currency })
       end
+      deprecate deprecator: Spree::Deprecation,
+        line_item_shipment_price: "use Spree::LineItem#display_amount instead"
 
       def avs_response_code
         {

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -18,6 +18,6 @@
           <%= count %> x <%= t(state, scope: 'spree.inventory_states') %>
         <% end %>
     </td>
-    <td class="item-total"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
+    <td class="item-total"><%= item.line_item.display_amount %></td>
   </tr>
 <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -20,7 +20,7 @@
           <%= count %> x <%= t(state, scope: 'spree.inventory_states') %>
         <% end %>
     </td>
-    <td class="item-total"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
+    <td class="item-total"><%= item.line_item.display_amount %></td>
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>

--- a/backend/app/views/spree/admin/orders/confirm/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_line_items.html.erb
@@ -25,7 +25,7 @@
             <%= item.quantity %>
           </td>
           <td class="line-item-total">
-            <%= line_item_shipment_price(item, item.quantity) %>
+            <%= item.display_amount %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -17,6 +17,6 @@
           <%= count %> x <%= t(state, scope: 'spree.inventory_states') %>
         <% end %>
     </td>
-    <td class="item-total"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
+    <td class="item-total"><%= item.line_item.display_amount %></td>
   </tr>
 <% end %>


### PR DESCRIPTION
## Summary

I started by documenting the response code methods trying to understand how they would fit into solidus_stripe; ended up documenting the whole file and realizing `line_item_shipment_price` was completely redundant with `LineItem#display_amount`.
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

<del>
- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
</del>