### PR TITLE
[Admin] Start with testing components

### DIFF
--- a/admin/spec/components/solidus_admin/sidebar/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::Sidebar::Component, type: :component do
+  it "renders the logo component" do
+    logo_component = mock_component { erb_template "Logo" }
+
+    render_inline(described_class.new(solidus_logo_component: logo_component))
+
+    expect(page).to have_content("Logo")
+  end
+
+  it "renders the main navigation component" do
+    main_nav_component = mock_component { erb_template "Main navigation" }
+
+    render_inline(described_class.new(main_nav_component: main_nav_component))
+
+    expect(page).to have_content("Main navigation")
+  end
+end

--- a/admin/spec/components/solidus_admin/solidus_logo/component_spec.rb
+++ b/admin/spec/components/solidus_admin/solidus_logo/component_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::SolidusLogo::Component, type: :component do
+  it "renders the solidus logo" do
+    render_inline(described_class.new)
+
+    expect(page).to have_css("img[src*='solidus_admin/solidus_logo']")
+  end
+end

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -90,6 +90,7 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
+  config.include SolidusAdmin::ComponentHelpers, type: :component
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
 

--- a/admin/spec/support/solidus_admin/component_helpers.rb
+++ b/admin/spec/support/solidus_admin/component_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  module ComponentHelpers
+    # Mocks a component class with the given definition.
+    #
+    # @param definition [Proc] the component definition
+    # @example
+    #  mock_component do
+    #    def call
+    #      "Rendered"
+    #    end
+    #  end
+    def mock_component(&definition)
+      Class.new(SolidusAdmin::BaseComponent) do
+        # ViewComponent will complain if we don't fake a class name:
+        # @see https://github.com/ViewComponent/view_component/blob/5decd07842c48cbad82527daefa3fe9c65a4226a/lib/view_component/base.rb#L371
+        def self.name
+          "Foo"
+        end
+      end.tap { |klass| klass.class_eval(&definition) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

For now, we start with testing for the logo and sidebar components. We skip the
main navigation one as it's just a placeholder for now.

For mocking nested components, we need to define a `name` class method
on the component class. Otherwise, we get the following error:

```
NoMethodError:
 undefined method `demodulize' for nil:NilClass

 component_name = name.demodulize.underscore
```

From: https://github.com/ViewComponent/view_component/blob/5decd07842c48cbad82527daefa3fe9c65a4226a/lib/view_component/base.rb#L371

References #5157 & #5106

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
