### PR TITLE
[Admin] `ui/table` component preview

### DIFF
--- a/admin/lib/generators/solidus_admin/component/component_generator.rb
+++ b/admin/lib/generators/solidus_admin/component/component_generator.rb
@@ -84,7 +84,8 @@ module SolidusAdmin
     def preview_playground_yard_tags
       return if attributes.blank?
 
-      attributes.map { |attr| "@param #{attr.name} [String]" }.join("\n  ")
+      # See https://lookbook.build/guide/previews/params#input-types
+      attributes.map { |attr| "# @param #{attr.name} text" }.join("\n  ")
     end
 
     def preview_playground_body

--- a/admin/lib/generators/solidus_admin/component/templates/component_preview.rb.tt
+++ b/admin/lib/generators/solidus_admin/component/templates/component_preview.rb.tt
@@ -6,7 +6,7 @@ class <%= File.join(*[namespaced_path, file_path].compact).classify %>::Componen
   include SolidusAdmin::ContainerHelper
 
   def overview
-    render_with_template(locals: { name: name, component: component(<%= component_registry_id.inspect %>) })
+    render_with_template(locals: { component: component(<%= component_registry_id.inspect %>) })
   end
 
   <%= preview_playground_yard_tags %>

--- a/admin/lib/generators/solidus_admin/component/templates/component_preview.rb.tt
+++ b/admin/lib/generators/solidus_admin/component/templates/component_preview.rb.tt
@@ -2,11 +2,10 @@
 
 # @component <%= component_registry_id.inspect %>
 class <%= File.join(*[namespaced_path, file_path].compact).classify %>::ComponentPreview < ViewComponent::Preview
-  layout "solidus_admin/preview"
-  include SolidusAdmin::ContainerHelper
+  include SolidusAdmin::Preview
 
   def overview
-    render_with_template(locals: { component: component(<%= component_registry_id.inspect %>) })
+    render_with_template
   end
 
   <%= preview_playground_yard_tags %>

--- a/admin/lib/solidus_admin/engine.rb
+++ b/admin/lib/solidus_admin/engine.rb
@@ -3,6 +3,7 @@
 require "view_component"
 require "solidus_admin/container"
 require "solidus_admin/importmap_reloader"
+require "solidus_admin/preview"
 
 module SolidusAdmin
   class Engine < ::Rails::Engine
@@ -16,6 +17,14 @@ module SolidusAdmin
 
     initializer "solidus_admin.view_component" do |app|
       app.config.view_component.preview_paths << SolidusAdmin::Engine.root.join("spec/components/previews").to_s
+
+      app.config.to_prepare do
+        preview_controller_class = app.config.view_component.preview_controller.constantize
+
+        # This is needed to make the preview controller have access to the same
+        # set of helpers that are available to the Preview class.
+        preview_controller_class.include SolidusAdmin::Preview::ControllerHelper
+      end
     end
 
     initializer "solidus_admin.inflections" do

--- a/admin/lib/solidus_admin/preview.rb
+++ b/admin/lib/solidus_admin/preview.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# This module will add all the necessary harness to a ViewComponent::Preview
+# to be able to render Solidus components.
+#
+# Adds a `current_component` helper method that will return the the component class
+# based on the preview class name. The component class name is inferred by removing
+# the `Preview` suffix from the preview class name.
+#
+# Adds a `helpers` method that will return the helpers module from SolidusAdmin::BaseController
+# making them available to the preview class (which is not a standard controller). All helpers
+# are available to the preview class via `method_missing`.
+#
+# @example
+#   class SolidusAdmin::UI::Badge::ComponentPreview < ViewComponent::Preview
+#     include SolidusAdmin::Preview
+#
+#     def default
+#       render current_component.new(name: time_ago_in_words(1.day.ago))
+#     end
+#   end
+#
+module SolidusAdmin::Preview
+  extend ActiveSupport::Concern
+
+  module ControllerHelper
+    extend ActiveSupport::Concern
+
+    included do
+      helper ActionView::Helpers
+      helper_method :current_component
+    end
+
+    private
+
+    def current_component
+      @current_component ||= begin
+        # Lookbook sets the @preview instance variable with a PreviewEntity instance, while ViewComponent uses the preview class.
+        # Lookbook's PreviewEntity has `#preview_class_name` as part of its public api.
+        # Since we want to support both ways or rendering components, we need to check.
+        preview_class_name = @preview.respond_to?(:preview_class_name) ? @preview.preview_class_name : @preview.name
+        preview_class_name.chomp("Preview").constantize
+      end
+    end
+  end
+
+  included do
+    layout "solidus_admin/preview"
+
+    delegate :helpers, to: SolidusAdmin::BaseController
+    private :helpers # hide it from preview "example" methods
+  end
+
+  def current_component
+    @current_component ||= self.class.name.chomp("Preview").constantize
+  end
+
+  private
+
+  def method_missing(name, ...)
+    if helpers.respond_to?(name)
+      helpers.send(name, ...)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(name, include_private = false)
+    helpers.respond_to?(name) || super
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/badge/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/badge/component_preview.rb
@@ -2,28 +2,27 @@
 
 # @component "ui/badge"
 class SolidusAdmin::UI::Badge::ComponentPreview < ViewComponent::Preview
