### PR TITLE
Remove automatic propagation of generators options

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/payment_method/bolt.rb
+++ b/core/lib/generators/solidus/install/app_templates/payment_method/bolt.rb
@@ -10,4 +10,4 @@ unless Bundler.locked_gems.dependencies['solidus_bolt']
   bundle_command 'add solidus_bolt'
 end
 
-generate 'solidus_bolt:install'
+generate "solidus_bolt:install --auto-run-migrations=#{options[:migrate]}"

--- a/core/lib/generators/solidus/install/app_templates/payment_method/braintree.rb
+++ b/core/lib/generators/solidus/install/app_templates/payment_method/braintree.rb
@@ -2,4 +2,4 @@ unless Bundler.locked_gems.dependencies['solidus_braintree']
   bundle_command 'add solidus_braintree --version "~> 3.0"'
 end
 
-generate 'solidus_braintree:install'
+generate "solidus_braintree:install --migrate=#{options[:migrate]}"

--- a/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
+++ b/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
@@ -2,9 +2,16 @@ unless Bundler.locked_gems.dependencies['solidus_frontend']
   say_status :warning, "Support for frontends other than `solidus_frontend` by `solidus_paypal_commerce_platform` is still in progress.", :yellow
 end
 
+if @selected_frontend == 'classic'
+  version = '< 1'
+  migrations_flag = options[:migrate] ? '--auto-run-migrations' : '--skip-migrations'
+else
+  version = '~> 1.0'
+  migrations_flag = "--migrate=#{options[:migrate]}"
+end
+
 unless Bundler.locked_gems.dependencies['solidus_paypal_commerce_platform']
-  version = @selected_frontend == 'classic' ? '< 1' : '~> 1.0'
   bundle_command "add solidus_paypal_commerce_platform --version='#{version}'"
 end
 
-generate 'solidus_paypal_commerce_platform:install'
+generate "solidus_paypal_commerce_platform:install #{migrations_flag}"

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -222,12 +222,6 @@ module Solidus
 
     private
 
-    def generate(what, *args, abort_on_failure: true)
-      args << '--auto-accept' if options[:auto_accept]
-      args << '--auto-run-migrations' if options[:migrate]
-      super(what, *args, abort_on_failure: abort_on_failure)
-    end
-
     def bundle_command(command, env = {})
       # Make `bundle install` less verbose by skipping the "Using ..." messages
       super(command, env.reverse_merge('BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES' => 'true'))


### PR DESCRIPTION
## Summary

Ref: https://github.com/solidusio/solidus_starter_frontend/issues/295. 

By removing the override of the `generate` method in this
generator, we stop propagating those custom arguments to
all the inner generators called by the installer.

For example, at the moment, the installer is running

	rails    generate rspec:install --auto-accept --auto-run-migrations

which doesn't make sense and might also have
unexpected behaviors if we (or any dependency) run a generator
during their installation, which accepts those arguments.

Instead of always propaging these option, we are explicitely
declaring them when needed.

<details><summary>Install Output Example after this change</summary>
<p>

