### PR TITLE
Fix sticky admin nav on long menu

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/navigation.js
+++ b/backend/app/assets/javascripts/spree/backend/navigation.js
@@ -3,11 +3,21 @@ Spree.ready(function() {
     return $('.admin-nav-header').outerHeight() + $('.admin-nav-menu').outerHeight() + $('.admin-nav-footer').outerHeight();
   };
 
-  var checkSideBarFit = function() {
-    $('.admin-nav').toggleClass('fits', navHeight() < $(window).height());
+  var initStickyNavbar = function() {
+    $(".admin-nav-sticky, .admin-nav").stick_in_parent();
   };
 
-  $(".admin-nav-sticky, .admin-nav").stick_in_parent();
+  var detachStickyNavbar = function() {
+    $(".admin-nav-sticky, .admin-nav").trigger("sticky_kit:detach");
+  };
+
+  var checkSideBarFit = function() {
+    var fits = navHeight() < $(window).height();
+
+    $('.admin-nav').toggleClass('fits', fits);
+
+    fits ? initStickyNavbar() : detachStickyNavbar();
+  };
 
   checkSideBarFit();
   $(window).on('resize', checkSideBarFit);


### PR DESCRIPTION
## Summary

In Solidus, the admin nav menu becomes sticky after scrolling the page. If the menu contains a few entries, everything works fine. But if the menu includes some entries and the height exceed the window height, since the menu is sticky, the latest entries will be hidden.

#### Example with short menu:
https://user-images.githubusercontent.com/1719696/214903942-24a05d54-b74d-4524-968f-b5da056cbdec.mov

#### Example with long menu:
https://user-images.githubusercontent.com/1719696/214904177-ef017cc8-d3bc-4a6e-ab4b-cb5b192463ca.mov

This PR applies the sticky only if the menu height does not exceed the window height.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- [ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
