### PR TITLE
Ensure db:seed runs before spree_sample:load

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,16 @@ bin/rails g solidus:install --migrate=false --sample=false --seed=false
 
 You can always perform any of these steps later by using these commands.
 
+**Note: Loading sample data will automatically load seed data as well because the sample data depends on the data provided by the seeds.**
+
 ```bash
 bin/rails railties:install:migrations
 bin/rails db:migrate
-bin/rails db:seed
 bin/rails spree_sample:load
 ```
+
+If you don't want to load sample data you can use `bin/rails db:seed` instead. This command
+will populate the database with only the basic data needed for Solidus to work.
 
 There are also options and rake tasks provided by
 [solidus\_auth\_devise](https://github.com/solidusio/solidus_auth_devise).

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -67,7 +67,7 @@ module Spree
 
     private
 
-    # Retreive a matching line item from the existing order
+    # Retrieve a matching line item from the existing order
     #
     # It will compare line items based on variants, and all line item
     # comparison hooks on the order.

--- a/core/spec/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/generators/solidus/install/install_generator_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Solidus::InstallGenerator do
         expect(generator.instance_variable_get(:@selected_authentication)).to eq("devise")
         expect(generator.instance_variable_get(:@selected_payment_method)).to eq("paypal")
         expect(generator.instance_variable_get(:@run_migrations)).to eq(true)
-        expect(generator.instance_variable_get(:@load_seed_data)).to eq(true)
-        expect(generator.instance_variable_get(:@load_sample_data)).to eq(true)
+        expect(generator.instance_variable_get(:@run_seeds)).to eq(false)
+        expect(generator.instance_variable_get(:@run_sample)).to eq(true)
       end
     end
 
@@ -36,8 +36,19 @@ RSpec.describe Solidus::InstallGenerator do
 
       aggregate_failures do
         expect(generator.instance_variable_get(:@run_migrations)).to eq(false)
-        expect(generator.instance_variable_get(:@load_seed_data)).to eq(false)
-        expect(generator.instance_variable_get(:@load_sample_data)).to eq(false)
+        expect(generator.instance_variable_get(:@run_seeds)).to eq(false)
+        expect(generator.instance_variable_get(:@run_sample)).to eq(false)
+      end
+    end
+
+    it 'disables "seeds" when "sample" is enabled' do
+      generator = described_class.new([], ['--auto-accept', '--sample=true'])
+      generator.prepare_options
+
+      aggregate_failures do
+        expect(generator.instance_variable_get(:@run_migrations)).to eq(true)
+        expect(generator.instance_variable_get(:@run_seeds)).to eq(false)
+        expect(generator.instance_variable_get(:@run_sample)).to eq(true)
       end
     end
 
@@ -68,17 +79,8 @@ RSpec.describe Solidus::InstallGenerator do
       generator.prepare_options
 
       expect(generator.instance_variable_get(:@run_migrations)).to eq(false)
-      expect(generator.instance_variable_get(:@load_seed_data)).to eq(false)
-      expect(generator.instance_variable_get(:@load_sample_data)).to eq(false)
-    end
-
-    it 'skips sample data if seeds are disabled' do
-      generator = described_class.new([], ['--auto-accept', '--seed=false'])
-      generator.prepare_options
-
-      expect(generator.instance_variable_get(:@run_migrations)).to eq(true)
-      expect(generator.instance_variable_get(:@load_seed_data)).to eq(false)
-      expect(generator.instance_variable_get(:@load_sample_data)).to eq(false)
+      expect(generator.instance_variable_get(:@run_seeds)).to eq(false)
+      expect(generator.instance_variable_get(:@run_sample)).to eq(false)
     end
 
     context 'supports legacy frontend option names' do
@@ -127,6 +129,60 @@ RSpec.describe Solidus::InstallGenerator do
         expect(strip_ansi questions.first[:desc]).not_to include('[bolt]')
         expect(strip_ansi questions.first[:desc]).to include('[none]')
       end
+    end
+  end
+
+  describe "#run_data_loaders" do
+    it "executes spree_sample:load task only when sample and seed are enabled" do
+      generator = described_class.new([], ['--auto-accept', '--sample=true', '--seed=true'])
+      allow(generator).to receive(:say_status_and_run_task)
+
+      generator.prepare_options
+      generator.run_data_loaders
+
+      aggregate_failures do
+        expect(generator).to have_received(:say_status_and_run_task).with("seed and sample data", "spree_sample:load")
+        expect(generator).not_to have_received(:say_status_and_run_task).with("seed data", "db:seed")
+      end
+    end
+
+    it "does not execute spree_sample:load task when sample is disabled" do
+      generator = described_class.new([], ['--auto-accept', '--sample=false', '--seed=true'])
+      allow(generator).to receive(:say_status_and_run_task)
+      allow(generator).to receive(:say_status)
+
+      generator.prepare_options
+      generator.run_data_loaders
+
+      aggregate_failures do
+        expect(generator).to have_received(:say_status_and_run_task).with("seed data", "db:seed AUTO_ACCEPT=1")
+        expect(generator).to have_received(:say_status).with(:skipping, "sample data (you can always run rake spree_sample:load)")
+      end
+    end
+
+    it "skips both spree_sample:load and db:seed tasks when task and sample are disabled" do
+      generator = described_class.new([], ['--auto-accept', '--sample=false', '--seed=false'])
+      allow(generator).to receive(:say_status_and_run_task)
+      allow(generator).to receive(:say_status)
+
+      generator.prepare_options
+      generator.run_data_loaders
+
+      aggregate_failures do
+        expect(generator).to have_received(:say_status).with(:skipping, "seed data (you can always run rake db:seed)")
+        expect(generator).to have_received(:say_status).with(:skipping, "sample data (you can always run rake spree_sample:load)")
+      end
+    end
+
+    it "includes expected rake options for db:seed" do
+      generator = described_class.new([], ['--auto-accept', '--sample=false', '--seed=true', '--admin_email=test@solidus.io', '--admin_password=P@55word!'])
+      allow(generator).to receive(:say_status_and_run_task)
+      allow(generator).to receive(:say_status)
+
+      generator.prepare_options
+      generator.run_data_loaders
+
+      expect(generator).to have_received(:say_status_and_run_task).with("seed data", "db:seed AUTO_ACCEPT=1 ADMIN_EMAIL=test@solidus.io ADMIN_PASSWORD=P@55word!")
     end
   end
 

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -3,8 +3,11 @@
 begin
 north_america = Spree::Zone.find_by!(name: "North America")
 rescue ActiveRecord::RecordNotFound
-  puts "Couldn't find 'North America' zone. Did you run `rake db:seed` first?"
-  puts "That task will set up the countries, states and zones required for Spree."
+  puts <<~TEXT
+    Couldn't find 'North America' zone. Did you run `rails db:seed` first?
+
+    That task will set up the countries, states and zones required for your store.
+  TEXT
   exit
 end
 

--- a/sample/db/samples/tax_rates.rb
+++ b/sample/db/samples/tax_rates.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
-north_america = Spree::Zone.find_by!(name: "North America")
+begin
+  north_america = Spree::Zone.find_by!(name: "North America")
+rescue ActiveRecord::RecordNotFound
+  puts <<~TEXT
+    Couldn't find 'North America' zone. Did you run `rails db:seed` first?
+
+    That task will set up the countries, states and zones required for your store.
+  TEXT
+  exit
+end
+
 clothing = Spree::TaxCategory.find_by!(name: "Default")
 tax_rate = Spree::TaxRate.create(
   name: "North America",

--- a/sample/lib/spree/sample.rb
+++ b/sample/lib/spree/sample.rb
@@ -7,7 +7,7 @@ module Spree
   module Sample
     class << self
       def load_sample(file, shell: Thor::Base.shell.new)
-        # If file is exists within application it takes precendence.
+        # If file is exists within application it takes precedence.
         if File.exist?(File.join(Rails.root, 'db', 'samples', "#{file}.rb"))
           path = File.expand_path(File.join(Rails.root, 'db', 'samples', "#{file}.rb"))
         else

--- a/sample/lib/tasks/sample.rake
+++ b/sample/lib/tasks/sample.rake
@@ -5,7 +5,7 @@ require 'spree/sample'
 
 namespace :spree_sample do
   desc 'Loads sample data'
-  task load: :environment do
+  task load: ['db:seed', :environment] do
     if ARGV.include?("db:migrate")
       puts <<~TEXT
         Please run db:migrate separately from spree_sample:load.

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
-  s.homepage    = 'http://solidus.io'
+  s.homepage    = 'https://solidus.io'
   s.license     = 'BSD-3-Clause'
 
   s.metadata['rubygems_mfa_required'] = 'true'

--- a/sample/spec/lib/load_sample_spec.rb
+++ b/sample/spec/lib/load_sample_spec.rb
@@ -1,12 +1,38 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
+require "rake"
 
 describe "Load samples" do
   it "doesn't raise any error" do
-    expect {
-      Spree::Core::Engine.load_seed
+    expect do
+      pid = fork { Spree::Core::Engine.load_seed }
+      Process.wait(pid)
       SpreeSample::Engine.load_samples
-    }.to output.to_stdout
+    ensure
+      Process.kill(:KILL, pid) unless $?.exitstatus.zero?
+    end.not_to raise_error
+  end
+
+  it "has db:seed as a prerequisite" do
+    Rails.application.load_tasks
+
+    task = Rake::Task["spree_sample:load"]
+    seed_task = Rake::Task["db:seed"]
+    expect(task.prerequisite_tasks).to include(seed_task)
+  end
+end
+
+describe "Load seeds multiple times" do
+  it "doesn't duplicate records" do
+    4.times do
+      pid = fork { Spree::Core::Engine.load_seed }
+      Process.wait(pid)
+    ensure
+      Process.kill(:KILL, pid) unless $?.exitstatus.zero?
+    end
+
+    expect(Spree::Store.count).to eq(1)
+    expect(Spree::Zone.count).to eq(2)
   end
 end


### PR DESCRIPTION
## Summary

When running `bundle exec rake spree_sample:load` against an empty database, an exception is raised in `db/samples/tax_rates.rb` on account of missing a `Spree::Zone` with the name "North America.

In this PR we:

- Add `db:seed` as a dependent task of `spree_sample:load`
- Check that `Spree::Zone` "North America" is present in `db/samples/tax_rates.rb` before running the rest of the seed file. This makes it consistent with [db/samples/shipping_methods.rb](https://github.com/solidusio/solidus/blob/2dcd90e9aca83c6e570ccbb03ea4844c6ef53efe/sample/db/samples/shipping_methods.rb#L3-L9)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 ~~I have updated the README to account for my changes.~~
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