```
❯ bin/sandbox --payment_method=bolt --frontend=classic
~~~> Removing the old sandbox
~~~> Creating a pristine Rails app
      create
      create  README.md
      create  Rakefile
      create  .ruby-version
      create  config.ru
      create  Gemfile
      create  app
      create  app/assets/config/manifest.js
      create  app/assets/stylesheets/application.css
      create  app/channels/application_cable/channel.rb
      create  app/channels/application_cable/connection.rb
      create  app/controllers/application_controller.rb
      create  app/helpers/application_helper.rb
      create  app/jobs/application_job.rb
      create  app/mailers/application_mailer.rb
      create  app/models/application_record.rb
      create  app/views/layouts/application.html.erb
      create  app/views/layouts/mailer.html.erb
      create  app/views/layouts/mailer.text.erb
      create  app/assets/images
      create  bin
      create  bin/rails
      create  bin/rake
      create  bin/setup
      create  config
      create  config/routes.rb
      create  config/application.rb
      create  config/environment.rb
      create  config/cable.yml
      create  config/puma.rb
      create  config/storage.yml
      create  config/environments
      create  config/environments/development.rb
      create  config/environments/production.rb
      create  config/environments/test.rb
      create  config/initializers
      create  config/initializers/assets.rb
      create  config/initializers/content_security_policy.rb
      create  config/initializers/cors.rb
      create  config/initializers/filter_parameter_logging.rb
      create  config/initializers/inflections.rb
      create  config/initializers/new_framework_defaults_7_0.rb
      create  config/initializers/permissions_policy.rb
      create  config/locales
      create  config/locales/en.yml
      create  config/master.key
      create  config/boot.rb
      create  config/database.yml
      create  db
      create  db/seeds.rb
      create  lib
      create  lib/tasks
      create  lib/assets
      create  log
      create  public
      create  public/404.html
      create  public/422.html
      create  public/500.html
      create  public/apple-touch-icon-precomposed.png
      create  public/apple-touch-icon.png
      create  public/favicon.ico
      create  public/robots.txt
      create  tmp
      create  tmp/pids
      create  tmp/cache
      create  tmp/cache/assets
      create  vendor
      create  storage
      create  tmp/storage
      remove  config/initializers/cors.rb
      remove  config/initializers/new_framework_defaults_7_0.rb
         run  bundle install
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Using rake 13.0.6
Using concurrent-ruby 1.2.2
Using minitest 5.18.0
Using builder 3.2.4
Using erubi 1.12.0
Using bundler 2.4.6
Using racc 1.6.2
Using io-console 0.6.0
Using method_source 1.0.0
Using bindex 0.8.1
Using mini_mime 1.1.2
Using i18n 1.12.0
Using tzinfo 2.0.6
Using nokogiri 1.14.3 (arm64-darwin)
Using reline 0.3.3
Using rack 2.2.6.4
Using irb 1.6.4
Using marcel 1.0.2
Using websocket-extensions 0.1.5
Using zeitwerk 2.6.7
Using sqlite3 1.6.2 (arm64-darwin)
Using websocket-driver 0.7.5
Using timeout 0.3.2
Using crass 1.0.6
Using activesupport 7.0.4.3
Using loofah 2.20.0
Using thor 1.2.1
Using sprockets 4.2.0
Using nio4r 2.5.9
Using rack-test 2.1.0
Using date 3.3.3
Using activemodel 7.0.4.3
Using rails-html-sanitizer 1.5.0
Using globalid 1.1.0
Using debug 1.7.2
Using net-protocol 0.2.1
Using rails-dom-testing 2.0.3
Using activerecord 7.0.4.3
Using activejob 7.0.4.3
Using puma 5.6.5
Using net-imap 0.3.4
Using net-smtp 0.3.3
Using actionview 7.0.4.3
Using net-pop 0.1.2
Using actionpack 7.0.4.3
Using jbuilder 2.11.5
Using actioncable 7.0.4.3
Using activestorage 7.0.4.3
Using railties 7.0.4.3
Using sprockets-rails 3.4.2
Using mail 2.8.1
Using actionmailbox 7.0.4.3
Using actionmailer 7.0.4.3
Using actiontext 7.0.4.3
Using importmap-rails 1.1.5
Using stimulus-rails 1.2.1
Using turbo-rails 1.4.0
Using web-console 4.2.0
Using rails 7.0.4.3
Bundle complete! 11 Gemfile dependencies, 59 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle binstubs bundler
       rails  importmap:install
Add Importmap include tags in application layout
      insert  app/views/layouts/application.html.erb
Create application.js module as entrypoint
      create  app/javascript/application.js
Use vendor/javascript for downloaded pins
      create  vendor/javascript
      create  vendor/javascript/.keep
Ensure JavaScript files are in the Sprocket manifest
      append  app/assets/config/manifest.js
Configure importmap paths in config/importmap.rb
      create  config/importmap.rb
Copying binstub
      create  bin/importmap
       rails  turbo:install stimulus:install
Import Turbo
      append  app/javascript/application.js
Pin Turbo
      append  config/importmap.rb
Enable redis in bundle
        gsub  Gemfile
         run  bundle install
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Using rake 13.0.6
Using concurrent-ruby 1.2.2
Using erubi 1.12.0
Using crass 1.0.6
Using rack 2.2.6.4
Using nio4r 2.5.9
Using websocket-extensions 0.1.5
Using mini_mime 1.1.2
Using date 3.3.3
Using timeout 0.3.2
Using bindex 0.8.1
Using bundler 2.4.6
Using method_source 1.0.0
Using thor 1.2.1
Using zeitwerk 2.6.7
Using redis 4.8.1
Using sqlite3 1.6.2 (arm64-darwin)
Using minitest 5.18.0
Using i18n 1.12.0
Using tzinfo 2.0.6
Using racc 1.6.2
Using marcel 1.0.2
Using io-console 0.6.0
Using rack-test 2.1.0
Using websocket-driver 0.7.5
Using reline 0.3.3
Using puma 5.6.5
Using sprockets 4.2.0
Using builder 3.2.4
Using irb 1.6.4
Using activesupport 7.0.4.3
Using net-protocol 0.2.1
Using globalid 1.1.0
Using nokogiri 1.14.3 (arm64-darwin)
Using activemodel 7.0.4.3
Using activejob 7.0.4.3
Using rails-dom-testing 2.0.3
Using activerecord 7.0.4.3
Using loofah 2.20.0
Using net-imap 0.3.4
Using net-pop 0.1.2
Using net-smtp 0.3.3
Using debug 1.7.2
Using rails-html-sanitizer 1.5.0
Using mail 2.8.1
Using actionview 7.0.4.3
Using jbuilder 2.11.5
Using actionpack 7.0.4.3
Using actioncable 7.0.4.3
Using activestorage 7.0.4.3
Using railties 7.0.4.3
Using sprockets-rails 3.4.2
Using actionmailer 7.0.4.3
Using actionmailbox 7.0.4.3
Using actiontext 7.0.4.3
Using importmap-rails 1.1.5
Using stimulus-rails 1.2.1
Using turbo-rails 1.4.0
Using web-console 4.2.0
Using rails 7.0.4.3
Bundle complete! 12 Gemfile dependencies, 60 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Switch development cable to use redis
        gsub  config/cable.yml
Create controllers directory
      create  app/javascript/controllers
      create  app/javascript/controllers/index.js
      create  app/javascript/controllers/application.js
      create  app/javascript/controllers/hello_controller.js
Import Stimulus controllers
      append  app/javascript/application.js
Pin Stimulus
Appending: pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true"
      append  config/importmap.rb
Appending: pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
      append  config/importmap.rb
Pin all controllers
Appending: pin_all_from "app/javascript/controllers", under: "controllers"
      append  config/importmap.rb
~~~> Adding solidus (with i18n) to the Gemfile
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Bundle complete! 16 Gemfile dependencies, 113 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Dropped database 'db/development.sqlite3'
Database 'db/test.sqlite3' does not exist
Created database 'db/development.sqlite3'
Created database 'db/test.sqlite3'
~~~> Running the solidus:install generator
      create  config/initializers/spree.rb
      assets  Active Storage
        rake  active_storage:install
Copied migration 20230414074847_create_active_storage_tables.active_storage.rb from active_storage
       exist  app/assets/images
      create  vendor/assets/javascripts/spree/backend
      create  vendor/assets/stylesheets/spree/backend
      create  vendor/assets/images/spree/backend
      create  vendor/assets/javascripts/spree/backend/all.js
      create  vendor/assets/stylesheets/spree/backend/all.css
      create  app/overrides
      append  db/seeds.rb
     copying  migrations
        rake  railties:install:migrations
Copied migration 20230414074850_create_action_mailbox_tables.action_mailbox.rb from action_mailbox
Copied migration 20230414074851_create_action_text_tables.action_text.rb from action_text
Copied migration 20230414074852_solidus_one_four.spree.rb from spree
Copied migration 20230414074853_create_spree_wallet_payment_sources.spree.rb from spree
Copied migration 20230414074854_migrate_credit_cards_to_wallet_payment_sources.spree.rb from spree
Copied migration 20230414074855_remove_is_default_from_prices.spree.rb from spree
Copied migration 20230414074856_remove_currency_from_line_items.spree.rb from spree
Copied migration 20230414074857_add_available_to_columns_and_remove_display_on_from_payment_methods.spree.rb from spree
Copied migration 20230414074858_create_spree_promotion_code_batch.spree.rb from spree
Copied migration 20230414074859_add_available_to_users_and_remove_display_on_from_shipping_methods.spree.rb from spree
Copied migration 20230414074860_add_index_to_spree_payments_number.spree.rb from spree
Copied migration 20230414074861_remove_spree_store_credits_column.spree.rb from spree
Copied migration 20230414074862_add_lft_and_rgt_indexes_to_taxons.spree.rb from spree
Copied migration 20230414074863_remove_order_id_from_inventory_units.spree.rb from spree
Copied migration 20230414074864_transform_tax_rate_category_relation.spree.rb from spree
Copied migration 20230414074865_add_roles_unique_constraints.spree.rb from spree
Copied migration 20230414074866_add_time_range_to_tax_rate.spree.rb from spree
Copied migration 20230414074867_rename_bogus_gateways.spree.rb from spree
Copied migration 20230414074868_remove_default_tax_from_spree_zones.spree.rb from spree
Copied migration 20230414074869_create_promotion_rule_stores.spree.rb from spree
Copied migration 20230414074870_create_store_shipping_methods.spree.rb from spree
Copied migration 20230414074871_add_available_locales_to_stores.spree.rb from spree
Copied migration 20230414074872_add_amount_remaining_to_store_credit_events.spree.rb from spree
Copied migration 20230414074873_add_join_characters_to_promotion_code_batch.spree.rb from spree
Copied migration 20230414074874_add_apply_to_all_to_variant_property_rule.spree.rb from spree
Copied migration 20230414074875_create_spree_store_credit_reasons_table.spree.rb from spree
Copied migration 20230414074876_remove_code_from_spree_promotions.spree.rb from spree
Copied migration 20230414074877_drop_spree_store_credit_update_reasons.spree.rb from spree
Copied migration 20230414074878_add_default_billng_flag_to_user_addresses.spree.rb from spree
Copied migration 20230414074879_add_bcc_email_to_spree_stores.spree.rb from spree
Copied migration 20230414074880_add_discontinue_on_to_spree_products.spree.rb from spree
Copied migration 20230414074881_add_type_before_removal_to_spree_payment_methods.spree.rb from spree
Copied migration 20230414074882_add_name_to_spree_addresses.spree.rb from spree
Copied migration 20230414074883_change_column_null_on_prices.spree.rb from spree
Copied migration 20230414074884_set_promotions_with_any_policy_to_all_if_possible.spree.rb from spree
Copied migration 20230414074885_add_level_to_spree_tax_rates.spree.rb from spree
Copied migration 20230414074886_add_shipping_category_to_spree_variants.spree.rb from spree
Copied migration 20230414074887_add_api_key_to_spree_users.spree_api.rb from spree_api
Copied migration 20230414074888_resize_api_key_field.spree_api.rb from spree_api
Copied migration 20230414074889_rename_api_key_to_spree_api_key.spree_api.rb from spree_api
Copied migration 20230414074890_add_index_to_user_spree_api_key.spree_api.rb from spree_api
    creating  database
        rake  db:create
       route  # This line mounts Solidus's routes at the root of your application.
              # This means, any requests to URLs such as /products, will go to Spree::ProductsController.
              # If you would like to change where this engine is mounted, simply change the :at option to something different.
              #
              # We ask that you don't use the :as option here, as Solidus relies on it being the default of "spree"
              mount Spree::Core::Engine, at: '/'
     running  migrations
        rake  db:migrate
  installing  [authentication] devise
       apply  /Users/kennyadsl/Code/nebulab/solidus/core/lib/generators/solidus/install/app_templates/authentication/devise.rb
         run    bundle add solidus_auth_devise
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
    generate    solidus:auth:install --auto-run-migrations
       rails    generate solidus:auth:install --auto-run-migrations
      create  config/initializers/devise.rb
        rake  railties:install:migrations FROM=solidus_auth
Copied migration 20230414074913_create_users.solidus_auth.rb from solidus_auth
Copied migration 20230414074914_rename_columns_for_devise.solidus_auth.rb from solidus_auth
Copied migration 20230414074915_convert_user_remember_field.solidus_auth.rb from solidus_auth
Copied migration 20230414074916_add_reset_password_sent_at_to_spree_users.solidus_auth.rb from solidus_auth
Copied migration 20230414074917_make_users_email_index_unique.solidus_auth.rb from solidus_auth
Copied migration 20230414074918_add_deleted_at_to_users.solidus_auth.rb from solidus_auth
Copied migration 20230414074919_add_confirmable_to_users.solidus_auth.rb from solidus_auth
Copied migration 20230414074920_add_reset_password_token_index_to_spree_users.solidus_auth.rb from solidus_auth
Copied migration 20230414074921_add_unconfirmed_email_to_spree_users.solidus_auth.rb from solidus_auth
        rake  db:migrate
      append    db/seeds.rb
  installing  [frontend] classic
       apply  /Users/kennyadsl/Code/nebulab/solidus/core/lib/generators/solidus/install/app_templates/frontend/classic.rb
         run    bundle add solidus_frontend --github solidusio/solidus_frontend
Fetching https://github.com/solidusio/solidus_frontend.git
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
    generate    solidus_frontend:install
       rails    generate solidus_frontend:install
      create  config/initializers/solidus_frontend.rb
      append  public/robots.txt
       exist  app/assets/images
      create  vendor/assets/javascripts/spree/frontend
      create  vendor/assets/stylesheets/spree/frontend
      create  vendor/assets/images/spree/frontend
      create  vendor/assets/javascripts/spree/frontend/all.js
      create  vendor/assets/stylesheets/spree/frontend/all.css
  installing  [payment_method] bolt
       apply  /Users/kennyadsl/Code/nebulab/solidus/core/lib/generators/solidus/install/app_templates/payment_method/bolt.rb
         run    bundle add solidus_bolt
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Fetching multi_xml 0.6.0
Fetching version_gem 1.1.2
Fetching rack-protection 3.0.6
Fetching oa-core 0.3.2
Fetching jwt 2.7.0
Fetching tweetnacl 1.0.0
Fetching coffee-script-source 1.12.2
Fetching hashie 5.0.0
Installing multi_xml 0.6.0
Installing version_gem 1.1.2
Installing rack-protection 3.0.6
Fetching httparty 0.21.0
Fetching oauth-tty 1.0.5
Installing hashie 5.0.0
Installing jwt 2.7.0
Fetching snaky_hash 2.0.1
Fetching omniauth 2.1.1
Installing coffee-script-source 1.12.2
Fetching coffee-script 2.4.1
Installing httparty 0.21.0
Installing oa-core 0.3.2
Installing snaky_hash 2.0.1
Installing omniauth 2.1.1
Fetching oauth2 2.0.9
Fetching omniauth-rails_csrf_protection 1.0.1
Installing coffee-script 2.4.1
Installing tweetnacl 1.0.0 with native extensions
Fetching coffee-rails 5.0.0
Installing oauth-tty 1.0.5
Fetching oauth 1.1.0
Installing oauth2 2.0.9
Fetching omniauth-oauth2 1.8.0
Installing coffee-rails 5.0.0
Installing omniauth-rails_csrf_protection 1.0.1
Installing oauth 1.1.0
Fetching omniauth-oauth 1.2.0
Installing omniauth-oauth2 1.8.0
Fetching omniauth-facebook 9.0.0
Fetching omniauth-google-oauth2 1.1.1
Fetching omniauth-github 2.0.1
Installing omniauth-oauth 1.2.0
Fetching omniauth-bolt 0.3.0
Installing omniauth-github 2.0.1
Installing omniauth-google-oauth2 1.1.1
Installing omniauth-facebook 9.0.0
Fetching solidus_social 1.5.0
Installing omniauth-bolt 0.3.0
Installing solidus_social 1.5.0
Fetching solidus_bolt 0.7.2
Installing solidus_bolt 0.7.2
    generate    solidus_bolt:install --auto-run-migrations=true
       rails    generate solidus_bolt:install --auto-run-migrations=true
     install  solidus_social extension
         run  bin/rails generate solidus_social:install --auto-run-migrations from "."
      insert  vendor/assets/stylesheets/spree/frontend/all.css
         run  bin/rails railties:install:migrations FROM=solidus_social from "."
Copied migration 20230414074954_create_user_authentications.solidus_social.rb from solidus_social
Copied migration 20230414074955_create_authentication_methods.solidus_social.rb from solidus_social
      create  config/initializers/solidus_social.rb
         run  bin/rails db:migrate from "."
      create  config/initializers/solidus_bolt.rb
      append  vendor/assets/javascripts/spree/frontend/all.js
      append  vendor/assets/javascripts/spree/backend/all.js
      insert  vendor/assets/stylesheets/spree/frontend/all.css
      insert  vendor/assets/stylesheets/spree/backend/all.css
         run  bin/rails railties:install:migrations FROM=solidus_bolt from "."
Copied migration 20230414075005_create_solidus_bolt_payment_sources.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075006_create_solidus_bolt_bolt_configurations.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075007_swap_url_for_env_boolean_in_bolt_configuration.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075008_rework_solidus_bolt_payment_sources.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075009_add_create_bolt_account_to_solidus_bolt_payment_source.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075010_add_user_to_solidus_bolt_payment_source.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075011_remove_user_id_from_solidus_bolt_payment_source.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075012_rename_bolt_configuration_merchant_id_to_division_public_id.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075013_update_bolt_configuration_environment_column_restrictions.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075014_remove_bearer_token_on_solidus_bolt_bolt_configuration.solidus_bolt.rb from solidus_bolt
Copied migration 20230414075015_remove_merchant_id_and_division_public_id_on_bolt_configuration.solidus_bolt.rb from solidus_bolt
        gsub  config/initializers/solidus_social.rb
      append  config/initializers/solidus_social.rb
         run  bin/rails db:migrate from "."
     loading  bolt seed data
        rake  db:seed:solidus_bolt
Seeding /Users/kennyadsl/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/solidus_bolt-0.7.2/db/seeds.rb...
     loading  seed data
        rake  db:seed AUTO_ACCEPT=1
        seed  stores
        seed  store_credit
        seed  countries
        seed  return_reasons
        seed  states
        seed  stock_locations
        seed  zones
        seed  refund_reasons
        seed  roles
        seed  shipping_categories
Creating admin user with:
  - email: admin@example.com
  - password: test123
(please use the ADMIN_EMAIL and ADMIN_PASSWORD environment variables to control how the default admin user is created)
     loading  sample data
        rake  spree_sample:load
      sample  Payment Methods
      sample  Tax Categories
      sample  Tax Rates
      sample  Shipping Categories
      sample  Shipping Methods
      sample  Products
      sample  Taxons
      sample  Taxonomies
      sample  Option Values
      sample  Option Types
      sample  Product Option Types
      sample  Product Properties
      sample  Variants
      sample  Stock
      sample  Assets
      sample  images for Solidus Snapback Cap
      sample  images for Solidus Hoodie Zip
      sample  images for Ruby Hoodie
      sample  images for Ruby Hoodie Zip
      sample  images for Ruby Polo
      sample  images for Solidus Mug
      sample  images for Ruby Mug
      sample  images for Solidus Tote
      sample  images for Ruby Tote
      sample  Orders
      sample  Addresses
      sample  Stores
      sample  Payments
      sample  Reimbursements
    complete  Solidus has been installed successfully. Enjoy!

🚀 This app is intended for test purposes. If you're interested in running
🚀 Solidus in production, visit:
🚀 https://guides.solidus.io/developers/getting-started/first-time-installation
```

</p>
</details> 


Co-Authored @safafa 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
