### PR TITLE
Improve Product Details tab layout

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -1,30 +1,70 @@
 <div data-hook="admin_product_form_fields">
 
   <div class="row">
+    <div class="left col-9">
+      <div data-hook="admin_product_form_left">
+        <div data-hook="admin_product_form_name">
+          <%= f.field_container :name do %>
+            <%= f.label :name, class: 'required' %>
+            <%= f.text_field :name, class: 'fullwidth title', required: true %>
+            <%= f.error_message_on :name %>
+          <% end %>
+        </div>
 
-    <div class="left col-9" data-hook="admin_product_form_left">
-      <div data-hook="admin_product_form_name">
-        <%= f.field_container :name do %>
-          <%= f.label :name, class: 'required' %>
-          <%= f.text_field :name, class: 'fullwidth title', required: true %>
-          <%= f.error_message_on :name %>
-        <% end %>
+        <div data-hook="admin_product_form_slug">
+          <%= f.field_container :slug do %>
+            <%= f.label :slug, class: ('required' if !f.object.new_record?) %>
+            <%= f.text_field :slug, class: 'fullwidth title', required: !f.object.new_record?, disabled: f.object.new_record? %>
+            <%= f.error_message_on :slug %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_description">
+          <%= f.field_container :description do %>
+            <%= f.label :description %>
+            <%= f.text_area :description, {rows: "#{unless @product.has_variants? then '22' else '15' end}", class: 'fullwidth'} %>
+            <%= f.error_message_on :description %>
+          <% end %>
+        </div>
       </div>
 
-      <div data-hook="admin_product_form_slug">
-        <%= f.field_container :slug do %>
-          <%= f.label :slug, class: ('required' if !f.object.new_record?) %>
-          <%= f.text_field :slug, class: 'fullwidth title', required: !f.object.new_record?, disabled: f.object.new_record? %>
-          <%= f.error_message_on :slug %>
-        <% end %>
-      </div>
+      <div class="mt-4">
+        <div data-hook="admin_product_form_taxons">
+          <%= f.field_container :taxons do %>
+            <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
+            <%= f.hidden_field :taxon_ids, value: @product.taxon_ids.join(',') %>
+          <% end %>
+        </div>
 
-      <div data-hook="admin_product_form_description">
-        <%= f.field_container :description do %>
-          <%= f.label :description %>
-          <%= f.text_area :description, {rows: "#{unless @product.has_variants? then '22' else '15' end}", class: 'fullwidth'} %>
-          <%= f.error_message_on :description %>
-        <% end %>
+        <div data-hook="admin_product_form_option_types">
+          <%= f.field_container :option_types do %>
+            <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
+            <%= f.hidden_field :option_type_ids, value: @product.option_type_ids.join(',') %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_meta">
+          <div data-hook="admin_product_form_meta_title">
+            <%= f.field_container :meta_title do %>
+              <%= f.label :meta_title %>
+              <%= f.text_field :meta_title, class: 'fullwidth' %>
+            <% end %>
+          </div>
+
+          <div data-hook="admin_product_form_meta_keywords">
+            <%= f.field_container :meta_keywords do %>
+              <%= f.label :meta_keywords %>
+              <%= f.text_field :meta_keywords, class: 'fullwidth' %>
+            <% end %>
+          </div>
+
+          <div data-hook="admin_product_form_meta_description">
+            <%= f.field_container :meta_description do %>
+              <%= f.label :meta_description %>
+              <%= f.text_field :meta_description, class: 'fullwidth' %>
+            <% end %>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -161,49 +201,6 @@
           <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select' }) %>
           <%= f.error_message_on :tax_category %>
         <% end %>
-      </div>
-    </div>
-
-  </div>
-
-  <div class="row">
-
-    <div class="col-9">
-      <div data-hook="admin_product_form_taxons">
-        <%= f.field_container :taxons do %>
-          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
-          <%= f.hidden_field :taxon_ids, value: @product.taxon_ids.join(',') %>
-        <% end %>
-      </div>
-
-      <div data-hook="admin_product_form_option_types">
-        <%= f.field_container :option_types do %>
-          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
-          <%= f.hidden_field :option_type_ids, value: @product.option_type_ids.join(',') %>
-        <% end %>
-      </div>
-
-      <div data-hook="admin_product_form_meta">
-        <div data-hook="admin_product_form_meta_title">
-          <%= f.field_container :meta_title do %>
-            <%= f.label :meta_title %>
-            <%= f.text_field :meta_title, class: 'fullwidth' %>
-          <% end %>
-        </div>
-
-        <div data-hook="admin_product_form_meta_keywords">
-          <%= f.field_container :meta_keywords do %>
-            <%= f.label :meta_keywords %>
-            <%= f.text_field :meta_keywords, class: 'fullwidth' %>
-          <% end %>
-        </div>
-
-        <div data-hook="admin_product_form_meta_description">
-          <%= f.field_container :meta_description do %>
-            <%= f.label :meta_description %>
-            <%= f.text_field :meta_description, class: 'fullwidth' %>
-          <% end %>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

This PR prevents the right bar in the admin **Product Details** tab to push down some fields (_Taxons_, _Option Types_, etc.) when it gets longer than the form on the left (_Name_, _Slug_, etc.). This may happens if additional fields are being added to the right bar.

This can be easily solved by moving the form currently at the bottom of the page, under the same column of the one on the top, now they're divided by two `row` elements.

**Before**

![ezgif-2-1e5d6e5b3b](https://user-images.githubusercontent.com/1730394/215847955-49d51292-b429-4e0b-a14b-a2ff94e52791.gif)

**After**

![ezgif-2-2855150ad0](https://user-images.githubusercontent.com/1730394/215847973-d00a7b55-57b3-4895-8b94-1ecefdf8e22c.gif)

### How to test this change

1. Open the admin
2. Go to Products
3. Select any product
4. Scroll down to see the change

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- [ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
