### PR TITLE
Spree::ProductDuplicator bug on price

### DIFF
--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -45,7 +45,7 @@ module Spree
         new_master.sku = "COPY OF #{master.sku}"
         new_master.deleted_at = nil
         new_master.images = master.images.map { |image| duplicate_image image } if @include_images
-        new_master.price = master.price
+        new_master.prices = master.prices.map(&:dup)
       end
     end
 

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -61,6 +61,10 @@ module Spree
         expect(new_product.name).to eql "COPY OF #{product.name}"
       end
 
+      it "will set the same price" do
+        expect(new_product.reload.price).to eql product.price
+      end
+
       it "will set an unique sku" do
         expect(new_product.sku).to include "COPY OF SKU"
       end


### PR DESCRIPTION
## Summary
Created to support https://github.com/solidusio/solidus/issues/4970
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

Until v3.2.3 duplicating a product duplicated the price.
Since v3.2.4 the product duplication does not duplicate the price.

Looks like it comes from the PR https://github.com/solidusio/solidus/pull/4639 :/

The code looks like price is supposed to be copied:
`Spree::ProductDuplicator#duplicate_master`
```
    def duplicate_master
      master = product.master
      master.dup.tap do |new_master|
        new_master.sku = "COPY OF #{master.sku}"
        new_master.deleted_at = nil
        new_master.images = master.images.map { |image| duplicate_image image } if @include_images
        new_master.price = master.price
      end
    end
```

To fix it I duplicated all of the master prices on the new_product.master.
Looks like it work for the test and for our app.
## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