-  layout "solidus_admin/preview"
-  include SolidusAdmin::ContainerHelper
+  include SolidusAdmin::Preview
 
   # @param name [String]
   def overview(name: "Label")
-    render_with_template(locals: { name: name, component: component("ui/badge") })
+    render_with_template(locals: { name: name })
   end
 
   # @param name [String]
   # @param color select :color_options
   # @param size select :size_options
   def playground(name: "Label", color: :green, size: :m)
-    render component("ui/badge").new(name: name, color: color, size: size)
+    render current_component.new(name: name, color: color, size: size)
   end
 
   private
 
   def size_options
-    component('ui/badge')::SIZES.keys
+    current_component::SIZES.keys
   end
 
   def color_options
-    component('ui/badge')::COLORS.keys
+    current_component::COLORS.keys
   end
 end

--- a/admin/spec/components/previews/solidus_admin/ui/badge/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/badge/component_preview.rb
@@ -4,12 +4,12 @@
 class SolidusAdmin::UI::Badge::ComponentPreview < ViewComponent::Preview
   include SolidusAdmin::Preview
 
-  # @param name [String]
+  # @param name text
   def overview(name: "Label")
     render_with_template(locals: { name: name })
   end
 
-  # @param name [String]
+  # @param name text
   # @param color select :color_options
   # @param size select :size_options
   def playground(name: "Label", color: :green, size: :m)

--- a/admin/spec/components/previews/solidus_admin/ui/badge/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/badge/component_preview/overview.html.erb
@@ -1,19 +1,19 @@
 <table>
   <tr>
     <td></td>
-    <% component::SIZES.keys.each do |size| %>
+    <% current_component::SIZES.keys.each do |size| %>
       <td class="px-3 py-1 text-gray-500 text-center"><%= size.to_s.humanize %></td>
     <% end %>
   </tr>
-  <% component::COLORS.keys.each do |color| %>
+  <% current_component::COLORS.keys.each do |color| %>
     <tr>
       <td class="font-bold px-3 py-1"><%= color.to_s.humanize %></td>
     </tr>
     <tr>
       <td class="text-gray-500 px-3 py-1">None</td>
-      <% component::SIZES.keys.each do |size| %>
+      <% current_component::SIZES.keys.each do |size| %>
         <td class="px-3 py-1">
-          <%= render component.new(name: name, color: color, size: size) %>
+          <%= render current_component.new(name: name, color: color, size: size) %>
         </td>
       <% end %>
     </tr>

--- a/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# @component "ui/table"
+class SolidusAdmin::UI::Table::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  # Render a simple table with 10 products.
+  # - The first column is the product `#name` attribute, and uses a **symbol** for both the content and the header
+  # - The second column is the product `#available_on` attribute, and uses **a block returning strings** for both the content and the header
+  # - The third column is the product `#price` attribute, uses **blocks returning component instances** for both the content and the header
+  #
+  # All these ways to header and data cells can be mixed and matched.
+  def simple
+    model_class = Spree::Product
+    rows = Array.new(10) do |n|
+      model_class.new(name: "Product #{n}", price: n * 10.0, available_on: n.days.ago)
+    end
+
+    render component("ui/table").new(rows: rows, model_class: model_class).tap { |t|
+      t.column(:name) { _1.name }
+      t.column(:available_on) { "#{time_ago_in_words _1.available_on} ago" }
+      t.column(:price) { component("ui/badge").new(name: _1.display_price, color: :green) }
+    }
+  end
+end

