### PR TITLE
Fix CI only testing with the legacy event system adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,9 +263,9 @@ jobs:
       paperclip:
         type: boolean
         default: true
-      legacy:
-        type: string
-        default: "0"
+      legacy_events:
+        type: boolean
+        default: false
     executor:
       name: << parameters.database >>
       ruby: << parameters.ruby >>
@@ -273,7 +273,7 @@ jobs:
     environment:
       DISABLE_ACTIVE_STORAGE: << parameters.paperclip >>
       RAILS_VERSION: "~> << parameters.rails >>"
-      USE_LEGACY_EVENTS: << parameters.legacy >>
+      USE_LEGACY_EVENTS: << parameters.legacy_events >>
       BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX: "(<< parameters.ruby >>:<< parameters.rails >>:<< parameters.database >>:<< parameters.paperclip >>)"
     steps:
       - setup
@@ -333,15 +333,15 @@ workflows:
       # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
       - test_solidus:
           context: slack-secrets
-          name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
-          matrix: { parameters: { rails: ['7.0'], ruby: ['3.1', '3.2'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false] } }
+          name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>><<#matrix.legacy_events>>-legacy_events<</matrix.legacy_events>>"
+          matrix: { parameters: { rails: ['7.0'], ruby: ['3.1', '3.2'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false], legacy_events: [false] } }
       - test_solidus:
           context: slack-secrets
           name: *name
-          matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0', '3.1'], database: ['sqlite'], paperclip: [false] } }
+          matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0', '3.1'], database: ['sqlite'], paperclip: [false], legacy_events: [false] } }
       - test_solidus:
           context: slack-secrets
           name: *name
-          matrix: { parameters: { rails: ['6.0'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true] } }
+          matrix: { parameters: { rails: ['6.0'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true], legacy_events: [true] } }
       - dev_tools:
           context: slack-secrets

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -138,7 +138,7 @@ end
 Spree.user_class = 'Spree::LegacyUser'
 Spree.load_defaults(Spree.solidus_version)
 Spree.config do |config|
-  config.use_legacy_events = ENV['USE_LEGACY_EVENTS'].present?
+  config.use_legacy_events = (ENV['USE_LEGACY_EVENTS'] == 'true')
 
   if ENV['DISABLE_ACTIVE_STORAGE']
     config.image_attachment_module = 'Spree::Image::PaperclipAttachment'


### PR DESCRIPTION
## Summary

From https://github.com/solidusio/solidus/pull/4666 all CI jobs have
been running with the legacy event system. We were defaulting the
`legacy` parameter to `0`, which we copied over to the
`USE_LEGACY_EVENTS` environment variable. However, the test suite was
checking for the mere existence of the environment variable to select
the legacy adapter and not for an actual `1` value.

We are now:

- Renaming the `legacy` parameter to `legacy_events` to be clearer.
- Making the parameter a boolean one, defaulting to false.
- Checking that `USE_LEGACY_EVENTS` is the string `"true"` before
  selecting the legacy adapter.
- Using the legacy adapter for the job on Ruby 2.7 & Rails 6.0.
- Adding `-legacy_events` to the job name when selected.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- ~[ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
