### PR TITLE
Update Taxon PaperClip attributes on attachment destroy

### DIFF
--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -26,5 +26,6 @@ module Spree::Taxon::PaperclipAttachment
     return false unless attached_file.exists?
 
     attached_file.destroy
+    save
   end
 end

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -96,7 +96,7 @@ module Solidus
         rake 'active_storage:install'
       else
         say_status :assets, "Paperclip", :green
-        gsub_file 'config/initializers/spree.rb', "ActiveStorageAttachment", "PaperclipAttachment"
+        gsub_file 'config/initializers/spree.rb', "::ActiveStorageAttachment", "::PaperclipAttachment"
       end
     end
 

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -20,15 +20,14 @@ RSpec.describe Spree::Taxon, type: :model do
   describe "#destroy_attachment" do
     context "when trying to destroy a valid attachment definition" do
       context "and taxon has a file attached " do
-        it "removes the attachment" do
-          taxon = create(:taxon, :with_icon)
+        let(:taxon) { create(:taxon, :with_icon)}
 
+        it "removes the attachment" do
           expect(taxon.destroy_attachment(:icon)).to be_truthy
         end
 
         if Spree::Config.taxon_attachment_module == Spree::Taxon::PaperclipAttachment
           it "resets paperclip attributes when using Paperclip", aggregate_failures: true do
-            taxon = create(:taxon, :with_icon)
             expect(taxon.destroy_attachment(:icon)).to be_truthy
             expect(taxon.reload.icon_file_name).to_not be_present
             expect(taxon.reload.icon_content_type).to_not be_present
@@ -39,18 +38,18 @@ RSpec.describe Spree::Taxon, type: :model do
       end
 
       context "and the taxon does not have any file attached yet" do
-        it "returns false" do
-          taxon = create(:taxon)
+        let(:taxon) { create(:taxon)}
 
+        it "returns false" do
           expect(taxon.destroy_attachment(:icon)).to be_falsey
         end
       end
     end
 
     context "when trying to destroy an invalid attachment" do
-      it 'returns false' do
-        taxon = create(:taxon)
+      let(:taxon) { create(:taxon)}
 
+      it 'returns false' do
         expect(taxon.destroy_attachment(:foo)).to be_falsey
       end
     end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe Spree::Taxon, type: :model do
 
           expect(taxon.destroy_attachment(:icon)).to be_truthy
         end
+
+        if Spree::Config.taxon_attachment_module == Spree::Taxon::PaperclipAttachment
+          it "resets paperclip attributes when using Paperclip", aggregate_failures: true do
+            taxon = create(:taxon, :with_icon)
+            expect(taxon.destroy_attachment(:icon)).to be_truthy
+            expect(taxon.reload.icon_file_name).to_not be_present
+            expect(taxon.reload.icon_content_type).to_not be_present
+            expect(taxon.reload.icon_file_size).to_not be_present
+            expect(taxon.reload.icon_updated_at).to_not be_present
+          end
+        end
       end
 
       context "and the taxon does not have any file attached yet" do


### PR DESCRIPTION
## Summary
When using Paperclip, calling destroy on the attachment removes it from
from the storage location, such as S3, and leaves dirty changes on the
Paperclip attributes, such as icon_file_name.

If a store used `.present?` on the icon, it would return continue to
return `true`, as it looks at the file_name attribute [1], yet the
icon no longer exists on storage (`.exists? => false`).

A view such as the backend Taxon edit view, could therefore attempt to
show the icon, but it would fail and show a broken icon image.

Note:
- an assertion was not added for `.present?` as ActiveStorage's API
  works a little differently;
- stores using Paperclip may have Taxons with Paperclip attributes
  present, yet the image on storage no longer exists. For these Taxons, a broken image and the remove button will appear in the backend. Frontend could be affected as well.

[1] https://github.com/kreeti/kt-paperclip/blob/91923a6ee1bd692696b51ea839f2f2578cb485b4/lib/paperclip/attachment.rb#L357-L361

### Screenshots
| Description | Screenshot |
|--|--|
| Attached icon before deletion | <img width="1728" alt="Screenshot 2023-05-24 at 08 36 19" src="https://github.com/solidusio/solidus/assets/76776099/1b63fa96-0d3f-41be-8daa-20a6e4017c88">|
| Attached icon after deletion but before fix | <img width="1728" alt="Screenshot 2023-05-24 at 08 37 55" src="https://github.com/solidusio/solidus/assets/76776099/a3ef2b29-6b49-4eb1-8d49-2f7cb3e559c9"> |
| Attempting to remove a broken Taxon's icon which does not exist | <img width="1728" alt="Screenshot 2023-05-24 at 09 58 46" src="https://github.com/solidusio/solidus/assets/76776099/bc5b6c19-87a5-4cf9-9791-f8c9da1c985a"> |
| Attached icon after deletion and after fix | <img width="1728" alt="Screenshot 2023-05-24 at 09 59 14" src="https://github.com/solidusio/solidus/assets/76776099/8a053b0d-fcd7-47ac-9448-3f8b5a080b2a"> |

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
