### PR TITLE
[Admin] products#index empty shell

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -9,5 +9,9 @@ module SolidusAdmin
     def stimulus_id
       @stimulus_id ||= self.class.module_parent.to_s.underscore.dasherize.gsub(%r{/}, '--')
     end
+
+    def spree
+      @spree ||= Spree::Core::Engine.routes.url_helpers
+    end
   end
 end

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -1,0 +1,7 @@
+<div class="<%= stimulus_id %>">
+  <header class="mb-[24px]">
+    <div class="text-[20px] font-[600] leading-[24px]">
+      <%= Spree::Product.model_name.human.pluralize %>
+    </div>
+  </header>
+</div>

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
+  def initialize(products:)
+    @products = products
+  end
+end

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class ProductsController < SolidusAdmin::BaseController
+    def index
+      @products = Spree::Product.all
+    end
+  end
+end

--- a/admin/app/views/solidus_admin/products/index.html.erb
+++ b/admin/app/views/solidus_admin/products/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Products#index</h1>
+<p>Find me in app/views/solidus_admin/products/index.html.erb</p>

--- a/admin/app/views/solidus_admin/products/index.html.erb
+++ b/admin/app/views/solidus_admin/products/index.html.erb
@@ -1,2 +1,1 @@
-<h1>Products#index</h1>
-<p>Find me in app/views/solidus_admin/products/index.html.erb</p>
+<%= render component('products/index').new(products: @products) %>

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -2,4 +2,5 @@
 
 SolidusAdmin::Engine.routes.draw do
   resource :account, only: :show
+  resources :products, only: :index
 end

--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::BaseComponent, type: :component do
+  describe "#spree" do
+    it "gives access to spree routing helpers" do
+      # The spree/core routes start as empty, so we need to add a route to test
+      Spree::Core::Engine.routes.draw { get '/foo/bar', to: 'foo#bar', as: :foo_bar }
+
+      component = described_class.new
+
+      expect(component.spree).to respond_to(:foo_bar_path)
+    ensure
+      Spree::Core::Engine.routes.clear!
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Just sets up a simple controller with an almost empty component for products#index.

Also adds a `#spree` method to the base component to allow links to go across engines from the new admin back to the old backend (the component context has no access to engine routes natively).

<img width="1273" alt="image" src="https://github.com/solidusio/solidus/assets/1051/4dedbff4-89a4-4d55-b657-7c0c77dd6f84">


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
