### PR TITLE
[WIP] Deprecate registering abilities

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -38,6 +38,18 @@ module Spree
     # Before, this was the only way to extend this ability. Permission sets have been added since.
     # It is recommended to use them instead for extension purposes if possible.
     def register_extension_abilities
+      Spree::Deprecation.warn <<~MSG, caller_locations[1, 1] if Ability.abilities.any?
+        Registering abilities is deprecated and will be removed in the next major version.
+        Please, use permission sets instead (https://guides.solidus.io/advanced-solidus/permission-management)
+
+        The following methods will be removed from `Spree::Ability`:
+
+        - .abilities
+        - .abilities=
+        - .register_ability
+        - .remove_ability
+      MSG
+
       Ability.abilities.each do |clazz|
         ability = clazz.send(:new, user)
         merge(ability)

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -2,6 +2,9 @@
 
 module Spree
   module PermissionSets
+    # Permissions for e-commerce visitors
+    #
+    # This set of permissions is automatically applied to the `:default` role
     class DefaultCustomer < PermissionSets::Base
       def activate!
         can :read, Country


### PR DESCRIPTION
## Summary

This is initial work to deprecate registering abilities, as permission sets have been the default way for a long time. However, it's on hold due to the poor testability of permission sets. We need to fix that and improve permission set's API before that.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
