### PR TITLE
Add webrick as explicit dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :backend do
   # JavaScript testing
   gem 'teaspoon', github: 'jejacks0n/teaspoon', require: false
   gem 'teaspoon-mocha', github: 'jejacks0n/teaspoon', require: false
+  gem 'webrick', require: false
 end
 
 group :utils do


### PR DESCRIPTION
## Summary

We need webrick to run JS tests using Teaspoon.
This dependency is no more bundled with latest ruby versions and won't be available unless explicitely added to the Gemfile.

Ref: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

Not sure why this started to pop now, maybe something with the ruby versions available in CircleCI. Anyway, it seems legit and we should do it.

This is an example of failing build: https://app.circleci.com/pipelines/github/nebulab/solidus/915/workflows/5865af00-dbdd-49f9-8bbb-d057f621a02f/jobs/13055

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
