### PR TITLE
[Admin] Add an alternative navigation sidebar

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -1,3 +1,5 @@
+@import "./navigation_solidus_admin";
+
 $padding-x-navbar: 26px;
 $padding-y-navbar: 13px;
 $padding-y-navbar-submenu: 9px;

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -1,0 +1,146 @@
+$color-navbar-hover-bg: $color-navbar-bg !default;
+$color-navbar-hover: $color-navbar !default;
+
+.solidus-admin--nav {
+  background-color: $color-white;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: $zindex-sticky;
+  width: $width-sidebar;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
+
+  @media print {
+    display: none
+  }
+
+  &--section {
+    text-align: center;
+    width: 100%;
+    flex-grow: 0;
+    flex-shrink: 0;
+
+    &:not(:last-child) {
+      margin-bottom: 16px;
+    }
+  }
+
+  >nav {
+    flex-grow: 1;
+  }
+
+  &--logo {
+    height: $main-header-height - (16px * 2);
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    text-align: left;
+    margin-bottom: 16px;
+    padding: 12px 8px;
+
+    img {
+      max-height: $main-header-height - (16px * 2) - (12px * 2);
+      max-width: calc(100% - (8px * 2));
+      object-fit: contain;
+    }
+  }
+
+  &--store-link {
+    display: block;
+    width: 100%;
+    border: $border-color 1px solid;
+    border-radius: $border-radius;
+    padding: 6px (8px - 1px);
+    text-align: left;
+
+    &:hover {
+      background: $color-navbar-hover-bg;
+      color: $color-navbar-hover;
+    }
+
+    i {
+      float: right;
+      padding: 6px 8px;
+      color: $color-dark-light;
+    }
+
+    &--name {
+      font-size: 14px;
+      font-weight: bold;
+      color: $color-dark;
+      display: block;
+    }
+
+    &--url {
+      font-size: 12px;
+      color: $color-dark-light;
+      display: block;
+    }
+  }
+
+  &--menu {
+    padding: 0;
+    list-style: none;
+    text-align: left;
+
+    li {
+      padding: 1px 0;
+    }
+
+    li>a,
+    li>label {
+      margin: 0;
+      display: block;
+      font-size: 14px;
+      line-height: 16.8px;
+      font-weight: 600;
+      padding: 8px 12px;
+      width: 100%;
+      border-radius: $border-radius;
+      color: $color-primary;
+
+      &::before {
+        margin-right: 12px;
+        display: inline-block;
+        width: 16px;
+        padding: 0;
+      }
+
+      display: flex;
+      align-items: baseline;
+    }
+
+    li.selected>a {
+      background: $color-navbar-active-bg;
+      color: $color-navbar-active;
+    }
+
+    li:not(.selected):hover>a,
+    li:not(.selected):hover>label {
+      background: $color-navbar-hover-bg;
+      color: $color-navbar-hover;
+    }
+
+    ul {
+      padding: 0;
+      padding-left: 12px + 16px;
+      margin: 0;
+      list-style: none;
+
+      li a {
+        padding-left: 12px;
+        font-weight: 400;
+        color: $color-dark-dark;
+      }
+    }
+
+    li:not(.selected)>ul {
+      display: none;
+    }
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -4,7 +4,7 @@ html {
 
 body {
   position: relative;
-  min-height: 100%;
+  min-height: 100vh;
   padding-left: $width-sidebar;
 }
 

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -1,0 +1,82 @@
+<% default_store = Spree::Store.default %>
+
+<aside class="solidus-admin--nav">
+  <header class="solidus-admin--nav--section">
+    <%= link_to spree.admin_path, class: 'solidus-admin--nav--logo' do %>
+      <%= image_tag(Spree::Config[:admin_interface_logo]) %>
+    <%- end %>
+
+    <%= link_to "//#{default_store.url}", target: '_blank', class: 'solidus-admin--nav--store-link' do %>
+      <i class='fa fa-external-link' title="<%= t("spree.back_to_store") %>"></i>
+      <span class="solidus-admin--nav--store-link--name"><%= default_store.name %></span>
+      <span class="solidus-admin--nav--store-link--url"><%= default_store.url %></span>
+    <% end %>
+  </header>
+
+  <nav class="solidus-admin--nav--section">
+    <ul class="solidus-admin--nav--menu">
+      <% Spree::Backend::Config.menu_items.sort_by { |item| item.position || Float::INFINITY }.each do |menu_item| %>
+        <% if instance_exec(&menu_item.condition) %>
+          <%= tab(
+            *menu_item.sections,
+            icon: menu_item.icon,
+            label: menu_item.label,
+            url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url,
+            match_path: menu_item.match_path,
+          ) do %>
+            <%- render partial: menu_item.partial if menu_item.partial %>
+          <%- end %>
+        <% end %>
+      <% end %>
+    </ul>
+  </nav>
+
+  <footer class="solidus-admin--nav--section">
+    <ul class="solidus-admin--nav--menu">
+      <% available_locales = Spree.i18n_available_locales %>
+      <% if available_locales.any? %>
+        <li class="tab-with-icon">
+          <label class="fa fa-globe">
+            <select class="js-locale-selection custom-select fullwidth">
+              <%= options_for_select(
+                available_locales
+                  .map do |locale|
+                    [
+                      t(
+                        "spree.i18n.this_file_language",
+                        locale: locale,
+                        default: locale.to_s,
+                        fallback: false
+                      ),
+                      locale
+                    ]
+                  end
+                  .sort,
+                selected: I18n.locale
+              ) %>
+            </select>
+          </label>
+        </li>
+      <% end %>
+
+      <% if spree_current_user %>
+        <li class="tab-with-icon" data-hook="user-account-link">
+          <%= link_to_if(
+            can?(:admin, spree_current_user),
+            spree_current_user&.email || "Test user",
+            spree.edit_admin_user_path(spree_current_user),
+            class: "fa fa-user"
+          ) %>
+        </li>
+
+        <% if spree.respond_to? :admin_logout_path %>
+          <li class="tab-with-icon" data-hook="user-logout-link">
+            <%= link_to spree.admin_logout_path, method: Devise.sign_out_via, class: "fa fa-sign-out" do %>
+              <%= t("spree.logout") %>
+            <% end %>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </footer>
+</aside>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -3,8 +3,12 @@
   <head data-hook="admin_inside_head">
     <%= render 'spree/admin/shared/head' %>
   </head>
-  <body class="admin <%= "admin-nav-hidden" if cookies[:admin_nav_hidden] == "true" %>">
-    <%= render "spree/admin/shared/navigation" %>
+  <body class="admin <%= "admin-nav-hidden" if !Spree::Backend::Config.admin_updated_navbar && cookies[:admin_nav_hidden] == "true" %>">
+    <% if Spree::Backend::Config.admin_updated_navbar  %>
+      <%= render partial: 'spree/admin/shared/navigation_solidus_admin' %>
+    <% else %>
+      <%= render "spree/admin/shared/navigation" %>
+    <% end %>
     <%= render "spree/admin/shared/header" %>
     <%= render "spree/admin/shared/flash" %>
     <%= render "spree/admin/shared/spinner" %>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -22,6 +22,12 @@ module Spree
       user_theme ? themes.fetch(user_theme.to_sym) : themes.fetch(theme.to_sym)
     end
 
+    # @!attribute [rw] admin_updated_navbar
+    #   @return [Boolean] Should the updated navbar be used in admin (default: +false+)
+    #
+    # TODO: Update boundaries before merging to `main`
+    versioned_preference :admin_updated_navbar, :boolean, initial_value: false, boundaries: { "4.1.0.a" => true }
+
     preference :frontend_product_path,
       :proc,
       default: proc {
@@ -76,13 +82,13 @@ module Spree
       @menu_items ||= [
         MenuItem.new(
           ORDER_TABS,
-          'shopping-cart',
+          admin_updated_navbar ? 'inbox' : 'shopping-cart',
           condition: -> { can?(:admin, Spree::Order) },
           position: 0
         ),
         MenuItem.new(
           PRODUCT_TABS,
-          'th-large',
+          admin_updated_navbar ? 'tag' : 'th-large',
           condition: -> { can?(:admin, Spree::Product) },
           partial: 'spree/admin/shared/product_sub_menu',
           position: 1
@@ -97,7 +103,7 @@ module Spree
         ),
         MenuItem.new(
           STOCK_TABS,
-          'cubes',
+          admin_updated_navbar ? 'tasks' : 'cubes',
           condition: -> { can?(:admin, Spree::StockItem) },
           label: :stock,
           url: :admin_stock_items_path,
@@ -106,14 +112,14 @@ module Spree
         ),
         MenuItem.new(
           USER_TABS,
-          'user',
+          admin_updated_navbar ? 'user-o' : 'user',
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
           url: :admin_users_path,
           position: 4
         ),
         MenuItem.new(
           CONFIGURATION_TABS,
-          'wrench',
+          admin_updated_navbar ? 'cog' : 'wrench',
           condition: -> {
             can?(:admin, Spree::Store) ||
             can?(:admin, Spree::AdjustmentReason) ||

--- a/backend/spec/features/admin/configuration/store_spec.rb
+++ b/backend/spec/features/admin/configuration/store_spec.rb
@@ -14,10 +14,7 @@ describe "Store", type: :feature, js: true do
 
   before(:each) do
     visit spree.admin_path
-    click_link "Settings"
-    within('.admin-nav') do
-      click_link "Stores"
-    end
+    click_nav "Settings", "Stores"
   end
 
   context "visiting general store settings" do

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -12,7 +12,7 @@ describe "Homepage", type: :feature do
       end
 
       it "should have a link to overview" do
-        within(".admin-nav-header") { expect(page).to have_link(nil, href: "/admin") }
+        within_nav { expect(page).to have_link(nil, href: "/admin") }
       end
 
       it "should have a link to orders" do

--- a/backend/spec/support/feature/base_feature_helper.rb
+++ b/backend/spec/support/feature/base_feature_helper.rb
@@ -1,14 +1,34 @@
 # frozen_string_literal: true
 
 module BaseFeatureHelper
+  def within_nav(&block)
+    if Spree::Backend::Config.admin_updated_navbar
+      within(".solidus-admin--nav", &block)
+    else
+      within(".admin-nav", &block)
+    end
+  end
+
   def click_nav(nav_text, subnav_text = nil)
-    primary_nav = find(".admin-nav-menu>ul>li>a", text: /#{nav_text}/i)
+    if Spree::Backend::Config.admin_updated_navbar
+      primary_nav = find("ul.solidus-admin--nav--menu>li>a", text: /#{nav_text}/i)
+    else
+      primary_nav = find(".admin-nav-menu>ul>li>a", text: /#{nav_text}/i)
+    end
+
     if subnav_text
-      unless Capybara.current_driver == :rack_test
-        # we need to make the navigation visible with Selenium driver,
-        # and RackTest implementation of `hover`raises NotImplementedError
-        primary_nav.hover
+      if Capybara.current_driver == :rack_test
+        # RackTest implementation of `hover`raises NotImplementedError
+        # noop
+      else
+        # Make the navigation visible with Selenium driver,
+        if Spree::Backend::Config.admin_updated_navbar # rubocop:disable Style/IfInsideElse
+          primary_nav.click
+        else
+          primary_nav.hover
+        end
       end
+
       primary_nav.sibling("ul").find("li > a", text: /#{subnav_text}/i).click
     else
       primary_nav.click


### PR DESCRIPTION
## Summary

- Related to #5106 

Since we're going to have a new sidebar for solidus_admin we should match it (as much as possible) in the legacy admin so that switching between the two is smooth on the eyes and not confusing.

<img width="1259" alt="image" src="https://github.com/solidusio/solidus/assets/1051/2cf93071-8fae-4e89-b3b4-901a905563e4">


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
