### PR TITLE
[Admin] Admin UI showcase

### DIFF
--- a/admin/app/components/solidus_admin/ui/badge/component.rb
+++ b/admin/app/components/solidus_admin/ui/badge/component.rb
@@ -12,12 +12,18 @@ class SolidusAdmin::UI::Badge::Component < SolidusAdmin::BaseComponent
     yellow: 'text-yellow bg-[#feecd4]',
   }.freeze
 
-  def initialize(name:, color: :graphite_light)
+  SIZES = {
+    s: 'leading-[16px] px-[8px] py-[2px] text-[12px] font-[500]',
+    m: 'leading-[20px] px-[12px] py-[2px] text-[14px] font-[500]',
+    l: 'leading-[24px] px-[12px] py-[2px] text-[16px] font-[500]',
+  }.freeze
+
+  def initialize(name:, color: :graphite_light, size: :m)
     @name = name
 
     @class_name = [
       'inline-flex items-center rounded-full', # layout
-      'leading-[20px] px-[12px] py-[2px] text-[14px] font-[500]', # size
+      SIZES.fetch(size.to_sym), # size
       COLORS.fetch(color.to_sym), # color
     ].join(' ')
   end

--- a/admin/app/views/layouts/solidus_admin/preview.html.erb
+++ b/admin/app/views/layouts/solidus_admin/preview.html.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%= stylesheet_link_tag "solidus_admin/application.css", "inter-font", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags "solidus_admin/application", shim: false, importmap: SolidusAdmin.importmap %>
+  </head>
+  <body class="p-3">
+    <%= yield %>
+  </body>
+</html>

--- a/admin/lib/generators/solidus_admin/component/templates/component_preview.rb.tt
+++ b/admin/lib/generators/solidus_admin/component/templates/component_preview.rb.tt
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# @component <%= component_registry_id.inspect %>
+class <%= File.join(*[namespaced_path, file_path].compact).classify %>::ComponentPreview < ViewComponent::Preview
+  layout "solidus_admin/preview"
+  include SolidusAdmin::ContainerHelper
+
+  def overview
+    render_with_template(locals: { name: name, component: component(<%= component_registry_id.inspect %>) })
+  end
+
+  <%= preview_playground_yard_tags %>
+  def playground<%= preview_signature %>
+    <%= preview_playground_body %>
+  end
+end

--- a/admin/lib/generators/solidus_admin/component/templates/component_preview_overview.html.erb
+++ b/admin/lib/generators/solidus_admin/component/templates/component_preview_overview.html.erb
@@ -1,0 +1,7 @@
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Scenario 1
+  </h6>
+
+  <%%= render component.new<%= preview_signature %> %>
+</div>

--- a/admin/lib/generators/solidus_admin/component/templates/component_spec.rb.tt
+++ b/admin/lib/generators/solidus_admin/component/templates/component_spec.rb.tt
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe <%= File.join(*[namespaced_path, file_path].compact).classify %>::Component, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
 
   # it "renders something useful" do
   #   render_inline(described_class.new(<%= attributes.map { |attr| "#{attr.name}: #{attr.name.to_s.inspect}" }.join(", ") %>))

--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -3,7 +3,9 @@
 module SolidusAdmin
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      source_root File.expand_path('templates', __dir__)
+      class_option :lookbook, type: :boolean, default: !!ENV['SOLIDUS_ADMIN_LOOKBOOK'], desc: 'Install Lookbook for component previews'
+
+      source_root "#{__dir__}/templates"
 
       def install_solidus_core_support
         route <<~RUBY
@@ -23,6 +25,18 @@ module SolidusAdmin
 
       def build_tailwind
         rake "solidus_admin:tailwindcss:build"
+      end
+
+      def install_lookbook
+        return unless options[:lookbook]
+
+        gem_group :development, :test do
+          gem "lookbook"
+          gem "listen"
+          gem "actioncable"
+        end
+
+        route "mount Lookbook::Engine, at: '/lookbook' if Rails.env.development?"
       end
     end
   end

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -27,6 +27,7 @@ module SolidusAdmin
       SolidusAdmin::Engine.root.join("app/assets/javascripts/**/*.js"),
       SolidusAdmin::Engine.root.join("app/views/**/*.erb"),
       SolidusAdmin::Engine.root.join("app/components/**/*.{rb,erb,js}"),
+      SolidusAdmin::Engine.root.join("spec/components/previews/**/*.erb"),
 
       Rails.root.join("public/solidus_admin/*.html"),
       Rails.root.join("app/helpers/solidus_admin/**/*.rb"),

