### PR TITLE
Remove deprecated order updater promotions code

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -162,9 +162,6 @@ module Spree
       order.included_tax_total = all_items.sum(&:included_tax_total) + order_tax_adjustments.select(&:included?).sum(&:amount)
       order.additional_tax_total = all_items.sum(&:additional_tax_total) + order_tax_adjustments.reject(&:included?).sum(&:amount)
 
-      # TODO: Delete this line in Solidus 4.0, when it is run in `update_promotions`.
-      order.promo_total = all_items.sum(&:promo_total) + adjustments.select(&:eligible?).select(&:promotion?).sum(&:amount)
-
       update_order_total
     end
 
@@ -199,32 +196,6 @@ module Spree
     def update_promotions
       Spree::Config.promotion_adjuster_class.new(order).call
     end
-
-    # DEPRECATED; this functionality is handled in #update_promotions
-    def update_item_promotions
-      [*line_items, *shipments].each do |item|
-        promotion_adjustments = item.adjustments.select(&:promotion?)
-
-        promotion_adjustments.each(&:recalculate)
-        Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
-
-        item.promo_total = promotion_adjustments.select(&:eligible?).sum(&:amount)
-      end
-    end
-    deprecate update_item_promotions: :update_promotions, deprecator: Spree::Deprecation
-
-    # Update and select the best promotion adjustment for the order.
-    # We don't update the order.promo_total yet. Order totals are updated later
-    # in #update_adjustment_total since they include the totals from the order's
-    # line items and/or shipments.
-    #
-    # DEPRECATED; this functionality is handled in #update_promotions
-    def update_order_promotions
-      promotion_adjustments = order.adjustments.select(&:promotion?)
-      promotion_adjustments.each(&:recalculate)
-      Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
-    end
-    deprecate update_order_promotions: :update_promotions, deprecator: Spree::Deprecation
 
     def update_taxes
       Spree::Config.tax_adjuster_class.new(order).adjust!


### PR DESCRIPTION


## Summary

This is a followup to #4460. As part of the transition to using the configurable order adjuster and removing some of the knowledge around promotions from the order updater, we were still updating the order's promo total in  `#update_adjustment_total`. This removes the deprecated methods and the line that supports them.

This is for Solidus 4.0.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- [ ] ~I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the README to account for my changes.~
