### PR TITLE
Add Spree::Migration

### DIFF
--- a/core/db/migrate/20160101010000_solidus_one_four.rb
+++ b/core/db/migrate/20160101010000_solidus_one_four.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class SolidusOneFour < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class SolidusOneFour < Spree::Migration
   def up
     # This migration is just a compressed version of all the previous
     # migrations for spree_core. Do not run it if one of the core tables

--- a/core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
+++ b/core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class CreateSpreeWalletPaymentSources < ActiveRecord::Migration[4.2]
+require "spree/migration"
+
+class CreateSpreeWalletPaymentSources < Spree::Migration
   def change
     return if table_exists?(:spree_wallet_payment_sources)
 

--- a/core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
+++ b/core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class MigrateCreditCardsToWalletPaymentSources < ActiveRecord::Migration[4.2]
+require "spree/migration"
+
+class MigrateCreditCardsToWalletPaymentSources < Spree::Migration
   class CreditCard < ActiveRecord::Base
     self.table_name = 'spree_credit_cards'
   end

--- a/core/db/migrate/20160924135758_remove_is_default_from_prices.rb
+++ b/core/db/migrate/20160924135758_remove_is_default_from_prices.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class RemoveIsDefaultFromPrices < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class RemoveIsDefaultFromPrices < Spree::Migration
   def change
     remove_column :spree_prices, :is_default, :boolean, default: true
   end

--- a/core/db/migrate/20161009141333_remove_currency_from_line_items.rb
+++ b/core/db/migrate/20161009141333_remove_currency_from_line_items.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class RemoveCurrencyFromLineItems < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class RemoveCurrencyFromLineItems < Spree::Migration
   def change
     remove_column :spree_line_items, :currency, :string
   end

--- a/core/db/migrate/20161014221052_add_available_to_columns_and_remove_display_on_from_payment_methods.rb
+++ b/core/db/migrate/20161014221052_add_available_to_columns_and_remove_display_on_from_payment_methods.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddAvailableToColumnsAndRemoveDisplayOnFromPaymentMethods < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddAvailableToColumnsAndRemoveDisplayOnFromPaymentMethods < Spree::Migration
   def up
     add_column(:spree_payment_methods, :available_to_users, :boolean, default: true)
     add_column(:spree_payment_methods, :available_to_admin, :boolean, default: true)

--- a/core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
+++ b/core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
@@ -20,21 +20,11 @@ class CreateSpreePromotionCodeBatch < Spree::Migration
       column: :promotion_id
     )
 
