### PR TITLE
Fix Taxon taxonomy id validation regression

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -22,7 +22,7 @@ module Spree
     validates :meta_keywords, length: { maximum: 255 }
     validates :meta_description, length: { maximum: 255 }
     validates :meta_title, length: { maximum: 255 }
-    validates :taxonomy_id, uniqueness: { message: :can_have_only_one_root }, if: -> { root? }
+    validates :taxonomy_id, uniqueness: { scope: :parent_id, message: :can_have_only_one_root }, if: -> { root? }
 
     after_save :touch_ancestors_and_taxonomy
     after_touch :touch_ancestors_and_taxonomy

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -205,6 +205,16 @@ RSpec.describe Spree::Taxon, type: :model do
         taxon = taxonomy.root.children.create!(name: 'First child', taxonomy: taxonomy)
         expect(taxon).to be_valid
         expect(taxonomy.taxons.many?).to eq(true)
+        second_taxon = taxonomy.root.children.create!(name: 'Second child', taxonomy: taxonomy)
+        expect(second_taxon).to be_valid
+        expect(taxonomy.root.children.many?).to eq(true)
+      end
+
+      # Regression test https://github.com/solidusio/solidus/issues/5187
+      it "does not invalidate the root taxon after having children taxons" do
+        taxonomy.root.children.create!(name: 'New node', taxonomy: taxonomy)
+        expect(taxonomy.taxons.many?).to eq(true)
+        expect(taxonomy.root).to be_valid
       end
     end
 

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -194,15 +194,16 @@ RSpec.describe Spree::Taxon, type: :model do
   context "validations" do
     context "taxonomy_id validations" do
       let(:taxonomy) { create(:taxonomy) }
-      let(:taxon) { taxonomy.taxons.create(name: 'New node') }
 
       it "ensures that only one root can be created" do
+        taxon = taxonomy.taxons.create(name: 'New node')
         expect(taxon).to be_invalid
         expect(taxon.errors.full_messages).to match_array(["Taxonomy can only have one root Taxon"])
       end
 
-      it "allows for multiple taxons under taxonomy" do
-        expect(taxon.update(parent_id: taxonomy.root.id)).to eq(true)
+      it "allows for multiple taxons under a taxonomy" do
+        taxon = taxonomy.root.children.create!(name: 'First child', taxonomy: taxonomy)
+        expect(taxon).to be_valid
         expect(taxonomy.taxons.many?).to eq(true)
       end
     end


### PR DESCRIPTION
## Summary
Fixes https://github.com/solidusio/solidus/issues/5187.

In v3.4 I added optional Taxon validations which become mandatory in v4.0. This caused a regression which made all root taxons with children always invalid. This is a fix for v4, another PR for v3.4 was made:
https://github.com/solidusio/solidus/pull/5190

---

This optional validation for root taxons (parent_id is nil), was
checking for uniqueness of taxonomy_id among all Taxons. This is wrong
however, as the children Taxons of this root Taxon will point to the
same Taxonomy. Instead, we should only look among other root Taxons.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
