### PR TITLE
Remove Deprecated Preferences

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -18,11 +18,11 @@ module Spree
     after_update :update_child_permalinks, if: :saved_change_to_permalink?
 
     validates :name, presence: true
-    validates :name, uniqueness: { scope: :parent_id, message: :must_be_unique_under_same_parent }, if: -> { Spree::Config.extra_taxon_validations}
+    validates :name, uniqueness: { scope: :parent_id, message: :must_be_unique_under_same_parent }
     validates :meta_keywords, length: { maximum: 255 }
     validates :meta_description, length: { maximum: 255 }
     validates :meta_title, length: { maximum: 255 }
-    validates :taxonomy_id, uniqueness: { message: :can_have_only_one_root }, if: -> { Spree::Config.extra_taxon_validations && root? }
+    validates :taxonomy_id, uniqueness: { message: :can_have_only_one_root }, if: -> { root? }
 
     after_save :touch_ancestors_and_taxonomy
     after_touch :touch_ancestors_and_taxonomy

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -5,7 +5,7 @@ module Spree
     acts_as_list
 
     validates :name, presence: true
-    validates :name, uniqueness: true, if: -> { Spree::Config.extra_taxonomy_validations }
+    validates :name, uniqueness: true
 
     has_many :taxons, inverse_of: :taxonomy
     has_one :root, -> { where parent_id: nil }, class_name: "Spree::Taxon", dependent: :destroy

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -207,20 +207,6 @@ module Spree
     #     entity expansion attacks.
     preference :log_entry_allow_aliases, :boolean, default: true
 
-    # @!attribute [rw] mails_from
-    #   @return [String] Email address used as +From:+ field in transactional emails.
-    #   @deprecated Spree::Store#mail_from_address is used instead
-    preference :mails_from, :string, default: 'solidus@example.com'
-    def mails_from=(value)
-      Spree::Deprecation.warn(<<~MSG) && preferences[:mail_from] = value
-        Solidus doesn't use `Spree::Config.mails_from` preference and it'll
-        removed on the next major release. Please, remove its definition in
-        `config/initializers/spree.rb`. Use the `Spree::Store#mail_from_address`
-        attribute for the default email address used as the 'From:' field in
-        transactional emails.
-      MSG
-    end
-
     # @!attribute [rw] max_level_in_taxons_menu
     #   @return [Integer] maximum nesting level in taxons menu (default: +1+)
     preference :max_level_in_taxons_menu, :integer, default: 1

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -171,22 +171,6 @@ module Spree
     #   @return [Regexp] Regex to be used in email validations, for example in Spree::EmailValidator
     preference :default_email_regexp, :regexp, default: URI::MailTo::EMAIL_REGEXP
 
-    # @!attribute [rw] extra_taxon_validations
-    #   Use extra validations on Taxons in 3.4.0, but default to false so stores can
-    #   upgrade and then fix any now invalid Taxons before enabling.
-    #   @return [Boolean]
-    versioned_preference :extra_taxon_validations, :boolean, initial_value: false, boundaries: { "3.4.0.dev" => true }
-    def extra_taxon_validations=(value)
-      Spree::Deprecation.warn <<~MSG
-        Solidus will remove `Spree::Config.extra_taxon_validations` preference
-        in the next major release and will always use the extra Taxon validations.
-        Before upgrading to the next major, please fix any now invalid Taxons
-        and then remove the preference definition in `config/initializers/spree.rb`.
-      MSG
-
-      preferences[:extra_taxon_validations] = value
-    end
-
     # @!attribute [rw] extra_taxonomy_validations
     #   Use extra validations on Taxonomies in 3.4.0, but default to false so stores can
     #   upgrade and then fix any now invalid Taxonomies before enabling.

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -171,22 +171,6 @@ module Spree
     #   @return [Regexp] Regex to be used in email validations, for example in Spree::EmailValidator
     preference :default_email_regexp, :regexp, default: URI::MailTo::EMAIL_REGEXP
 
-    # @!attribute [rw] extra_taxonomy_validations
-    #   Use extra validations on Taxonomies in 3.4.0, but default to false so stores can
-    #   upgrade and then fix any now invalid Taxonomies before enabling.
-    #   @return [Boolean]
-    versioned_preference :extra_taxonomy_validations, :boolean, initial_value: false, boundaries: { "3.4.0.dev" => true }
-    def extra_taxonomy_validations=(value)
-      Spree::Deprecation.warn <<~MSG
-        Solidus will remove `Spree::Config.extra_taxonomy_validations` preference
-        in the next major release and will always use the extra Taxonomy validations.
-        Before upgrading to the next major, please fix any now invalid Taxons
-        and then remove the preference definition in `config/initializers/spree.rb`.
-      MSG
-
-      preferences[:extra_taxonomy_validations] = value
-    end
-
     # @!attribute [rw] generate_api_key_for_all_roles
     #   @return [Boolean] Allow generating api key automatically for user
     #   at role_user creation for all roles. (default: +false+)

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -161,20 +161,4 @@ RSpec.describe Spree::AppConfiguration do
   it 'has default Event adapter' do
     expect(prefs.events.adapter).to eq Spree::Event::Adapters::ActiveSupportNotifications
   end
-
-  context 'mails_from' do
-    it 'is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn).with(/Solidus doesn't use `Spree::Config.mails_from`/)
-
-      prefs.mails_from=('solidus@example.com')
-    end
-
-    it "still sets the value so that consumers aren't broken" do
-      Spree::Deprecation.silence do
-        prefs.mails_from=('solidus@example.com')
-      end
-
-      expect(prefs.mails_from).to eq('solidus@example.com')
-    end
-  end
 end

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -177,20 +177,4 @@ RSpec.describe Spree::AppConfiguration do
       expect(prefs.mails_from).to eq('solidus@example.com')
     end
   end
-
-  context 'extra_taxonomy_validations=' do
-    it 'is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn).with(/Solidus will remove `Spree::Config.extra_taxonomy_validations`/)
-
-      prefs.extra_taxonomy_validations=(false)
-    end
-
-    it "still sets the value so that consumers aren't broken" do
-      Spree::Deprecation.silence do
-        prefs.extra_taxonomy_validations=(false)
-      end
-
-      expect(prefs.extra_taxonomy_validations).to eq(false)
-    end
-  end
 end

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -178,22 +178,6 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
-  context 'extra_taxon_validations=' do
-    it 'is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn).with(/Solidus will remove `Spree::Config.extra_taxon_validations`/)
-
-      prefs.extra_taxon_validations=(false)
-    end
-
-    it "still sets the value so that consumers aren't broken" do
-      Spree::Deprecation.silence do
-        prefs.extra_taxon_validations=(false)
-      end
-
-      expect(prefs.extra_taxon_validations).to eq(false)
-    end
-  end
-
   context 'extra_taxonomy_validations=' do
     it 'is deprecated' do
       expect(Spree::Deprecation).to receive(:warn).with(/Solidus will remove `Spree::Config.extra_taxonomy_validations`/)


### PR DESCRIPTION
This PR is part of [3.x Deprecations Removal](https://github.com/solidusio/solidus/issues/4983).

## Summary

This PR removes all deprecated preferences. Please refer to each commit to better understand what has been removed and their replacements. 


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
