### PR TITLE
Fix links to PR & author not being added into the automatic Changelog

### DIFF
--- a/dev_tools/lib/solidus/release_drafter.rb
+++ b/dev_tools/lib/solidus/release_drafter.rb
@@ -44,10 +44,6 @@ module Solidus
 
     private
 
-    def builder(draft, current_diff_source_tag, candidate_tag)
-      Builder.new(draft: draft, categories: LABELS.values, prepend: NO_EDIT_WARNING, append: full_changelog(current_diff_source_tag, candidate_tag))
-    end
-
     def add_pr(builder, pr, labels)
       builder.add(
         number: pr.number,

--- a/dev_tools/lib/solidus/release_drafter.rb
+++ b/dev_tools/lib/solidus/release_drafter.rb
@@ -24,6 +24,8 @@ module Solidus
       <!-- Please, don't edit manually. The content is automatically generated. -->
     TXT
 
+    USER_LINK_BUILDER = ->(user) { "https://github.com/#{user}" }
+
     def initialize(github_token:, repository:,
                    client: Client.new(github_token: github_token, repository: repository))
       @repository = repository
@@ -37,7 +39,14 @@ module Solidus
       return if pr_labels.include?(SKIP_LABEL) || matching_labels.empty?
 
       draft = @client.fetch_draft(tag: candidate_tag)
-      Builder.new(draft: draft, categories: LABELS.values, prepend: NO_EDIT_WARNING, append: full_changelog(current_diff_source_tag, candidate_tag))
+      Builder.new(
+        draft: draft,
+        categories: LABELS.values,
+        prepend: NO_EDIT_WARNING,
+        append: full_changelog(current_diff_source_tag, candidate_tag),
+        number_link_builder: number_link_builder,
+        user_link_builder: USER_LINK_BUILDER
+      )
         .then { |builder| add_pr(builder, pr, matching_labels) }
         .then { |draft| save_release(draft, candidate_tag, branch) }
     end
@@ -67,6 +76,10 @@ module Solidus
 
         **Full Changelog**: https://github.com/#{@repository}/compare/#{current_diff_source_tag}...#{candidate_tag}
       TXT
+    end
+
+    def number_link_builder
+      ->(number) { "https://github.com/#{@repository}/pull/#{number}" }
     end
   end
 end

--- a/dev_tools/lib/solidus/release_drafter/builder.rb
+++ b/dev_tools/lib/solidus/release_drafter/builder.rb
@@ -18,16 +18,18 @@ module Solidus
 
       TITLE_SEPARATOR = SEPARATOR
 
-      ENTRY_TEMPLATE = lambda do |title, number, user|
-        "- #{title} ##{number} (@#{user})"
+      ENTRY_TEMPLATE = lambda do |title, number, user, number_link_builder, user_link_builder|
+        "- #{title} [##{number}](#{number_link_builder.(number)}) ([@#{user}](#{user_link_builder.(user)}))"
       end.freeze
 
       ENTRY_SEPARATOR = SEPARATOR
 
       SECTION_SEPARATOR = SEPARATOR + SEPARATOR
 
-      def initialize(draft:, categories:, prepend: '', append: '')
+      def initialize(draft:, categories:, number_link_builder:, user_link_builder:, prepend: '', append: '')
         @categories = Set[*categories]
+        @number_link_builder = number_link_builder
+        @user_link_builder = user_link_builder
         @prepend = prepend
         @prepend_pattern = /^#{Regexp.quote(@prepend)}/m
         @append = append
@@ -39,7 +41,7 @@ module Solidus
       end
 
       def add(title:, number:, user:, categories:)
-        ENTRY_TEMPLATE.(title, number, user)
+        ENTRY_TEMPLATE.(title, number, user, @number_link_builder, @user_link_builder)
           .then { |entry| add_to_ast(entry, categories) }
           .then { |ast| @draft.with(content: unparse(ast)) }
       end

--- a/dev_tools/spec/lib/solidus/release_drafter_spec.rb
+++ b/dev_tools/spec/lib/solidus/release_drafter_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Solidus::ReleaseDrafter do
 
       expect(
         subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
-      ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 #1 (@alice)")}/)
+      ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 [#1](https://github.com/fake/solidus/pull/1) ([@alice](https://github.com/alice))")}/)
     end
 
     it 'adds the PR under more than one matching label' do
@@ -59,7 +59,7 @@ RSpec.describe Solidus::ReleaseDrafter do
 
       expect(
         subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
-      ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 #1 (@alice)")}.*#{Regexp.escape("## Solidus API\n- PR number 1 #1 (@alice)")}/m)
+      ).to match(/#{Regexp.escape("## Solidus Core\n- PR number 1 [#1](https://github.com/fake/solidus/pull/1) ([@alice](https://github.com/alice))")}.*#{Regexp.escape("## Solidus API\n- PR number 1 [#1](https://github.com/fake/solidus/pull/1) ([@alice](https://github.com/alice))")}/m)
     end
 
     it 'ignores if no matching label is present' do


### PR DESCRIPTION
## Summary

Although GitHub automatically autolinks references to PR and author in the release notes, it doesn't create them for the files in a repository. From [theirs docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-url):

> Note: Autolinked references are not created in wikis or files in a repository.

As we're copying the automatically generated release notes into the Changelog file, that resulted in the missing links. We fix it from the source to be safe from future changes.

Fixes #4904 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
