### PR TITLE
Fix rake error testing the update generator

### DIFF
--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -24,7 +24,7 @@ describe 'Customer returns', type: :feature do
     let(:order) { create :shipped_order, line_items_count: 2 }
 
     context 'when creating a return with state "Received"' do
-      it 'marks the order as returned', :js do
+      it 'marks the order as returned', :js, :flaky do
         create_customer_return('receive')
 
         expect(page).to have_content 'Customer Return has been successfully created'

--- a/core/lib/generators/solidus/update/update_generator.rb
+++ b/core/lib/generators/solidus/update/update_generator.rb
@@ -37,6 +37,11 @@ module Solidus
                  default: 'config/initializers/',
                  hide: true
 
+    class_option :install_migrations,
+                 type: :boolean,
+                 default: true,
+                 hide: true
+
     def create_new_defaults_initializer
       previous_version_prompt = options[:previous_version_prompt]
       return if previous_version_prompt && !yes?(<<~MSG, :red)
@@ -58,6 +63,8 @@ module Solidus
     end
 
     def install_migrations
+      return unless options[:install_migrations]
+
       say_status :copying, "migrations"
       rake 'spree:install:migrations'
     end

--- a/core/spec/lib/generators/solidus/update/update_generator_spec.rb
+++ b/core/spec/lib/generators/solidus/update/update_generator_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Solidus::UpdateGenerator do
       Rails::Generators.invoke('solidus:update', [
         "--initializer_directory=#{Rails.root.join('tmp')}",
         "--previous_version_prompt=false",
+        "--install_migrations=false",
         "--from=#{from}",
         "--to=#{to}",
         "--quiet"


### PR DESCRIPTION
## Summary

It looks like the `spree:install:migrations` task is not available when running through `Rails::Generators.invoke`, as it context differs from common shell invocation.

We fix that by not trying to run the task on test environment. In the end, it wouldn't be a good idea to copy the migrations at the test suite runtime.

Fixes #4978

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
