### PR TITLE
Allow lambda in menu item :match_path option and URL

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -44,6 +44,7 @@ module Spree
       #   * :label to override link text, otherwise based on the first resource name (translated)
       #   * :route to override automatically determining the default route
       #   * :match_path as an alternative way to control when the tab is active, /products would match /admin/products, /admin/products/5/variants etc.
+      #   * :match_path can also be a callable that takes a request and determines whether the menu item is selected for the request.
       def tab(*args, &_block)
         options = { label: args.first.to_s }
 
@@ -66,6 +67,8 @@ module Spree
 
         selected = if options[:match_path].is_a? Regexp
           request.fullpath =~ options[:match_path]
+        elsif options[:match_path].respond_to?(:call)
+          options[:match_path].call(request)
         elsif options[:match_path]
           request.fullpath.starts_with?("#{spree.admin_path}#{options[:match_path]}")
         else

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spree/preferences/configuration'
+require 'spree/backend_configuration/menu_item'
 
 module Spree
   class BackendConfiguration < Preferences::Configuration
@@ -46,49 +47,6 @@ module Spree
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
     STOCK_TABS         ||= [:stock_items]
     USER_TABS          ||= [:users, :store_credits]
-
-    # An item which should be drawn in the admin menu
-    class MenuItem
-      attr_reader :icon, :label, :partial, :condition, :sections, :url, :match_path
-
-      attr_accessor :position
-
-      # @param sections [Array<Symbol>] The sections which are contained within
-      #   this admin menu section.
-      # @param icon [String] The icon to draw for this menu item
-      # @param condition [Proc] A proc which returns true if this menu item
-      #   should be drawn. If nil, it will be replaced with a proc which always
-      #   returns true.
-      # @param label [Symbol] The translation key for a label to use for this
-      #   menu item.
-      # @param partial [String] A partial to draw within this menu item for use
-      #   in declaring a submenu
-      # @param url [String] A url where this link should send the user to
-      # @param position [Integer] The position in which the menu item should render
-      #   nil will cause the item to render last
-      # @param match_path [String, Regexp] (nil) If the {url} to determine the active tab is ambigous
-      #   you can pass a String or Regexp to identify this menu item
-      def initialize(
-        sections,
-        icon,
-        condition: nil,
-        label: nil,
-        partial: nil,
-        url: nil,
-        position: nil,
-        match_path: nil
-      )
-
-        @condition = condition || -> { true }
-        @sections = sections
-        @icon = icon
-        @label = label || sections.first
-        @partial = partial
-        @url = url
-        @position = position
-        @match_path = match_path
-      end
-    end
 
     # Items can be added to the menu by using code like the following:
     #

--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -4,7 +4,7 @@ module Spree
   class BackendConfiguration < Preferences::Configuration
     # An item which should be drawn in the admin menu
     class MenuItem
-      attr_reader :icon, :label, :partial, :condition, :sections, :url, :match_path
+      attr_reader :icon, :label, :partial, :condition, :sections, :match_path
 
       attr_accessor :position
 
@@ -21,8 +21,9 @@ module Spree
       # @param url [String] A url where this link should send the user to
       # @param position [Integer] The position in which the menu item should render
       #   nil will cause the item to render last
-      # @param match_path [String, Regexp] (nil) If the {url} to determine the active tab is ambigous
-      #   you can pass a String or Regexp to identify this menu item
+      # @param match_path [String, Regexp, callable] (nil) If the {url} to determine the active tab is ambigous
+      #   you can pass a String, Regexp or callable to identify this menu item. The callable
+      #   accepts a request object and returns a Boolean value.
       def initialize(
         sections,
         icon,
@@ -42,6 +43,14 @@ module Spree
         @url = url
         @position = position
         @match_path = match_path
+      end
+
+      def url
+        if @url.respond_to?(:call)
+          @url.call
+        else
+          @url
+        end
       end
     end
   end

--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Spree
+  class BackendConfiguration < Preferences::Configuration
+    # An item which should be drawn in the admin menu
+    class MenuItem
+      attr_reader :icon, :label, :partial, :condition, :sections, :url, :match_path
+
+      attr_accessor :position
+
+      # @param sections [Array<Symbol>] The sections which are contained within
+      #   this admin menu section.
+      # @param icon [String] The icon to draw for this menu item
+      # @param condition [Proc] A proc which returns true if this menu item
+      #   should be drawn. If nil, it will be replaced with a proc which always
+      #   returns true.
+      # @param label [Symbol] The translation key for a label to use for this
+      #   menu item.
+      # @param partial [String] A partial to draw within this menu item for use
+      #   in declaring a submenu
+      # @param url [String] A url where this link should send the user to
+      # @param position [Integer] The position in which the menu item should render
+      #   nil will cause the item to render last
+      # @param match_path [String, Regexp] (nil) If the {url} to determine the active tab is ambigous
+      #   you can pass a String or Regexp to identify this menu item
+      def initialize(
+        sections,
+        icon,
+        condition: nil,
+        label: nil,
+        partial: nil,
+        url: nil,
+        position: nil,
+        match_path: nil
+      )
+
+        @condition = condition || -> { true }
+        @sections = sections
+        @icon = icon
+        @label = label || sections.first
+        @partial = partial
+        @url = url
+        @position = position
+        @match_path = match_path
+      end
+    end
+  end
+end

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -68,6 +68,22 @@ describe Spree::Admin::NavigationHelper, type: :helper do
           tab = helper.tab(:orders, match_path: /shady$|shady\//)
           expect(tab).not_to include('class="selected"')
         end
+
+        context "when the match_path is a callable" do
+          subject { helper.tab(:orders, match_path: match_path) }
+
+          context "when the callable returns false" do
+            let(:match_path) { ->(_request) { false } }
+
+            it { is_expected.not_to include('class="selected"') }
+          end
+
+          context "when the callable returns true" do
+            let(:match_path) { ->(_request) { true } }
+
+            it { is_expected.to include('class="selected"') }
+          end
+        end
       end
     end
 

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -12,4 +12,25 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
       is_expected.to eq('/stock_items')
     end
   end
+
+  describe "#url" do
+    subject { described_class.new([], nil, url: url).url }
+
+    context "if url is a string" do
+      let(:url) { "/admin/promotions" }
+      it { is_expected.to eq("/admin/promotions") }
+    end
+
+    context "if url is a symbol" do
+      let(:url) { :admin_promotions_path }
+      it { is_expected.to eq(:admin_promotions_path) }
+    end
+
+    context "if url is a lambda" do
+      let(:route_proxy) { double(my_path: "/admin/friendly_promotions") }
+      let(:url) { -> { route_proxy.my_path } }
+
+      it { is_expected.to eq("/admin/friendly_promotions") }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This allows setting a path for a menu item via a lambda executed at runtime. If engines other than spree would like their route in the main menu, this is how they can do dynamically without having to hard-code the path. 

Similarly, we allow the `match_path` option for Menu Items to be a callable taking a request. 

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- ✅ I have added automated tests to cover my changes.
