### PR TITLE
Mark another spec as flaky

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -404,7 +404,7 @@ describe "Order Details", type: :feature, js: true do
 
         context 'there is not enough stock at the other location' do
           context 'and it cannot backorder' do
-            it 'should not allow me to split stock' do
+            it 'should not allow me to split stock', :flaky do
               product.master.stock_items.last.update_column(:backorderable, false)
               product.master.stock_items.last.update_column(:count_on_hand, 0)
 


### PR DESCRIPTION
## Summary

Continuation of #4893.

In Buildkite, we have a list of specs ordered by reliability.

![Screenshot 2023-02-14 at 09 47 09@2x](https://user-images.githubusercontent.com/167946/218684950-b8ef81c7-07cf-4ae6-8d63-6b48ea0f701f.png)

Buildkite is only tracking the master branch, though. There might be other flakys that only failed on a branch suite and are not reported in the list.

By the way, following this list, it seems like we still miss marking one spec as flaky, which is what this PR does.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
