### PR TITLE
[v3.4] Revert "Fix selenium-webdriver version to avoid bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :backend do
 
   gem 'capybara', '~> 3.13', require: false
   gem 'capybara-screenshot', '>= 1.0.18', require: false
-  gem 'selenium-webdriver', '4.9.0', require: false
+  gem 'selenium-webdriver', require: false
   gem 'webdrivers', require: false
 
   # JavaScript testing


### PR DESCRIPTION
## Summary

This reverts commit 9224baf44ebbff9daf47490dbb7f4a2a62a46e27.

After the release of capybara 3.39.1 with a fix for the issue for the newest selenium-webdriver release, there's no longer the need to lock the later.

See:

- https://github.com/teamcapybara/capybara/pull/2667
- https://github.com/teamcapybara/capybara/issues/2666
- https://github.com/SeleniumHQ/selenium/issues/12005

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
