### PR TITLE
Prepare admin container for sidecar components

### DIFF
--- a/admin/app/components/solidus_admin/main_nav/component.rb
+++ b/admin/app/components/solidus_admin/main_nav/component.rb
@@ -2,9 +2,9 @@
 
 module SolidusAdmin
   # Renders the main navigation of Solidus Admin.
-  class MainNavComponent < BaseComponent
+  class MainNav::Component < BaseComponent
     include Import[
-      "main_nav_item_component",
+      main_nav_item_component: "components.main_nav_item.component",
       items: "main_nav_items"
     ]
 

--- a/admin/app/components/solidus_admin/main_nav_item/component.rb
+++ b/admin/app/components/solidus_admin/main_nav_item/component.rb
@@ -2,7 +2,7 @@
 
 module SolidusAdmin
   # Menu item within a {MainNavComponent}
-  class MainNavItemComponent < BaseComponent
+  class MainNavItem::Component < BaseComponent
     with_collection_parameter :item
 
     attr_reader :item

--- a/admin/app/helpers/solidus_admin/container_helper.rb
+++ b/admin/app/helpers/solidus_admin/container_helper.rb
@@ -9,7 +9,7 @@ module SolidusAdmin
     end
 
     def component(name)
-      container.resolve("#{name}_component")
+      container.resolve("components.#{name}.component")
     end
   end
 end

--- a/admin/lib/solidus_admin/container.rb
+++ b/admin/lib/solidus_admin/container.rb
@@ -16,9 +16,9 @@ module SolidusAdmin
   class Container < Dry::System::Container
     configure do |config|
       config.root = Pathname(__FILE__).dirname.join("../..").realpath
-      config.component_dirs.add("app/components") do |dir|
+      config.component_dirs.add("app/components/solidus_admin") do |dir|
         dir.loader = System::Loaders::HostOverridableConstant.method(:call).curry["components"]
-        dir.namespaces.add "solidus_admin", key: nil
+        dir.namespaces.add nil, const: "solidus_admin", key: "components"
       end
     end
 


### PR DESCRIPTION
## Summary

We prepare the admin container to resolve components from within sidecar
directories and we namespace all components within a `components` key.

Example, from the engine directory:

    app/components/solidus_admin/main_nav/component.rb

gets registered as:

    components.main_nav.component

and can be overriden by the following in the host application:

    app/components/sandbox/solidus_admin/main_nav/component.rb

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
