### PR TITLE
mark a shipment as canceled if all the inventory units have been canceled

### DIFF
--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -118,7 +118,9 @@ class Spree::OrderCancellations
       to_a
 
     shipments.each do |shipment|
-      if shipment.inventory_units.all? { |iu| iu.shipped? || iu.canceled? }
+      if shipment.inventory_units_canceled?
+        shipment.update!(state: 'canceled', shipped_at: nil)
+      elsif shipment.inventory_units_shipped_or_canceled?
         shipment.update!(state: 'shipped', shipped_at: Time.current)
       end
     end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -83,15 +83,15 @@ RSpec.describe Spree::OrderCancellations do
     end
 
     it "cancels the inventory unit" do
-      expect { subject }.to change { inventory_unit.state }.to "canceled"
+      expect { subject }.to change { inventory_unit.state }.to 'canceled'
     end
 
     it "updates the shipment.state" do
-      expect { subject }.to change { shipment.reload.state }.from('ready').to('shipped')
+      expect { subject }.to change { shipment.reload.state }.from('ready').to('canceled')
     end
 
     it "updates the order.shipment_state" do
-      expect { subject }.to change { order.shipment_state }.from('ready').to('shipped')
+      expect { subject }.to change { order.shipment_state }.from('ready').to('canceled')
     end
 
     it "adjusts the order" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe Spree::Shipment, type: :model do
       expect(shipment.determine_state(order)).to eq 'canceled'
     end
 
+    it 'returns canceled if all of the inventory units are canceled' do
+      shipment.inventory_units.each(&:cancel!)
+      expect(shipment.determine_state(order)).to eql 'canceled'
+    end
+
     it 'returns pending unless order.can_ship?' do
       allow(order).to receive_messages can_ship?: false
       expect(shipment.determine_state(order)).to eq 'pending'


### PR DESCRIPTION
## Summary

I noticed that if a multi-shipment order goes through and you cancel one of the shipments, an order recalculation will set the shipment as pending/ready. See:

https://github.com/solidusio/solidus/blob/main/core/app/models/spree/shipment.rb#L208

This is because it's only checking if the order is canceled. While this is a correct method to check if a shipment should be marked as canceled, it falls short if the it's only 1 shipment in an order that needs to be canceled out of many. If I cancel a shipment, then the shipment will be marked as shipped and that can be quite surprising for customers and admins.

Instead, let's increase the guarantee on canceling a shipment for now by checking if the order is canceled _or_ all of the inventory units for said shipment have been canceled.

In the future, I think it would be better that when a shipment is canceled, an inventory unit cancellation should be done on the inventory units it's responsible for. That would help create a guarantee for resolving the bug highlighted above. But for now, just marking a shipment as canceled when the inventory units have been canceled is progress in the right direction.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
