### PR TITLE
Remove Slack notifications for CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.3
   codecov: codecov/codecov@3.2.3
-  slack: circleci/slack@4.9.3
 
 executors:
   base:
@@ -84,13 +83,6 @@ commands:
           key: solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-
-  notify:
-    steps:
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-          branch_pattern: master, v[0-9]+\.[0-9]+
 
   test:
     steps:
@@ -247,7 +239,6 @@ jobs:
             bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
             export LIB_NAME=set # dummy requireable file
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
-      - notify
 
   test_solidus:
     parameters:
@@ -279,7 +270,6 @@ jobs:
       - setup
       - libvips
       - test
-      - notify
 
   test_with_coverage:
     parameters:
@@ -301,7 +291,6 @@ jobs:
       - setup
       - libvips
       - test_with_coverage
-      - notify
 
   dev_tools:
     docker:
@@ -314,17 +303,14 @@ jobs:
             cd dev_tools
             bundle
             bundle exec rspec
-      - notify
 
 workflows:
   build:
     jobs:
-      - solidus_installer:
-          context: slack-secrets
+      - solidus_installer
 
       # Only test with coverage support with the default versions
       - test_with_coverage:
-          context: slack-secrets
           post-steps:
             - codecov/upload:
                 file: $COVERAGE_FILE
@@ -332,16 +318,12 @@ workflows:
       # Based on supported versions for the current Solidus release and recommended versions from
       # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
       - test_solidus:
-          context: slack-secrets
           name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>><<#matrix.legacy_events>>-legacy_events<</matrix.legacy_events>>"
           matrix: { parameters: { rails: ['7.0'], ruby: ['3.1', '3.2'], database: ['mysql', 'sqlite', 'postgres'], paperclip: [true, false], legacy_events: [false] } }
       - test_solidus:
-          context: slack-secrets
           name: *name
           matrix: { parameters: { rails: ['6.1'], ruby: ['2.7', '3.0', '3.1'], database: ['sqlite'], paperclip: [false], legacy_events: [false] } }
       - test_solidus:
-          context: slack-secrets
           name: *name
           matrix: { parameters: { rails: ['6.0'], ruby: ['2.7'], database: ['sqlite'], paperclip: [true], legacy_events: [true] } }
-      - dev_tools:
-          context: slack-secrets
+      - dev_tools


### PR DESCRIPTION
## Summary

We were storing the Slack secrets on a [CircleCI context](https://circleci.com/docs/contexts/). Although we were also [passing them to forks](https://circleci.com/docs/oss/#pass-secrets-to-builds-from-forked-pull-requests), it resulted on unauthorized builds for external contributions.

We could work around the issue in two ways:

- Having the secrets outside of any context, but that would compromise the security of the associated Slack channel for:
  - Send messages as @<!---->CircleCI notifications
  - Send messages to channels @<!---->CircleCI notifications isn't a member of
  - Upload, edit, and delete files as CircleCI notifications
- Using CircleCI [logic statements](https://circleci.com/docs/configuration-reference/#logic-statements) to conditionally run jobs when `CIRCLECI_USERNAME` or `CIRCLE_PR_USERNAME` [env vars](https://circleci.com/docs/variables/) are in a list of allowed users. However, that would be something difficult to maintain, and there's no other way to check the user's role.

Given that we don't find those trade-offs to be acceptable, we remove the integration for now.

Closes #4902

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
