### PR TITLE
Fetch solidus_frontend from RubyGems instead of GitHub

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/frontend/classic.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/classic.rb
@@ -3,10 +3,7 @@ solidus = Bundler.locked_gems.dependencies['solidus']
 if Bundler.locked_gems.dependencies['solidus_frontend']
   say_status :skipping, "solidus_frontend is already in the bundle", :blue
 else
-  # `solidus_frontend` is not sourced from rubygems if the solidus gem was not.
-  github_solidus_frontend = '--github solidusio/solidus_frontend' unless solidus.nil? || solidus.source.is_a?(Bundler::Source::Rubygems)
-
-  bundle_command("add solidus_frontend #{github_solidus_frontend}")
+  bundle_command("add solidus_frontend")
 end
 
 # Disable solidus_bolt installation from solidus_frontend as it can be


### PR DESCRIPTION
## Summary

Fixes https://github.com/solidusio/solidus/issues/4878.

With this change, we're breaking from the practice of testing Solidus against the edge version of SolidusFrontend. We're assuming that there won't be significant development on SolidusFrontend and thus it would be safe to test Solidus against the latest stable version of SolidusFrontend.

## Screenschot

![image](https://user-images.githubusercontent.com/61476/214979914-03e1adc7-4509-4cab-8e3a-528e1f57214d.png)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- ~[ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ]~ I have updated the README to account for my changes.~
