### PR TITLE
Use JS in the sandbox app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,16 +169,16 @@ commands:
             cat /tmp/.tool-versions
       - restore_cache:
           keys:
-            - solidus-installer-v6-{{ checksum "/tmp/.tool-versions" }}
-            - solidus-installer-v6-
+            - solidus-installer-v7-{{ checksum "/tmp/.tool-versions" }}
+            - solidus-installer-v7-
       - run:
           name: "Prepare the rails application"
           command: |
             cd /tmp
             test -d my_app || gem install rails solidus
-            test -d my_app || rails new my_app --skip-javascript --skip-git
+            test -d my_app || rails new my_app --skip-git
       - save_cache:
-          key: solidus-installer-v5-{{ checksum "/tmp/.tool-versions" }}
+          key: solidus-installer-v7-{{ checksum "/tmp/.tool-versions" }}
           paths:
             - /tmp/my_app
             - /home/circleci/.rubygems

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -47,8 +47,7 @@ unbundled bundle exec rails new sandbox --database="$RAILSDB" \
   --skip-keeps \
   --skip-rc \
   --skip-spring \
-  --skip-test \
-  --skip-javascript
+  --skip-test
 
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'


### PR DESCRIPTION
## Summary

New Rails versions do not come with Webpacker anymore. We can safely generate sandboxes with Javascript now.
This is also needed because the Starter Frontend has some Stimulus/Turbo code that relies on the Rails JS stack.

Fixes CI failures, like https://app.circleci.com/pipelines/github/solidusio/solidus/4021/workflows/0a92bb5c-2fd6-460c-8cc7-7ff1a69b968e/jobs/38086


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
