### PR TITLE
Allow running bin/rails from Solidus engines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -312,7 +312,7 @@ Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   Exclude:
     - '*/lib/generators/**/*'
-    - 'bin/**/*'
+    - '**/bin/**/*'
     - '*/db/migrate/**/*'
 
 # json.() is idiomatic in jbuilder files

--- a/api/bin/rails
+++ b/api/bin/rails
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/api/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"

--- a/backend/bin/rails
+++ b/backend/bin/rails
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/backend/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"

--- a/bin/rails
+++ b/bin/rails
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-app_root = File.expand_path "#{__dir__}/../sandbox"
+app_name = File.executable?("#{__dir__}/../#{ARGV.first}/bin/rails") ? ARGV.shift : 'sandbox'
+app_root = File.expand_path "#{__dir__}/../#{app_name}"
 
 unless File.exist? app_root
   system "#{__dir__}/sandbox" or begin
@@ -15,4 +16,3 @@ Dir.chdir app_root
 require 'bundler'
 
 exec Bundler.unbundled_env, 'bin/rails', *ARGV
-

--- a/core/bin/rails
+++ b/core/bin/rails
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/core/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"


### PR DESCRIPTION
## Summary

Generators and other tasks will behave differently if ran from an engine directory:
- they'll use the engine namespaces
- they'll write files to the engine dir

With this change it will be possible to `bin/rails core g migration …` and have migrations or other generators work from the `core` folder.

The `sandbox` app is still the default.

_This has been extracted from work on SolidusAdmin in which the component generator must be ran from the `admin/` folder in order to create components in the engine vs. the sandbox._
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
