### PR TITLE
[v3.4] Backport recent changes to the development tools

### DIFF
--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Check for the presence of a changelog label"
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr view \
             ${{ github.event.pull_request.number }} \

--- a/.github/workflows/prepare_post_release.yml
+++ b/.github/workflows/prepare_post_release.yml
@@ -3,7 +3,7 @@ name: "Prepare post-release"
 on:
   pull_request:
     branches:
-      - master
+      - main
       - v*
     types:
       - closed
@@ -31,17 +31,17 @@ jobs:
           cd dev_tools/ && bin/bump-to-dev-version \
             ${{ steps.pipeline_context.outputs.next_candidate_dev_version }}
       - name: "Bump previous solidus minor version"
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         run: |
           cd dev_tools/ && bin/bump-previous-minor-version \
             ${{ steps.pipeline_context.outputs.candidate_minor_version }}
       - name: "Bump to the development version in docker-compose"
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         run: |
           cd dev_tools/ && bin/bump-docker-image-to-dev-version \
             ${{ steps.pipeline_context.outputs.next_candidate_dev_version }}
       - name: "Bump installer starter frontend version"
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         run: |
           cd dev_tools/ && bin/bump-starter-frontend-version \
             main
@@ -51,15 +51,23 @@ jobs:
             ${{ github.token }} \
             ${{ github.repository }} \
             ${{ steps.pipeline_context.outputs.candidate_tag }}
+      - name: "Create backport label"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create \
+            backport-${{ steps.pipeline_context.outputs.candidate_patch_branch }} \
+            --description "Backport this pull-request to ${{ steps.pipeline_context.outputs.candidate_patch_branch }}" \
+            --color 3E4538
       - name: "Create patch branch"
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           candidate_patch_branch="${{ steps.pipeline_context.outputs.candidate_patch_branch }}"
           git checkout -b $candidate_patch_branch
           git push --set-upstream origin $candidate_patch_branch
-      - name: "Create PR for master"
+      - name: "Create PR for main"
         uses: ./.github/actions/commit_and_submit_pull_request
         with:
           labels: changelog:skip
@@ -74,3 +82,4 @@ jobs:
             
             - [ ] The new release has been published, along with its tag. See https://github.com/${{ github.repository }}/releases/tag/${{ steps.pipeline_context.outputs.candidate_tag }}
             - [ ] The corresponding patch branch exists. See https://github.com/${{ github.repository }}/tree/${{ steps.pipeline_context.outputs.candidate_patch_branch }}
+            - [ ] The corresponding backport-${{ steps.pipeline_context.outputs.candidate_patch_branch }} label exists. See https://github.com/${{ github.repository }}/labels

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -28,12 +28,12 @@ jobs:
           cd dev_tools/ && bin/bump-version \
             ${{ steps.pipeline_context.outputs.candidate_version }}
       - name: "Bump docker image version"
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         run: |
           cd dev_tools/ && bin/bump-docker-image-version \
             ${{ steps.pipeline_context.outputs.candidate_version }}
       - name: "Bump installer starter frontend version"
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         run: |
           cd dev_tools/ && bin/bump-starter-frontend-version \
             ${{ steps.pipeline_context.outputs.candidate_patch_branch }}

--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -3,7 +3,7 @@ name: "Update Release Draft on GitHub"
 on:
   pull_request_target:
     branches:
-      - master
+      - main
       - v*
     types:
       - closed

--- a/dev_tools/lib/solidus/pipeline_context.rb
+++ b/dev_tools/lib/solidus/pipeline_context.rb
@@ -7,7 +7,7 @@ module Solidus
   #
   # @api private
   class PipelineContext
-    MAIN_BRANCH = 'master'
+    MAIN_BRANCH = 'main'
 
     VERSION_PREFIX = 'v'
 

