### PR TITLE
Update descend_by_popularity scope spec

### DIFF
--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -117,12 +117,13 @@ RSpec.describe "Product scopes", type: :model do
   end
 
   context "descend_by_popularity" do
-    let!(:variant_1) { create(:master_variant) }
-    let!(:variant_2) { create(:master_variant) }
-
-    let!(:line_item_1) { create(:line_item, variant: variant_1, quantity: 3) }
-    let!(:line_item_2) { create(:line_item, variant: variant_2, quantity: 2) }
     it "orders products by popularity" do
+      variant_1 = create(:master_variant)
+      variant_2 = create(:master_variant)
+
+      create_list(:line_item, 3, variant: variant_1)
+      create_list(:line_item, 2, variant: variant_2)
+
       expect(Spree::Product.descend_by_popularity.map(&:id)).to eq([variant_1.product.id, variant_2.product.id, product.id])
     end
   end


### PR DESCRIPTION
So that it doesn't depend on the line item quantity.

Closes #4977 

## Summary

The scope is not taking into account the line item quantity and was actually evaluating both line items with the same order. variant_1 was picked first only because it was created first.

In fact, switching the creating order of the two variants it was failing consistently.

The flaky was due to the fact that it's not guarantee that the databases will return the record in the order they are created, unless specified.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
