### PR TITLE
[Admin] add batch actions to the `products/index` component

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -7,6 +7,26 @@
 
   <%= render component("ui/table").new(
     page: @page,
+    batch_actions: [
+      {
+        display_name: t('.batch_actions.delete'),
+        action: solidus_admin.products_path,
+        method: :delete,
+        icon: 'delete-bin-7-line',
+      },
+      {
+        display_name: t('.batch_actions.discontinue'),
+        action: solidus_admin.discontinue_products_path,
+        method: :put,
+        icon: 'pause-circle-line',
+      },
+      {
+        display_name: t('.batch_actions.activate'),
+        action: solidus_admin.activate_products_path,
+        method: :put,
+        icon: 'play-circle-line',
+      },
+    ],
     columns: [
       {
         class_name: "w-[72px]",

--- a/admin/app/components/solidus_admin/products/index/component.yml
+++ b/admin/app/components/solidus_admin/products/index/component.yml
@@ -7,3 +7,7 @@ en:
     infinity: '∞'
     in_stock: '%{on_hand} in stock'
   for_variants: 'for %{count} variants'
+  batch_actions:
+    delete: 'Delete'
+    discontinue: 'Discontinue'
+    activate: 'Activate'

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -36,6 +36,18 @@
       </tr>
     </thead>
 
+    <% if @batch_actions %>
+      <thead
+        data-<%= stimulus_id %>-target="batchHeader"
+        class="bg-white color-black text-xs leading-none text-left"
+      >
+        <tr>
+          <%= render_header_cell(selectable_column.header) %>
+          <%= render_header_cell(content_tag(:div, " #{t('.rows_selected')}."), colspan: @columns.count - 1) %>
+        </div>
+      </thead>
+    <% end %>
+
     <tbody class="bg-white text-3.5 line-[150%] text-black">
       <% @rows.each do |row| %>
         <tr class="border-b border-gray-100">

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -6,17 +6,18 @@
     overflow-hidden
   "
   data-controller="<%= stimulus_id %>"
+  data-<%= stimulus_id %>-selected-row-class="bg-gray-15"
 >
-  <% toolbar_classes = "h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex" %>
+  <% toolbar_classes = "h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 visible:flex hidden:hidden" %>
 
-  <div class="<%= toolbar_classes %>">
+  <div class="<%= toolbar_classes %>" data-<%= stimulus_id %>-target="scopesToolbar">
     <%= render component('ui/tab').new(text: "All", active: true, scheme: :secondary, href: "") %>
   </div>
 
   <% if @batch_actions %>
     <%= form_tag '', id: batch_actions_form_id %>
 
-    <div class="<%= toolbar_classes %>">
+    <div class="<%= toolbar_classes %>" data-<%= stimulus_id %>-target="batchToolbar">
       <% @batch_actions.each do |batch_action| %>
         <%= render_batch_action_button(batch_action) %>
       <% end %>
@@ -30,7 +31,10 @@
       <% end %>
     </colgroup>
 
-    <thead class="bg-gray-15 text-gray-700 text-left text-small">
+    <thead
+      class="bg-gray-15 text-gray-700 text-left text-small"
+      data-<%= stimulus_id %>-target="defaultHeader"
+    >
       <tr>
         <% @columns.each do |column| %>
           <%= render_header_cell(column.header) %>
@@ -45,7 +49,10 @@
       >
         <tr>
           <%= render_header_cell(selectable_column.header) %>
-          <%= render_header_cell(content_tag(:div, " #{t('.rows_selected')}."), colspan: @columns.count - 1) %>
+          <%= render_header_cell(content_tag(:div, safe_join([
+            content_tag(:span, "0", "data-#{stimulus_id}-target": "selectedRowsCount"),
+            " #{t('.rows_selected')}.",
+          ])), colspan: @columns.count - 1) %>
         </div>
       </thead>
     <% end %>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -7,9 +7,19 @@
   "
   data-controller="<%= stimulus_id %>"
 >
-  <div class="h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex">
+  <% toolbar_classes = "h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex" %>
+
+  <div class="<%= toolbar_classes %>">
     <%= render component('ui/tab').new(text: "All", active: true, scheme: :secondary, href: "") %>
   </div>
+
+  <% if @batch_actions %>
+    <div class="<%= toolbar_classes %>">
+      <% @batch_actions.each do |batch_action| %>
+        <%= render_batch_action_button(batch_action) %>
+      <% end %>
+    </div>
+  <% end %>
 
   <table class="table-fixed w-full border-collapse">
     <colgroup>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -14,6 +14,8 @@
   </div>
 
   <% if @batch_actions %>
+    <%= form_tag '', id: batch_actions_form_id %>
+
     <div class="<%= toolbar_classes %>">
       <% @batch_actions.each do |batch_action| %>
         <%= render_batch_action_button(batch_action) %>

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["checkbox", "headerCheckbox", "batchToolbar", "scopesToolbar", "defaultHeader", "batchHeader", "selectedRowsCount"]
+  static classes = ["selectedRow"]
+
+  connect() {
+    this.mode = "default"
+
+    this.render()
+  }
+
+  selectRow(event) {
+    if (this.checkboxTargets.some((checkbox) => checkbox.checked)) {
+      this.mode = "batch"
+    } else {
+      this.mode = "default"
+    }
+
+    this.render()
+  }
+
+  selectAllRows(event) {
+    this.mode = event.target.checked ? "batch" : "default"
+    this.checkboxTargets.forEach((checkbox) => (checkbox.checked = event.target.checked))
+
+    this.render()
+  }
+
+  render() {
+    const selectedRows = this.checkboxTargets.filter((checkbox) => checkbox.checked)
+
+    this.batchToolbarTarget.toggleAttribute("hidden", this.mode !== "batch")
+    this.batchHeaderTarget.toggleAttribute("hidden", this.mode !== "batch")
+    this.scopesToolbarTarget.toggleAttribute("hidden", this.mode !== "default")
+    this.defaultHeaderTarget.toggleAttribute("hidden", this.mode !== "default")
+
+    // Update the rows background color
+    this.checkboxTargets.filter((checkbox) => checkbox.closest('tr').classList.toggle(this.selectedRowClass, checkbox.checked))
+
+    // Update the selected rows count
+    this.selectedRowsCountTarget.textContent = `${selectedRows.length}`
+
+    // Update the header checkboxes
+    this.headerCheckboxTargets.forEach((checkbox) => {
+      checkbox.indeterminate = false
+      checkbox.checked = false
+
+      if (selectedRows.length === this.checkboxTargets.length) checkbox.checked = true
+      else if (selectedRows.length > 0) checkbox.indeterminate = true
+    })
+  }
+}

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -37,6 +37,14 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     )
   end
 
+  def render_batch_action_button(batch_action)
+    render component('ui/button').new(
+      icon: batch_action.icon,
+      text: batch_action.display_name,
+      scheme: :secondary,
+    )
+  end
+
   def render_header_cell(cell)
     cell =
       case cell

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -28,17 +28,36 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   def selectable_column
     @selectable_column ||= Column.new(
       header: -> {
-        component('ui/forms/checkbox').new
+        component('ui/forms/checkbox').new(
+          form: batch_actions_form_id,
+        )
       },
       data: ->(data) {
-        component('ui/forms/checkbox').new
+        component('ui/forms/checkbox').new(
+          name: "id[]",
+          form: batch_actions_form_id,
+          value: data.id,
+        )
       },
       class_name: 'w-[52px]',
     )
   end
 
+  def batch_actions_form_id
+    @batch_actions_form_id ||= "#{stimulus_id}--batch-actions-#{SecureRandom.hex}"
+  end
+
   def render_batch_action_button(batch_action)
     render component('ui/button').new(
+      name: request_forgery_protection_token,
+      value: form_authenticity_token(form_options: {
+        action: batch_action.action,
+        method: batch_action.method,
+      }),
+      formaction: batch_action.action,
+      formmethod: batch_action.method,
+      form: batch_actions_form_id,
+      type: :submit,
       icon: batch_action.icon,
       text: batch_action.display_name,
       scheme: :secondary,

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -32,6 +32,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           form: batch_actions_form_id,
           "data-action": "#{stimulus_id}#selectAllRows",
           "data-#{stimulus_id}-target": "headerCheckbox",
+          "aria-label": t('.select_all'),
         )
       },
       data: ->(data) {
@@ -41,6 +42,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           value: data.id,
           "data-action": "#{stimulus_id}#selectRow",
           "data-#{stimulus_id}-target": "checkbox",
+          "aria-label": t('.select_row'),
         )
       },
       class_name: 'w-[52px]',

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -21,6 +21,20 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     @pagination_component = pagination_component
     @model_class = page.records.model
     @rows = page.records
