### PR TITLE
move Spree::Variant#price_for and #price_selector to the Spree::DefaultPrice concern

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -8,6 +8,12 @@ module Spree
       delegate :display_price, :display_amount, :price, to: :default_price, allow_nil: true
       delegate :price=, to: :default_price_or_build
 
+      # Chooses an appropriate price for the given pricing options
+      # This has been deprecated in favor of #price_for_options.
+      #
+      # @see Spree::Variant::PriceSelector#price_for_options
+      delegate :price_for, to: :price_selector
+
       # @see Spree::Variant::PricingOptions.default_price_attributes
       def self.default_price_attributes
         Spree::Config.default_pricing_options.desired_attributes
@@ -53,6 +59,14 @@ module Spree
     # @see Spree::Variant.default_price_attributes
     def default_price
       price_selector.price_for_options(Spree::Config.default_pricing_options)
+    end
+
+    # Returns an instance of the globally configured variant price selector class for this variant.
+    # It's cached so we don't create too many objects.
+    #
+    # @return [Spree::Variant::PriceSelector] The default price selector class
+    def price_selector
+      @price_selector ||= Spree::Config.variant_price_selector_class.new(self)
     end
 
     def has_default_price?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -279,20 +279,6 @@ module Spree
       option_values.detect { |option| option.option_type.name == opt_name }.try(:presentation)
     end
 
-    # Returns an instance of the globally configured variant price selector class for this variant.
-    # It's cached so we don't create too many objects.
-    #
-    # @return [Spree::Variant::PriceSelector] The default price selector class
-    def price_selector
-      @price_selector ||= Spree::Config.variant_price_selector_class.new(self)
-    end
-
-    # Chooses an appropriate price for the given pricing options
-    # This has been deprecated in favor of #price_for_options.
-    #
-    # @see Spree::Variant::PriceSelector#price_for_options
-    delegate :price_for, to: :price_selector
-
     # Returns the difference in price from the master variant
     def price_difference_from_master(pricing_options = Spree::Config.default_pricing_options)
       master_price = product.master.price_for_options(pricing_options)


### PR DESCRIPTION
## Summary

When doing `include Spree::DefualtPrice` in another model, I receive an error when calling `#price` for the `#price_selector` method. This fixes that issue.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
