### PR TITLE
Add a deprecation warning for allow_promotions_any_match_policy = true

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -2,7 +2,8 @@
 
 module Spree
   class Promotion < Spree::Base
-    MATCH_POLICIES = %w(all any)
+
+    autoload(:MATCH_POLICIES, "spree/promotion/match_policies")
 
     UNACTIVATABLE_ORDER_STATES = ["complete", "awaiting_return", "returned"]
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -65,6 +65,22 @@ module Spree
     #   @return [Boolean] When false, admins cannot create promotions with an "any" match policy (default: +false+)
     #                     Create individual, separate promotions for each of your rules instead.
     preference :allow_promotions_any_match_policy, :boolean, default: false
+    def allow_promotions_any_match_policy=(value)
+      if value == true
+        Spree::Deprecation.warn <<~MSG
+          Solidus 4.0 will remove support for combining promotion rules with the "any" match policy.
+
+          Instead, it's suggested to create individual, separate promotions for each of your current
+          rules combined with the "any" policy. To automate this task, you can use the provided
+          task:
+
+                  bin/rake solidus:split_promotions_with_any_match_policy
+        MSG
+      end
+
+      preferences[:allow_promotions_any_match_policy] = value
+    end
+
 
     # @!attribute [rw] guest_token_cookie_options
     #   @return [Hash] Add additional guest_token cookie options here (ie. domain or path)

--- a/core/lib/spree/promotion/match_policies.rb
+++ b/core/lib/spree/promotion/match_policies.rb
@@ -1,0 +1,2 @@
+Spree::Promotion::MATCH_POLICIES = %w(all any)
+Spree::Deprecation.warn('Spree::Promotion::MATCH_POLICIES is deprecated')

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -993,4 +993,11 @@ RSpec.describe Spree::Promotion, type: :model do
       expect(order.adjustment_total).to eq(-10)
     end
   end
+
+  describe "MATCH_POLICIES" do
+    it "prints a deprecation warning when used" do
+      expect(Spree::Deprecation).to receive(:warn).once.with(/Spree::Promotion::MATCH_POLICIES is deprecated/)
+      expect(Spree::Promotion::MATCH_POLICIES).to eq %w(all any)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

We are going to remove this preference in Solidus 4.0, along with the possibility to create promotion rules with the "Any" match policy. 

The only accepted value for those who want to upgrade is `false`.

Ref https://github.com/solidusio/solidus/pull/4304


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