--- a/dev_tools/spec/lib/solidus/pipeline_context_spec.rb
+++ b/dev_tools/spec/lib/solidus/pipeline_context_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Solidus::PipelineContext do
     it 'ignores tags that do not match a full stable version number' do
       context = described_class.new(
         tags: %w[v3.0.0 v3.0 v3.0 v3 v3.0.0.beta invalid v.3.0.0],
-        base_branch: 'master'
+        base_branch: 'main'
       )
 
       expect(context.tags).to eq(['v3.0.0'])
@@ -15,7 +15,7 @@ RSpec.describe Solidus::PipelineContext do
 
     it 'raises when tags is empty' do
       expect {
-        described_class.new(tags: [], base_branch: 'master')
+        described_class.new(tags: [], base_branch: 'main')
       }.to raise_error(ArgumentError, 'tags cannot be empty')
     end
 
@@ -27,7 +27,7 @@ RSpec.describe Solidus::PipelineContext do
 
     it 'raises when branch is not the main one and tracks last minor is true' do
       expect {
-        described_class.new(tags: %w[v3.0.0], base_branch: 'v3.1', last_minor: true)
+        described_class.new(tags: %w[v3.0.0], base_branch: 'v3.1', last_minor: true, tracking_major: false)
       }.to raise_error(ArgumentError, 'branch v3.1 cannot track a last minor release')
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe Solidus::PipelineContext do
       it 'returns the highest tag' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0],
-          base_branch: 'master'
+          base_branch: 'main'
         )
 
         expect(context.current_tag).to eq('v3.0.0')
@@ -46,7 +46,7 @@ RSpec.describe Solidus::PipelineContext do
       it 'compares tags as versions' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v3.0.0.alpha v3.0.0],
-          base_branch: 'master'
+          base_branch: 'main'
         )
 
         expect(context.current_tag).to eq('v3.0.0')
@@ -57,7 +57,8 @@ RSpec.describe Solidus::PipelineContext do
       it 'returns the highest tag matching the base branch' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0],
-          base_branch: 'v2.0'
+          base_branch: 'v2.0',
+          tracking_major: false
         )
 
         expect(context.current_tag).to eq('v2.0.2')
@@ -66,7 +67,8 @@ RSpec.describe Solidus::PipelineContext do
       it 'compares tags as versions' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0.alpha v2.0.0 v3.0.0],
-          base_branch: 'v2.0'
+          base_branch: 'v2.0',
+          tracking_major: false
         )
 
         expect(context.current_tag).to eq('v2.0.0')
@@ -79,7 +81,7 @@ RSpec.describe Solidus::PipelineContext do
       it 'returns the current tag adjusted to its first patch version' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0 v3.0.1],
-          base_branch: 'master'
+          base_branch: 'main'
         )
 
         expect(context.current_diff_source_tag).to eq('v3.0.0')
@@ -90,7 +92,8 @@ RSpec.describe Solidus::PipelineContext do
       it 'returns the current tag' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2 v3.0.0 v3.0.1],
-          base_branch: 'v3.0'
+          base_branch: 'v3.0',
+          tracking_major: false
         )
 
         expect(context.current_diff_source_tag).to eq('v3.0.1')
@@ -103,7 +106,8 @@ RSpec.describe Solidus::PipelineContext do
       it 'returns the next patch level tag on the base branch' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-          base_branch: 'v2.0'
+          base_branch: 'v2.0',
+          tracking_major: false
         )
 
         expect(context.candidate_tag).to eq('v2.0.3')
@@ -114,7 +118,7 @@ RSpec.describe Solidus::PipelineContext do
       it "returns the next minor level tag when not tracking a major release" do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-          base_branch: 'master',
+          base_branch: 'main',
           tracking_major: false
         )
 
@@ -124,7 +128,7 @@ RSpec.describe Solidus::PipelineContext do
       it "returns the next major level tag when tracking a major release" do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-          base_branch: 'master',
+          base_branch: 'main',
           tracking_major: true
         )
 
@@ -137,7 +141,8 @@ RSpec.describe Solidus::PipelineContext do
     it 'returns the candidate tag without the patch level' do
       context = described_class.new(
         tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-        base_branch: 'master'
+        base_branch: 'main',
+        tracking_major: false
       )
 
       expect(context.candidate_patch_branch).to eq('v2.1')
