### PR TITLE
Fix duplicate context name in spec

### DIFF
--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Spree::LegacyUser, type: :model do
         stub_spree_preferences(completable_order_created_cutoff_days: 1)
       end
 
-      it "excludes orders updated outside of the cutoff date" do
+      it "excludes orders created outside of the cutoff date" do
         create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
         expect(user.last_incomplete_spree_order).to eq nil
       end
     end
 
-    context "with completable_order_created_cutoff set" do
+    context "with completable_order_updated_cutoff set" do
       before do
         stub_spree_preferences(completable_order_updated_cutoff_days: 1)
       end


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

In this spec file, there are two `context` blocks with the same name. The second one should be `completable_order_updated_cutoff` because it's stubbing the `completable_order_updated_cutoff_days` value.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
