### PR TITLE
Introduce allowed_ransackable_scopes

### DIFF
--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -5,6 +5,7 @@ module Spree::RansackableAttributes
   included do
     class_attribute :allowed_ransackable_associations, default: []
     class_attribute :allowed_ransackable_attributes, default: []
+    class_attribute :allowed_ransackable_scopes, default: []
 
     def self.whitelisted_ransackable_associations
       Spree::Deprecation.deprecation_warning(:whitelisted_ransackable_associations, 'use allowed_ransackable_associations instead')
@@ -37,6 +38,10 @@ module Spree::RansackableAttributes
 
     def ransackable_attributes(*_args)
       default_ransackable_attributes | allowed_ransackable_attributes
+    end
+
+    def ransackable_scopes(*_args)
+      allowed_ransackable_scopes
     end
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -133,10 +133,7 @@ module Spree
 
     self.allowed_ransackable_associations = %w[stores variants_including_master master variants]
     self.allowed_ransackable_attributes = %w[name slug]
-
-    def self.ransackable_scopes(_auth_object = nil)
-      %i(available with_discarded with_variant_sku_cont with_all_variant_sku_cont with_kept_variant_sku_cont)
-    end
+    self.allowed_ransackable_scopes = %i[available with_discarded with_variant_sku_cont with_all_variant_sku_cont with_kept_variant_sku_cont]
 
     # @return [Boolean] true if there are any variants
     def has_variants?

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -54,9 +54,7 @@ module Spree
 
     self.allowed_ransackable_associations = ['codes']
     self.allowed_ransackable_attributes = %w[name path promotion_category_id]
-    def self.ransackable_scopes(*)
-      %i(active)
-    end
+    self.allowed_ransackable_scopes = %i[active]
 
     def self.order_activatable?(order)
       order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)

--- a/core/spec/models/spree/concerns/ransackable_attributes_spec.rb
+++ b/core/spec/models/spree/concerns/ransackable_attributes_spec.rb
@@ -75,5 +75,25 @@ RSpec.describe Spree::RansackableAttributes do
         expect(test_class.ransackable_attributes).to match_array(["id", "test", "new_value"])
       end
     end
+
+    context "allowed_ransackable_scopes" do
+      before do
+        test_class.allowed_ransackable_scopes = []
+      end
+
+      it 'reads' do
+        expect(test_class.allowed_ransackable_scopes).to be_empty
+      end
+
+      it 'allows setting an array' do
+        test_class.allowed_ransackable_scopes = [:test]
+        expect(test_class.allowed_ransackable_scopes).to match_array([:test])
+      end
+
+      it 'allows concatenating' do
+        test_class.allowed_ransackable_scopes.concat([:new_value])
+        expect(test_class.allowed_ransackable_scopes).to match_array([:new_value])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Introduce `allowed_ransackable_scopes` to:
- consistent with the other[ Ransackable methods](https://github.com/solidusio/solidus/blob/master/core/app/models/concerns/spree/ransackable_attributes.rb) we have declared; and
- allow for easy concatenation of `ransackable_scopes` values already on `Product` and `Promotion` (by using `allowed_ransackable_scopes`).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
