### PR TITLE
Remove Deprecated code from Backend component

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -17,27 +17,8 @@
     *                                                       you need to ensure that the attributes are allowed to be Ransacked.
     */
   $.fn.variantAutocomplete = function(options) {
-    function extraParameters(term) {
-      if (typeof(options) === 'object') {
-        if (typeof(options['searchParameters']) === 'function') {
-          return options['searchParameters'](term)
-        } else {
-          console.warn(
-            "Solidus deprecation: Passing an object of parameters to variantAutocomplete is deprecated. Instead, on the options object, please declare `searchParameters` as a function returning the parameters.\n\n",
-            "Deprecated usage:\n",
-            "$('#id').variantAutocomplete({\n",
-            "  suppliable_only: true\n",
-            "})",
-            "\n\nNew usage:\n",
-            "$('#id').variantAutocomplete({\n",
-            "  searchParameters: function (_selectSearchTerm) { return { suppliable_only: true  } }\n",
-            "})"
-          )
-        }
-      }
-
-      return {}
-    }
+    // Default options
+    options = options || {}
 
     this.select2({
       placeholder: Spree.translations.variant_placeholder,
@@ -58,14 +39,15 @@
           }
         },
         data: function(term, page) {
-          var searchData = {
+          const extraParameters = options["searchParameters"] ? options["searchParameters"](term) : {}
+
+          return {
             variant_search_term: term,
             token: Spree.api_key,
-            page: page
-          };
-          return _.extend(searchData, extraParameters(term));
+            page: page,
+            ...extraParameters,
+          }
         },
-
         results: function(data, page) {
           window.variants = data["variants"];
           return {

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -22,13 +22,6 @@ module Spree
         safe_join(links, "&nbsp;".html_safe)
       end
 
-      # @deprecated use `Spree::LineItem#display_amount` instead
-      def line_item_shipment_price(line_item, quantity)
-        Spree::Money.new(line_item.price * quantity, { currency: line_item.currency })
-      end
-      deprecate deprecator: Spree::Deprecation,
-        line_item_shipment_price: "use Spree::LineItem#display_amount instead"
-
       # Addresss Verification System response code
       #
       # @see https://en.wikipedia.org/wiki/Address_verification_service


### PR DESCRIPTION
This PR is part of [3.x Deprecations Removal](https://github.com/solidusio/solidus/issues/4983).

## Summary

This PR removes all the code deprecated in the Backend component. Please refer to each commit to better understand what has been removed and their replacements. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
