### PR TITLE
ResourceController: Allow overriding routes proxy

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -193,7 +193,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
                   .find_by!(self.class.parent_data[:find_by] => params["#{parent_model_name}_id"])
     instance_variable_set("@#{parent_model_name}", @parent)
   rescue ActiveRecord::RecordNotFound => e
-    resource_not_found(flash_class: e.model.constantize, redirect_url: spree.polymorphic_url([:admin, parent_model_name.pluralize.to_sym]))
+    resource_not_found(flash_class: e.model.constantize, redirect_url: routes_proxy.polymorphic_url([:admin, parent_model_name.pluralize.to_sym]))
   end
 
   def parent?
@@ -238,17 +238,17 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def new_object_url(options = {})
     if parent?
-      spree.new_polymorphic_url([:admin, parent, model_class], options)
+      routes_proxy.new_polymorphic_url([:admin, parent, model_class], options)
     else
-      spree.new_polymorphic_url([:admin, model_class], options)
+      routes_proxy.new_polymorphic_url([:admin, model_class], options)
     end
   end
 
   def edit_object_url(object, options = {})
     if parent?
-      spree.polymorphic_url([:edit, :admin, parent, object], options)
+      routes_proxy.polymorphic_url([:edit, :admin, parent, object], options)
     else
-      spree.polymorphic_url([:edit, :admin, object], options)
+      routes_proxy.polymorphic_url([:edit, :admin, object], options)
     end
   end
 
@@ -256,18 +256,22 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     target = object ? object : @object
 
     if parent?
-      spree.polymorphic_url([:admin, parent, target], options)
+      routes_proxy.polymorphic_url([:admin, parent, target], options)
     else
-      spree.polymorphic_url([:admin, target], options)
+      routes_proxy.polymorphic_url([:admin, target], options)
     end
   end
 
   def collection_url(options = {})
     if parent?
-      spree.polymorphic_url([:admin, parent, model_class], options)
+      routes_proxy.polymorphic_url([:admin, parent, model_class], options)
     else
-      spree.polymorphic_url([:admin, model_class], options)
+      routes_proxy.polymorphic_url([:admin, model_class], options)
     end
+  end
+
+  def routes_proxy
+    spree
   end
 
   # Allow all attributes to be updatable.

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -22,10 +22,12 @@ describe Spree::Admin::WidgetsController, type: :controller do
     # Database
     class CreateWidgets < ActiveRecord::Migration[5.1]
       def change
-        create_table(:widgets) do |t|
-          t.string :name
-          t.integer :position
-          t.timestamps null: false
+        unless table_exists?(:widgets)
+          create_table(:widgets) do |t|
+            t.string :name
+            t.integer :position
+            t.timestamps null: false
+          end
         end
       end
     end
@@ -288,6 +290,15 @@ describe Spree::Admin::WidgetsController, type: :controller do
 
       expect(response).to redirect_to('/admin/widgets')
       expect(flash[:error]).to eql('Product is not found')
+    end
+  end
+
+  describe "#routes_proxy" do
+    subject { controller.send(:routes_proxy) }
+
+    it "forwards to the #spree routing proxy" do
+      expect(controller).to receive(:spree).and_call_original
+      expect(subject).to be_a(ActionDispatch::Routing::RoutesProxy)
     end
   end
 end


### PR DESCRIPTION
## Summary

Within Solidus, we always want to use the `spree` routes proxy as that is where all routes are defined. However, many people use the Resource controller as a parent controller in their main app, and because of this they need to override all the URL generation methods in the Resource Controller.

This allows one to specify the routes proxy in a custom controller as follows:

```rb
module MyApp
  class WidgetsController < Spree::Admin::ResourceController
  private

  def routes_proxy
    main_app
  end
end
```

Engine Developers can use this for engines, as well:

```rb
module MyEngine
  class WidgetsController < Spree::Admin::ResourceController
  private

  def routes_proxy
    my_engine
  end
end
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
