### PR TITLE
Style store link from the admin sidebar

### DIFF
--- a/admin/app/assets/images/solidus_admin/arrow_right_up_line.svg
+++ b/admin/app/assets/images/solidus_admin/arrow_right_up_line.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="arrow-right-up-line">
+<path id="Vector" d="M10.6691 6.27614L4.93141 12.0139L3.98861 11.0711L9.72633 5.33333H4.66915V4H12.0025V11.3333H10.6691V6.27614Z" fill="#A3A3A3"/>
+</g>
+</svg>

--- a/admin/app/components/solidus_admin/sidebar/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/component.rb
@@ -3,6 +3,7 @@
 # Renders the sidebar
 class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
   def initialize(
+    store:,
     logo_path: SolidusAdmin::Config.logo_path,
     items: container["main_nav_items"],
     item_component: component("sidebar/item")
@@ -10,6 +11,7 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
     @logo_path = logo_path
     @items = items
     @item_component = item_component
+    @store = store
   end
 
   erb_template <<~ERB
@@ -17,10 +19,31 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
       border-r border-r-gray-100
       col-start-1 col-end-2
       lg:col-start-1 lg:col-end-3
+      bg-white
       h-screen
       p-[16px]
     ">
       <%= image_tag @logo_path, alt: "Solidus" %>
+      <%= link_to @store.url,
+            class: "
+              block
+              mt-4 px-2 py-1.5
+              border border-gray-100 rounded-sm shadow-sm
+              bg-arrow-right-up-line bg-right-top bg-no-repeat bg-origin-content
+            " do %>
+        <p class="
+          text-sm text-black
+          font-sans font-bold
+        ">
+          <%= @store.name %>
+        </p>
+        <p class="
+          text-tiny text-gray-500
+          font-sans
+        ">
+          <%= @store.url %>
+        </p>
+      <% end %>
       <nav data-controller="main-nav">
         <%= render @item_component.with_collection(items) %>
       </nav>

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -9,7 +9,7 @@
     lg:grid-cols-12
     bg-gray-15
   ">
-    <%= render component("sidebar").new %>
+    <%= render component("sidebar").new(store: current_store) %>
 
     <main class="
       col-start-2 col-end-4

--- a/admin/config/solidus_admin/tailwind.config.js.erb
+++ b/admin/config/solidus_admin/tailwind.config.js.erb
@@ -9,6 +9,13 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
+      fontSize: {
+        tiny: ['0.75rem', '120%'],
+        sm: ['0.875rem', '120%'],
+      },
+      fontWeight: {
+        bold: '600',
+      },
       colors: {
         transparent: "transparent",
         current: "currentColor",
@@ -61,6 +68,15 @@ module.exports = {
           700: "#4a4a4a",
           800: "#333333",
         },
+      },
+      borderRadius: {
+        sm: '4px',
+      },
+      backgroundImage: {
+        'arrow-right-up-line': "url('solidus_admin/arrow_right_up_line.svg')",
+      },
+      boxShadow: {
+        sm: '0px 1px 2px 0px rgba(0, 0, 0, 0.04)',
       },
     },
   },

--- a/admin/spec/components/solidus_admin/sidebar/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/component_spec.rb
@@ -4,15 +4,19 @@ require "spec_helper"
 
 RSpec.describe SolidusAdmin::Sidebar::Component, type: :component do
   it "renders the solidus logo" do
-    render_inline(described_class.new)
+    render_inline(described_class.new(store: build(:store)))
 
     expect(page).to have_css("img[src*='solidus_admin/solidus_logo']")
   end
 
-  it "renders the main navigation" do
-    render_inline(described_class.new)
+  it "renders the store link" do
+    render_inline(described_class.new(store: build(:store, url: "https://example.com")))
 
-    render_inline(described_class.new)
+    expect(page).to have_content("https://example.com")
+  end
+
+  it "renders the main navigation" do
+    render_inline(described_class.new(store: build(:store)))
 
     expect(page).to have_css("nav[data-controller='main-nav']")
   end


### PR DESCRIPTION
## Summary

A few decisions are made here when it comes to following the provided Figma design. TL;DR: Figma, from which we have less control, wins over Tailwind, which we can change at any time:

- We start configuring Tailwind to avoid using hardcoded `[style]` attributes. We'll continue this whenever we find the need to add new styles.
- Even when both Tailwind and Figma use the same style name and value, we still explicitly configure it in Tailwind. This is to avoid future discrepancies and to make it easier to change. Example: `fontSize/sm`.
- When Tailwind and Figma use the same style value but with different names, we add the Figma name to Tailwind. Ideally, we should try to change Figma to use the same name as Tailwind, but, for now, it'll be easy to compare styles in this way, and a rename from the code part will be straightforward. Example: `fontSize/tiny`.
- When Tailwind and Figma use different style values for the same style name, we change Tailwind to use the Figma value. Example: `fontWeight/bold`, which is `600` for the Figma style and `700` for Tailwind.
- For spacing, we didn't find the need to configure anything different from the default Tailwind spacing scale, so we use it as is. That keeps things much simpler in something that could be cumbersome to think about.

Another rule we followed is that when needing to separate different blocks, we use the top margin from the element below.

We also followed a loose rule where we stack the CSS classes in different lines, from top to bottom:

- Spacing in relation to other elements: display, flex, etc...
- Spacing in relation to the element itself: padding, margin, etc...
- Border styles: color, width, radius...
- Text styles: font size, color...
- Font styles: familiy, weight...
- Background styles: color, image...

![screenshot-localhost_3000-2023 06 22-17_14_35](https://github.com/solidusio/solidus/assets/52650/f0555a20-9e29-4370-a977-51ecca7f1b6f)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
