### PR TITLE
Add the `/admin/orders/:number` route

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -10,6 +10,10 @@ module Spree
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
       respond_to :html
 
+      def show
+        redirect_to action: :edit
+      end
+
       def index
         params[:q] ||= {}
         params[:q][:completed_at_not_null] ||= '1' if Spree::Config[:show_only_complete_orders_by_default]

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -70,7 +70,7 @@ Spree::Core::Engine.routes.draw do
 
     delete '/product_properties/:id', to: "product_properties#destroy", as: :product_property
 
-    resources :orders, except: [:show] do
+    resources :orders do
       member do
         get :cart
         put :advance

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -159,6 +159,13 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
     end
 
+    describe "#show" do
+      it "redirects to :edit" do
+        get :show, params: { id: order.number }
+        expect(response).to redirect_to(spree.edit_admin_order_path(order.number))
+      end
+    end
+
     describe '#advance' do
       subject do
         put :advance, params: { id: order.number }


### PR DESCRIPTION
## Summary

Tiny quality-of-life improvement ☺️.

Very handy when switching from an order on the storefront to the _admin_ by just prepending `/admin` to the `/order/R1234567890` path.



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

<del>
- [ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
</del>