### PR TITLE
[Admin] Add a `products#index` feature spec

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -8,8 +8,10 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
   # @!visibility private
 
   def image_column(product)
+    image = product.gallery.images.first or return
+
     link_to(
-      image_tag(product.gallery.images.first.url(:small), class: 'h-10 w-10 max-w-min'),
+      image_tag(image.url(:small), class: 'h-10 w-10 max-w-min'),
       spree.edit_admin_product_path(product),
     )
   end

--- a/admin/lib/solidus_admin.rb
+++ b/admin/lib/solidus_admin.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree_core'
+require 'solidus_core'
+require 'solidus_backend'
 require 'solidus_admin/version'
 require 'solidus_admin/engine'
 

--- a/admin/solidus_admin.gemspec
+++ b/admin/solidus_admin.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'dry-system', '~> 1.0'
   s.add_dependency 'importmap-rails', '~> 1.2', '>= 1.2.1'
+  s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version
   s.add_dependency 'tailwindcss-rails', '~> 2.0'
   s.add_dependency 'view_component', '~> 3.3'

--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -5,14 +5,10 @@ require "spec_helper"
 RSpec.describe SolidusAdmin::BaseComponent, type: :component do
   describe "#spree" do
     it "gives access to spree routing helpers" do
-      # The spree/core routes start as empty, so we need to add a route to test
-      Spree::Core::Engine.routes.draw { get '/foo/bar', to: 'foo#bar', as: :foo_bar }
-
+      allow(Spree::Core::Engine.routes.url_helpers).to receive(:foo_path).and_return("/foo/bar")
       component = described_class.new
 
-      expect(component.spree.foo_bar_path).to eq("/foo/bar")
-    ensure
-      Spree::Core::Engine.routes.clear!
+      expect(component.spree.foo_path).to eq("/foo/bar")
     end
   end
 

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Products", type: :feature do
+  it "lists products" do
+    create(:product, name: "Just a product", price: 19.99)
+
+    visit "/admin/products"
+
+    expect(page).to have_content("Just a product")
+    expect(page).to have_content("$19.99")
+  end
+end

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -22,6 +22,13 @@ DummyApp.setup(
   lib_name: 'solidus_admin'
 )
 
+# Calling `draw` will completely rewrite the routes defined in the dummy app,
+# so we need to include the main solidus route.
+DummyApp::Application.routes.draw do
+  mount SolidusAdmin::Engine, at: '/admin'
+  mount Spree::Core::Engine, at: '/'
+end
+
 # RAILS
 require "rspec/rails"
 ENV["RAILS_ENV"] ||= 'test'


### PR DESCRIPTION
## Summary

Improve our coverage and protection against regression by adding a feature spec for products#index.

Eventually we'll need feature parity with the legacy version and/or cover for newly added features. In the meantime at least we ensure that we can visit the page and products are listed.

The first commit is also added to `main` in https://github.com/solidusio/solidus/pull/5224 and is needed because there's no `Spree::Store` in the database unless we add it.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
