### PR TITLE
Add `covered_by_store_credit` translation in en.yml

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1432,6 +1432,7 @@ en:
     coupon_code_not_present: The coupon code you are trying to remove is not present on this order.
     coupon_code_removed: The coupon code was successfully removed from this order.
     coupon_code_unknown_error: This coupon code could not be applied to the cart at this time.
+    covered_by_store_credit: Your order is fully covered by store credits, no additional payment method is required.
     create: Create
     create_a_new_account: Create a new account
     create_one: Create One.


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

This PR adds a new translation key 'covered_by_store_credit' in en.yml.
The new key provides a specific message to inform users when their order is fully covered by store credits and no additional payment method is required.
This change is connected to an update made in Solidus Starter Frontend: https://github.com/solidusio/solidus_starter_frontend/pull/348

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
