### PR TITLE
Deprecate other code related to old factories loading

### DIFF
--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
+require 'spree/deprecation'
+
+Spree::Deprecation.warn <<-WARN
+  Using `require 'spree/testing_support'` is deprecated and will be removed in
+  Solidus 4.0.
+WARN
 
 module Spree
   module TestingSupport
@@ -11,5 +17,6 @@ module Spree
     def check_factory_bot_version
       Spree::TestingSupport::FactoryBot.check_version
     end
+    deprecate :check_factory_bot_version, deprecator: Spree::Deprecation
   end
 end

--- a/core/lib/spree/testing_support/factory_bot.rb
+++ b/core/lib/spree/testing_support/factory_bot.rb
@@ -30,6 +30,7 @@ module Spree
           MSG
         end
       end
+      deprecate :check_version, deprecator: Spree::Deprecation
 
       def self.add_definitions!
         ::FactoryBot.definition_file_paths.unshift(*definition_file_paths).uniq!


### PR DESCRIPTION
## Summary

Ref #5023 

People should have started to use `require 'spree/testing_support/factory_bot'`now, so this workaround is no longer needed.

Also, no one is calling the methods that check for the version of factory_bot, so we can safely deprecate that code.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
