### PR TITLE
[v3.2] Allow to disable track inventory for product without variants

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -146,7 +146,7 @@
           <%= f.field_container :track_inventory do %>
             <label>
               <%= f.check_box :track_inventory %>
-              <%= Spree::Product.human_attribute_name(:track_inventory) %>
+              <%= Spree::Variant.human_attribute_name(:track_inventory) %>
             </label>
           <% end %>
         </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -142,7 +142,14 @@
             </div>
           <% end %>
         </div>
-
+        <div data-hook="admin_product_form_track_inventory">
+          <%= f.field_container :track_inventory do %>
+            <label>
+              <%= f.check_box :track_inventory %>
+              <%= Spree::Product.human_attribute_name(:track_inventory) %>
+            </label>
+          <% end %>
+        </div>
       <% end %>
 
       <div data-hook="admin_product_form_shipping_categories">

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -270,6 +270,13 @@ describe "Products", type: :feature do
       it "should show default tax category" do
         expect(page).to have_select('product_tax_category_id', selected: 'Alcohol taxes')
       end
+
+      it "can disable track_inventory" do
+        expect(page).to have_field("product_track_inventory", checked: true)
+        uncheck "product_track_inventory"
+        click_button "Create"
+        expect(page).to have_field("product_track_inventory", checked: false)
+      end
     end
 
     context "cloning a product", js: true do
@@ -341,6 +348,23 @@ describe "Products", type: :feature do
             visit spree.admin_product_path(product)
             expect(page).to have_select('product_tax_category_id', selected: clothing.name)
           end
+        end
+      end
+
+      it "can disable track_inventory" do
+        visit spree.admin_product_path(product)
+        expect(page).to have_field("product_track_inventory", checked: true)
+        uncheck "product_track_inventory"
+        click_button "Update"
+        expect(page).to have_field("product_track_inventory", checked: false)
+      end
+
+      context "with variants" do
+        let(:product) { create(:variant).product }
+
+        it "cannot disable track_inventory" do
+          visit spree.admin_product_path(product)
+          expect(page).to_not have_field("product_track_inventory")
         end
       end
     end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -83,6 +83,7 @@ module Spree
       :height,
       :price,
       :sku,
+      :track_inventory,
       :weight,
       :width,
     ]

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -640,4 +640,22 @@ RSpec.describe Spree::Product, type: :model do
       expect(result).to eq([product_1, product_2])
     end
   end
+
+  describe "inventory tracking" do
+    let(:product) { build(:product) }
+
+    describe "#track_inventory=" do
+      it "delegates to master variant" do
+        expect(product.master).to receive(:track_inventory=).with(true)
+        product.track_inventory = true
+      end
+    end
+
+    describe "#track_inventory" do
+      it "delegates to master variant" do
+        expect(product.master).to receive(:track_inventory) { true }
+        expect(product.track_inventory).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Backports #5039

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
