### PR TITLE
Create Payment LogEntry when performing a refund

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -53,7 +53,11 @@ module Spree
       credit_cents = money.cents
 
       @perform_response = process!(credit_cents)
+
       log_entries.build(parsed_payment_response_details_with_fallback: perform_response)
+
+      log_entry = payment.log_entries.build(parsed_payment_response_details_with_fallback: perform_response)
+      log_entry.save
 
       self.transaction_id = perform_response.authorization
       save!

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe Spree::Refund, type: :model do
       expect { subject }.to change(Spree::LogEntry, :count)
     end
 
+    it "creates a LogEntry on the Payment" do
+      expect { subject }.to change { refund.payment.log_entries.count }
+    end
+
     context "when transaction_id exists" do
       let(:transaction_id) { "12kfjas0" }
 


### PR DESCRIPTION
This way, the information can be seeing at the Payment level in the Admin

## Summary

  Fixes [#4866 ](https://github.com/solidusio/solidus/issues/4866)

  A LogEntry for the Payment is created when performing the refund. The old Spree::LogEntry for the refund is preserved.
  You can follow the steps-to-reproduce in the issue to test:

<img width="990" alt="image" src="https://github.com/solidusio/solidus/assets/14350934/c74d7b42-5d06-4580-afb2-c77ec8e6415e">

-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
