### PR TITLE
Remove stale warning about paypal not being fully supported

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
+++ b/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
@@ -1,7 +1,3 @@
-unless Bundler.locked_gems.dependencies['solidus_frontend']
-  say_status :warning, "Support for frontends other than `solidus_frontend` by `solidus_paypal_commerce_platform` is still in progress.", :yellow
-end
-
 if @selected_frontend == 'classic'
   version = '< 1'
   migrations_flag = options[:migrate] ? '--auto-run-migrations' : '--skip-migrations'


### PR DESCRIPTION
## Summary

We already released version v1.0 targeting solidus_starter_frontend, so
the warning is no longer valid.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