--- a/admin/spec/components/solidus_admin/ui/table/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/table/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Table::Component, type: :component do
+  it "renders a simple table" do
+    render_preview(:simple)
+  end
+end

--- a/admin/spec/generator/solidus_admin/component_generator_spec.rb
+++ b/admin/spec/generator/solidus_admin/component_generator_spec.rb
@@ -5,16 +5,32 @@ require 'generators/solidus_admin/component/component_generator'
 
 RSpec.describe SolidusAdmin::ComponentGenerator, type: :generator do
   it "creates a component with the given name" do
-    run_generator %w[ui/foo]
+    run_generator %w[ui/foo bar baz]
 
     aggregate_failures do
-      expect(engine_path('app/components/solidus_admin/ui/foo/component.rb').read).to include('class SolidusAdmin::UI::Foo::Component <')
-      expect(engine_path('app/components/solidus_admin/ui/foo/component.yml').read).to match(/^en:$/)
-      expect(engine_path('app/components/solidus_admin/ui/foo/component.html.erb').read).to start_with(%{<div class="<%= stimulus_id %>"})
-      expect(engine_path('app/components/solidus_admin/ui/foo/component.js').read).to include(%{export default class extends Controller})
-      expect(engine_path('spec/components/solidus_admin/ui/foo/component_spec.rb').read).to include(%{RSpec.describe SolidusAdmin::UI::Foo::Component})
-      expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview.rb').read).to include(%{class SolidusAdmin::UI::Foo::ComponentPreview < ViewComponent::Preview})
-      expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview/overview.html.erb').read).to include(%{<%= render component.new %>})
+      expect(engine_path('app/components/solidus_admin/ui/foo/component.rb').read)
+        .to include('class SolidusAdmin::UI::Foo::Component <')
+        .and include(%{def initialize(bar:, baz:)})
+
+      expect(engine_path('app/components/solidus_admin/ui/foo/component.yml').read)
+        .to match(/^en:$/)
+
+      expect(engine_path('app/components/solidus_admin/ui/foo/component.html.erb').read)
+        .to start_with(%{<div class="<%= stimulus_id %>"})
+
+      expect(engine_path('app/components/solidus_admin/ui/foo/component.js').read)
+        .to include(%{export default class extends Controller})
+
+      expect(engine_path('spec/components/solidus_admin/ui/foo/component_spec.rb').read)
+        .to include(%{RSpec.describe SolidusAdmin::UI::Foo::Component})
+
+      expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview.rb').read)
+        .to include(%{class SolidusAdmin::UI::Foo::ComponentPreview < ViewComponent::Preview})
+        .and include(%{# @param bar text})
+        .and include(%{# @param baz text})
+
+      expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview/overview.html.erb').read)
+        .to include(%{<%= render component.new(bar: "bar", baz: "baz") %>})
     end
   end
 

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -101,7 +101,7 @@ RSpec.configure do |config|
   config.include FileUtils, type: :generator
   config.before type: :generator do
     self.generator_class = described_class
-    self.destination_root = SolidusAdmin::Engine.root.join('tmp')
+    self.destination_root = SolidusAdmin::Engine.root.join('../tmp/solidus_admin_generators')
     ::Rails::Generators.namespace = SolidusAdmin
     prepare_destination
   end


### PR DESCRIPTION
## Summary

This PR adds a preview and specs to the table component. ~~At the same time generalizes the rendering of both header and data cells.~~ _(Moved to https://github.com/solidusio/solidus/pull/5223)_

The preview demonstrates how header and data cells support different types of content:

<img width="1394" alt="image" src="https://github.com/solidusio/solidus/assets/1051/acd00ccd-9c0f-40df-9dc1-51862f0e3f5a">

The preview is also used in the spec to ensure it's not breaking and to provide basic coverage.


_The changes in this PR were extracted from the work on batch actions for which we'll need to fit a checkbox in a header cell, but I figured was easier to review it separately._

**Props to @waiting-for-dev for pushing me to try again the extraction of common things among SolidusAdmin preview classes 🙌 .**

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
