### PR TITLE
Allow to set order_update_attributes_class

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -42,7 +42,7 @@ module Spree
       def update
         authorize! :update, @order, order_token
 
-        if OrderUpdateAttributes.new(@order, update_params, request_env: request.headers.env).apply
+        if Spree::Config.order_update_attributes_class.new(@order, update_params, request_env: request.headers.env).apply
           if can?(:admin, @order) && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -42,7 +42,7 @@ module Spree
       def update
         authorize! :update, @order, order_token
 
-        if Spree::Config.order_update_attributes_class.new(@order, update_params, request_env: request.headers.env).apply
+        if Spree::Config.order_update_attributes_class.new(@order, update_params, request_env: request.headers.env).call
           if can?(:admin, @order) && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end

--- a/core/app/models/spree/order_update_attributes.rb
+++ b/core/app/models/spree/order_update_attributes.rb
@@ -15,7 +15,7 @@ module Spree
 
     # Assign the attributes to the order and save the order
     # @return true if saved, otherwise false and errors will be set on the order
-    def apply
+    def call
       order.validate_payments_attributes(@payments_attributes)
 
       assign_order_attributes
@@ -23,6 +23,8 @@ module Spree
 
       order.save
     end
+
+    alias_method :apply, :call
 
     private
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -426,6 +426,13 @@ module Spree
     #   signature as Spree::OrderMailer.confirm_email.
     class_name_attribute :order_mailer_class, default: 'Spree::OrderMailer'
 
+    # Allows providing your own order update attributes class for checkout.
+    #
+    # @!attribute [rw] order_update_attributes_class
+    # @return [Class] a class that responds to "apply"
+    #   with the same signature as Spree::OrderUpdateAttributes.
+    class_name_attribute :order_update_attributes_class, default: 'Spree::OrderUpdateAttributes'
+
     # Allows providing your own Mailer for promotion code batch mailer.
     #
     # @!attribute [rw] promotion_code_batch_mailer_class

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -429,7 +429,7 @@ module Spree
     # Allows providing your own order update attributes class for checkout.
     #
     # @!attribute [rw] order_update_attributes_class
-    # @return [Class] a class that responds to "apply"
+    # @return [Class] a class that responds to "call"
     #   with the same signature as Spree::OrderUpdateAttributes.
     class_name_attribute :order_update_attributes_class, default: 'Spree::OrderUpdateAttributes'
 

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -111,13 +111,13 @@ module Spree
       end
 
       it "keeps source attributes on assignment" do
-        OrderUpdateAttributes.new(order, { payments_attributes: [payment_attributes] }).apply
+        OrderUpdateAttributes.new(order, { payments_attributes: [payment_attributes] }).call
         expect(order.unprocessed_payments.last.source.number).to be_present
       end
 
       # For the reason of this test, please see spree/spree_gateway#132
       it "keeps source attributes through OrderUpdateAttributes" do
-        OrderUpdateAttributes.new(order, { payments_attributes: [payment_attributes] }).apply
+        OrderUpdateAttributes.new(order, { payments_attributes: [payment_attributes] }).call
         expect(order.unprocessed_payments.last.source.number).to be_present
       end
     end

--- a/core/spec/models/spree/order_update_attributes_spec.rb
+++ b/core/spec/models/spree/order_update_attributes_spec.rb
@@ -12,14 +12,14 @@ module Spree
     context 'empty attributes' do
       let(:attributes){ {} }
       it 'succeeds' do
-        expect(update.apply).to be_truthy
+        expect(update.call).to be_truthy
       end
     end
 
     context 'with coupon code' do
       let(:attributes){ { coupon_code: 'abc123' } }
       it "sets coupon code" do
-        expect(update.apply).to be_truthy
+        expect(update.call).to be_truthy
         expect(order.coupon_code).to eq('abc123')
       end
     end
@@ -39,7 +39,7 @@ module Spree
       context 'with params and a request_env' do
         let(:request_env){ { 'USER_AGENT' => 'Firefox' } }
         it 'sets the request_env on the payment' do
-          expect(update.apply).to be_truthy
+          expect(update.call).to be_truthy
           expect(order.payments.length).to eq 1
           expect(order.payments[0].request_env).to eq({ 'USER_AGENT' => 'Firefox' })
         end


### PR DESCRIPTION
## Summary

Allows providing your own order update attributes class for checkout.

Some shops may have additional attributes on payments that needs to be store during
checkout. This allows to provide a class that responds to "apply" with the same signature as Spree::OrderUpdateAttributes

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
