### PR TITLE
Add support for admin themes

### DIFF
--- a/backend/app/assets/config/solidus_backend_manifest.js
+++ b/backend/app/assets/config/solidus_backend_manifest.js
@@ -4,3 +4,5 @@
 //= link spree/backend/all.css
 
 //= link solidus_admin/select2_locales
+
+//= link_directory ../stylesheets/spree/backend/themes .css

--- a/backend/app/assets/stylesheets/spree/backend.css
+++ b/backend/app/assets/stylesheets/spree/backend.css
@@ -1,7 +1,6 @@
 /*
- * This is a manifest file that'll automatically include all the stylesheets available in this directory
- * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
- * the top of the compiled file, but it's generally better to create a new file per style scope.
-
- *= require spree/backend/spree_admin
-*/
+ * This is a manifest file that is here only for legacy support purposes, please refer to themes direcly via 
+ * appropriate `Spree::Config` settings.
+ *
+ *= require spree/backend/themes/classic
+ */

--- a/backend/app/assets/stylesheets/spree/backend.css
+++ b/backend/app/assets/stylesheets/spree/backend.css
@@ -3,9 +3,5 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
 
- *= require solidus_admin/select2
- *= require solidus_admin/flatpickr/flatpickr
- *= require prism
-
  *= require spree/backend/spree_admin
 */

--- a/backend/app/assets/stylesheets/spree/backend/components/index.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/index.scss
@@ -1,0 +1,15 @@
+@import 'spree/backend/components/actions';
+@import 'spree/backend/components/breadcrumb';
+@import 'spree/backend/components/buttons';
+@import 'spree/backend/components/number_with_currency';
+@import 'spree/backend/components/hint';
+@import 'spree/backend/components/image_placeholder';
+@import 'spree/backend/components/list_group';
+@import 'spree/backend/components/messages';
+@import 'spree/backend/components/progress';
+@import 'spree/backend/components/table-filter';
+@import 'spree/backend/components/navigation';
+@import 'spree/backend/components/sidebar';
+@import 'spree/backend/components/editable_table';
+@import 'spree/backend/components/pills';
+@import 'spree/backend/components/tabs';

--- a/backend/app/assets/stylesheets/spree/backend/globals/index.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/index.scss
@@ -1,0 +1,5 @@
+@import 'spree/backend/globals/functions';
+@import 'spree/backend/globals/deprecation';
+@import 'spree/backend/globals/variables_override';
+@import 'spree/backend/globals/variables';
+@import 'spree/backend/globals/deprecated_variables';

--- a/backend/app/assets/stylesheets/spree/backend/plugins/index.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/index.scss
@@ -1,0 +1,3 @@
+@import 'spree/backend/plugins/select2';
+@import 'spree/backend/plugins/bootstrap_tooltip';
+@import 'spree/backend/plugins/sortable';

--- a/backend/app/assets/stylesheets/spree/backend/sections/index.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/index.scss
@@ -1,0 +1,14 @@
+@import 'spree/backend/sections/adjustments';
+@import 'spree/backend/sections/orders';
+@import 'spree/backend/sections/products';
+@import 'spree/backend/sections/variants';
+@import 'spree/backend/sections/promotions';
+@import 'spree/backend/sections/bulk_transfer';
+@import 'spree/backend/sections/return_authorizations';
+@import 'spree/backend/sections/log_entries';
+@import 'spree/backend/sections/taxonomies';
+@import 'spree/backend/sections/taxons';
+@import 'spree/backend/sections/users';
+@import 'spree/backend/sections/store_credits';
+@import 'spree/backend/sections/stock_management';
+@import 'spree/backend/sections/style_guide';

--- a/backend/app/assets/stylesheets/spree/backend/shared/index.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/index.scss
@@ -1,0 +1,9 @@
+@import 'spree/backend/shared/fonts';
+@import 'spree/backend/shared/typography';
+@import 'spree/backend/shared/images';
+@import 'spree/backend/shared/tables';
+@import 'spree/backend/shared/icons';
+@import 'spree/backend/shared/forms';
+@import 'spree/backend/shared/layout';
+@import 'spree/backend/shared/header';
+@import 'spree/backend/shared/utilities';

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -1,56 +1,6 @@
-@import 'spree/backend/globals/functions';
-@import 'spree/backend/globals/deprecation';
-@import 'spree/backend/globals/variables_override';
-@import 'spree/backend/globals/variables';
-@import 'spree/backend/globals/deprecated_variables';
-
-@import 'bootstrap_custom';
-@import 'solidus_admin/bootstrap/bootstrap';
-
-@import 'spree/backend/globals/mixins';
-
-@import 'spree/backend/shared/fonts';
-@import 'spree/backend/shared/typography';
-@import 'spree/backend/shared/images';
-@import 'spree/backend/shared/tables';
-@import 'spree/backend/shared/icons';
-@import 'spree/backend/shared/forms';
-@import 'spree/backend/shared/layout';
-@import 'spree/backend/shared/header';
-@import 'spree/backend/shared/utilities';
-
-@import 'spree/backend/components/actions';
-@import 'spree/backend/components/breadcrumb';
-@import 'spree/backend/components/buttons';
-@import 'spree/backend/components/number_with_currency';
-@import 'spree/backend/components/hint';
-@import 'spree/backend/components/image_placeholder';
-@import 'spree/backend/components/list_group';
-@import 'spree/backend/components/messages';
-@import 'spree/backend/components/progress';
-@import 'spree/backend/components/table-filter';
-@import 'spree/backend/components/navigation';
-@import 'spree/backend/components/sidebar';
-@import 'spree/backend/components/editable_table';
-@import 'spree/backend/components/pills';
-@import 'spree/backend/components/tabs';
-
-@import 'font-awesome';
-@import 'spree/backend/plugins/select2';
-@import 'spree/backend/plugins/bootstrap_tooltip';
-@import 'spree/backend/plugins/sortable';
-
-@import 'spree/backend/sections/adjustments';
-@import 'spree/backend/sections/orders';
-@import 'spree/backend/sections/products';
-@import 'spree/backend/sections/variants';
-@import 'spree/backend/sections/promotions';
-@import 'spree/backend/sections/bulk_transfer';
-@import 'spree/backend/sections/return_authorizations';
-@import 'spree/backend/sections/log_entries';
-@import 'spree/backend/sections/taxonomies';
-@import 'spree/backend/sections/taxons';
-@import 'spree/backend/sections/users';
-@import 'spree/backend/sections/store_credits';
-@import 'spree/backend/sections/stock_management';
-@import 'spree/backend/sections/style_guide';
+@import 'spree/backend/globals';
+@import 'spree/backend/vendor';
+@import 'spree/backend/shared';
+@import 'spree/backend/components';
+@import 'spree/backend/plugins';
+@import 'spree/backend/sections';

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -1,6 +1,5 @@
-@import 'spree/backend/globals';
-@import 'spree/backend/vendor';
-@import 'spree/backend/shared';
-@import 'spree/backend/components';
-@import 'spree/backend/plugins';
-@import 'spree/backend/sections';
+@import 'spree/backend/themes/classic';
+
+@warn "[Solidus] [Deprecation] " +
+  "importing or requiring `spree/backend/spree_admin` is deprecated and will be removed in the next major. " +
+  "Please use `spree/backend/themes/classic` instead.";

