### PR TITLE
Add rake task to retrieve a list of available factories

### DIFF
--- a/core/lib/tasks/factories.rake
+++ b/core/lib/tasks/factories.rake
@@ -1,0 +1,27 @@
+namespace :factories do
+  desc "List all factories"
+  task list: :environment do
+    # TODO: search in all the common factories.rb paths in the various solidus gems
+    # Tested with solidus + solidus_stripe
+    Gem.loaded_specs.values.each do |spec|
+      factory_file = File.join(spec.full_gem_path, "lib/#{spec.name}/testing_support/factories.rb")
+      require factory_file if File.file?(factory_file)
+    end
+
+    factories = FactoryBot.factories.sort_by { |f| f.build_class.to_s }
+
+    # Find the length of the longest factory name and class name
+    longest_name_length = factories.map { |f| f.name.length }.max
+    longest_class_length = factories.map { |f| f.build_class.to_s.length }.max
+
+    puts "Factory Name".ljust(longest_name_length) + " | " + "Class Name".ljust(longest_class_length)
+    puts "-" * longest_name_length + " | " + "-" * longest_class_length
+
+    factories.each do |factory|
+      factory_name = factory.name.to_s.ljust(longest_name_length)
+      factory_class = factory.build_class.to_s.ljust(longest_class_length)
+
+      puts "#{factory_name} | #{factory_class}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

⚠️ WIP ⚠️

This is a first test to simplify the identification of the factories available in your Solidus environment during the implementation of the specs.

The idea is to use a rake task to print a list of all the available factories in Solidus and all the Solidus extensions included in your project.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
