### PR TITLE
[v3.2]  Fix occasional "database is locked" errors while loading sample data

### DIFF
--- a/sample/lib/spree_sample.rb
+++ b/sample/lib/spree_sample.rb
@@ -9,6 +9,16 @@ module SpreeSample
 
     # Needs to be here so we can access it inside the tests
     def self.load_samples
+      original_active_job_adapter = ActiveJob::Base.queue_adapter
+
+      # SQLite doesn't support full-concurrency and often fails with
+      # "SQLite3::BusyException: database is locked" when ActiveJob uses the default
+      # threaded `:async` adapter. ActiveJob is used by ActiveStorage to analyze uploaded
+      # images for metadata.
+      if ActiveRecord::Base.connection.adapter_name == "SQLite"
+        ActiveJob::Base.queue_adapter = :inline
+      end
+
       Spree::Sample.load_sample("payment_methods")
       Spree::Sample.load_sample("tax_categories")
       Spree::Sample.load_sample("tax_rates")
@@ -27,6 +37,8 @@ module SpreeSample
       Spree::Sample.load_sample("orders")
       Spree::Sample.load_sample("payments")
       Spree::Sample.load_sample("reimbursements")
+    ensure
+      ActiveJob::Base.queue_adapter = original_active_job_adapter
     end
   end
 end


### PR DESCRIPTION
## Summary

Backport PR  #4648. We're getting a few database is locked issues while testing sqlite3 + samples on v3.2. Easier to back port the fix than to keep rerunning jobs.

e.g. https://github.com/solidusio/solidus/pull/4939
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
