### PR TITLE
Remove references to legacy `:general_settings` resource

### DIFF
--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_tax_rate_form_fields">
     <fieldset data-hook="tax_rates" class=" no-border-bottom">
-      <legend align="center"><%= t('spree.general_settings') %></legend>
+      <legend align="center"><%= t('spree.store') %></legend>
       <div class="row">
 
         <div class="col-5">

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -3,7 +3,7 @@
 
     <div data-hook="admin_zone_form_fields">
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= t('spree.general_settings') %></legend>
+        <legend align="center"><%= t('spree.store') %></legend>
 
         <%= zone_form.field_container :name do %>
           <%= zone_form.label :name %><br>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1598,7 +1598,6 @@ en:
     gateway_config_unavailable: Gateway unavailable for environment
     gateway_error: Gateway Error
     general: General
-    general_settings: Store
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
     group_size: Group size

--- a/core/lib/spree/permission_sets/configuration_display.rb
+++ b/core/lib/spree/permission_sets/configuration_display.rb
@@ -4,7 +4,6 @@ module Spree
   module PermissionSets
     class ConfigurationDisplay < PermissionSets::Base
       def activate!
-          can [:edit, :admin], :general_settings
           can [:read, :admin], Spree::TaxCategory
           can [:read, :admin], Spree::TaxRate
           can [:read, :admin], Spree::Zone

--- a/core/lib/spree/permission_sets/configuration_management.rb
+++ b/core/lib/spree/permission_sets/configuration_management.rb
@@ -4,7 +4,6 @@ module Spree
   module PermissionSets
     class ConfigurationManagement < PermissionSets::Base
       def activate!
-        can :manage, :general_settings
         can :manage, Spree::TaxCategory
         can :manage, Spree::TaxRate
         can :manage, Spree::Zone

--- a/core/spec/models/spree/permission_sets/configuration_display.rb
+++ b/core/spec/models/spree/permission_sets/configuration_display.rb
@@ -12,7 +12,6 @@ RSpec.describe Spree::PermissionSets::ConfigurationDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:edit, :general_settings) }
     it { is_expected.to be_able_to(:read, Spree::TaxCategory) }
     it { is_expected.to be_able_to(:read, Spree::TaxRate) }
     it { is_expected.to be_able_to(:read, Spree::Zone) }
@@ -27,7 +26,6 @@ RSpec.describe Spree::PermissionSets::ConfigurationDisplay do
     it { is_expected.to be_able_to(:read, Spree::RefundReason) }
     it { is_expected.to be_able_to(:read, Spree::ReimbursementType) }
     it { is_expected.to be_able_to(:read, Spree::ReturnReason) }
-    it { is_expected.to be_able_to(:admin, :general_settings) }
     it { is_expected.to be_able_to(:admin, Spree::TaxCategory) }
     it { is_expected.to be_able_to(:admin, Spree::TaxRate) }
     it { is_expected.to be_able_to(:admin, Spree::Zone) }
@@ -45,7 +43,6 @@ RSpec.describe Spree::PermissionSets::ConfigurationDisplay do
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:edit, :general_settings) }
     it { is_expected.not_to be_able_to(:read, Spree::TaxCategory) }
     it { is_expected.not_to be_able_to(:read, Spree::TaxRate) }
     it { is_expected.not_to be_able_to(:read, Spree::Zone) }
@@ -60,7 +57,6 @@ RSpec.describe Spree::PermissionSets::ConfigurationDisplay do
     it { is_expected.not_to be_able_to(:read, Spree::RefundReason) }
     it { is_expected.not_to be_able_to(:read, Spree::ReimbursementType) }
     it { is_expected.not_to be_able_to(:read, Spree::ReturnReason) }
-    it { is_expected.not_to be_able_to(:admin, :general_settings) }
     it { is_expected.not_to be_able_to(:admin, Spree::TaxCategory) }
     it { is_expected.not_to be_able_to(:admin, Spree::TaxRate) }
     it { is_expected.not_to be_able_to(:admin, Spree::Zone) }

--- a/core/spec/models/spree/permission_sets/configuration_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/configuration_management_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Spree::PermissionSets::ConfigurationManagement do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:manage, :general_settings) }
     it { is_expected.to be_able_to(:manage, Spree::TaxCategory) }
     it { is_expected.to be_able_to(:manage, Spree::TaxRate) }
     it { is_expected.to be_able_to(:manage, Spree::Zone) }
@@ -30,7 +29,6 @@ RSpec.describe Spree::PermissionSets::ConfigurationManagement do
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:manage, :general_settings) }
     it { is_expected.not_to be_able_to(:manage, Spree::TaxCategory) }
     it { is_expected.not_to be_able_to(:manage, Spree::TaxRate) }
     it { is_expected.not_to be_able_to(:manage, Spree::Zone) }


### PR DESCRIPTION
## Summary

The resource was created in f83d9dbc0586d460c7e5f04cf94ff017b37f40ed (2015), but we stopped checking permissions on it in 60ea59a0dc5942c28ac69a4d786eb695b4b36ffc (2017), when we replaced it with checking on `Spree::Store`.

Currently, the [admin controller for `:general_settings`](https://github.com/solidusio/solidus/blob/main/backend/app/controllers/spree/admin/general_settings_controller.rb) is only used to redirect to stores.

We also remove the redundant admin locale key `spree.general_settings`. Instead, we can use `spree.store`.

Ref. #5102 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
