### PR TITLE
Move install generator spec in the proper directory

### DIFF
--- a/core/spec/lib/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/lib/generators/solidus/install/install_generator_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe Solidus::InstallGenerator do
         expect(questions.size).to eq(1)
         expect(questions.first[:limited_to]).to eq(['paypal', 'stripe', 'braintree', 'none'])
         expect(questions.first[:default]).to eq('paypal')
-        expect(strip_ansi questions.first[:desc]).to include('[paypal]')
-        expect(strip_ansi questions.first[:desc]).to include('[stripe]')
-        expect(strip_ansi questions.first[:desc]).not_to include('[bolt]')
-        expect(strip_ansi questions.first[:desc]).to include('[braintree]')
-        expect(strip_ansi questions.first[:desc]).to include('[none]')
+        expect(strip_ansi(questions.first[:desc])).to include('[paypal]')
+        expect(strip_ansi(questions.first[:desc])).to include('[stripe]')
+        expect(strip_ansi(questions.first[:desc])).not_to include('[bolt]')
+        expect(strip_ansi(questions.first[:desc])).to include('[braintree]')
+        expect(strip_ansi(questions.first[:desc])).to include('[none]')
       end
     end
   end


### PR DESCRIPTION
## Summary

🧹

We have a specific directory in core/spec/lib/generators for generator specs.

Moves 

`core/spec/generators/solidus/install/install_generator_spec.rb` 

at 

`core/spec/lib/generators/solidus/install/install_generator_spec.rb`.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