-    add_column(
+    add_reference(
       :spree_promotion_codes,
-      :promotion_code_batch_id,
-      :integer
-    )
-
-    add_foreign_key(
-      :spree_promotion_codes,
-      :spree_promotion_code_batches,
-      column: :promotion_code_batch_id
-    )
-
-    add_index(
-      :spree_promotion_codes,
-      :promotion_code_batch_id
+      :promotion_code_batch,
+      foreign_key: { to_table: :spree_promotion_code_batches },
+      index: true,
     )
   end
 end

--- a/core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
+++ b/core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class CreateSpreePromotionCodeBatch < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class CreateSpreePromotionCodeBatch < Spree::Migration
   def change
     create_table :spree_promotion_code_batches do |t|
       t.references :promotion, null: false, index: true

--- a/core/db/migrate/20161123154034_add_available_to_users_and_remove_display_on_from_shipping_methods.rb
+++ b/core/db/migrate/20161123154034_add_available_to_users_and_remove_display_on_from_shipping_methods.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddAvailableToUsersAndRemoveDisplayOnFromShippingMethods < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddAvailableToUsersAndRemoveDisplayOnFromShippingMethods < Spree::Migration
   def up
     add_column(:spree_shipping_methods, :available_to_users, :boolean, default: true)
     execute("UPDATE spree_shipping_methods "\

--- a/core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
+++ b/core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddIndexToSpreePaymentsNumber < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddIndexToSpreePaymentsNumber < Spree::Migration
   def change
     add_index 'spree_payments', ['number'], unique: true
   end

--- a/core/db/migrate/20170223235001_remove_spree_store_credits_column.rb
+++ b/core/db/migrate/20170223235001_remove_spree_store_credits_column.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class RemoveSpreeStoreCreditsColumn < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class RemoveSpreeStoreCreditsColumn < Spree::Migration
   def change
     remove_column :spree_store_credits, :spree_store_credits, :datetime
   end

--- a/core/db/migrate/20170317035819_add_lft_and_rgt_indexes_to_taxons.rb
+++ b/core/db/migrate/20170317035819_add_lft_and_rgt_indexes_to_taxons.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddLftAndRgtIndexesToTaxons < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddLftAndRgtIndexesToTaxons < Spree::Migration
   def change
     add_index :spree_taxons, :lft
     add_index :spree_taxons, :rgt

--- a/core/db/migrate/20170319191942_remove_order_id_from_inventory_units.rb
+++ b/core/db/migrate/20170319191942_remove_order_id_from_inventory_units.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class RemoveOrderIdFromInventoryUnits < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class RemoveOrderIdFromInventoryUnits < Spree::Migration
   class InconsistentInventoryUnitError < StandardError; end
 
   class InventoryUnit < ActiveRecord::Base

--- a/core/db/migrate/20170412103617_transform_tax_rate_category_relation.rb
+++ b/core/db/migrate/20170412103617_transform_tax_rate_category_relation.rb
@@ -13,12 +13,9 @@ class TransformTaxRateCategoryRelation < Spree::Migration
 
   def up
     create_table :spree_tax_rate_tax_categories do |t|
-      t.integer :tax_category_id, index: true, null: false
-      t.integer :tax_rate_id, index: true, null: false
+      t.references :tax_category, index: true, null: false, foreign_key: { to_table: :spree_tax_categories }
+      t.references :tax_rate, index: true, null: false, foreign_key: { to_table: :spree_tax_rates }
     end
-
-    add_foreign_key :spree_tax_rate_tax_categories, :spree_tax_categories, column: :tax_category_id
-    add_foreign_key :spree_tax_rate_tax_categories, :spree_tax_rates, column: :tax_rate_id
 
     TaxRate.where.not(tax_category_id: nil).find_each do |tax_rate|
       TaxRateTaxCategory.create!(

--- a/core/db/migrate/20170412103617_transform_tax_rate_category_relation.rb
+++ b/core/db/migrate/20170412103617_transform_tax_rate_category_relation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class TransformTaxRateCategoryRelation < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class TransformTaxRateCategoryRelation < Spree::Migration
   class TaxRate < ActiveRecord::Base
     self.table_name = "spree_tax_rates"
   end

--- a/core/db/migrate/20170422134804_add_roles_unique_constraints.rb
+++ b/core/db/migrate/20170422134804_add_roles_unique_constraints.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddRolesUniqueConstraints < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddRolesUniqueConstraints < Spree::Migration
   def change
     add_index :spree_roles, :name, unique: true
     add_index :spree_roles_users, [:user_id, :role_id], unique: true

--- a/core/db/migrate/20170522143442_add_time_range_to_tax_rate.rb
+++ b/core/db/migrate/20170522143442_add_time_range_to_tax_rate.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddTimeRangeToTaxRate < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddTimeRangeToTaxRate < Spree::Migration
   def change
     add_column :spree_tax_rates, :starts_at, :datetime
     add_column :spree_tax_rates, :expires_at, :datetime

--- a/core/db/migrate/20170608074534_rename_bogus_gateways.rb
+++ b/core/db/migrate/20170608074534_rename_bogus_gateways.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class RenameBogusGateways < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class RenameBogusGateways < Spree::Migration
   # This migration was only performing a data migration useful updating to
   # Solidus v2.3.
   # Once the update is done, this is no more required to run so we can clean

--- a/core/db/migrate/20170831201542_remove_default_tax_from_spree_zones.rb
+++ b/core/db/migrate/20170831201542_remove_default_tax_from_spree_zones.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class RemoveDefaultTaxFromSpreeZones < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class RemoveDefaultTaxFromSpreeZones < Spree::Migration
   def change
     remove_column :spree_zones, :default_tax, :boolean, default: false
   end

--- a/core/db/migrate/20180202190713_create_promotion_rule_stores.rb
+++ b/core/db/migrate/20180202190713_create_promotion_rule_stores.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class CreatePromotionRuleStores < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class CreatePromotionRuleStores < Spree::Migration
   def change
     create_table :spree_promotion_rules_stores do |t|
       t.references :store, null: false

--- a/core/db/migrate/20180202222641_create_store_shipping_methods.rb
+++ b/core/db/migrate/20180202222641_create_store_shipping_methods.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class CreateStoreShippingMethods < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class CreateStoreShippingMethods < Spree::Migration
   def change
     create_table :spree_store_shipping_methods do |t|
       t.references :store, null: false

--- a/core/db/migrate/20180313220213_add_available_locales_to_stores.rb
+++ b/core/db/migrate/20180313220213_add_available_locales_to_stores.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddAvailableLocalesToStores < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class AddAvailableLocalesToStores < Spree::Migration
   def change
     change_table :spree_stores do |t|
       t.column :available_locales, :string

--- a/core/db/migrate/20180322142651_add_amount_remaining_to_store_credit_events.rb
+++ b/core/db/migrate/20180322142651_add_amount_remaining_to_store_credit_events.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddAmountRemainingToStoreCreditEvents < ActiveRecord::Migration[5.0]
+require "spree/migration"
+
+class AddAmountRemainingToStoreCreditEvents < Spree::Migration
   class StoreCredit < ActiveRecord::Base
     self.table_name = 'spree_store_credits'
     has_many :store_credit_events

--- a/core/db/migrate/20180328172631_add_join_characters_to_promotion_code_batch.rb
+++ b/core/db/migrate/20180328172631_add_join_characters_to_promotion_code_batch.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddJoinCharactersToPromotionCodeBatch < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class AddJoinCharactersToPromotionCodeBatch < Spree::Migration
   def change
     add_column(:spree_promotion_code_batches,
                :join_characters,

--- a/core/db/migrate/20180416083007_add_apply_to_all_to_variant_property_rule.rb
+++ b/core/db/migrate/20180416083007_add_apply_to_all_to_variant_property_rule.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddApplyToAllToVariantPropertyRule < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class AddApplyToAllToVariantPropertyRule < Spree::Migration
   def change
     add_column :spree_variant_property_rules, :apply_to_all, :boolean, default: false, null: false
     change_column :spree_variant_property_rules, :apply_to_all, :boolean, default: true

--- a/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
+++ b/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class CreateSpreeStoreCreditReasonsTable < Spree::Migration
   class StoreCreditUpdateReason < ActiveRecord::Base
     self.table_name = "spree_store_credit_update_reasons"
   end

--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require 'solidus/migrations/promotions_with_code_handlers'
+require "spree/migration"
 
-class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
+class RemoveCodeFromSpreePromotions < Spree::Migration
   class Promotion < ActiveRecord::Base
     self.table_name = "spree_promotions"
     self.ignored_columns = %w(type)

--- a/core/db/migrate/20190220093635_drop_spree_store_credit_update_reasons.rb
+++ b/core/db/migrate/20190220093635_drop_spree_store_credit_update_reasons.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class DropSpreeStoreCreditUpdateReasons < ActiveRecord::Migration[5.1]
+require "spree/migration"
+
+class DropSpreeStoreCreditUpdateReasons < Spree::Migration
   # This migration should run in a subsequent deploy after 20180710170104
   # has been already deployed. See also migration 20180710170104.
 

--- a/core/db/migrate/20200320144521_add_default_billng_flag_to_user_addresses.rb
+++ b/core/db/migrate/20200320144521_add_default_billng_flag_to_user_addresses.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-class AddDefaultBillngFlagToUserAddresses < ActiveRecord::Migration[5.2]
+
+require "spree/migration"
+
+class AddDefaultBillngFlagToUserAddresses < Spree::Migration
   def change
     add_column :spree_user_addresses, :default_billing, :boolean, default: false
   end

--- a/core/db/migrate/20200530111458_add_bcc_email_to_spree_stores.rb
+++ b/core/db/migrate/20200530111458_add_bcc_email_to_spree_stores.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddBccEmailToSpreeStores < ActiveRecord::Migration[5.2]
+require "spree/migration"
+
+class AddBccEmailToSpreeStores < Spree::Migration
   def change
     add_column :spree_stores, :bcc_email, :string
   end

--- a/core/db/migrate/20201008213609_add_discontinue_on_to_spree_products.rb
+++ b/core/db/migrate/20201008213609_add_discontinue_on_to_spree_products.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddDiscontinueOnToSpreeProducts < ActiveRecord::Migration[5.2]
+require "spree/migration"
+
+class AddDiscontinueOnToSpreeProducts < Spree::Migration
   def change
     add_column :spree_products, :discontinue_on, :datetime
   end

--- a/core/db/migrate/20201127212108_add_type_before_removal_to_spree_payment_methods.rb
+++ b/core/db/migrate/20201127212108_add_type_before_removal_to_spree_payment_methods.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddTypeBeforeRemovalToSpreePaymentMethods < ActiveRecord::Migration[5.2]
+require "spree/migration"
+
+class AddTypeBeforeRemovalToSpreePaymentMethods < Spree::Migration
   def change
     add_column :spree_payment_methods, :type_before_removal, :string
   end

--- a/core/db/migrate/20210122110141_add_name_to_spree_addresses.rb
+++ b/core/db/migrate/20210122110141_add_name_to_spree_addresses.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class AddNameToSpreeAddresses < ActiveRecord::Migration[5.2]
+require "spree/migration"
+
+class AddNameToSpreeAddresses < Spree::Migration
   def up
     add_column :spree_addresses, :name, :string
     add_index :spree_addresses, :name

--- a/core/db/migrate/20210312061050_change_column_null_on_prices.rb
+++ b/core/db/migrate/20210312061050_change_column_null_on_prices.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class ChangeColumnNullOnPrices < ActiveRecord::Migration[5.2]
+require "spree/migration"
+
+class ChangeColumnNullOnPrices < Spree::Migration
   def change
     change_column_null(:spree_prices, :amount, false)
   end

--- a/core/db/migrate/20220317165036_set_promotions_with_any_policy_to_all_if_possible.rb
+++ b/core/db/migrate/20220317165036_set_promotions_with_any_policy_to_all_if_possible.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class SetPromotionsWithAnyPolicyToAllIfPossible < ActiveRecord::Migration[5.2]
+require "spree/migration"
+
+class SetPromotionsWithAnyPolicyToAllIfPossible < Spree::Migration
   def up
     Spree::Promotion.where(match_policy: :any).includes(:promotion_rules).all.each do |promotion|
       if promotion.promotion_rules.length <= 1

--- a/core/db/migrate/20220805202442_add_level_to_spree_tax_rates.rb
+++ b/core/db/migrate/20220805202442_add_level_to_spree_tax_rates.rb
@@ -1,4 +1,4 @@
-class AddLevelToSpreeTaxRates < ActiveRecord::Migration[5.2]
+class AddLevelToSpreeTaxRates < Spree::Migration
   def change
     add_column :spree_tax_rates, :level, :integer, default: 0, null: false
   end

--- a/core/db/migrate/20221123152807_add_shipping_category_to_spree_variants.rb
+++ b/core/db/migrate/20221123152807_add_shipping_category_to_spree_variants.rb
@@ -1,4 +1,4 @@
-class AddShippingCategoryToSpreeVariants < ActiveRecord::Migration[5.2]
+class AddShippingCategoryToSpreeVariants < Spree::Migration
   def change
     add_reference :spree_variants, :shipping_category, index: true
   end

--- a/core/lib/spree/migration.rb
+++ b/core/lib/spree/migration.rb
@@ -1,0 +1,4 @@
+module Spree
+  class Migration < ActiveRecord::Migration[ActiveRecord::Migration.current_version]
+  end
+end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
             expect(shipment.shipped?).to be false
             expect(shipment.inventory_units_for(variant)).to be_empty
             expect(variant.stock_location_ids.include?(shipment.stock_location_id)).to be true
-            expect(shipment.stock_location).not_to eql stock_item.stock_location
+            expect(shipment.stock_location_id).not_to eql stock_item.stock_location_id
           end
         end
       end


### PR DESCRIPTION
## Summary

Uses the current Rails version the app is running to run migrations. 

This makes sure, that 

a) extensions that are running an older Rails version (we still support down to Rails 5.2) are able to run migrations that are introduced in later Rails versions. 

b) the Solidus tables are created the same way as the rest of the host apps tables that most likely exist. 

Most of our migrations or very old (some of them still run with Rails 4.2 version). This changes tables and timestamps to very old Rails defaults. Leading to a misconfigured and inconsistent database schema for new Rails apps. 

Since this does not effect existing apps, it should be safe to do that.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
