### PR TITLE
Allow changing the order recalculator

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -258,12 +258,14 @@ module Spree
       end || store&.default_cart_tax_location
     end
 
-    def updater
-      @updater ||= Spree::OrderUpdater.new(self)
+    def recalculator
+      @recalculator ||= Spree::Config.order_recalculator_class.new(self)
     end
+    alias_method :updater, :recalculator
+    deprecate updater: :recalculator, deprecator: Spree::Deprecation
 
     def recalculate
-      updater.update
+      recalculator.recalculate
     end
 
     def assign_billing_to_shipping_address
@@ -397,7 +399,7 @@ module Spree
 
     def fulfill!
       shipments.each { |shipment| shipment.update_state if shipment.persisted? }
-      updater.update_shipment_state
+      recalculator.update_shipment_state
       save!
     end
 
@@ -744,13 +746,13 @@ module Spree
       all_adjustments.each(&:finalize!)
 
       # update payment and shipment(s) states, and save
-      updater.update_payment_state
+      recalculator.update_payment_state
       shipments.each do |shipment|
         shipment.update_state
         shipment.finalize!
       end
 
-      updater.update_shipment_state
+      recalculator.update_shipment_state
       save!
 
       touch :completed_at

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -13,8 +13,6 @@ module Spree
     #   @return [Spree::Order] The order which items wll be merged into.
     attr_accessor :order
 
-    delegate :updater, to: :order
-
     # Create the OrderMerger
     #
     # @api public
@@ -133,13 +131,13 @@ module Spree
 
     # Save the order totals after merge
     #
-    # It triggers the order updater to ensure that item counts and totals are
+    # It triggers the order recalculator to ensure that item counts and totals are
     # up to date.
     #
     # @api private
     # @return [void]
     def persist_merge
-      updater.update
+      order.recalculate
     end
   end
 end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -16,7 +16,7 @@ module Spree
     # This method should never do anything to the Order that results in a save call on the
     # object with callbacks (otherwise you will end up in an infinite recursion as the
     # associations try to save and then in turn try to call +update!+ again.)
-    def update
+    def recalculate
       order.transaction do
         update_item_count
         update_shipment_amounts
@@ -30,6 +30,8 @@ module Spree
         persist_totals
       end
     end
+    alias_method :update, :recalculate
+    deprecate update: :recalculate, deprecator: Spree::Deprecation
 
     # Updates the +shipment_state+ attribute according to the following logic:
     #

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -90,7 +90,7 @@ module Spree
     end
 
     def update_order
-      payment.order.updater.update
+      payment.order.recalculate
     end
   end
 end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -357,6 +357,14 @@ module Spree
     #   with the same signature as Spree::OrderUpdateAttributes.
     class_name_attribute :order_update_attributes_class, default: 'Spree::OrderUpdateAttributes'
 
+    # Allows providing a different order recalculator.
+    # @!attribute [rw] order_recalculator_class
+    # @see Spree::OrderUpdater
+    # @return [Class] an object that conforms to the API of
+    #   the standard order recalculator class
+    #   Spree::OrderUpdater.
+    class_name_attribute :order_recalculator_class, default: 'Spree::OrderUpdater'
+
     # Allows providing your own Mailer for promotion code batch mailer.
     #
     # @!attribute [rw] promotion_code_batch_mailer_class

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -40,7 +40,7 @@ module Spree
             end
 
             # Really ensure that the order totals & states are correct
-            order.updater.update
+            order.recalculate
             if shipments_attrs.present?
               order.shipments.each_with_index do |shipment, index|
                 shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe Spree::Order, type: :model do
           si.update(backorderable: false)
         end
 
-        Spree::OrderUpdater.new(order).update
+        Spree::OrderUpdater.new(order).recalculate
         order.save!
       end
 
@@ -494,7 +494,7 @@ RSpec.describe Spree::Order, type: :model do
         allow(order).to receive(:ensure_available_shipping_rates) { true }
         order.line_items << FactoryBot.create(:line_item)
 
-        Spree::OrderUpdater.new(order).update
+        Spree::OrderUpdater.new(order).recalculate
         order.save!
       end
 
@@ -533,7 +533,7 @@ RSpec.describe Spree::Order, type: :model do
           order.line_items << FactoryBot.create(:line_item)
           order.store = FactoryBot.create(:store)
 
-          Spree::OrderUpdater.new(order).update
+          Spree::OrderUpdater.new(order).recalculate
 
           order.save!
         end
@@ -558,7 +558,7 @@ RSpec.describe Spree::Order, type: :model do
         allow(order).to receive_messages(validate_line_item_availability: true)
         order.line_items << FactoryBot.create(:line_item)
         order.create_proposed_shipments
-        Spree::OrderUpdater.new(order).update
+        Spree::OrderUpdater.new(order).recalculate
 
         order.save!
       end
@@ -591,7 +591,7 @@ RSpec.describe Spree::Order, type: :model do
         allow(order).to receive_messages(validate_line_item_availability: true)
         order.line_items << FactoryBot.create(:line_item)
         order.create_proposed_shipments
-        Spree::OrderUpdater.new(order).update
+        Spree::OrderUpdater.new(order).recalculate
       end
 
       it "transitions to the payment state" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -707,7 +707,7 @@ RSpec.describe Spree::Order, type: :model do
         receive(:activate)
       ).and_call_original
 
-      expect(order.updater).to receive(:update).and_call_original
+      expect(order.recalculator).to receive(:recalculate).and_call_original
 
       order.apply_shipping_promotions
     end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -744,8 +744,8 @@ RSpec.describe Spree::Payment, type: :model do
       before { allow(order).to receive_messages completed?: true }
 
       it "updates payment_state and shipments" do
-        expect(order.updater).to receive(:update_payment_state)
-        expect(order.updater).to receive(:update_shipment_state)
+        expect(order.recalculator).to receive(:update_payment_state)
+        expect(order.recalculator).to receive(:update_shipment_state)
         Spree::Payment.create!(amount: 100, order: order, payment_method: payment_method)
       end
     end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Spree::Refund, type: :model do
         end
 
         it 'should update the payment total' do
-          expect(payment.order.updater).to receive(:update)
+          expect(payment.order).to receive(:recalculate)
           subject
         end
       end


### PR DESCRIPTION

## Summary

 This adds a preference to change the order updater. The order updater, a very central piece of Solidus' infrastructure, carries a bit of technical debt. Unfortunately, it's extremely hard to change because every line of this class might have been overwritten by implementors.

This configuration allows switching the order updater class, with the intention of being able to introduce breaking changes from a gem without patching the original order recalculator.

Additionally, the `order.recalculate` and `order.recalculator` are introduced as aliases to the now deprecated `order.update` and `order.updater` in order to clarify the intention of these methods.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 ~I have updated the README to account for my changes.~
- 📑 ~I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~
- 🛣️ ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ✅ ~I have added automated tests to cover my changes.~
- 📸 ~I have attached screenshots to demo visual changes.~