+
+    @columns.unshift selectable_column if batch_actions.present?
+  end
+
+  def selectable_column
+    @selectable_column ||= Column.new(
+      header: -> {
+        component('ui/forms/checkbox').new
+      },
+      data: ->(data) {
+        component('ui/forms/checkbox').new
+      },
+      class_name: 'w-[52px]',
+    )
   end
 
   def render_header_cell(cell)

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -45,7 +45,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     )
   end
 
-  def render_header_cell(cell)
+  def render_header_cell(cell, **attrs)
     cell =
       case cell
       when Symbol
@@ -67,7 +67,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       font-semibold
       vertical-align-middle
       leading-none
-    })
+    }, **attrs)
   end
 
   def render_data_cell(cell, data)

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -30,6 +30,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       header: -> {
         component('ui/forms/checkbox').new(
           form: batch_actions_form_id,
+          "data-action": "#{stimulus_id}#selectAllRows",
+          "data-#{stimulus_id}-target": "headerCheckbox",
         )
       },
       data: ->(data) {
@@ -37,6 +39,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           name: "id[]",
           form: batch_actions_form_id,
           value: data.id,
+          "data-action": "#{stimulus_id}#selectRow",
+          "data-#{stimulus_id}-target": "checkbox",
         )
       },
       class_name: 'w-[52px]',

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -7,11 +7,17 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   # @option columns [Symbol|Proc|#to_s] :header The column header.
   # @option columns [Symbol|Proc|#to_s] :data The data accessor for the column.
   # @option columns [String] :class_name (optional) The class name for the column.
