### PR TITLE
[Admin] ACL index page listing existing roles

### DIFF
--- a/admin/app/components/solidus_admin/roles/index/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/index/component.html.erb
@@ -1,0 +1,15 @@
+<div class=" <%= stimulus_id %> ">
+  <header class="mb-[24px]">
+    <div class="text-[20px] font-[600] leading-[24px]">
+      <%= Spree::Role.model_name.human.pluralize %>
+    </div>
+  </header>
+
+  <%= render component("ui.table").new(
+    columns: [
+      component("ui.table").column(Spree::Role.human_attribute_name(:name)) { _1.name },
+      component("ui.table").column(Spree::Role.human_attribute_name(:permissions)) { render_permission_sets(_1.permission_sets) },
+    ],
+    rows: @roles,
+  ) %>
+</div>

--- a/admin/app/components/solidus_admin/roles/index/component.rb
+++ b/admin/app/components/solidus_admin/roles/index/component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Roles::Index::Component < SolidusAdmin::BaseComponent
+  def initialize(roles:)
+    @roles = roles
+  end
+
+  # @!visibility private
+
+  def render_permission_sets(permission_sets)
+    safe_join(
+      permission_sets.map do |permission_set|
+        render component('ui.badge').new(
+          name: permission_set.name.remove('Spree::PermissionSets::').underscore.humanize
+        )
+      end
+    )
+  end
+end

--- a/admin/app/components/solidus_admin/roles/index/component.yml
+++ b/admin/app/components/solidus_admin/roles/index/component.yml
@@ -1,0 +1,4 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  hello: "Hello world!"

--- a/admin/app/components/solidus_admin/sidebar/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/component.rb
@@ -13,17 +13,12 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
   end
 
   erb_template <<~ERB
-    <aside class="
-      col-start-1 col-end-2
-      lg:col-start-1 lg:col-end-3
-      bg-gray-100
-      h-screen
-    ">
+    <div>
       <%= image_tag @logo_path, alt: "Solidus" %>
       <nav data-controller="main-nav">
         <%= render @item_component.with_collection(items) %>
       </nav>
-    </aside>
+    </div>
   ERB
 
   def items

--- a/admin/app/components/solidus_admin/ui/badge/component.rb
+++ b/admin/app/components/solidus_admin/ui/badge/component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Badge::Component < SolidusAdmin::BaseComponent
+  STYLES = {
+    graphite_light: "color-black bg-graphiteLight",
+    red: 'color-red-500 bg-red-100',
+    green: 'color-forest bg-seafoam',
+    blue: 'color-blue bg-sky',
+    black: 'color-white bg-black',
+    yellow: 'color-yellow bg-[#feecd4]',
+  }.freeze
+
+  SIZES = {
+    m: 'leading-[20px] px-[12px] py-[2px] text-[14px] font-[500]',
+  }.freeze
+
+  def initialize(name:, style: :graphite_light, size: :m)
+    @name = name
+    @style = style.to_sym
+    @size = size.to_sym
+  end
+
+  erb_template <<~ERB
+    <div class="
+      inline-flex
+      items-center
+      rounded-full
+      <%= SIZES.fetch(@size) %>
+      <%= STYLES.fetch(@style) %>
+    "><%= @name %></div>
+  ERB
+end

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -1,0 +1,43 @@
+<div
+  class="
+    <%= stimulus_id %>
+    rounded-lg
+    border
+    border-gray-100
+    border-gray-100
+    overflow-hidden
+  "
+  data-controller="<%= stimulus_id %>"
+>
+  <table class=" table-auto w-full border-collapse ">
+    <thead class="bg-gray-15 color-gray-100">
+      <tr>
+        <% @columns.each do |column| %>
+          <th
+            class="
+              border-b
+              border-gray-100
+              py-[12px]
+              px-[16px]
+              text-[#4f4f4f]
+              text-left
+              text-[14px]
+              font-[600]
+              line-[120%]
+            "
+          ><%= column.name %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @rows.each do |row| %>
+        <tr class="!last:border-b border-gray-100">
+          <% @columns.each do |column| %>
+            <td class="bg-white py-[8px] px-[16px] text-[14px] line-[150%] text-black "><%= column.content.call(row) %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['output']
+
+  typed(event) {
+    this.text = event.currentTarget.value
+    this.render()
+  }
+
+  render() {
+    this.outputTarget.innerText = this.text
+  }
+}

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
+  def initialize(rows:, columns:)
+    @rows = rows
+    @columns = columns
+  end
+
+  def self.column(name, &block)
+    Column.new(name: name, content: block)
+  end
+
+  Column = Struct.new(:name, :content, keyword_init: true)
+  private_constant :Column
+end

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -1,0 +1,4 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  hello: "Hello world!"

--- a/admin/app/controllers/solidus_admin/roles_controller.rb
+++ b/admin/app/controllers/solidus_admin/roles_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class RolesController < SolidusAdmin::BaseController
+    def index
+      @roles = Spree::Role.all
+    end
+  end
+end

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -4,21 +4,32 @@
     <%= stylesheet_link_tag "solidus_admin/application.css", "inter-font", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags "solidus_admin/application", shim: false, importmap: SolidusAdmin.importmap %>
   </head>
