### PR TITLE
Fix CI only testing with the paperclip adapter

### DIFF
--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -90,7 +90,7 @@ module DummyApp
     config.active_record.dump_schema_after_migration = false
 
     # Configure active storage to use storage within tmp folder
-    unless ENV['DISABLE_ACTIVE_STORAGE']
+    unless (ENV['DISABLE_ACTIVE_STORAGE'] == 'true')
       initializer 'solidus.active_storage' do
         config.active_storage.service_configurations = {
           test: {
@@ -140,7 +140,7 @@ Spree.load_defaults(Spree.solidus_version)
 Spree.config do |config|
   config.use_legacy_events = (ENV['USE_LEGACY_EVENTS'] == 'true')
 
-  if ENV['DISABLE_ACTIVE_STORAGE']
+  if (ENV['DISABLE_ACTIVE_STORAGE'] == 'true')
     config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
     config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
   end

--- a/core/spec/models/spree/concerns/active_storage_adapter/attachment_spec.rb
+++ b/core/spec/models/spree/concerns/active_storage_adapter/attachment_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-unless ENV['DISABLE_ACTIVE_STORAGE']
+unless (ENV['DISABLE_ACTIVE_STORAGE'] == 'true')
   RSpec.describe Spree::ActiveStorageAdapter::Attachment do
     describe '#variant' do
       it "converts to resize_to_limit when definition doesn't contain any special symbol" do

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -37,7 +37,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.before :suite do
-    FileUtils.rm_rf(Rails.configuration.active_storage.service_configurations[:test][:root]) unless ENV['DISABLE_ACTIVE_STORAGE']
+    FileUtils.rm_rf(Rails.configuration.active_storage.service_configurations[:test][:root]) unless (ENV['DISABLE_ACTIVE_STORAGE'] == 'true')
     DatabaseCleaner.clean_with :truncation
   end
 


### PR DESCRIPTION
## Summary

Since https://github.com/solidusio/solidus/pull/4666, all jobs have been running with the paperclip adapter.

The reason is that when the `paperclip` parameter was `false` on CircleCI, that translated into the 
 `DISABLE_ACTIVE_STORAGE` env var being the string `"false"`. As we were checking for the mere presence of
`DISABLE_ACTIVE_STORAGE`, it always evaluated to `true`.

Fixes #4901

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
