### PR TITLE
fix: update Nebulab missing logo asset reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,12 @@ As a community-driven project, Solidus relies on funds and time donated by devel
 ### Main Contributor & Director
 At present, Nebulab is the main code contributor and director of Solidus, providing technical guidance and coordinating community efforts and activities.
 
-[![Nebulab](https://nebulab.com/assets/img/logo-nebulab_gh-dark-light-mode.svg)](https://nebulab.com/)
+[![Nebulab](https://raw.githubusercontent.com/solidusio/brand/master/partners/Nebulab/logo-dark-light.svg)](https://nebulab.com/)
 
 ### Ambassadors
 Support this project by becoming a Solidus Ambassador. Your logo will show up here with a link to your website. [Become an Ambassador](https://opencollective.com/solidus).
 
-[![Super Good Software](https://images.opencollective.com/supergoodsoft/f720462/logo/100.png)](https://supergood.software/)
-[![Karma Creative](https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fab94d2a0-7253-11e9-a366-37673cc38cee.png&height=100)](https://karmacreative.io/)
-[![ModdedEuros](https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fimages.opencollective.com%2Fmodded-euros%2Ff1a80ae%2Flogo.png&height=100)](https://www.moddedeuros.com)
+[![Super Good Software](https://raw.githubusercontent.com/solidusio/brand/master/partners/SuperGood/logo-dark-light.png)](https://supergood.software/)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the `README.md` with the following stuff:
- fix of the broken Nebulab logo
- reference change of SuperGood Software logo
- remove the logos of Karma Creative and ModdedEuros: they're not Solidus ambassadors anymore.