-  <body class="
-    grid grid-cols-4 gap-4
-    lg:grid-cols-12 lg:gap-7
-  ">
-    <%= render component("sidebar").new %>
+  <body class=" grid grid-cols-4 lg:grid-cols-12 bg-gray-15">
+    <aside
+      class="
+        border-r
+        border-r-gray-100
+        col-start-1
+        col-end-2
+        lg:col-start-1
+        lg:col-end-3
+        h-screen
+        p-[16px]
+      "
+    >
+      <%= render component("sidebar").new %>
+    </aside>
 
-    <main class="
-      col-start-2 col-end-4
-      lg:col-start-3 lg:col-end-12
-    ">
-      <h1
-        data-controller="hello"
-        class="text-4xl"
-      ><a href="#" data-action="hello#greet">Layout is rendered</a></h1>
-
+    <main
+      class="
+        col-start-2
+        col-end-4
+        lg:col-start-3
+        lg:col-end-12
+        py-[24px]
+        px-[16px]
+      "
+    >
       <%= yield %>
     </main>
   </body>

--- a/admin/app/views/solidus_admin/accounts/show.html.erb
+++ b/admin/app/views/solidus_admin/accounts/show.html.erb
@@ -1,1 +1,6 @@
-<h2 class="text-3xl underline">Template is rendered</h1>
+<h1
+  data-controller="hello"
+  class="text-4xl"
+><a href="#" data-action="hello#greet">Account</a></h1>
+
+<h2 class="text-3xl underline">Your account info</h1>

--- a/admin/app/views/solidus_admin/roles/index.html.erb
+++ b/admin/app/views/solidus_admin/roles/index.html.erb
@@ -1,0 +1,1 @@
+<%= render component('roles.index').new(roles: @roles) %>

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -2,4 +2,5 @@
 
 SolidusAdmin::Engine.routes.draw do
   resource :account, only: :show
+  resources :roles
 end

--- a/admin/lib/generators/solidus_admin/component/component_generator.rb
+++ b/admin/lib/generators/solidus_admin/component/component_generator.rb
@@ -11,6 +11,11 @@ module SolidusAdmin
     class_option :js, type: :boolean, default: true
     class_option :spec, type: :boolean, default: true
 
+    def setup_inflections
+      # This is needed to ensure that UI is not rendered as Ui
+      SolidusAdmin::Engine.initializers.find { _1.name =~ /inflections/ }.run
+    end
+
     def create_component_files
       template "component.html.erb", destination(".html.erb")
       unless options["html"]

--- a/admin/lib/solidus_admin/container.rb
+++ b/admin/lib/solidus_admin/container.rb
@@ -15,6 +15,7 @@ module SolidusAdmin
   # @api private
   class Container < Dry::System::Container
     configure do |config|
+      config.inflector = ActiveSupport::Inflector
       config.root = Pathname(__FILE__).dirname.join("../..").realpath
       config.component_dirs.add("app/components/solidus_admin") do |dir|
         dir.loader = System::Loaders::HostOverridableConstant.method(:call).curry["components"]

--- a/admin/lib/solidus_admin/engine.rb
+++ b/admin/lib/solidus_admin/engine.rb
@@ -12,6 +12,11 @@ module SolidusAdmin
       require "solidus_admin/configuration"
     end
 
+    initializer "solidus_admin.inflections" do
+      # Suport for UI as an acronym
+      ActiveSupport::Inflector.inflections { |inflect| inflect.acronym 'UI' }
+    end
+
     initializer "solidus_admin.importmap" do
       SolidusAdmin::Config.importmap_paths.each { |path| SolidusAdmin.importmap.draw(path) }
     end

--- a/admin/spec/components/solidus_admin/roles/index/component_spec.rb
+++ b/admin/spec/components/solidus_admin/roles/index/component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Roles::Index::Component, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   render_inline(described_class.new(roles: "roles"))
+  #
+  #   expect(page).to have_text "Hello, components!"
+  #   expect(page).to have_css '.value'
+  # end
+end

--- a/admin/spec/components/solidus_admin/ui/badge/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/badge/component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ui::Badge::Component, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   render_inline(described_class.new(name: "name", color: "color"))
+  #
+  #   expect(page).to have_text "Hello, components!"
+  #   expect(page).to have_css '.value'
+  # end
+end

--- a/admin/spec/components/solidus_admin/ui/table/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/table/component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Table::Component, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   render_inline(described_class.new(objects: "objects", columns: "columns"))
+  #
+  #   expect(page).to have_text "Hello, components!"
+  #   expect(page).to have_css '.value'
+  # end
+end

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -7,6 +7,10 @@ module Spree
 
     validates_uniqueness_of :name, case_sensitive: true
 
+    def permission_sets
+      Spree::Config.roles.roles[name]&.permission_sets
+    end
+
     def admin?
       name == "admin"
     end


### PR DESCRIPTION
## Summary

As a starting point the goal will be a basic index page listing defined roles with associated permissions in a table.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
