### PR TITLE
[Admin] Make Solidus Admin on by default

### DIFF
--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -8,7 +8,7 @@ module SolidusAdmin
       def install_solidus_core_support
         route <<~RUBY
           mount SolidusAdmin::Engine, at: '/admin', constraints: ->(req) {
-            req.cookies['solidus_admin'] == 'true'
+            req.cookies['solidus_admin'] != 'false'
           }
         RUBY
       end


### PR DESCRIPTION
## Summary

At least, that's what we want until the development phase is over. That way, we can test the admin interface without having to manually enable it through the cookie.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
