### PR TITLE
Add a tooltip for default currency in store settings

### DIFF
--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -52,6 +52,7 @@
 
     <%= f.field_container :default_currency do %>
       <%= f.label :default_currency %>
+      <%= f.field_hint :default_currency %>
       <%= f.select :default_currency,
         Spree::Config.available_currencies.map(&:iso_code),
         { include_blank: true },

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1644,6 +1644,7 @@ en:
         available_locales: This determines which locales are available for your customers to choose from in the storefront.
         cart_tax_country_iso: 'This determines which country is used for taxes on carts (orders which don''t yet have an address).<br> Default: None.'
         code: An identifier for your store. Developers may need this value if you operate multiple storefronts.
+        default_currency: This determines which currency will be used for the storefront's product prices. Please, be aware that changing this configuration, only products that have prices in the selected currency will be listed on your storefront. <br><br>This setting won't change the default currency used when you create a product. For that, only the global `Spree::Config.currency` is taken into account.
       spree/tax_category:
         is_default: When checked, this tax category will be selected by default when creating new products or variants.
       spree/tax_rate:


### PR DESCRIPTION
## Summary

This PR comes from some support requests we had in Slack, highlighting some confusion when a currency switch is required. I hope this will mitigate that confusion.  By the way, this is just a little help, a proper page on the guide would be a good next step.

<img width="862" alt="Screenshot 2023-04-12 at 11 27 55@2x" src="https://user-images.githubusercontent.com/167946/231415919-9f9a385c-037d-4032-abc9-4d15db937eb9.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
