### PR TITLE
Improve REST OpenAPI documentation for auth

### DIFF
--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -5925,9 +5925,8 @@ components:
                 type: integer
   securitySchemes:
     api-key:
-      type: apiKey
-      name: Authorization
-      in: header
+      type: http
+      scheme: bearer
       description: 'The `API key` is mandatory for each endpoint by default. You can change this configuration [with the Spree::Api::Config.requires_authentication preference](https://github.com/solidusio/solidus/blob/2b79f72aa53f5caa850c587888fff46c1c91f7b7/api/lib/spree/api_configuration.rb#L5) to avoid the default behavior and expose some endpoints without an API key. An example could be the [GET product list](https://solidus.stoplight.io/docs/solidus/08307f3d809e7-list-products) endpoint.'
     order-token:
       type: apiKey

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -560,7 +560,7 @@ describe "Order Details", type: :feature, js: true do
         end
 
         context 'receiving shipment can backorder' do
-          it 'should add more to the backorder' do
+          it 'should add more to the backorder', :flaky do
             shipment1.inventory_units.update_all(state: :on_hand)
             product.master.stock_items.last.update_column(:backorderable, true)
             product.master.stock_items.last.update_column(:count_on_hand, 0)


### PR DESCRIPTION
## Summary

This change will show the correct format of the api key token in the generated documentation.

### Before
<img width="702" alt="Screenshot 2023-02-20 at 17 04 17@2x" src="https://user-images.githubusercontent.com/167946/220154572-24824f1c-faf8-4567-97f9-cd77ab7dc184.png">

### After
<img width="708" alt="Screenshot 2023-02-20 at 17 07 23@2x" src="https://user-images.githubusercontent.com/167946/220154907-ea3bcb36-55f9-4fa7-86d5-61c31b6dd08f.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
