### PR TITLE
Prefer delegating recalculate without a method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -154,6 +154,8 @@ module Spree
       find_by! number: value
     end
 
+    delegate :recalculate, to: :recalculator
+
     delegate :name, to: :bill_address, prefix: true, allow_nil: true
     alias_method :billing_name, :bill_address_name
 
@@ -263,10 +265,6 @@ module Spree
     end
     alias_method :updater, :recalculator
     deprecate updater: :recalculator, deprecator: Spree::Deprecation
-
-    def recalculate
-      recalculator.recalculate
-    end
 
     def assign_billing_to_shipping_address
       self.ship_address = bill_address if bill_address


### PR DESCRIPTION
## Summary

As Rubocop suggests, in fact this PR fixes Rubocop linting after merging #5110, which had the CI green before we introduced Rubocop linting. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
