### PR TITLE
Do not install paypal commerce plattform on auto-accept

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -336,7 +336,7 @@ module Solidus
         descriptions.delete(:bolt)
       end
 
-      selected = options[:payment_method] || (options[:auto_accept] && 'paypal') ||
+      selected = options[:payment_method] || (options[:auto_accept] && 'none') ||
         ask_with_description(
           default: 'paypal',
           limited_to: payment_methods,

--- a/core/spec/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/generators/solidus/install/install_generator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Solidus::InstallGenerator do
       aggregate_failures do
         expect(generator.instance_variable_get(:@selected_frontend)).to eq("starter")
         expect(generator.instance_variable_get(:@selected_authentication)).to eq("devise")
-        expect(generator.instance_variable_get(:@selected_payment_method)).to eq("paypal")
+        expect(generator.instance_variable_get(:@selected_payment_method)).to eq("none")
         expect(generator.instance_variable_get(:@run_migrations)).to eq(true)
         expect(generator.instance_variable_get(:@load_seed_data)).to eq(true)
         expect(generator.instance_variable_get(:@load_sample_data)).to eq(true)


### PR DESCRIPTION
## Summary

Whenever we run the installer in ie. a dummy app for an extension on a CI server with --auto-accept option we now get the paypal commerce plattform extension installed. Most extension tests are very fine with the dummy payment methods core provides and does not need a real payment method (that wont work in a dummy env anyway).

If we want to install this payment method for new stores or the demo should explicitely do that and not without asking.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
