### PR TITLE
Remove order token authorization option from current order API documentation

### DIFF
--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -229,7 +229,6 @@ paths:
         - Orders
       security:
         - api-key: []
-        - order-token: []
   /countries:
     get:
       responses:

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -297,6 +297,29 @@ module Spree::Api
         expect(current_api_user).to receive(:last_incomplete_spree_order).with(store: Spree::Store.default)
         get spree.api_current_order_path(format: 'json')
       end
+
+      context "when the current user is not present" do
+        let(:current_api_user) { nil }
+        let(:order_token) { nil }
+
+        before do
+          get spree.api_current_order_path(format: 'json'), params: { order_token: order_token }
+        end
+
+        context "when the spree guest token is not present" do
+          it "returns a 401" do
+            expect(response.status).to eq(401)
+          end
+        end
+
+        context "when the spree guest token is present" do
+          let(:order_token) { order.guest_token }
+
+          it "returns a 401" do
+            expect(response.status).to eq(401)
+          end
+        end
+      end
     end
 
     it "can view their own order" do

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -300,13 +300,14 @@ module Spree::Api
 
       context "when the current user is not present" do
         let(:current_api_user) { nil }
-        let(:order_token) { nil }
 
         before do
           get spree.api_current_order_path(format: 'json'), params: { order_token: order_token }
         end
 
         context "when the spree guest token is not present" do
+          let(:order_token) { nil }
+
           it "returns a 401" do
             expect(response.status).to eq(401)
           end


### PR DESCRIPTION
## Summary

The stoplight documentation lists that you can authorize the requests to `api/orders/current` by providing either a user api key or a guest order token. The code, however is designed to only work with api key.

This PR adds tests to ensure that trying to provide the order token without a user api key will result in a `401` status response and updates the documentation to remove order token as an authorization option.

## Before
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/8895134/221821783-158f7daa-e1af-49c5-b277-d6cf06853d01.png">

## After
<img width="761" alt="image" src="https://user-images.githubusercontent.com/8895134/221821831-960e3c61-4ffa-4324-9300-4142fef8dd8d.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
