### PR TITLE
Fix flaky spec helper for local testing

### DIFF
--- a/core/lib/spree/testing_support/flaky.rb
+++ b/core/lib/spree/testing_support/flaky.rb
@@ -15,6 +15,8 @@ RSpec.configure do |config|
   config.around(:each, :flaky) do |example|
     if ENV['CI']
       example.run_with_retry retry: 2
+    else
+      example.run
     end
   end
 end


### PR DESCRIPTION
## Summary

Locally, it was not running flaky specs, because I forgot to add the normal run when we are not in the CI.

I noticed this by running specs locally and seeing that flaky were skipped.



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
