### PR TITLE
[Admin] Add the preview for the sidebar admin component

### DIFF
--- a/admin/spec/components/previews/solidus_admin/sidebar/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/sidebar/component_preview.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "solidus_admin/main_nav_item"
+
+# @component "sidebar"
+class SolidusAdmin::Sidebar::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  class ItemComponent < SolidusAdmin::Sidebar::Item::Component
+    def path
+      "#"
+    end
+
+    def active?
+      false
+    end
+  end
+
+  # @param store_name text
+  # @param store_url url
+  # @param logo_path text { description: "Asset path to the store logo" }
+  def overview(store_name: "Solidus store", store_url: "https://example.com", logo_path: SolidusAdmin::Config.logo_path)
+    store = Struct.new(:name, :url).new(store_name, store_url)
+
+    render_with_template(
+      locals: {
+        logo_path: logo_path,
+        store: store,
+        item_component: ItemComponent
+      }
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/sidebar/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/sidebar/component_preview/overview.html.erb
@@ -1,0 +1,7 @@
+<div class="w-[17.78rem]">
+  <%= render current_component.new(
+    store: store,
+    logo_path: logo_path,
+    item_component: item_component
+  ) %>
+</div>

--- a/admin/spec/components/solidus_admin/sidebar/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/component_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe SolidusAdmin::Sidebar::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+
   it "renders the solidus logo" do
     component = described_class.new(
       store: build(:store),


### PR DESCRIPTION
## Summary

We inject a tweaked item component to avoid rendering actual links in the embedded preview.

We'll leave the preview of active state of the main navigation to the item component preview.

Ref. #5221

![screenshot-localhost_3000-2023 07 06-16_08_11](https://github.com/solidusio/solidus/assets/52650/30e696ae-466d-4b53-985a-2b65cb417836)


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
