### PR TITLE
Allow admin components to easily access admin routes

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -12,5 +12,9 @@ module SolidusAdmin
     def spree
       @spree ||= Spree::Core::Engine.routes.url_helpers
     end
+
+    def solidus_admin
+      @solidus_admin ||= SolidusAdmin::Engine.routes.url_helpers
+    end
   end
 end

--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -10,9 +10,18 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
 
       component = described_class.new
 
-      expect(component.spree).to respond_to(:foo_bar_path)
+      expect(component.spree.foo_bar_path).to eq("/foo/bar")
     ensure
       Spree::Core::Engine.routes.clear!
+    end
+  end
+
+  describe "#solidus_admin" do
+    it "gives access to solidus_admin routing helpers" do
+      allow(SolidusAdmin::Engine.routes.url_helpers).to receive(:foo_path).and_return("/foo/bar")
+      component = described_class.new
+
+      expect(component.solidus_admin.foo_path).to eq("/foo/bar")
     end
   end
 end


### PR DESCRIPTION
## Summary

By default ViewComponent will include the application routes.

We're opting for explicitly call `solidus_admin` to access it's routes to:

1. Avoid mixing with the host app routes, since it's currently impossible  to remove them when inheriting from ViewComponent::Base
2. To make a copy of the component templates work even if copied to the host app with the intent of modifying/extending them


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
