### PR TITLE
[v3.1] Allow storing static preferences using string class names

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -72,6 +72,7 @@ module Spree
 
       config.after_initialize do
         Spree::Config.check_load_defaults_called('Spree::Config')
+        Spree::Config.static_model_preferences.validate!
       end
 
       config.after_initialize do

--- a/core/lib/spree/preferences/static_model_preferences.rb
+++ b/core/lib/spree/preferences/static_model_preferences.rb
@@ -7,13 +7,8 @@ module Spree
         attr_reader :preferences
 
         def initialize(klass, hash)
-          hash = hash.symbolize_keys
-          hash.keys.each do |key|
-            if !klass.defined_preferences.include?(key)
-              raise "Preference #{key.inspect} is not defined on #{klass}"
-            end
-          end
-          @preferences = hash
+          @klass = klass
+          @preferences = hash.symbolize_keys
         end
 
         def fetch(key, &block)
@@ -27,6 +22,8 @@ module Spree
         def to_hash
           @preferences.deep_dup
         end
+
+        delegate :keys, to: :@preferences
       end
 
       def initialize
@@ -36,13 +33,31 @@ module Spree
       end
 
       def add(klass, name, preferences)
-        # We use class name instead of class to allow reloading in dev
-        raise "Static model preference '#{name}' on #{klass} is already defined" if @store[klass.to_s][name]
-        @store[klass.to_s][name] = Definition.new(klass, preferences)
+        @store[klass.to_s][name] = Definition.new(klass.to_s, preferences)
       end
 
       def for_class(klass)
         @store[klass.to_s]
+      end
+
+      def validate!
+        @store.keys.map(&:constantize).each do |klass|
+          validate_for_class!(klass)
+        end
+      end
+
+      private
+
+      def validate_for_class!(klass)
+        for_class(klass).each do |name, preferences|
+          klass_keys = klass.defined_preferences.map(&:to_s)
+          extra_keys = preferences.keys.map(&:to_s) - klass_keys
+          next if extra_keys.empty?
+
+          raise \
+            "Unexpected keys found for #{klass} under #{name}: #{extra_keys.sort.join(', ')} " \
+            "(expected keys: #{klass_keys.sort.join(', ')})"
+        end
       end
     end
   end

--- a/core/spec/models/spree/preferences/static_model_preferences_spec.rb
+++ b/core/spec/models/spree/preferences/static_model_preferences_spec.rb
@@ -23,10 +23,12 @@ module Spree
       expect(definitions).to have_key('my_definition')
     end
 
-    it "errors assigning invalid preferences" do
-      expect {
-        subject.add(preference_class, 'my_definition', { ice_cream: 'chocolate' })
-      }.to raise_error(/\APreference :ice_cream is not defined/)
+    it "can replace preferences" do
+      subject.add(preference_class, 'my_definition', { color: "red" })
+
+      subject.add(preference_class, 'my_definition', { color: "blue" })
+
+      expect(definitions['my_definition'].fetch(:color)).to eq("blue")
     end
 
     context "with stored definitions" do
@@ -73,6 +75,19 @@ module Spree
 
       it "is still empty for other classes" do
         expect(subject.for_class(other_class)).to be_empty
+      end
+    end
+
+    describe '.validate!' do
+      it "errors assigning invalid preferences" do
+        stub_const("SomeClass", preference_class)
+        subject.add(preference_class, 'my_definition', { ice_cream: 'chocolate', spoon: true })
+
+        expect {
+          subject.validate!
+        }.to raise_error(
+          /\AUnexpected keys found for SomeClass under my_definition: ice_cream, spoon \(expected keys: color\)/
+        )
       end
     end
   end


### PR DESCRIPTION
## Summary

Backports https://github.com/solidusio/solidus/pull/4858 to v3.1

This will make unnecessary to wrap these definitions under `.to_prepare`
blocks.

Additionally the error message for unexpected keys has improved and
now lists both all the unexpected keys along with the expected keys,
mentioning the name associated to the definition.

References https://github.com/solidusio/solidus_stripe/issues/170

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
