### PR TITLE
Drop unused table promotion_action_line_items

### DIFF
--- a/core/db/migrate/20230325161633_drop_unused_promo_action_line_items.rb
+++ b/core/db/migrate/20230325161633_drop_unused_promo_action_line_items.rb
@@ -1,0 +1,13 @@
+class DropUnusedPromoActionLineItems < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :spree_promotion_action_line_items, force: :cascade do |t|
+      t.integer "promotion_action_id"
+      t.integer "variant_id"
+      t.integer "quantity", default: 1
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
+      t.index ["promotion_action_id"], name: "index_spree_promotion_action_line_items_on_promotion_action_id"
+      t.index ["variant_id"], name: "index_spree_promotion_action_line_items_on_variant_id"
+    end
+  end
+end


### PR DESCRIPTION


## Summary

Drops an unused table. 
There's another table with identical columns that is actually being referenced in the codebase,  `spree_line_item_actions`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- [x] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the README to account for my changes.~
