### PR TITLE
Fix from argument for starter frontend release bumper

### DIFF
--- a/dev_tools/bin/bump-starter-frontend-version
+++ b/dev_tools/bin/bump-starter-frontend-version
@@ -6,7 +6,7 @@ require_relative '../lib/solidus/bumper'
 candidate_version = ARGV[0]
 
 path = File.expand_path('../../core/lib/generators/solidus/install/app_templates/frontend/starter.rb', __dir__)
-File.read(path)[%r{solidusio/solidus_starter_frontend/raw/(.+)/template.rb}, 1]
+from = File.read(path)[%r{solidusio/solidus_starter_frontend/raw/(.+)/template.rb}, 1]
 to = candidate_version
 
 puts <<~MSG


### PR DESCRIPTION
## Summary

Implementing this suggestion

https://github.com/solidusio/solidus/pull/5013#discussion_r1171087672

I made a mistake and removed the variable assignment.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
