### PR TITLE
Mark FulfilmentChanger::TRACK_INVENTORY_NOT_PROVIDED as private

### DIFF
--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -17,7 +17,11 @@ module Spree
   # @attr [Integer] quantity How many units we want to move
   #
   class FulfilmentChanger
+    # @note This private constant is only used to deprecate not passing the `track_inventory` argument
+    #   on initialization. It will be removed in Solidus 4.0, please do not use it.
     TRACK_INVENTORY_NOT_PROVIDED = Object.new.freeze
+    private_constant :TRACK_INVENTORY_NOT_PROVIDED
+
     include ActiveModel::Validations
 
     attr_accessor :current_shipment, :desired_shipment


### PR DESCRIPTION
## Summary

This constant is only used internally for the deprecation of not passing the track_inventory argument to the initializer of this class.

We are marking it as private so we are sure no one is using it.

Ref https://github.com/solidusio/solidus/pull/4989/commits/49c701bd68c2d9805309334411a187ef9f443e23#r1170779558

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
