### PR TITLE
Remove unused ActiveRecord join class `Spree::PromotionRuleRole`

### DIFF
--- a/core/app/models/spree/promotion_rule_role.rb
+++ b/core/app/models/spree/promotion_rule_role.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Spree
-  class PromotionRuleRole < Spree::Base
-    belongs_to :promotion_rule, class_name: 'Spree::PromotionRule', optional: true
-    belongs_to :role, class_name: 'Spree::Role', optional: true
-  end
-end


### PR DESCRIPTION


## Summary

This class never had a database table to back it. The promotion rule "User Role" uses a preferences array of role IDs to store the roles it needs.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
