### PR TITLE
Don't require calling super for components

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -334,3 +334,9 @@ Naming/MemoizedInstanceVariableName:
 
 Lint/SuppressedException:
   Enabled: false
+
+Lint/MissingSuper:
+  Exclude:
+    - '*/app/components/**/*' # components need pristine initializer methods
+    - 'core/lib/spree/deprecation.rb' # this is a known class that doesn't require super
+    - 'core/lib/spree/preferences/configuration.rb' # this class has no superclass defining `self.inherited`

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -243,12 +243,6 @@ Lint/EmptyConditionalBody:
   Exclude:
     - 'core/lib/spree/preferences/statically_configurable.rb'
 
-# Offense count: 2
-Lint/MissingSuper:
-  Exclude:
-    - 'core/lib/spree/deprecation.rb'
-    - 'core/lib/spree/preferences/configuration.rb'
-
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Lint/ParenthesesAsGroupedExpression:

--- a/admin/app/components/solidus_admin/main_nav_item/component.rb
+++ b/admin/app/components/solidus_admin/main_nav_item/component.rb
@@ -9,7 +9,6 @@ module SolidusAdmin
 
     def initialize(item:)
       @item = item
-      super
     end
 
     erb_template <<~ERB


### PR DESCRIPTION
## Summary

It's not a standard practice for view components that are meant to be very minimal and almost POROs.

Move the configuration _excludes_ from the rubocop todo to the main config as they seem legitimate exceptions.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
