### PR TITLE
Keep all the LogEntry serialization logic in one place

### DIFF
--- a/api/spec/requests/spree/api/payments_spec.rb
+++ b/api/spec/requests/spree/api/payments_spec.rb
@@ -178,7 +178,7 @@ module Spree::Api
 
           context "authorization fails" do
             before do
-              fake_response = double(success?: false, to_s: "Could not authorize card")
+              fake_response = ActiveMerchant::Billing::Response.new(false, "Could not authorize card")
               expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:authorize).and_return(fake_response)
               put spree.authorize_api_order_payment_path(order, payment)
             end
@@ -201,7 +201,7 @@ module Spree::Api
 
           context "capturing fails" do
             before do
-              fake_response = double(success?: false, to_s: "Insufficient funds")
+              fake_response = ActiveMerchant::Billing::Response.new(false, "Insufficient funds")
               expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:capture).and_return(fake_response)
             end
 
@@ -224,7 +224,7 @@ module Spree::Api
 
           context "purchasing fails" do
             before do
-              fake_response = double(success?: false, to_s: "Insufficient funds")
+              fake_response = ActiveMerchant::Billing::Response.new(false, "Insufficient funds")
               expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:purchase).and_return(fake_response)
             end
 
@@ -247,7 +247,7 @@ module Spree::Api
 
           context "voiding fails" do
             before do
-              fake_response = double(success?: false, to_s: "NO REFUNDS")
+              fake_response = ActiveMerchant::Billing::Response.new(false, "NO REFUNDS")
               expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:void).and_return(fake_response)
             end
 

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -80,5 +80,9 @@ module Spree
     rescue Psych::BadAlias => e
       raise BadAlias.new(psych_exception: e)
     end
+
+    def parsed_details=(value)
+      self.details = value.to_yaml
+    end
   end
 end

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -70,19 +70,33 @@ module Spree
     belongs_to :source, polymorphic: true, optional: true
 
     def parsed_details
-      @details ||= YAML.safe_load(
-        details,
-        permitted_classes: self.class.permitted_classes,
-        aliases: Spree::Config.log_entry_allow_aliases
-      )
+      handle_psych_serialization_errors do
+        @details ||= YAML.safe_load(
+          details,
+          permitted_classes: self.class.permitted_classes,
+          aliases: Spree::Config.log_entry_allow_aliases,
+        )
+      end
+    end
+
+    def parsed_details=(value)
+      handle_psych_serialization_errors do
+        self.details = YAML.safe_dump(
+          value,
+          permitted_classes: self.class.permitted_classes,
+          aliases: Spree::Config.log_entry_allow_aliases,
+        )
+      end
+    end
+
+    private
+
+    def handle_psych_serialization_errors
+      yield
     rescue Psych::DisallowedClass => e
       raise DisallowedClass.new(psych_exception: e)
     rescue Psych::BadAlias => e
       raise BadAlias.new(psych_exception: e)
-    end
-
-    def parsed_details=(value)
-      self.details = value.to_yaml
     end
   end
 end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -206,7 +206,7 @@ module Spree
       end
 
       def record_response(response)
-        log_entries.create!(details: response.to_yaml)
+        log_entries.create!(parsed_details: response)
       end
 
       def protect_from_connection_error

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Spree::LogEntry, type: :model do
   describe '#parsed_details' do
-    it 'allow aliases by default' do
+    it 'allows aliases by default' do
       x = []
       x << x
 
@@ -39,7 +39,7 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details }.not_to raise_error
     end
 
-    it 'can parse user specified classes instances' do
+    it 'can parse user specified class instances' do
       stub_spree_preferences(log_entry_permitted_classes: ['Date'])
 
       log_entry = described_class.new(details: Date.today)

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -56,13 +56,61 @@ RSpec.describe Spree::LogEntry, type: :model do
 
   describe '#parsed_details=' do
     it 'serializes the provided value to YAML' do
-      value = double("an object", to_yaml: "---\nfoo: bar")
+      log_entry = described_class.new(parsed_details: { "foo" => "bar" })
 
-      log_entry = described_class.new(parsed_details: value)
+      expect(log_entry.details).to eq("---\nfoo: bar\n")
+      expect(log_entry.parsed_details).to eq("foo" => "bar")
+    end
 
-      expect(value).to have_received(:to_yaml)
-      expect(log_entry.details).to eq("---\nfoo: bar")
-      expect(log_entry.parsed_details).to eq({"foo" => "bar"})
+    it 'allows aliases by default' do
+      x = []
+      x << x
+
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = x }.not_to raise_error
+    end
+
+    it 'can disable aliases and raises a meaningful exception when used' do
+      stub_spree_preferences(log_entry_allow_aliases: false)
+      x = []
+      x << x
+
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = x }.to raise_error(described_class::BadAlias, /log_entry_allow_aliases/)
+    end
+
+    it 'can dump ActiveMerchant::Billing::Response instances' do
+      response = ActiveMerchant::Billing::Response.new('success', 'message')
+
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = response }.not_to raise_error
+    end
+
+    it 'can dump ActiveSupport::TimeWithZone instances' do
+      time = Time.zone.now
+
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = time }.not_to raise_error
+    end
+
+    it 'can dump user specified class instances' do
+      stub_spree_preferences(log_entry_permitted_classes: ['Date'])
+
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = Date.new }.not_to raise_error
+    end
+
+    it 'raises a meaningful exception when a disallowed class is found' do
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = Date.new }.to raise_error(
+        described_class::DisallowedClass, /log_entry_permitted_classes/
+      )
     end
   end
 end

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -53,4 +53,16 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details }.to raise_error(described_class::DisallowedClass, /log_entry_permitted_classes/)
     end
   end
+
+  describe '#parsed_details=' do
+    it 'serializes the provided value to YAML' do
+      value = double("an object", to_yaml: "---\nfoo: bar")
+
+      log_entry = described_class.new(parsed_details: value)
+
+      expect(value).to have_received(:to_yaml)
+      expect(log_entry.details).to eq("---\nfoo: bar")
+      expect(log_entry.parsed_details).to eq({"foo" => "bar"})
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Moving all the serialization/deserialization of Spree::LogEntry details to one place and using a consistent proxy attribute.

This begs for [proper ActiveRecord serialization](https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize) but before doing that we need to think through the migration path for existing stores.

This change is intentionally minimal, enough to allow all writers of log entries to use the same serialization method.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
