### PR TITLE
Deprecate `Spree::Payment` offsets

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -572,7 +572,7 @@ module Spree
 
     def has_non_reimbursement_related_refunds?
       refunds.non_reimbursement.exists? ||
-        payments.offset_payment.exists? # how old versions of spree stored refunds
+        payments.where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'").exists? # how old versions of spree stored refunds
     end
 
     def tax_total

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -671,9 +671,8 @@ RSpec.describe Spree::Payment, type: :model do
     # Regression test for https://github.com/spree/spree/issues/4403 and https://github.com/spree/spree/issues/4407
     it "is the difference between offsets total and payment amount" do
       payment.amount = 100
-      allow(payment).to receive(:offsets_total).and_return(0)
       expect(payment.credit_allowed).to eq(100)
-      allow(payment).to receive(:offsets_total).and_return(-80)
+      create(:payment, amount: -80, source: payment, source_type: 'Spree::Payment', state: 'completed', payment_method: create(:check_payment_method))
       expect(payment.credit_allowed).to eq(20)
     end
   end
@@ -1330,6 +1329,20 @@ RSpec.describe Spree::Payment, type: :model do
 
     it 'does not include void, failed and invalid payments' do
       expect(described_class.valid).to be_empty
+    end
+  end
+
+  describe '::offset_payment' do
+    it 'is deprecated' do
+      expect(Spree::Deprecation).to receive(:warn).with(/offsets` are deprecated/)
+
+      described_class.offset_payment
+    end
+
+    it 'still calls the original method' do
+      Spree::Deprecation.silence do
+        expect(described_class.offset_payment.class.name).to eq('ActiveRecord::Relation')
+      end
     end
   end
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -675,6 +675,14 @@ RSpec.describe Spree::Payment, type: :model do
       create(:payment, amount: -80, source: payment, source_type: 'Spree::Payment', state: 'completed', payment_method: create(:check_payment_method))
       expect(payment.credit_allowed).to eq(20)
     end
+
+    it "is the difference between refunds total and payment amount" do
+      payment.amount = 100
+
+      expect {
+        create(:refund, payment: payment, amount: 80)
+      }.to change { payment.credit_allowed }.from(100).to(20)
+    end
   end
 
   describe "#can_credit?" do


### PR DESCRIPTION
## Summary

The old system for refunds was removed in [2014](https://github.com/spree/spree/pull/4883).

We deprecate the `.offset_payment` scope, which is in turn used by the `.offsets` association. We inline its usage on a couple of methods until we perform the full removal.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
