### PR TITLE
Make Spree::MigrationHelpers Ruby 3.0 compatible

### DIFF
--- a/core/lib/spree/migration_helpers.rb
+++ b/core/lib/spree/migration_helpers.rb
@@ -6,9 +6,9 @@ module Spree
       remove_index(table, column) if index_exists?(table, column)
     end
 
-    def safe_add_index(table, column, options = {})
-      if columns_exist?(table, column) && !index_exists?(table, column, options)
-        add_index(table, column, options)
+    def safe_add_index(table, column, **options)
+      if columns_exist?(table, column) && !index_exists?(table, column, **options)
+        add_index(table, column, **options)
       end
     end
 

--- a/core/spec/lib/spree/migration_helpers_spec.rb
+++ b/core/spec/lib/spree/migration_helpers_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Spree::MigrationHelpers do
+  let(:helper) do
+    double.as_null_object.tap do |object|
+      object.extend(described_class)
+      object.extend(ActiveRecord::ConnectionAdapters::SchemaStatements)
+    end
+  end
+
+  subject { helper.safe_add_index(double, double) }
+
+  # regression test
+  describe "#safe_add_index" do
+    context "when the column exists" do
+      context "and the index does" do
+        it "passes compatible arguments to index_exists?" do
+          expect { subject }.to_not raise_error(ArgumentError)
+        end
+      end
+
+      context "and the index does not" do
+        before do
+          allow(helper).to receive(:index_exists?).with(any_args).and_return(false)
+        end
+
+        it "passes compatible arguments to add_index" do
+          expect { subject }.to_not raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Due to the separation of positional and keyword arguments in Ruby 3.0, the options default value of a hash can no longer be coerced into keyword arguments. Using double splat avoids this by only allowing optional arguments as keywords.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
