### PR TITLE
Don't gsub attachment comment during install generator

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -96,7 +96,7 @@ module Solidus
         rake 'active_storage:install'
       else
         say_status :assets, "Paperclip", :green
-        gsub_file 'config/initializers/spree.rb', "ActiveStorageAttachment", "PaperclipAttachment"
+        gsub_file 'config/initializers/spree.rb', "::ActiveStorageAttachment", "::PaperclipAttachment"
       end
     end
 


### PR DESCRIPTION
## Summary

Passing `--no-active-storage` to the install generator changes the Solidus configuration to use Paperclip instead of ActiveStorage, by using a gsub. However, this also changed the comment in the spree initializer[1] which lead to a confusing comment:
`(use PaperclipAttachment or PaperclipAttachment)`

[1] https://github.com/solidusio/solidus/blob/a8f56d585dd50f802827df53630e4a08e10bcfe2/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt#L20

The install generator option `--no-active-storage \` still works and does not affect the comment:
<img width="1728" alt="Screenshot 2023-05-24 at 13 30 35" src="https://github.com/solidusio/solidus/assets/76776099/c3388ac6-0f22-45f8-bb27-b61aab4aaffc">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
