### PR TITLE
Generate solidus_admin initializer on installation

### DIFF
--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -3,12 +3,18 @@
 module SolidusAdmin
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
       def install_solidus_core_support
         route <<~RUBY
           mount SolidusAdmin::Engine, at: '/admin', constraints: ->(req) {
             req.cookies['solidus_admin'] == 'true'
           }
         RUBY
+      end
+
+      def copy_initializer
+        copy_file "config/initializers/solidus_admin.rb"
       end
 
       def ignore_tailwind_build_files

--- a/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb
+++ b/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+SolidusAdmin::Config.configure do |config|
+  # Add custom paths for TailwindCSS to scan for styles. By default, it already
+  # includes the following paths:
+  #
+  # - public/solidus_admin/*.html
+  # - app/helpers/solidus_admin/**/*.rb
+  # - app/assets/javascripts/solidus_admin/**/*.js
+  # - app/views/solidus_admin/**/*.{erb,haml,html,slim}
+  # - app/components/solidus_admin/**/*.rb
+  # config.tailwind_content << Rails.root.join("app/my/custom/path/**.rb")
+
+  # Append custom stylesheets to be compiled by TailwindCSS.
+  # config.tailwind_stylesheets << Rails.root.join("app/my/custom/path/style.css")
+end


### PR DESCRIPTION
## Summary

It's good to have a solidus_admin initializer on installation, so that users can easily configure the admin interface and see what options are available.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