--- a/admin/lib/solidus_admin/engine.rb
+++ b/admin/lib/solidus_admin/engine.rb
@@ -12,6 +12,12 @@ module SolidusAdmin
       require "solidus_admin/configuration"
     end
 
+    config.autoload_paths << SolidusAdmin::Engine.root.join("spec/components/previews")
+
+    initializer "solidus_admin.view_component" do |app|
+      app.config.view_component.preview_paths << SolidusAdmin::Engine.root.join("spec/components/previews").to_s
+    end
+
     initializer "solidus_admin.inflections" do
       # Support for UI as an acronym
       ActiveSupport::Inflector.inflections { |inflect| inflect.acronym 'UI' }

--- a/admin/solidus_admin.gemspec
+++ b/admin/solidus_admin.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'importmap-rails', '~> 1.2', '>= 1.2.1'
   s.add_dependency 'solidus_core', s.version
   s.add_dependency 'tailwindcss-rails', '~> 2.0'
-  s.add_dependency 'view_component', '~> 3.0'
+  s.add_dependency 'view_component', '~> 3.3'
 end

--- a/admin/spec/components/previews/solidus_admin/ui/badge/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/badge/component_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# @component "ui/badge"
+class SolidusAdmin::UI::Badge::ComponentPreview < ViewComponent::Preview
+  layout "solidus_admin/preview"
+  include SolidusAdmin::ContainerHelper
+
+  # @param name [String]
+  def overview(name: "Label")
+    render_with_template(locals: { name: name, component: component("ui/badge") })
+  end
+
+  # @param name [String]
+  # @param color select :color_options
+  # @param size select :size_options
+  def playground(name: "Label", color: :green, size: :m)
+    render component("ui/badge").new(name: name, color: color, size: size)
+  end
+
+  private
+
+  def size_options
+    component('ui/badge')::SIZES.keys
+  end
+
+  def color_options
+    component('ui/badge')::COLORS.keys
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/badge/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/badge/component_preview/overview.html.erb
@@ -1,0 +1,21 @@
+<table>
+  <tr>
+    <td></td>
+    <% component::SIZES.keys.each do |size| %>
+      <td class="px-3 py-1 text-gray-500 text-center"><%= size.to_s.humanize %></td>
+    <% end %>
+  </tr>
+  <% component::COLORS.keys.each do |color| %>
+    <tr>
+      <td class="font-bold px-3 py-1"><%= color.to_s.humanize %></td>
+    </tr>
+    <tr>
+      <td class="text-gray-500 px-3 py-1">None</td>
+      <% component::SIZES.keys.each do |size| %>
+        <td class="px-3 py-1">
+          <%= render component.new(name: name, color: color, size: size) %>
+        </td>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/admin/spec/components/solidus_admin/ui/badge/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/badge/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Badge::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end

--- a/admin/spec/generator/solidus_admin/component_generator_spec.rb
+++ b/admin/spec/generator/solidus_admin/component_generator_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SolidusAdmin::ComponentGenerator, type: :generator do
       expect(engine_path('app/components/solidus_admin/ui/foo/component.html.erb').read).to start_with(%{<div class="<%= stimulus_id %>"})
       expect(engine_path('app/components/solidus_admin/ui/foo/component.js').read).to include(%{export default class extends Controller})
       expect(engine_path('spec/components/solidus_admin/ui/foo/component_spec.rb').read).to include(%{RSpec.describe SolidusAdmin::UI::Foo::Component})
+      expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview.rb').read).to include(%{class SolidusAdmin::UI::Foo::ComponentPreview < ViewComponent::Preview})
+      expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview/overview.html.erb').read).to include(%{<%= render component.new %>})
     end
   end
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -95,9 +95,8 @@ fi
 unbundled bin/rails db:drop db:create
 
 echo "~~~> Running the solidus:install generator"
-unbundled bin/rails generate solidus:install \
-  --auto-accept \
-  $@
+export SOLIDUS_ADMIN_LOOKBOOK=true
+unbundled bin/rails generate solidus:install --auto-accept $@
 
 echo "
 🚀 This app is intended for test purposes. If you're interested in running


### PR DESCRIPTION
## Summary

Now that we're getting into the nitty gritty of building the new UI with components we need.

