### PR TITLE
[Admin] Load `component.js` files from app/components as Stimulus controllers

### DIFF
--- a/admin/app/assets/config/solidus_admin_manifest.js
+++ b/admin/app/assets/config/solidus_admin_manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_tree ../stylesheets .css
 //= link_tree ../../javascript .js
+//= link_tree ../../components .js

--- a/admin/app/components/solidus_admin/main_nav/component.js
+++ b/admin/app/components/solidus_admin/main_nav/component.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    console.log(`The main-nav has been loaded!`)
+  }
+}

--- a/admin/app/components/solidus_admin/main_nav/component.rb
+++ b/admin/app/components/solidus_admin/main_nav/component.rb
@@ -9,7 +9,7 @@ module SolidusAdmin
     end
 
     erb_template <<~ERB
-      <nav>
+      <nav data-controller="main-nav">
         <%= render @item_component.with_collection(items) %>
       </nav>
     ERB

--- a/admin/app/javascript/solidus_admin/controllers/components.js
+++ b/admin/app/javascript/solidus_admin/controllers/components.js
@@ -1,0 +1,34 @@
+import "@hotwired/stimulus"
+
+const registeredControllers = {}
+
+// Eager load all controllers registered beneath the `under` path in the import map to the passed application instance.
+export function eagerLoadComponentsFrom(under, application) {
+  const paths = Object.keys(parseImportmapJson()).filter(path => path.match(new RegExp(`^${under}/.*/component$`)))
+  paths.forEach(path => registerControllerFromPath(path, under, application))
+}
+
+function parseImportmapJson() {
+  return JSON.parse(document.querySelector("script[type=importmap]").text).imports
+}
+
+function registerControllerFromPath(path, under, application) {
+  const name = path
+    .replace(new RegExp(`^${under}/`), "")
+    .replace(/\/component$/, "")
+    .replace(/\//g, "--")
+    .replace(/_/g, "-")
+
+  if (!(name in registeredControllers)) {
+    import(path)
+      .then(module => registerController(name, module, application))
+      .catch(error => console.error(`Failed to register controller: ${name} (${path})`, error))
+  }
+}
+
+function registerController(name, module, application) {
+  if (!(name in registeredControllers)) {
+    application.register(name, module.default)
+    registeredControllers[name] = true
+  }
+};

--- a/admin/app/javascript/solidus_admin/controllers/index.js
+++ b/admin/app/javascript/solidus_admin/controllers/index.js
@@ -9,3 +9,6 @@ eagerLoadControllersFrom("solidus_admin/controllers", application)
 // Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
 // import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
 // lazyLoadControllersFrom("controllers", application)
+
+import { eagerLoadComponentsFrom } from "./components"
+eagerLoadComponentsFrom("solidus_admin", application)

--- a/admin/config/importmap.rb
+++ b/admin/config/importmap.rb
@@ -1,3 +1,5 @@
+# Remember to restart your application after editing this file.
+
 # Stimulus & Turbo
 pin "@hotwired/stimulus", to: "stimulus.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"

--- a/admin/config/importmap.rb
+++ b/admin/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.js"
 
 pin "solidus_admin/application", preload: true
 pin_all_from SolidusAdmin::Engine.root.join("app/javascript/solidus_admin/controllers"), under: "solidus_admin/controllers"
+pin_all_from SolidusAdmin::Engine.root.join("app/components")

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -47,6 +47,7 @@ module SolidusAdmin
     preference :importmap_cache_sweepers, :array, default: [
       SolidusAdmin::Engine.root.join("app", "assets", "javascripts"),
       SolidusAdmin::Engine.root.join("app", "javascript"),
+      SolidusAdmin::Engine.root.join("app", "components"),
     ]
 
     preference :importmap_paths, :array, default: [

--- a/admin/lib/solidus_admin/engine.rb
+++ b/admin/lib/solidus_admin/engine.rb
@@ -39,7 +39,10 @@ module SolidusAdmin
     end
 
     initializer "solidus_admin.importmap.assets" do |app|
-      app.config.assets.paths << SolidusAdmin::Engine.root.join("app/javascript")
+      app.config.assets.paths += [
+        SolidusAdmin::Engine.root.join("app/javascript"),
+        SolidusAdmin::Engine.root.join("app/components"),
+      ]
     end
 
     initializer "solidus_admin.main_nav_items_provider" do


### PR DESCRIPTION
## Summary

Adds the folder to both sprockets and the importmap, requires a slightly modified version of the stimulus-loading helper.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
