### PR TITLE
Split ruby and gems versions as a CI cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,17 +152,19 @@ commands:
           name: "Cleanup & check rails version"
           command: |
             gem environment path
-            rm -rf /tmp/my_app /tmp/.tool-versions # cleanup previous runs
+            rm -rf /tmp/my_app /tmp/.ruby-versions # cleanup previous runs
+            rm -rf /tmp/my_app /tmp/.gems-versions # cleanup previous runs
 
-            ruby -v >> /tmp/.tool-versions
-            gem search -eq rails >> /tmp/.tool-versions # get the latest rails from rubygems
-            gem search -eq solidus >> /tmp/.tool-versions # get the latest solidus from rubygems
+            ruby -v >> /tmp/.ruby-versions
+            gem search -eq rails >> /tmp/.gems-versions # get the latest rails from rubygems
+            gem search -eq solidus >> /tmp/.gems-versions # get the latest solidus from rubygems
 
-            cat /tmp/.tool-versions
+            cat /tmp/.ruby-versions
+            cat /tmp/.gems-versions
       - restore_cache:
           keys:
-            - solidus-installer-v7-{{ checksum "/tmp/.tool-versions" }}
-            - solidus-installer-v7-
+            - solidus-installer-v7-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+            - solidus-installer-v7-{{ checksum "/tmp/.ruby-versions" }}-
       - run:
           name: "Prepare the rails application"
           command: |
@@ -170,7 +172,7 @@ commands:
             test -d my_app || gem install rails solidus
             test -d my_app || rails new my_app --skip-git
       - save_cache:
-          key: solidus-installer-v7-{{ checksum "/tmp/.tool-versions" }}
+          key: solidus-installer-v7-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
           paths:
             - /tmp/my_app
             - /home/circleci/.rubygems


### PR DESCRIPTION

## Summary

Since the ruby version is way more integral to the installation and should not be conflated with gem versions that are easy to upgrade.

The lack of this difference generated a situation in which a patch level ruby update ended up restoring a cache for the previous version.

E.G. see https://app.circleci.com/pipelines/github/solidusio/solidus/4199/workflows/81285fc7-0bc6-4709-9389-e60027f0d0c6/jobs/40237 on https://github.com/solidusio/solidus/pull/4999

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