@@ -148,7 +153,8 @@ RSpec.describe Solidus::PipelineContext do
     it 'returns the candidate tag without the tag prefix' do
       context = described_class.new(
         tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-        base_branch: 'master'
+        base_branch: 'main',
+        tracking_major: false
       )
 
       expect(context.candidate_version).to eq('2.1.0')
@@ -159,7 +165,8 @@ RSpec.describe Solidus::PipelineContext do
     it 'returns the candidate version without the patch segment' do
       context = described_class.new(
         tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-        base_branch: 'master'
+        base_branch: 'main',
+        tracking_major: false
       )
 
       expect(context.candidate_minor_version).to eq('2.1')
@@ -171,7 +178,8 @@ RSpec.describe Solidus::PipelineContext do
       it 'returns the next patch level version after the candidate' do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-          base_branch: 'v2.0'
+          base_branch: 'v2.0',
+          tracking_major: false
         )
 
         expect(context.next_candidate_tag).to eq('v2.0.4')
@@ -182,7 +190,7 @@ RSpec.describe Solidus::PipelineContext do
       it "returns the next minor level version after the candidate when last_minor is false" do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-          base_branch: 'master',
+          base_branch: 'main',
           tracking_major: false,
           last_minor: false
         )
@@ -193,7 +201,7 @@ RSpec.describe Solidus::PipelineContext do
       it "returns the next major level version after the candidate when last_minor is true" do
         context = described_class.new(
           tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-          base_branch: 'master',
+          base_branch: 'main',
           tracking_major: false,
           last_minor: true
         )
@@ -207,7 +215,7 @@ RSpec.describe Solidus::PipelineContext do
     it "returns the next candidate tag without the tag prefix and with '.dev' appended" do
       context = described_class.new(
         tags: %w[v1.0.0 v1.0.1 v1.1.0 v2.0.0 v2.0.1 v2.0.2],
-        base_branch: 'master',
+        base_branch: 'main',
         tracking_major: false,
         last_minor: false
       )

--- a/dev_tools/spec/lib/solidus/release_drafter_spec.rb
+++ b/dev_tools/spec/lib/solidus/release_drafter_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: ['changelog:solidus_core'])
 
       expect(
-        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'main').content
       ).to match(/#{Regexp.escape("## Solidus Core\n* PR number 1 by @alice in https://github.com/fake/solidus/pull/1")}/)
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
 
       expect(
-        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'main').content
       ).to match(/#{Regexp.escape("## Solidus Core\n* PR number 1 by @alice in https://github.com/fake/solidus/pull/1")}.*#{Regexp.escape("## Solidus API\n* PR number 1 by @alice in https://github.com/fake/solidus/pull/1")}/m)
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[other])
 
       expect(
-        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'main')
       ).to be(nil)
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:skip])
 
       expect(
-        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master')
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'main')
       ).to be(nil)
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
 
       expect(
-        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'main').content
       ).to include("don't edit manually")
     end
 
@@ -90,7 +90,7 @@ RSpec.describe Solidus::ReleaseDrafter do
       client.add_pr(pr_number: 1, labels: %w[changelog:solidus_core changelog:solidus_api])
 
       expect(
-        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'master').content
+        subject.call(pr_number: 1, current_diff_source_tag: 'v3.0.0', candidate_tag: 'v3.1.0', branch: 'main').content
       ).to include("**Full Changelog**: https://github.com/fake/solidus/compare/v3.0.0...v3.1.0")
     end
   end


### PR DESCRIPTION
## Summary

Although it's not required, keeping parity makes them easier to maintain. We're backporting:

- 6c508a0d3a036fedcf970abd4592189cf3f62a36
- dc9b9dff5b406002f8b0d2c10e3fad7ba45331f7
- ecaa92efdf96dfcd32500412ce3685acc1c16103
- a823c04b36eff71ced1064acffcf658002fe3374
- b5acc4a8b0f31901d90b05740df55559238eb847
- c035686bc571998676a8e0657e912ce2dafaf50c


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
