### PR TITLE
Update the SolidusFrontend dependency to 3.4.0.dev

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/frontend/classic.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/classic.rb
@@ -3,7 +3,10 @@ solidus = Bundler.locked_gems.dependencies['solidus']
 if Bundler.locked_gems.dependencies['solidus_frontend']
   say_status :skipping, "solidus_frontend is already in the bundle", :blue
 else
-  bundle_command("add solidus_frontend")
+  # `solidus_frontend` is not sourced from rubygems if the solidus gem was not.
+  github_solidus_frontend = '--github solidusio/solidus_frontend' unless solidus.nil? || solidus.source.is_a?(Bundler::Source::Rubygems)
+
+  bundle_command("add solidus_frontend #{github_solidus_frontend}")
 end
 
 # Disable solidus_bolt installation from solidus_frontend as it can be

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', s.version
   s.add_dependency 'solidus_sample', s.version
 
-  s.add_dependency 'solidus_frontend', '~> 3.3.0.alpha'
+  s.add_dependency 'solidus_frontend', '~> 3.4.0.dev'
 end


### PR DESCRIPTION
## Summary

Fixes https://github.com/solidusio/solidus/issues/4878.

Also reverts aaa136f11121560cc903c8a223332e6220b04779. Since solidus_frontend 3.4.0.dev is released, we should be able to fetch the unreleased updates to 3.4.0.dev from GitHub.

## Testing

The SolidusBraintree CI passes when pointing to this branch: https://app.circleci.com/pipelines/github/solidusio/solidus_braintree/218/workflows/09db5b6d-df33-4b27-9adb-9eaee4196163.

Here's the change to the SolidusBraintree Gemfile: https://github.com/solidusio/solidus_braintree/commit/3e958989a4d9d8d4ec276bc0067b51a577078ae9.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- ~[ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