+  # @param batch_actions [Array<Hash>] The array of batch action definitions.
+  # @option batch_actions [String] :display_name The batch action display name.
+  # @option batch_actions [String] :icon The batch action icon.
+  # @option batch_actions [String] :action The batch action path.
+  # @option batch_actions [String] :method The batch action HTTP method for the provided path.
   # @param pagination_component [Class] The pagination component class (default: component("ui/table/pagination")).
-  def initialize(page:, path: nil, columns: [], pagination_component: component("ui/table/pagination"))
+  def initialize(page:, path: nil, columns: [], batch_actions: [], pagination_component: component("ui/table/pagination"))
     @page = page
     @path = path
     @columns = columns.map { Column.new(**_1) }
+    @batch_actions = batch_actions.map { BatchAction.new(**_1) }
     @pagination_component = pagination_component
     @model_class = page.records.model
     @rows = page.records
@@ -78,5 +84,6 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   Column = Struct.new(:header, :data, :class_name, keyword_init: true)
-  private_constant :Column
+  BatchAction = Struct.new(:display_name, :icon, :action, :method, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+  private_constant :Column, :BatchAction
 end

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -1,3 +1,5 @@
 en:
   no_resources_found: "No %{resources} found"
   rows_selected: 'selected'
+  select_all: 'Select all'
+  select_row: 'Select row'

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -1,2 +1,3 @@
 en:
   no_resources_found: "No %{resources} found"
+  rows_selected: 'selected'

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -8,5 +8,46 @@ module SolidusAdmin
         per_page: SolidusAdmin::Config[:products_per_page]
       )
     end
