### PR TITLE
Copy new migrations as part of the update task

### DIFF
--- a/core/lib/generators/solidus/update/update_generator.rb
+++ b/core/lib/generators/solidus/update/update_generator.rb
@@ -8,7 +8,7 @@ module Solidus
   class UpdateGenerator < ::Rails::Generators::Base
     FROM = Spree.previous_solidus_minor_version
 
-    desc 'Generates a new initializer to preview the new defaults for current Solidus version'
+    desc 'Generates a new initializer to preview the new defaults for current Solidus version and copy new migrations'
 
     source_root File.expand_path('templates', __dir__)
 
@@ -40,7 +40,7 @@ module Solidus
     def create_new_defaults_initializer
       previous_version_prompt = options[:previous_version_prompt]
       return if previous_version_prompt && !yes?(<<~MSG, :red)
-        The update process is only supported if you are coming from version #{FROM}. If this is not the case, please, skip it and update your application to use Solidus #{FROM} before retrying.
+        The default preferences update process is only supported if you are coming from version #{FROM}. If this is not the case, please, skip it and update your application to use Solidus #{FROM} before retrying.
         If you are confident you want to upgrade from a previous version, you must rerun the generator with the "--from={OLD_VERSION}" argument.
         Are you sure you want to continue? (y/N)
       MSG
@@ -55,6 +55,11 @@ module Solidus
 
       template 'config/initializers/new_solidus_defaults.rb.tt',
                File.join(options[:initializer_directory], "#{options[:initializer_basename]}.rb")
+    end
+
+    def install_migrations
+      say_status :copying, "migrations"
+      rake 'spree:install:migrations'
     end
 
     def print_message


### PR DESCRIPTION
## Summary
Running `bin/rails solidus:update`, we are not currently copying the new migrations introduced with the new Solidus version. This new install step will copy migrations and it's left to the user to run `db:migrate`, before checking them.

This commit also updates some copy of the task to reflect the new content of the file.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
