### PR TITLE
Allow bad payloads to be saved in payment log entries

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -84,6 +84,17 @@ module Spree
       end
     end
 
+    def parsed_payment_response_details_with_fallback=(response)
+      self.parsed_details = response
+    rescue SerializationError, YAML::Exception => e
+      # Fall back on wrapping the response and signaling the error to the end user.
+      self.parsed_details = ActiveMerchant::Billing::Response.new(
+        response.success?,
+        "[WARNING: An error occurred while trying to serialize the payment response] #{response.message}",
+        { 'data' => response.inspect, 'error' => e.message.to_s },
+      )
+    end
+
     private
 
     def handle_psych_serialization_errors

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -15,15 +15,17 @@ module Spree
       ActiveSupport::TimeZone
     ].freeze
 
-    # Raised when a disallowed class is tried to be loaded
-    class DisallowedClass < RuntimeError
+    class SerializationError < RuntimeError
       attr_reader :psych_exception
 
       def initialize(psych_exception:)
         @psych_exception = psych_exception
         super(default_message)
       end
+    end
 
+    # Raised when a disallowed class is tried to be loaded
+    class DisallowedClass < SerializationError
       private
 
       def default_message
@@ -40,14 +42,7 @@ module Spree
     end
 
     # Raised when YAML contains aliases and they're not enabled
-    class BadAlias < RuntimeError
-      attr_reader :psych_exception
-
-      def initialize(psych_exception:)
-        @psych_exception = psych_exception
-        super(default_message)
-      end
-
+    class BadAlias < SerializationError
       private
 
       def default_message

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -206,7 +206,7 @@ module Spree
       end
 
       def record_response(response)
-        log_entries.create!(parsed_details: response)
+        log_entries.create!(parsed_payment_response_details_with_fallback: response)
       end
 
       def protect_from_connection_error

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -53,7 +53,7 @@ module Spree
       credit_cents = money.cents
 
       @perform_response = process!(credit_cents)
-      log_entries.build(details: perform_response.to_yaml)
+      log_entries.build(parsed_payment_response_details_with_fallback: perform_response)
 
       self.transaction_id = perform_response.authorization
       save!

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -518,8 +518,7 @@ RSpec.describe Spree::Payment, type: :model do
         it "should do nothing" do
           expect(payment).not_to receive(:complete)
           expect(payment.payment_method).not_to receive(:capture)
-          expect(payment.log_entries).not_to receive(:create!)
-          subject
+          expect{ subject }.not_to change(payment.log_entries, :count)
         end
       end
     end


### PR DESCRIPTION
## Summary

A followup to https://github.com/solidusio/solidus/pull/4950 after @gsmendoza and @kennyadsl pointed out that if a payment integration was feeding content that couldn't be deserialized the payment processing could have been disrupted vs. just breaking the payment details page in the admin console.

<del>So we're now falling back to the old and very generous `response.to_yaml`, but not before showing a proper warning asking it to be fixed. The wording of the warning is intentionally avoiding a promise that we'll reject bad payloads but instead just says that we might skip them, so we ensure to never interrupt payment processing for a secondary issue in the payment logs.</del>

So we're wrapping the bad response into a serializable one that will also report that a problem occurred.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
