### PR TITLE
Reproduce missing refund log entry bug

### DIFF
--- a/backend/spec/features/admin/orders/new_refund_spec.rb
+++ b/backend/spec/features/admin/orders/new_refund_spec.rb
@@ -19,7 +19,25 @@ RSpec.describe 'New Refund creation', :js do
       click_button 'Refund'
     end
     expect(page).to have_content 'Refund has been successfully created!'
-    expect(page).to have_selector 'td', text: amount
+    within 'tr[data-hook="refunds_row"]' do
+      expect(page).to have_selector 'td', text: amount
+    end
+  end
+
+  it 'creates a new log entry for a refund', pending: 'This is pending because currently no log entry is created for this refund.' do
+    visit spree.new_admin_order_payment_refund_path(order, payment)
+    expect(page).not_to have_selector 'td', text: amount
+    within '.new_refund' do
+      fill_in 'refund_amount', with: amount
+      select reason.name, from: 'Reason'
+      click_button 'Refund'
+    end
+    expect(page).to have_content 'Refund has been successfully created!'
+    within 'tr[data-hook="payments_row"]' do
+      payment_number = find_all('td').first.text
+      click_on payment_number
+      expect(page).to have_selector 'tr.log_entry'
+    end
   end
 
   it 'disables the button at submit' do


### PR DESCRIPTION
This reproduces the issue mentioned here #4866

## Summary

We don't know the source of the issue but we were able to reproduce it.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
