### PR TITLE
Only require changelog label on PRs to main & v* branches

### DIFF
--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -3,6 +3,9 @@ name: "Ensure Changelog label"
 on:
   pull_request:
     types: ["labeled", "unlabeled"]
+    branches:
+      - main
+      - v*
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Summary

There's no need to require a changelog label on PRs to feature branches.

This one will prevent failures in the long-running branch for the new admin once we rebase on top of main.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
