### PR TITLE
[backend] Add dark mode to the backend UI

### DIFF
--- a/backend/app/assets/config/solidus_backend_manifest.js
+++ b/backend/app/assets/config/solidus_backend_manifest.js
@@ -1,9 +1,7 @@
 //= link_tree ../images
+//= link_tree "../stylesheets/spree/backend/themes" .css
 
 //= link spree/backend/all.js
 //= link spree/backend/all.css
 
 //= link solidus_admin/select2_locales
-
-//= link spree/backend/themes/classic.css
-//= link spree/backend/themes/solidus_admin.css

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -301,7 +301,8 @@ nav.menu {
 }
 
 .admin-navbar-selection {
-  margin: 0 1.5em;
+  padding: 0 1.5em;
+  width: 100%;
   position: relative;
   overflow: hidden;
   display: inline-flex;
@@ -323,7 +324,7 @@ nav.menu {
     padding: .5rem 0 .5rem .25rem;
   }
 
-   .admin-nav-hidden & {
+  .admin-nav-hidden & {
     position: relative;
 
     select {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -122,6 +122,22 @@ nav.menu {
   @media print {
     display: none
   }
+
+
+  .dark-only {
+    display: none;
+    @media (prefers-color-scheme: dark) {
+      display: block;
+    }
+  }
+
+  .light-only {
+    display: block;
+    @media (prefers-color-scheme: dark) {
+      display: none;
+    }
+  }
+
 }
 
 .admin-nav-header {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -19,6 +19,20 @@ $color-navbar-hover: $color-navbar !default;
   min-height: 100vh;
   border-right: $color-light-accent 1px solid;
 
+  .dark-only {
+    display: none;
+    @media (prefers-color-scheme: dark) {
+      display: block;
+    }
+  }
+
+  .light-only {
+    display: none;
+    @media (prefers-color-scheme: light) {
+      display: block;
+    }
+  }
+
   &--wrapper {
     position: absolute;
     top: 0;

--- a/backend/app/assets/stylesheets/spree/backend/themes/classic_dark.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/classic_dark.css.scss
@@ -1,0 +1,16 @@
+@import 'spree/backend/themes/classic';
+
+html {
+  background-color: #fff;
+  color: #fff;
+  -webkit-filter: invert(100%);
+  filter: invert(100%) hue-rotate(180deg);
+
+  img {
+    filter: invert(100%) hue-rotate(-180deg);
+  }
+
+  .brand-link img {
+    filter: invert(0%) hue-rotate(0deg);
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/themes/classic_dimmed.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/classic_dimmed.css.scss
@@ -1,0 +1,16 @@
+@import 'spree/backend/themes/classic';
+
+html {
+  background-color: #fff;
+  color: #fff;
+  -webkit-filter: invert(85%);
+  filter: invert(85%) hue-rotate(180deg);
+
+  img {
+    filter: invert(100%) hue-rotate(-180deg);
+  }
+
+  .brand-link img {
+    filter: invert(0%) hue-rotate(0deg);
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin.css.scss
@@ -1,6 +1,7 @@
 @import "spree/backend/globals";
 
 @import "./solidus_admin/variables";
+@import "./solidus_admin/colors";
 
 @import "spree/backend/vendor";
 @import "spree/backend/shared";

--- a/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin/_tables.scss
@@ -1,3 +1,5 @@
+@import "./colors";
+
 table.index {
   // Borders
   border-collapse: separate;

--- a/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin_dark.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin_dark.css.scss
@@ -1,0 +1,16 @@
+@import "./solidus_admin";
+
+html {
+  background-color: #fff;
+  color: #fff;
+  -webkit-filter: invert(100%);
+  filter: invert(100%) hue-rotate(180deg);
+
+  img {
+    filter: invert(100%) hue-rotate(-180deg);
+  }
+
+  .brand-link img {
+    filter: invert(0%) hue-rotate(0deg);
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin_dimmed.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin_dimmed.css.scss
@@ -1,0 +1,16 @@
+@import "./solidus_admin";
+
+html {
+  background-color: #fff;
+  color: #fff;
+  -webkit-filter: invert(85%);
+  filter: invert(85%) hue-rotate(180deg);
+
+  img {
+    filter: invert(100%) hue-rotate(-180deg);
+  }
+
+  .brand-link img {
+    filter: invert(0%) hue-rotate(0deg);
+  }
+}

--- a/backend/app/controllers/spree/admin/locale_controller.rb
+++ b/backend/app/controllers/spree/admin/locale_controller.rb
@@ -11,9 +11,15 @@ module Spree
         if locale_is_available?(requested_locale)
           I18n.locale = requested_locale
           session[set_user_language_locale_key] = requested_locale
-          render json: { locale: requested_locale, location: spree.admin_url }
+          respond_to do |format|
+            format.json { render json: { locale: requested_locale, location: spree.admin_url } }
+            format.html { redirect_back_or_to spree.admin_url, notice: t('spree.locale_changed') }
+          end
         else
-          render json: { locale: I18n.locale }, status: 404
+          respond_to do |format|
+            format.json { render json: { locale: I18n.locale }, status: 404 }
+            format.html { redirect_back_or_to spree.admin_url, error: t('spree.error') }
+          end
         end
       end
 

--- a/backend/app/controllers/spree/admin/theme_controller.rb
+++ b/backend/app/controllers/spree/admin/theme_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class ThemeController < Spree::Admin::BaseController
+      skip_before_action :authorize_admin, only: [:set]
+
+      def set
+        requested_theme = params[:switch_to_theme].presence
+
+        # Avoid interpolating user content into the session key
+        system_theme = params[:system_theme].presence == "dark" ? "dark" : "light"
+        session_key = :"admin_#{system_theme}_theme"
+
+        if theme_is_available?(requested_theme)
+          session[session_key] = requested_theme
+          redirect_back_or_to spree.admin_url, notice: t('spree.theme_changed')
+        else
+          redirect_back_or_to spree.admin_url, error: t('spree.error')
+        end
+      end
+
+      private
+
+      def theme_is_available?(theme)
+        theme && Spree::Backend::Config.themes.key?(theme.to_sym)
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -6,7 +6,8 @@
 <title><%= admin_page_title %></title>
 
 <%= favicon_link_tag 'favicon.ico' %>
-<%= stylesheet_link_tag Spree::Backend::Config.theme_path, media: 'all', data: {turbolinks_track: 'reload'} %>
+<%= stylesheet_link_tag Spree::Backend::Config.theme_path(session[:admin_light_theme]), media: '(prefers-color-scheme: light)', data: {turbolinks_track: 'reload'} %>
+<%= stylesheet_link_tag Spree::Backend::Config.theme_path(session[:admin_dark_theme]), media: '(prefers-color-scheme: dark)', data: {turbolinks_track: 'reload'} %>
 <%= javascript_include_tag 'spree/backend/all', data: {turbolinks_track: 'reload'} %>
 
 <%- if Rails.env.test? %>

--- a/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
+++ b/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
@@ -33,7 +33,7 @@
 <script data-hook='admin-custom-translations'>
 </script>
 
-<% if I18n.locale != :en %>
-  <%= javascript_include_tag "solidus_admin/select2_locales/select2_locale_#{I18n.locale}",
-    data: {turbolinks_track: 'reload'} %>
+<% if I18n.locale != :en && I18n.locale %>
+  <% select2_locale_path = "solidus_admin/select2_locales/select2_locale_#{I18n.locale}" %>
+  <%= javascript_include_tag select2_locale_path, data: {turbolinks_track: 'reload'} if Rails.application.assets.find_asset(select2_locale_path) %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_locale_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection.html.erb
@@ -1,16 +1,14 @@
-<% available_locales = Spree.i18n_available_locales %>
-<% if available_locales.size > 1 %>
-  <label class="admin-navbar-selection admin-locale-selection">
-    <i class="fa fa-globe fa-fw" title="<%= I18n.t('spree.choose_dashboard_locale') %>"></i>
-    <select class="js-locale-selection custom-select fullwidth">
-      <%=
-        options_for_select(
-          available_locales.map do |locale|
-            [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
-          end.sort,
-          selected: I18n.locale,
-        )
-      %>
-    </select>
-  </label>
+<% available_locale_options_for_select = Spree.i18n_available_locales.map {
+  [I18n.t('spree.i18n.this_file_language', locale: _1, default: _1.to_s, fallback: false), _1]
+}.sort %>
+
+<% if available_locale_options_for_select.size > 1 %>
+  <%= form_tag(admin_set_locale_path(format: :html), method: :put, style: "width: 100%;") do %>
+    <label class="admin-navbar-selection admin-locale-selection">
+      <i class="fa fa-globe fa-fw" title="<%= I18n.t('spree.choose_dashboard_locale') %>"></i>
+      <select class="custom-select fullwidth" onchange="this.form.requestSubmit()">
+        <%= options_for_select(available_locale_options_for_select, I18n.locale) %>
+      </select>
+    </label>
+  <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_locale_selection_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection_solidus_admin.html.erb
@@ -1,0 +1,17 @@
+<% available_locale_options_for_select = Spree.i18n_available_locales.map {
+  [I18n.t('spree.i18n.this_file_language', locale: _1, default: _1.to_s, fallback: false), _1]
+}.sort %>
+
+<% if available_locale_options_for_select.size > 1 %>
+  <li>
+    <%= form_tag(admin_set_locale_path(format: :html), method: :put, style: "width: 100%;") do %>
+      <label>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-global-line"></use></svg>
+        <select name="switch_to_locale" onchange="this.form.requestSubmit()">
+          <%= options_for_select(available_locale_options_for_select, selected: I18n.locale) %>
+        </select>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
+      </label>
+    <% end %>
+  </li>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_navigation.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation.html.erb
@@ -7,6 +7,7 @@
         <span class="text"><%= t('spree.minimize_menu') %></span>
       <% end %>
       <%= render partial: 'spree/admin/shared/locale_selection' %>
+      <%= render partial: 'spree/admin/shared/theme_selection' %>
       <% if lookup_context.exists?('spree/admin/shared/_navigation_footer') %>
         <%= render partial: 'spree/admin/shared/navigation_footer' %>
       <% else %>

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -50,6 +50,7 @@
 
           <ul>
             <%= render 'spree/admin/shared/locale_selection_solidus_admin' %>
+            <%= render 'spree/admin/shared/theme_selection_solidus_admin' %>
 
             <% if can?(:admin, spree_current_user) %>
               <li data-hook="user-account-link">

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -49,32 +49,7 @@
           </summary>
 
           <ul>
-            <% if (available_locales = Spree.i18n_available_locales).any? %>
-              <li>
-                <label>
-                  <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-global-line"></use></svg>
-                  <select class="js-locale-selection">
-                    <%= options_for_select(
-                      available_locales
-                        .map do |locale|
-                          [
-                            t(
-                              "spree.i18n.this_file_language",
-                              locale: locale,
-                              default: locale.to_s,
-                              fallback: false
-                            ),
-                            locale
-                          ]
-                        end
-                        .sort,
-                      selected: I18n.locale
-                    ) %>
-                  </select>
-                  <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
-                </label>
-              </li>
-            <% end %>
+            <%= render 'spree/admin/shared/locale_selection_solidus_admin' %>
 
             <% if can?(:admin, spree_current_user) %>
               <li data-hook="user-account-link">

--- a/backend/app/views/spree/admin/shared/_theme_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_theme_selection.html.erb
@@ -1,0 +1,21 @@
+<% theme_options_for_select = Spree::Backend::Config.themes.keys.map { |theme| [theme.to_s.humanize, theme] }.sort %>
+
+<%= form_tag(admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
+  <%= hidden_field_tag :system_theme, :light %>
+  <label class="admin-navbar-selection">
+    <i class="fa fa-sun-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
+    <select name="switch_to_theme" class="custom-select fullwidth" onchange="this.form.requestSubmit()">
+      <%= options_for_select(theme_options_for_select, session[:admin_light_theme] || Spree::Backend::Config.theme) %>
+    </select>
+  </label>
+<% end %>
+
+<%= form_tag(admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
+  <%= hidden_field_tag :system_theme, :dark %>
+  <label class="admin-navbar-selection">
+    <i class="fa fa-moon-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
+    <select name="switch_to_theme" class="custom-select fullwidth" onchange="this.form.requestSubmit()">
+      <%= options_for_select(theme_options_for_select, session[:admin_dark_theme] || Spree::Backend::Config.dark_theme) %>
+    </select>
+  </label>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_theme_selection_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_theme_selection_solidus_admin.html.erb
@@ -1,0 +1,25 @@
+<% theme_options_for_select = Spree::Backend::Config.themes.keys.map { |theme| [theme.to_s.humanize, theme] }.sort %>
+
+<li>
+  <%= form_tag(admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
+    <%= hidden_field_tag :system_theme, :light %>
+    <label>
+      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-sun-line"></use></svg>
+      <select name="switch_to_theme" onchange="this.form.requestSubmit()">
+        <%= options_for_select(theme_options_for_select, session[:admin_light_theme] || Spree::Backend::Config.theme) %>
+      </select>
+      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
+    </label>
+  <% end %>
+
+  <%= form_tag(admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
+    <%= hidden_field_tag :system_theme, :dark %>
+    <label>
+      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-moon-line"></use></svg>
+      <select name="switch_to_theme" onchange="this.form.requestSubmit()">
+        <%= options_for_select(theme_options_for_select, session[:admin_dark_theme] || Spree::Backend::Config.dark_theme) %>
+      </select>
+      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
+    </label>
+  <% end %>
+</li>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,7 @@ Spree::Core::Engine.routes.draw do
     get '/search/products', to: "search#products", as: :search_products
 
     put '/locale/set', to: 'locale#set', defaults: { format: :json }, as: :set_locale
+    put '/theme/set', to: 'theme#set', defaults: { format: :json }, as: :set_theme
 
     resources :dashboards, only: [] do
       collection do

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -11,15 +11,24 @@ module Spree
     #   @return [Hash] A hash containing the themes that are available for the admin panel
     preference :themes, :hash, default: {
       classic: 'spree/backend/all',
+      classic_dark: 'spree/backend/themes/classic_dark',
+      classic_dark_dimmed: 'spree/backend/themes/classic_dimmed',
+      solidus: 'spree/backend/themes/solidus_admin',
+      solidus_dark: 'spree/backend/themes/solidus_admin_dark',
+      solidus_dimmed: 'spree/backend/themes/solidus_admin_dimmed',
       solidus_admin: 'spree/backend/themes/solidus_admin'
     }
 
     # @!attribute [rw] theme
     #   @return [String] Default admin theme name
-    versioned_preference :theme, :string, initial_value: 'classic', boundaries: { "4.2.0" => "solidus_admin" }
+    versioned_preference :theme, :string, initial_value: 'classic', boundaries: { "4.2.0" => "solidus_admin", "4.4.0" => "solidus" }
 
-    def theme_path(user_theme = nil)
-      user_theme ? themes.fetch(user_theme.to_sym) : themes.fetch(theme.to_sym)
+    # @!attribute [rw] dark_theme
+    #   @return [String] Dark admin theme name
+    versioned_preference :dark_theme, :string, initial_value: 'classic', boundaries: { "4.2.0" => "solidus_admin", "4.4.0" => 'solidus_dark' }
+
+    def theme_path(user_theme)
+      themes.fetch(user_theme&.to_sym, themes.fetch(theme.to_sym))
     end
 
     # @!attribute [rw] admin_updated_navbar

--- a/backend/spec/controllers/spree/admin/theme_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/theme_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::ThemeController, type: :controller do
+  stub_authorization!
+
+  it 'sets the theme in a different session key for each system theme' do
+    stub_spree_preferences(Spree::Backend::Config, themes: { foo: 'foo-path', bar: 'bar-path' })
+
+    get :set, params: { switch_to_theme: 'foo', system_theme: 'light', format: :json }
+
+    expect(session[:admin_light_theme]).to eq('foo')
+    expect(session[:admin_dark_theme]).to eq(nil)
+    expect(response).to have_http_status(:redirect)
+
+    get :set, params: { switch_to_theme: 'bar', system_theme: 'dark', format: :json }
+    expect(session[:admin_light_theme]).to eq('foo')
+    expect(session[:admin_dark_theme]).to eq('bar')
+    expect(response).to have_http_status(:redirect)
+  end
+
+  it 'responds with "not found" for a missing theme' do
+    stub_spree_preferences(Spree::Backend::Config, themes: { foo: 'foo-path' })
+
+    get :set, params: { switch_to_theme: 'bar', system_theme: 'dark', format: :json }
+
+    expect(session[:admin_light_theme]).to eq(nil)
+    expect(session[:admin_dark_theme]).to eq(nil)
+    expect(response).to have_http_status(:redirect)
+  end
+end

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -79,25 +79,25 @@ RSpec.describe Spree::BackendConfiguration do
   end
 
   describe '#theme_path' do
-    it 'returns the default theme path' do
+    it 'returns the default theme path if the user theme is not set' do
       subject.themes = { foo: 'foo-theme-path' }
       subject.theme = :foo
 
-      expect(subject.theme_path).to eq('foo-theme-path')
+      expect(subject.theme_path(nil)).to eq('foo-theme-path')
     end
 
     it 'returns the default theme path when the theme is a string' do
       subject.themes = { foo: 'foo-theme-path' }
       subject.theme = 'foo'
 
-      expect(subject.theme_path).to eq('foo-theme-path')
+      expect(subject.theme_path(nil)).to eq('foo-theme-path')
     end
 
     it 'returns the fallback theme path when the default theme is missing' do
       subject.themes = { foo: 'foo-theme-path', classic: 'classic-theme-path' }
       subject.theme = :bar
 
-      expect{ subject.theme_path }.to raise_error(KeyError)
+      expect{ subject.theme_path(:baz) }.to raise_error(KeyError)
     end
 
     it 'gives priority to the user defined theme' do
@@ -107,11 +107,11 @@ RSpec.describe Spree::BackendConfiguration do
       expect(subject.theme_path(:user)).to eq('user-theme-path')
     end
 
-    it 'raises an error if the user theme is missing' do
+    it 'falls back to the configure theme if the user theme is missing' do
       subject.themes = { foo: 'foo-theme-path', classic: 'classic-theme-path' }
       subject.theme = :foo
 
-      expect{ subject.theme_path(:bar) }.to raise_error(KeyError)
+      expect(subject.theme_path(:bar)).to eq('foo-theme-path')
     end
   end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1141,6 +1141,7 @@ en:
     choose_a_taxon_to_sort_products_for: Choose a taxon to sort products for
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
+    choose_dashboard_theme: Choose Dashboard Theme
     choose_location: Choose Location
     choose_promotion_action: Choose Action
     choose_promotion_rule: Choose Rule
@@ -2347,6 +2348,7 @@ en:
         subject: Test Mail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business. Please print out a copy of this confirmation page for your records.
+    theme_changed: Theme Changed
     there_are_no_items_for_this_order: There are no items for this order. Please add an item to the order to continue.
     there_were_problems_with_the_following_fields: There were problems with the following fields
     this_order_has_already_received_a_refund: This order has already received a refund


### PR DESCRIPTION
## Summary

_Incorporates #5113_

_Compation SolidusAdmin PR #5511_

This PR aims to add a dark theme switcher for the Solidus backend. The theme can be switched using a new select added in the left sidebar, and the choice is saved in local-storage.

| System in dark mode | System in light mode |
|--------|--------|
| <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/fb631abd-6ef9-4399-9fec-390136bd4c7f"> | <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/a4605f59-fc08-4743-9675-6b47c6ab03ff"> |
| <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/cedf561d-ac90-4610-aaee-7d57aac5a0ad"> | <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/cdb5d1a0-557e-4c72-a33c-187bf74e8c4d"> | 
| <img width="337" alt="image" src="https://github.com/solidusio/solidus/assets/1051/3ea9b323-6a19-4629-915d-4115e4387431"> | <img width="273" alt="image" src="https://github.com/solidusio/solidus/assets/1051/1cc6df5b-ee8d-451e-ab29-80076b5994be"> |

| System in dark mode (new navbar) | System in light mode (new navbar) |
|--------|--------|
| <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/ee7d22e7-674d-4453-8a29-8a0990a248f4"> | <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/842ec1ef-acfe-4cec-a7cc-88b05ea77891"> |
| <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/3a0006b2-5ede-4340-989a-139294fb594c"> | <img width="1329" alt="image" src="https://github.com/solidusio/solidus/assets/1051/a9ef147d-5c19-4038-9e4c-646447483a14"> |
| <img width="275" alt="image" src="https://github.com/solidusio/solidus/assets/1051/b82da715-af88-49ba-83e3-9eefeb2738b5"> | <img width="248" alt="image" src="https://github.com/solidusio/solidus/assets/1051/6b4a3e2d-77de-49bd-b7c7-666e56d2750d">|


This is just an easy way to invert theme colors as suggested by @elia following [this StackOverflow example](https://stackoverflow.com/questions/17741629/how-can-i-invert-color-using-css#21106143).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
