### PR TITLE
Authorize uuid for update_positions on ResourceController

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -82,7 +82,9 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       records = model_class.where(id: positions.keys).to_a
 
       positions.each do |id, index|
-        records.find { |r| r.id == id.to_i }&.set_list_position(index)
+        # To permit the use of UUID as id, we compare models id in database
+        # and in params under the string representation instead of integer
+        records.find { |r| r.id.to_s == id }&.set_list_position(index)
       end
     end
 


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

In the backend section, from Ref https://github.com/solidusio/solidus/commit/248b39f9b5c797fd0836277c2fdb7fe50380f045 we can't sort object list when we use uuid for the object's id.
We need to allow records save for the case of uuid.
This change need to be backported until the version 3.1.0 if I'm right ;)

Hope it can help.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
