### PR TITLE
Point the Solidus Installer to the right Starter Frontend version

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
@@ -1,3 +1,3 @@
 apply "#{__dir__}/break_down_solidus_gem.rb"
 run_bundle
-apply 'https://github.com/solidusio/solidus_starter_frontend/raw/main/template.rb'
+apply 'https://github.com/solidusio/solidus_starter_frontend/raw/v3.3/template.rb'


### PR DESCRIPTION
## Summary

Solidus v3.3 installer should install the starter frontend at the corresponding version.

This is already happening for [v3.2](https://github.com/solidusio/solidus/blob/v3.2/core/lib/generators/solidus/install/install_generator/install_frontend.rb#L46).

We need to find a way to make this dynamic, but in master, it should still point to the development version of the Starter Frontend.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
