### PR TITLE
Fix link to the contribution document

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 As a community-driven project, Solidus relies on funds and time donated by developers and stakeholders who use Solidus for their businesses. If you'd like to help Solidus keep growing, please consider:
 
 - [Become a backer or sponsor on Open Collective](https://opencollective.com/solidus).
-- [Contribute to the project](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md).
+- [Contribute to the project](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md).
 
 ### Main Contributor & Director
 At present, Nebulab is the main code contributor and director of Solidus, providing technical guidance and coordinating community efforts and activities.


### PR DESCRIPTION
## Summary

The link was broken since https://github.com/solidusio/solidus/pull/4713 was merged.

Closes #4896

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