--- a/backend/app/assets/stylesheets/spree/backend/themes/classic.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/classic.css.scss
@@ -1,0 +1,6 @@
+@import 'spree/backend/globals';
+@import 'spree/backend/vendor';
+@import 'spree/backend/shared';
+@import 'spree/backend/components';
+@import 'spree/backend/plugins';
+@import 'spree/backend/sections';

--- a/backend/app/assets/stylesheets/spree/backend/vendor/index.scss
+++ b/backend/app/assets/stylesheets/spree/backend/vendor/index.scss
@@ -1,0 +1,11 @@
+@import "solidus_admin/select2";
+@import "solidus_admin/flatpickr/flatpickr";
+@import "prism";
+
+@import 'spree/backend/bootstrap_custom';
+@import 'solidus_admin/bootstrap/bootstrap';
+@import 'font-awesome';
+
+// These mixins will modify existing Bootstrap ones and need to be imported
+// after the Bootstrap has been processed.
+@import 'spree/backend/globals/mixins';

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -6,7 +6,7 @@
 <title><%= admin_page_title %></title>
 
 <%= favicon_link_tag 'favicon.ico' %>
-<%= stylesheet_link_tag 'spree/backend/all', media: 'all', data: {turbolinks_track: 'reload'} %>
+<%= stylesheet_link_tag Spree::Backend::Config.theme_path, media: 'all', data: {turbolinks_track: 'reload'} %>
 <%= javascript_include_tag 'spree/backend/all', data: {turbolinks_track: 'reload'} %>
 
 <%- if Rails.env.test? %>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -6,6 +6,20 @@ module Spree
   class BackendConfiguration < Preferences::Configuration
     preference :locale, :string, default: I18n.default_locale
 
+    # @!attribute [rw] themes
+    #   @return [Hash] A hash containing the themes that are available for the admin panel
+    preference :themes, :hash, default: {
+      classic: 'spree/backend/all',
+    }
+
+    # @!attribute [rw] theme
+    #   @return [String] Default admin theme name
+    versioned_preference :theme, :string, initial_value: 'classic', boundaries: { "4.1.0.a" => "classic" }
+
+    def theme_path(user_theme = nil)
+      user_theme ? themes.fetch(user_theme.to_sym) : themes.fetch(theme.to_sym)
+    end
+
     preference :frontend_product_path,
       :proc,
       default: proc {

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -79,4 +79,41 @@ RSpec.describe Spree::BackendConfiguration do
       end
     end
   end
+
+  describe '#theme_path' do
+    it 'returns the default theme path' do
+      subject.themes = { foo: 'foo-theme-path' }
+      subject.theme = :foo
+
+      expect(subject.theme_path).to eq('foo-theme-path')
+    end
+
+    it 'returns the default theme path when the theme is a string' do
+      subject.themes = { foo: 'foo-theme-path' }
+      subject.theme = 'foo'
+
+      expect(subject.theme_path).to eq('foo-theme-path')
+    end
+
+    it 'returns the fallback theme path when the default theme is missing' do
+      subject.themes = { foo: 'foo-theme-path', classic: 'classic-theme-path' }
+      subject.theme = :bar
+
+      expect{ subject.theme_path }.to raise_error(KeyError)
+    end
+
+    it 'gives priority to the user defined theme' do
+      subject.themes = { foo: 'foo-theme-path', user: 'user-theme-path' }
+      subject.theme = :foo
+
+      expect(subject.theme_path(:user)).to eq('user-theme-path')
+    end
+
+    it 'raises an error if the user theme is missing' do
+      subject.themes = { foo: 'foo-theme-path', classic: 'classic-theme-path' }
+      subject.theme = :foo
+
+      expect{ subject.theme_path(:bar) }.to raise_error(KeyError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

We're going to refresh the UX/UI for the admin in the next future and we want to match it in the current admin so that switching between the two versions won't be too confusing.

The preference is split between light and dark because most likely the new UI will have dark mode support, and also to allow stores that desire it to easily add their own dark theme.

Selecting different themes as an individual preference for each user (or session) has been considered out of scope for this PR but it's something that will eventually be added.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
