### PR TITLE
Configurable cancelation adjuster class

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -217,9 +217,7 @@ module Spree
     end
 
     def update_cancellations
-      line_items.each do |line_item|
-        line_item.adjustments.select(&:cancellation?).each(&:recalculate)
-      end
+      Spree::Config.cancellations_recalculator_class.new(order).call
     end
 
     def update_item_totals

--- a/core/app/models/spree/unit_cancel/order_cancellations_recalculator.rb
+++ b/core/app/models/spree/unit_cancel/order_cancellations_recalculator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Spree
+  class UnitCancel < Spree::Base
+    # This class encapsulates what the system needs to do in order to recalculate
+    # adjustments originating from Unit Cancels.
+    class OrderCancellationsRecalculator
+      def initialize(order)
+        @order = order
+      end
+
+      def call
+        line_items.each do |line_item|
+          line_item.adjustments.select(&:cancellation?).each { |cancellation| recalculate(cancellation) }
+        end
+      end
+
+      private
+      attr_reader :order
+      delegate :line_items, to: :order
+
+      # Recalculate and persist the amount from this cancellation's source based on
+      # the adjustable ({LineItem})
+      #
+      # @return [BigDecimal] New amount of this adjustment
+      def recalculate(cancellation)
+        if cancellation.finalized?
+          return cancellation.amount
+        end
+
+        cancellation.amount = cancellation.source.compute_amount(cancellation.adjustable)
+
+        # Persist only if changed
+        # This is only not a save! to avoid the extra queries to load the order
+        # (for validations) and to touch the cancellation.
+        cancellation.update_columns(amount: cancellation.amount, updated_at: Time.current) if cancellation.changed?
+        cancellation.amount
+      end
+    end
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -334,6 +334,14 @@ module Spree
 
     class_name_attribute :shipping_rate_selector_class, default: 'Spree::Stock::ShippingRateSelector'
 
+    # Allows implementing custom cancellations recalculation.
+    # @!attribute [rw] cancellations_recalculator_class
+    # @ see Spree::UnitCancel::OrderCancellationsRecalculator
+    # @return [Class] a class that conforms to the API of the
+    #   standard cancellations recalculator class,
+    #   `Spree::UnitCancel::OrderCancellationsRecalculator`
+    class_name_attribute :cancellations_recalculator_class, default: 'Spree::UnitCancel::OrderCancellationsRecalculator'
+
     # Allows providing your own class for calculating taxes on a shipping rate.
     #
     # @!attribute [rw] shipping_rate_tax_calculator_class

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
   end
 
+  it "uses unit cancel recalculation class by default" do
+    expect(prefs.cancellations_recalculator_class).to eq Spree::UnitCancel::OrderCancellationsRecalculator
+  end
+
   it "has a getter for the pricing options class provided by the variant price selector class" do
     expect(prefs.pricing_options_class).to eq Spree::Variant::PriceSelector.pricing_options_class
   end

--- a/core/spec/models/spree/unit_cancel/order_cancellations_recalculator_spec.rb
+++ b/core/spec/models/spree/unit_cancel/order_cancellations_recalculator_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::UnitCancel::OrderCancellationsRecalculator do
+  let(:inventory_unit) { create(:inventory_unit, line_item: line_item) }
+  let(:line_item) { create(:line_item) }
+  let(:unit_cancel) { Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP) }
+  let(:cancellation) { unit_cancel.adjust! }
+
+  before do
+    cancellation.update_columns(amount: 10, finalized: false)
+    cancellation.reload
+    line_item.reload
+  end
+
+  subject { described_class.new(line_item.order).call }
+
+  it "recalculates the cancellation adjustment to the correct amount" do
+    expect { subject }.to change { cancellation.reload.amount }.from(10).to(-20)
+  end
+end


### PR DESCRIPTION
## Summary

This adds a class that handles recalculating adjustments originating from a Spree::UnitCancel. The goal is to eliminate uses of `Spree::Adjustment#recalculate`, similar to #4460 .

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 ~I have updated the README to account for my changes.~
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
