### PR TITLE
Fix generating the dummy app for extensions using solidus_frontend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,25 @@ commands:
             echo "Exited with $?"
             kill $(cat "tmp/pids/server.pid")
 
+  install_dummy_app:
+    parameters:
+      extra_gems:
+        type: string
+        default: ""
+        description: "Gems to be added to the extension's Gemfile before running the installer"
+    steps:
+      - run:
+          name: "Test `rake task: extensions:test_app` <<#parameters.extra_gems>>(with <<parameters.extra_gems>>)<</parameters.extra_gems>>"
+          command: |
+            rm -rf /tmp/dummy_extension # cleanup previous runs
+            mkdir -p /tmp/dummy_extension
+            cd /tmp/dummy_extension
+            bundle init
+            bundle add rails sqlite3 <<parameters.extra_gems>> --skip-install
+            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+            export LIB_NAME=set # dummy requireable file
+            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
+
 jobs:
   solidus_installer:
     executor:
@@ -219,37 +238,14 @@ jobs:
 
       - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise --payment-method=stripe" }
       - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
+
+      - install_dummy_app
+
+      - install_dummy_app: { extra_gems: "solidus_frontend" }
       - run:
-          name: Ensure the correct Stripe is installed for SSF
+          name: "Ensure solidus_frontend installer is run"
           command: |
-            cd /tmp/my_app
-            bundle list
-            bundle list | grep 'solidus_stripe (5.'
-
-      - install_solidus: { flags: "--sample=false --frontend=starter --payment-method=braintree" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-      - run:
-          name: Ensure the correct Braintree is installed for SSF
-          command: |
-            cd /tmp/my_app
-            bundle list | grep 'solidus_braintree (3.'
-
-      - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
-      - test_page: { expected_text: "<title>Ruby on Rails" }
-
-      - install_solidus: { flags: "--sample=false --frontend=starter --authentication=custom" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-
-      - run:
-          name: "Test `rake task: extensions:test_app`"
-          command: |
-            mkdir -p /tmp/dummy_extension
-            cd /tmp/dummy_extension
-            bundle init
-            bundle add rails sqlite3 --skip-install
-            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
-            export LIB_NAME=set # dummy requireable file
-            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
+            test -f /tmp/dummy_extension/spec/dummy/config/initializers/solidus_frontend.rb
 
   test_solidus:
     parameters:

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -40,9 +40,9 @@ class CommonRakeTasks
           "--quiet",
         ].shelljoin)
 
-        # TODO: Our extensions ecosystem expects the legacy frontend when the
-        # env FRONTEND variable is not given
-        ENV['FRONTEND'] || sh("bundle add solidus_frontend")
+        if Bundler.locked_gems.dependencies['solidus_frontend']
+          sh "bin/rails g solidus_frontend:install --auto-accept"
+        end
 
         puts "Setting up dummy database..."
 


### PR DESCRIPTION
## Summary

The dummy application uses the extension's Gemfile. If the extension is still relying on solidus_frontend, it'll already be present in its Gemfile. We don't need nor want adding it to the extension's Gemfile, but we do need to run its install generator.

Adding CI steps to cover it.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
