### PR TITLE
Fix solidus_core making use of responders API

### DIFF
--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -8,6 +8,8 @@ module Spree
 
       before_action :authorize_admin
 
+      respond_to :html
+
       private
 
       # Overrides ControllerHelpers::Common

--- a/core/app/controllers/spree/base_controller.rb
+++ b/core/app/controllers/spree/base_controller.rb
@@ -11,6 +11,4 @@ class Spree::BaseController < ApplicationController
   include Spree::Core::ControllerHelpers::Search
   include Spree::Core::ControllerHelpers::Store
   include Spree::Core::ControllerHelpers::StrongParameters
-
-  respond_to :html
 end


### PR DESCRIPTION
## Summary

We removed the responders dependency from solidus_core in https://github.com/solidusio/solidus/pull/2090. However, we forgot to remove the use of the responders API from solidus_core. We weren't catching this because all consumers of solidus_core's `Spree::BaseController` had the responders gen as a dependency (see https://github.com/solidusio/solidus/pull/3336)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
