### PR TITLE
Limit usage of pull_request_target event is our workflows

### DIFF
--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -1,7 +1,7 @@
 name: "Ensure Changelog label"
 
 on:
-  pull_request_target:
+  pull_request:
     types: ["labeled", "unlabeled"]
   workflow_call:
 
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Check for the presence of a changelog label"
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr view \
             ${{ github.event.pull_request.number }} \

--- a/.github/workflows/prepare_post_release.yml
+++ b/.github/workflows/prepare_post_release.yml
@@ -1,7 +1,7 @@
 name: "Prepare post-release"
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - v*


### PR DESCRIPTION
## Summary

The `pull_request_target` event has access to the target repository secrets, implying a [security threat](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) in the case that code from the head branch is executed. Although we're not affected, it's wiser to use the sibling `pull_request` event, which runs in the forked context, when possible:

- `ensure_changelog_label` doesn't need access to any secret, as it can fetch the labels through an unauthenticated API call.
- `prepare_post_release` is run after a branch from our repository is merged (the one generated by the `prepare_release` manually dispatchable action). When a fork is not involved, the `pull_request` event can already read the repository secrets.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
