### PR TITLE
[WIP] Use a non-cachable reference to retrieve the starter template

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
@@ -1,3 +1,8 @@
 apply "#{__dir__}/break_down_solidus_gem.rb"
 run_bundle
-apply 'https://github.com/solidusio/solidus_starter_frontend/raw/main/template.rb'
+
+branch = "main"
+current_timestamp = Time.now.strftime("%F %H:%M:%S")
+uncachable_reference = "#{branch}@{#{current_timestamp}}"
+
+apply URI.encode("https://github.com/solidusio/solidus_starter_frontend/raw/#{uncachable_reference}/template.rb")


### PR DESCRIPTION
## Summary

⚠️ The problem described above only happens for some time after we update the starter frontend. In fact, as some point, the described cache is invalidated, and we get the correct version of the starter template. 

This PR is in draft because we don't have the chance to verify if the solution attempted is working until this happens again (next change to the starter).

---

Apparently, something is caching the response of the URL that we call to retrieve the rails app template to install Solidus Starter Frontend.

The issue can be replicated ([rerunning any job with SSH in CircleCI and connecting to it](https://support.circleci.com/hc/en-us/articles/5170139355547-How-to-rerun-a-job-with-SSH)) with the following commands in a `irb` console, taken directly from [thor's apply](https://github.com/rails/thor/blob/05a79fc5de4446f37512b0aa6578940ed64b5057/lib/thor/actions.rb#L225-L226), which is what we use under the hood:

```ruby
path="https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/main/template.rb"
require "open-uri"
URI.open(path, "Accept" => "application/x-thor-template", &:read)
```

At the time of writing, this is returning a file that does not contain the last version of the `template.rb` on that branch, making that spec fail.

I wasn't able to understand where this cache is happening, but I have two suspects:

- CircleCI: for some reason, they have some sort of internal CDN. To support this, I only found [one related question](https://discuss.circleci.com/t/does-circleci-cache-http-requests-from-containers-to-external-resources/25872) on their forum with no answers. 
- GitHub: I'm sure they have some caching in place for raw content, but the behavior is different locally and on CircleCI. I suspect they have some sort of custom caching rules for CI systems, which might mitigate the number of calls they receive from these systems. 

### Attempt 1 (this PR, not working) 🔴 

To solve this problem, with @elia, we tried to find a non-cachable git reference so that we always get the latest version of the file and we went with what's proposed here: `main@{timestamp}`, which returns the content of the branch at a specific time, see [git-rev-parse doc](https://linux.die.net/man/1/git-rev-parse) for more info.

This is not a viable solution. In fact, [the template script uses the branch from the URL to clone the repository](https://github.com/solidusio/solidus_starter_frontend/blob/712c84d09d54f253eb9874116958885cdd0b8712/template.rb#L51), and this won't work with the new rev format used.

[Failure example](https://app.circleci.com/pipelines/github/nebulab/solidus/823/workflows/85206ed8-4290-4bed-8050-fb008db5d5e1/jobs/11405): `fatal: Remote branch main@%7B2023-02-08%2022:57:09%7D not found in upstream origin`

We could parse the URL and check out/clone at that specific rev, but I don't want to overcomplicate the script.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
