### PR TITLE
Ensure target shipments are evaluated in order of creation (fix flakey)

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -57,7 +57,7 @@ module Spree
     # first unshipped that's leaving from a stock_location that stocks this variant, with availability check
     # first unshipped that's leaving from a stock_location that stocks this variant, without availability check
     def determine_target_shipment(quantity)
-      potential_shipments = order.shipments.select(&:ready_or_pending?)
+      potential_shipments = order.shipments.order(:created_at, :id).select(&:ready_or_pending?)
 
       potential_shipments.detect do |shipment|
         shipment.include?(variant)

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
         end
 
         context 'when there is not enough availability at any stock location' do
-          it 'falls-back selecting first non-shipped shipment that leaves from same stock_location', :flaky do
+          it 'falls-back selecting first non-shipped shipment that leaves from same stock_location' do
             shipment = subject.send(:determine_target_shipment, 1)
             shipment.reload
 


### PR DESCRIPTION
## Summary

This solves a long standing flakey spec which was uncovering an actual issue with the method being dependent on the implicit db order and how it returned records.

I have added `:id` to the sorting to disambiguate ordering of shipments were created quickly one after the other and ended up having the same creation date (e.g. in specs).

Adding `.reverse` after `order.shipments.order(:created_at, :id)` is consistently reproducing the failure.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
