### PR TITLE
Use regular template file for the sidebar component

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -3,7 +3,6 @@
 module SolidusAdmin
   # BaseComponent is the base class for all components in Solidus Admin.
   class BaseComponent < ViewComponent::Base
-    include ViewComponent::InlineTemplate
     include SolidusAdmin::ContainerHelper
 
     def stimulus_id

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -1,0 +1,33 @@
+<aside class="
+  border-r border-r-gray-100
+  col-start-1 col-end-2
+  lg:col-start-1 lg:col-end-3
+  bg-white
+  h-screen
+  p-[16px]
+">
+  <%= image_tag @logo_path, alt: "Solidus" %>
+  <%= link_to @store.url,
+        class: "
+          block
+          mt-4 px-2 py-1.5
+          border border-gray-100 rounded-sm shadow-sm
+          bg-arrow-right-up-line bg-right-top bg-no-repeat bg-origin-content
+        " do %>
+    <p class="
+      text-sm text-black
+      font-sans font-bold
+    ">
+      <%= @store.name %>
+    </p>
+    <p class="
+      text-tiny text-gray-500
+      font-sans
+    ">
+      <%= @store.url %>
+    </p>
+  <% end %>
+  <nav data-controller="main-nav">
+    <%= render @item_component.with_collection(items) %>
+  </nav>
+</aside>

--- a/admin/app/components/solidus_admin/sidebar/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/component.rb
@@ -14,42 +14,6 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
     @store = store
   end
 
-  erb_template <<~ERB
-    <aside class="
-      border-r border-r-gray-100
-      col-start-1 col-end-2
-      lg:col-start-1 lg:col-end-3
-      bg-white
-      h-screen
-      p-[16px]
-    ">
-      <%= image_tag @logo_path, alt: "Solidus" %>
-      <%= link_to @store.url,
-            class: "
-              block
-              mt-4 px-2 py-1.5
-              border border-gray-100 rounded-sm shadow-sm
-              bg-arrow-right-up-line bg-right-top bg-no-repeat bg-origin-content
-            " do %>
-        <p class="
-          text-sm text-black
-          font-sans font-bold
-        ">
-          <%= @store.name %>
-        </p>
-        <p class="
-          text-tiny text-gray-500
-          font-sans
-        ">
-          <%= @store.url %>
-        </p>
-      <% end %>
-      <nav data-controller="main-nav">
-        <%= render @item_component.with_collection(items) %>
-      </nav>
-    </aside>
-  ERB
-
   def items
     @items.sort_by(&:position)
   end

--- a/admin/app/components/solidus_admin/sidebar/item/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.rb
@@ -2,6 +2,8 @@
 
 # Menu item within a {Sidebar}
 class SolidusAdmin::Sidebar::Item::Component < SolidusAdmin::BaseComponent
+  include ViewComponent::InlineTemplate
+
   with_collection_parameter :item
 
   def initialize(item:)

--- a/admin/app/components/solidus_admin/ui/badge/component.rb
+++ b/admin/app/components/solidus_admin/ui/badge/component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Badge::Component < SolidusAdmin::BaseComponent
+  include ViewComponent::InlineTemplate
+
   COLORS = {
     graphite_light: "text-black bg-graphiteLight",
     red: 'text-red-500 bg-red-100',

--- a/admin/docs/customizing_view_components.md
+++ b/admin/docs/customizing_view_components.md
@@ -67,17 +67,17 @@ running `Rails.application.class.module_parent_name`).
 
 ### Replacing a component's template
 
-> ⓘ This is not possible yet because of
-> https://github.com/ViewComponent/view_component/issues/411, but it would
-> probably be worth trying to find a way to make it work. Otherwise, we can
-> describe how to override the `erb_template` call.
-
 In the most typical case, you'll only need to replace the template used by a
-component. You can do that by creating a new template with a maching path in
-your application. For example, to replace the main nav template, you can create:
+component. You can do that by creating a new component with a maching path in
+your application, inheriting from the default one. Then, you can create a new
+template for it. For example, to replace the main nav template:
 
 ```erb
-<%# app/components/my_application/solidus_admin/main_nav/template.html.erb %>
+# app/components/my_application/solidus_admin/main_nav/component.rb %>
+class MyApplication::SolidusAdmin::MainNav::Component < ::SolidusAdmin::MainNav::Component
+end
+
+<%# app/components/my_application/solidus_admin/main_nav/component.html.erb %>
 <nav class="my_own_classes">
   <%=
     render main_nav_item_component.with_collection(
@@ -94,7 +94,7 @@ component. You can easily do that by rendering the Solidus Admin component and
 adding your markup before or after it.
 
 ```erb
-<%# app/components/my_application/solidus_admin/main_nav/template.html.erb %>
+<%# app/components/my_application/solidus_admin/main_nav/component.html.erb %>
 <h1>MY STORE ADMINISTRATION</h1>
 <%= render SolidusAdmin::MainNav::Component.new %>
 ```


### PR DESCRIPTION
## Summary

We wrongly assumed that we needed to use the `erb_template` helper to allow users to customize component templates. However, as our convention requires them to create a different component class, they are already free to use whatever they want.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
