### PR TITLE
Ensure the fallback `current_store` has a domain set

### DIFF
--- a/core/app/models/spree/store_selector/by_server_name.rb
+++ b/core/app/models/spree/store_selector/by_server_name.rb
@@ -25,7 +25,7 @@ module Spree
         store = Spree::Store.where(url: server_name).or(Store.where(default: true)).order(default: :asc).first
 
         # Provide a fallback, mostly for legacy/testing purposes
-        store || Spree::Store.new
+        store || Spree::Store.new(url: server_name)
       end
     end
   end

--- a/core/spec/models/spree/store_selector/by_server_name_spec.rb
+++ b/core/spec/models/spree/store_selector/by_server_name_spec.rb
@@ -5,6 +5,13 @@ require 'rails_helper'
 RSpec.describe Spree::StoreSelector::ByServerName do
   describe "#store" do
     subject { described_class.new(request).store }
+    let(:request) { double(headers: {}, env: { "SERVER_NAME" => "www.example.com" } ) }
+
+    context "with no match" do
+      it "returns a new store with current domain as the url" do
+        expect(subject).to be_a_new(Spree::Store).with(url: "www.example.com")
+      end
+    end
 
     context "with a default" do
       let(:request) { double(headers: {}, env: {}) }


### PR DESCRIPTION
## Summary

Whenever no store is found the fallback one should be initialized with the current domain.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
