### PR TITLE
Ensure to return false on Paperclip attachment destroy failure

### DIFF
--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -25,7 +25,6 @@ module Spree::Taxon::PaperclipAttachment
     attached_file = send(definition)
     return false unless attached_file.exists?
 
-    attached_file.destroy
-    save
+    attached_file.destroy && save
   end
 end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Spree::Taxon, type: :model do
         end
 
         if Spree::Config.taxon_attachment_module == Spree::Taxon::PaperclipAttachment
+          it "returns false if destroying the attachment fails" do
+            allow(taxon.icon).to receive(:destroy).and_return(false)
+            expect(taxon.destroy_attachment(:icon)).to be_falsey
+          end
+
           it "resets paperclip attributes when using Paperclip", aggregate_failures: true do
             expect(taxon.destroy_attachment(:icon)).to be_truthy
             expect(taxon.reload.icon_file_name).to_not be_present


### PR DESCRIPTION
## Summary
I recently changed the `destroy_attachment` method, to save the Spree::Taxon instance afterwards.  However, this caused it to always return `true`, regardless of if the attachment was actually destroyed. Causing potential incorrect feedback to the user.

---

If the attachment does exist, destroying the attachment will be attempted. However, destroying is not guaranteed by Paperclip. In case of failure, it will return `false` [1][2]. It should therefore return `false` in this case, so callees know it failed. Before, due to the `save` call afterwards, it was always returning `true`.

[1] https://github.com/kreeti/kt-paperclip/blob/v7.1.1/lib/paperclip/attachment.rb#L263
[2] https://github.com/kreeti/kt-paperclip/blob/v7.1.1/lib/paperclip/attachment.rb#L234-L235

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
