### PR TITLE
Fix rubocop violation enabled by a rubocop bugfix

### DIFF
--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.coordinator_class = MyCoordinator.to_s
 
       expect(subject).to be MyCoordinator
-
     ensure
       Object.send(:remove_const, :MyCoordinator)
     end
@@ -35,7 +34,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.estimator_class = MyEstimator.to_s
 
       expect(subject).to be MyEstimator
-
     ensure
       Object.send(:remove_const, :MyEstimator)
     end
@@ -53,7 +51,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.location_filter_class = MyFilter.to_s
 
       expect(subject).to be MyFilter
-
     ensure
       Object.send(:remove_const, :MyFilter)
     end
@@ -71,7 +68,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.location_sorter_class = MySorter.to_s
 
       expect(subject).to be MySorter
-
     ensure
       Object.send(:remove_const, :MySorter)
     end
@@ -89,7 +85,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.allocator_class = MyAllocator.to_s
 
       expect(subject).to be MyAllocator
-
     ensure
       Object.send(:remove_const, :MyAllocator)
     end
@@ -107,7 +102,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.inventory_unit_builder_class = MyInventoryUnitBuilder.to_s
 
       expect(subject).to be MyInventoryUnitBuilder
-
     ensure
       Object.send(:remove_const, :MyInventoryUnitBuilder)
     end
@@ -127,7 +121,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.availability_validator_class = MyAvailabilityValidator.to_s
 
       expect(subject).to be MyAvailabilityValidator
-
     ensure
       Object.send(:remove_const, :MyAvailabilityValidator)
     end
@@ -147,7 +140,6 @@ RSpec.describe Spree::Core::StockConfiguration do
       stock_configuration.inventory_validator_class = MyInventoryValidator.to_s
 
       expect(subject).to be MyInventoryValidator
-
     ensure
       Object.send(:remove_const, :MyInventoryValidator)
     end


### PR DESCRIPTION
## Summary

A recent rubocop bugfix made one file invalid, see rubocop's changelog for more details:

https://github.com/rubocop/rubocop/blob/v1.53.0/CHANGELOG.md#37
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
