### PR TITLE
Remove unused columns from spree_promotion_rules

### DIFF
--- a/core/db/migrate/20230325132905_remove_unused_columns_from_promotion_rules.rb
+++ b/core/db/migrate/20230325132905_remove_unused_columns_from_promotion_rules.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedColumnsFromPromotionRules < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :spree_promotion_rules, :code, :string
+    remove_column :spree_promotion_rules, :product_group_id, :integer
+  end
+end


### PR DESCRIPTION


## Summary

`product_group_id` refers to something that was removed from Spree in version 1.1 (see https://github.com/spree-contrib/spree_product_groups).

`code` refers to nothing.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- [x] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the README to account for my changes.~
