### PR TITLE
Automate backport label creation

### DIFF
--- a/.github/workflows/prepare_post_release.yml
+++ b/.github/workflows/prepare_post_release.yml
@@ -51,6 +51,14 @@ jobs:
             ${{ github.token }} \
             ${{ github.repository }} \
             ${{ steps.pipeline_context.outputs.candidate_tag }}
+      - name: "Create backport label"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create \
+            backport-${{ steps.pipeline_context.outputs.candidate_patch_branch }} \
+            --description "Backport this pull-request to ${{ steps.pipeline_context.outputs.candidate_patch_branch }}" \
+            --color 3E4538
       - name: "Create patch branch"
         if: github.ref_name == 'master'
         env:
@@ -74,3 +82,4 @@ jobs:
             
             - [ ] The new release has been published, along with its tag. See https://github.com/${{ github.repository }}/releases/tag/${{ steps.pipeline_context.outputs.candidate_tag }}
             - [ ] The corresponding patch branch exists. See https://github.com/${{ github.repository }}/tree/${{ steps.pipeline_context.outputs.candidate_patch_branch }}
+            - [ ] The corresponding backport-${{ steps.pipeline_context.outputs.candidate_patch_branch }} label exists. See https://github.com/${{ github.repository }}/labels


### PR DESCRIPTION
## Summary

At each release, we need to create a label dedicated to backporting: This procedure allows the [sqren/backport-github-action](https://github.com/sqren/backport-github-action) to be used in this [workflow](https://github.com/solidusio/solidus/blob/b0b31cc932c945b6a43f10a3f465dc069eadfc01/.github/workflows/backport.yml).

With this change, we automate this step by creating the label when running ["Prepare post-release"](https://github.com/solidusio/solidus/blob/b0b31cc932c945b6a43f10a3f465dc069eadfc01/.github/workflows/prepare_post_release.yml).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
