### PR TITLE
Deprecate the `Spree::Adjustment.return_authorization` scope

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -48,6 +48,8 @@ module Spree
     scope :is_included, -> { where(included: true) }
     scope :additional, -> { where(included: false) }
 
+    singleton_class.deprecate :return_authorization, deprecator: Spree::Deprecation
+
     extend DisplayMoney
     money_methods :amount
 


### PR DESCRIPTION

## Summary

There is no code path that creates adjustments from return authorizations (since a long time).

This line was introduced without a lot of context in 2013, and there is nothing in the current codebase that warrants this scope.

I don't think adding a deprecation notice will do anything for anyone. If anyone tells me this scope currently returns a record in their stores, I'll add one. :)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 ~I have updated the README to account for my changes.~
- 📑 ~I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~
- 🛣️ ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ✅ ~I have added automated tests to cover my changes.~
- 📸 ~I have attached screenshots to demo visual changes.~