This PR sets up component previews for SolidusAdmin and adds a basic [Lookbook](https://lookbook.build) setup to the sandbox. The reason lookbook wasn't added to SolidusAdmin directly is doesn't support being mounted at multiple paths with dedicated configurations. For that reason it's better to prioritize host application setting up their lookbook installation for storefront components if they wish to.

A basic component preview boilerplate is setup when generating components, mainly consisting in an `overview` and a `playground` preview scenarios.

The **playground** scenario will allow playing with dynamic params live from Lookbook, e.g. changing the color of a badge.

The **overview** scenario is intended to showcase the component in different modes (e.g. a button with all its states and options in a single matrix/table).
The `overview` can also act as a simple smoke test for the component and can act as basic spec coverage for the component that ensures is not breaking when provided with different options.

### Other approaches

Before settling to starting with the `overview` and `playground` scenarios I tried a bunch of different approaches using [Lookbook groups](https://lookbook.build/guide/previews/groups), including: 
- typing out all the scenarios manually: `def badge_with_green_color_and_m_size…`
- using a local macro `def self.add_scenario…` followed by `add_scenario color: :green, size: :m`
and other in-between approaches.

Eventually it was very time consuming and repetitive, even when using the `# !@macro` directive of YARD.
The solution I settled for is generating the overview template with a simple layout similar to the one used for Lookbook groups, and for the badge component using a simple table resembling the Figma designs I used to build it.

That seemed the best compromise that also minimized effort and duplication.

<details><summary>Details</summary>
<p>

```rb
  # @!macro [attach] with_color_and_size
  #   @!method $1_$2
  def self.with_color_and_size(color, size)
    define_method "#{color}_#{size}" do
      configurable(color: color, size: size)
    end
  end

  # @!group Graphite Light
  with_color_and_size :graphite_light, :s
  with_color_and_size :graphite_light, :m
  with_color_and_size :graphite_light, :l
  # @!endgroup

  # @!group Red
  with_color_and_size :red, :s
  with_color_and_size :red, :m
  with_color_and_size :red, :l
  # @!endgroup

  # @!group Green
  with_color_and_size :green, :s
  with_color_and_size :green, :m
  with_color_and_size :green, :l
  # @!endgroup

  # @!group Blue
  with_color_and_size :blue, :s
  with_color_and_size :blue, :m
  with_color_and_size :blue, :l
  # @!endgroup

  # @!group Black
  with_color_and_size :black, :s
  with_color_and_size :black, :m
  with_color_and_size :black, :l
  # @!endgroup

  # @!group Yellow
  with_color_and_size :yellow, :s
  with_color_and_size :yellow, :m
  with_color_and_size :yellow, :l
  # @!endgroup

  # # @!group Medium
  # with_color_and_size :graphite_light, :m
  # with_color_and_size :red, :m
  # with_color_and_size :green, :m
  # with_color_and_size :blue, :m
  # with_color_and_size :black, :m
  # with_color_and_size :yellow, :m
  # # @!endgroup

  # # @!group Small
  # with_color_and_size :graphite_light, :s
  # with_color_and_size :red, :s
  # with_color_and_size :green, :s
  # with_color_and_size :blue, :s
  # with_color_and_size :black, :s
  # with_color_and_size :yellow, :s
  # # @!endgroup
```

</p>
</details> 

## Screenshots

<img width="1258" alt="image" src="https://github.com/solidusio/solidus/assets/1051/5147cfea-7f83-4b40-86f4-af4bc0af7cbe">
<img width="1258" alt="image" src="https://github.com/solidusio/solidus/assets/1051/ff71e163-1f96-4480-9812-6430c883617d">

### ViewComponent previews

The original VC previews are still accessible at `http://localhost:3000/rails/view_components`

<img width="1083" alt="image" src="https://github.com/solidusio/solidus/assets/1051/289d6122-c35b-4432-979d-6e2c8046be3b">

`http://localhost:3000/rails/view_components/solidus_admin/ui/badge/component/overview`

<img width="1083" alt="image" src="https://github.com/solidusio/solidus/assets/1051/39ed8159-1acb-49bb-a5f4-5935c181d591">

`http://localhost:3000/rails/view_components/solidus_admin/ui/badge/component/playground`

<img width="1083" alt="image" src="https://github.com/solidusio/solidus/assets/1051/a786f92f-106f-43ef-bff9-f863749b2344">

`http://localhost:3000/rails/view_components/solidus_admin/ui/badge/component/playground?name=Foo`

<img width="1083" alt="image" src="https://github.com/solidusio/solidus/assets/1051/dddf3236-5773-4bb5-a26e-ec88ad87c7b2">



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