+
+    def destroy
+      @products = Spree::Product.where(id: params[:id])
+
+      Spree::Product.transaction do
+        @products.discard_all
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to products_path, status: :see_other
+    end
+
+    def discontinue
+      @products = Spree::Product.where(id: params[:id])
+
+      Spree::Product.transaction do
+        @products
+          .update_all(discontinue_on: Time.current)
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to products_path, status: :see_other
+    end
+
+    def activate
+      @products = Spree::Product.where(id: params[:id])
+
+      Spree::Product.transaction do
+        @products
+          .where.not(discontinue_on: nil)
+          .update_all(discontinue_on: nil)
+
+        @products
+          .where("available_on <= ?", Time.current)
+          .or(@products.where(available_on: nil))
+          .update_all(discontinue_on: nil)
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to products_path, status: :see_other
+    end
   end
 end

--- a/admin/config/locales/products.en.yml
+++ b/admin/config/locales/products.en.yml
@@ -2,3 +2,9 @@ en:
   solidus_admin:
     products:
       title: "Products"
+      destroy:
+        success: "Products were successfully removed."
+      discontinue:
+        success: "Products were successfully discontinued."
+      activate:
+        success: "Products were successfully activated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -2,5 +2,11 @@
 
 SolidusAdmin::Engine.routes.draw do
   resource :account, only: :show
-  resources :products, only: :index
+  resources :products, only: :index do
+    collection do
+      delete :destroy
+      put :discontinue
+      put :activate
+    end
+  end
 end

--- a/admin/config/solidus_admin/tailwind.config.js.erb
+++ b/admin/config/solidus_admin/tailwind.config.js.erb
@@ -1,4 +1,5 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
+const plugin = require('tailwindcss/plugin')
 
 module.exports = {
   content: [
@@ -82,5 +83,7 @@ module.exports = {
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
     require('@tailwindcss/container-queries'),
+    plugin(({ addVariant }) => addVariant('hidden', '&([hidden])')),
+    plugin(({ addVariant }) => addVariant('visible', '&:not([hidden])')),
   ]
 }

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -12,4 +12,50 @@ describe "Products", type: :feature do
     expect(page).to have_content("$19.99")
     expect(page).to be_axe_clean
   end
+
+  it "can delete multiple products at once", js: true do
+    create(:product, name: "Just a product", price: 19.99)
+    create(:product, name: "Another product", price: 29.99)
+
+    visit "/admin/products"
+    find('main tbody tr:nth-child(2)').find('input').check
+    click_button "Delete"
+
+    expect(page).to have_content("Products were successfully removed.", wait: 5)
+    expect(page).not_to have_content("Just a product")
+    expect(page).to have_content("Another product")
+    expect(Spree::Product.count).to eq(1)
+    expect(page).to be_axe_clean
+  end
+
+  it "can discontinue and (re)activate multiple products at once", js: true do
+    create(:product, name: "Just a product", price: 19.99)
+    create(:product, name: "Another product", price: 29.99)
+
+    visit "/admin/products"
+    find('main tbody tr:nth-child(2)').find('input').check
+    click_button "Discontinue"
+
+    expect(page).to have_content("Products were successfully discontinued.", wait: 5)
+    within('main tbody tr:nth-child(2)') {
+      expect(page).to have_content("Just a product")
+      expect(page).to have_content("Discontinued")
+      expect(page).not_to have_content("Available")
+    }
+    within('main tbody tr:nth-child(1)') {
+      expect(page).to have_content("Another product")
+      expect(page).not_to have_content("Discontinued")
+      expect(page).to have_content("Available")
+    }
+
+    find('main tbody tr:nth-child(2)').find('input').check
+    click_button "Activate"
+
+    expect(page).to have_content("Products were successfully activated.", wait: 5)
+    expect(page).to have_content("Just a product")
+    expect(page).to have_content("Another product")
+    expect(page).not_to have_content("Discontinued")
+    expect(page).to have_content("Available").twice
+    expect(page).to be_axe_clean
+  end
 end


### PR DESCRIPTION
## Summary

- based on #5259 

Add support for batch actions to the `ui/table` component and connects it to some example actions in the `products/index` component.

- the list of batch actions for products is tentative, but adding multiple batch actions was instrumental to testing the harness
- selecting beyond the current page is left for future development because it needs to involve filters and search

https://github.com/solidusio/solidus/assets/1051/8118c5bc-b404-4732-967a-cc4517fa23b6


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
