### PR TITLE
[v4.0] Fix development version

### DIFF
--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Spree
-  VERSION = "4.0.0"
+  VERSION = "4.0.1.dev"
 
   def self.solidus_version
     VERSION


### PR DESCRIPTION
## Summary

Currently, the update draft release task is [failing on v4](https://github.com/solidusio/solidus/actions/runs/5086912864) because it [looks like](https://github.com/solidusio/solidus/blob/474877aaad9139a0a9b8564a9e7279e5446bc12c/dev_tools/lib/solidus/pipeline_context.rb#L34) a patch branch (`v4`) is tracking a next major release (`v4.0.0`).

The underlying issue is that we don't bump to the development version when we [create a new patch branch](https://github.com/solidusio/solidus/blob/474877aaad9139a0a9b8564a9e7279e5446bc12c/.github/workflows/prepare_post_release.yml#L62). To fix that for next releases, we need to create another PR on the newly created patch branch.

The issue doesn't affect when bumping to the next release, as the candidate version is taken from the list of [git tags](https://github.com/solidusio/solidus/blob/474877aaad9139a0a9b8564a9e7279e5446bc12c/.github/actions/extract_pipeline_context/action.yml#L40), and not from the version file.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
