### PR TITLE
Remove support for the legacy frontend names

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -17,11 +17,6 @@ module Solidus
       starter
     ]
 
-    LEGACY_FRONTENDS = %w[
-      solidus_starter_frontend
-      solidus_frontend
-    ]
-
     AUTHENTICATIONS = %w[
       devise
       existing
@@ -67,7 +62,7 @@ module Solidus
     class_option :admin_email, type: :string
     class_option :admin_password, type: :string
 
-    class_option :frontend, type: :string, enum: FRONTENDS + LEGACY_FRONTENDS, default: nil, desc: "Indicates which frontend to install."
+    class_option :frontend, type: :string, enum: FRONTENDS, default: nil, desc: "Indicates which frontend to install."
     class_option :authentication, type: :string, enum: AUTHENTICATIONS, default: nil, desc: "Indicates which authentication system to install."
     class_option :payment_method, type: :string, enum: PAYMENT_METHODS.map { |payment_method| payment_method[:name] }, default: nil, desc: "Indicates which payment method to install."
 
@@ -272,13 +267,8 @@ module Solidus
     end
 
     def detect_frontend_to_install
-      # We need to support names that were available in v3.2
-      selected_frontend = 'starter' if options[:frontend] == 'solidus_starter_frontend'
-      selected_frontend = 'classic' if options[:frontend] == 'solidus_frontend'
-      selected_frontend ||= options[:frontend]
-
       ENV['FRONTEND'] ||
-        selected_frontend ||
+        options[:frontend] ||
         (Bundler.locked_gems.dependencies['solidus_frontend'] && 'classic') ||
         (options[:auto_accept] && 'starter') ||
         ask_with_description(

--- a/core/spec/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/generators/solidus/install/install_generator_spec.rb
@@ -81,22 +81,6 @@ RSpec.describe Solidus::InstallGenerator do
       expect(generator.instance_variable_get(:@load_sample_data)).to eq(false)
     end
 
-    context 'supports legacy frontend option names' do
-      it 'transform "solidus_frontend" into "classic"' do
-        generator = described_class.new([], ['--auto-accept', '--frontend=solidus_frontend'])
-        generator.prepare_options
-
-        expect(generator.instance_variable_get(:@selected_frontend)).to eq('classic')
-      end
-
-      it 'transform "solidus_starter_frontend" into "starter"' do
-        generator = described_class.new([], ['--auto-accept', '--frontend=solidus_starter_frontend'])
-        generator.prepare_options
-
-        expect(generator.instance_variable_get(:@selected_frontend)).to eq('starter')
-      end
-    end
-
     context 'when asked interactively' do
       it 'presents different options for the "classic"' do
         questions = []


### PR DESCRIPTION
## Summary

They were already deprecated and only used by the installer.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
