### PR TITLE
`bin/build-ci` cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
     steps:
       - run:
           name: Run Tests
-          command: ./bin/build-ci test
+          command: ./bin/build-ci
 
       - store_artifacts:
           path: /tmp/test-artifacts

--- a/bin/build-ci
+++ b/bin/build-ci
@@ -5,173 +5,122 @@ require 'fileutils'
 require 'pathname'
 
 class Project
-  attr_reader :name, :title, :weight
+  include FileUtils
 
-  NODE_TOTAL = Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1))
-  NODE_INDEX = Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0))
+  attr_reader :name, :title, :weight, :status
 
-  ROOT          = Pathname.pwd.freeze
-
+  ROOT = Pathname("#{__dir__}/..").expand_path.freeze
 
   def initialize(name, test_type: :rspec, title: nil, weight:)
     @name = name
     @title = title || name
     @test_type = test_type
     @weight = weight
+    @status = :pending
   end
 
-  ALL = [
-    new('api', weight: 50),
-    new('backend', weight: 215),
-    new('backend', test_type: :teaspoon, title: "backend JS", weight: 15),
-    new('core', weight: 220),
-    new('sample', weight: 22)
-  ].freeze
-
-  # Test subproject for passing its tests
-  #
-  # @return [Boolean]
-  #   the success of the build
-  def pass?
-    chdir do
-      run_tests
-    end
+  def self.all
+    [
+      new('api', weight: 50),
+      new('backend', weight: 215),
+      new('backend', test_type: :teaspoon, title: "backend JS", weight: 15),
+      new('core', weight: 220),
+      new('sample', weight: 22)
+    ]
   end
 
-  # Execute tests on subprojects
-  #
-  # @return [Boolean]
-  #   the success of ALL subprojects
-  def self.test
-    projects = current_projects
-    suffix   = "#{projects.length} projects(s) on node #{NODE_INDEX.succ} / #{NODE_TOTAL}"
-
-    log("Running #{suffix}")
-    projects.each do |project|
-      log("- #{project.name}")
-    end
-
-    builds = projects.map do |project|
-      log("Building: #{project.name}")
-      project.pass?
-    end
-    log("Finished running #{suffix}")
-
-    projects.zip(builds).each do |project, build|
-      log("- #{project.name} #{build ? 'SUCCESS' : 'FAILURE'}")
-    end
-
-    builds.all?
-  end
-  private_class_method :test
-
-  # Return the projects active on current node
+  # Return the projects active on the current node
   #
   # @return [Array<Project>]
-  def self.current_projects
-    unallocated = ALL.sort_by(&:weight).reverse
-    nodes = Array.new(NODE_TOTAL) { [] }
+  def self.weighted_projects(node_total:, node_index:)
+    unallocated = all.sort_by(&:weight).reverse
+    nodes = Array.new(node_total) { [] }
 
     while project = unallocated.shift
       nodes.min_by { |projects| projects.sum(&:weight) } << project
     end
 
-    nodes[NODE_INDEX]
-  end
-  private_class_method :current_projects
-
-  # Log a progress message to stderr
-  #
-  # @param [String] message
-  #
-  # @return [void]
-  def self.log(message)
-    warn(message)
-  end
-  private_class_method :log
-
-  # Process CLI arguments
-  #
-  # @param [Array<String>] arguments
-  #
-  # @return [Boolean]
-  #   the success of the CLI run
-  def self.run_cli(arguments)
-    fail ArgumentError if arguments.length > 1
-    mode = arguments.fetch(0, DEFAULT_MODE)
-
-    case mode
-    when 'install'
-      install
-      true
-    when 'test'
-      test
-    else
-      fail "Unknown mode: #{mode.inspect}"
+    nodes[node_index].tap do |projects|
+      warn("Selected #{projects.length} projects(s) on node #{node_index.succ} / #{node_total}")
+      projects.each { warn("- #{_1.name}") }
     end
+  end
+
+  # Run projects specs
+  # @param [Array<Project>] projects
+  # @return [Boolean] success of the run
+  def self.run(projects = current_projects)
+    warn("=" * 80)
+    warn("Running projects: #{projects.map(&:name).join(', ')}")
+
+    projects.each do |project|
+      warn("=" * 80)
+      warn("Building: #{project.name}")
+      project.run
+    end
+
+    warn("=" * 80)
+    warn("Results:")
+    projects.each do |project|
+      warn("- #{project.name} #{project.status.to_s.upcase}")
+    end
+    warn("=" * 80)
+
+    projects.all? { _1.status == :success }
+  end
+
+  # Run specs for the project
+  def run
+    @status = :running
+    chdir ROOT.join(name) do
+      @status = send(:"run_#{@test_type}") ? :success : :failure
+    end
+  rescue Interrupt
+    @status = :interrupted
+  rescue StandardError => e
+    warn(e)
+    @status = :error
   end
 
   private
 
-  # Run tests for subproject
-  #
-  # @return [Boolean]
-  #   the success of the tests
-  def run_tests
-    send(:"run_#{@test_type}")
-  end
-
   def run_rspec
-    run_test_cmd(%w[bundle exec rspec] + rspec_arguments)
+    run_test_cmd(%W[
+      bundle exec rspec
+      --profile 10
+      --format documentation
+      --require rspec_junit_formatter --format RspecJunitFormatter --out #{report_dir}/#{name}.xml
+    ])
   end
 
   def run_teaspoon
-    cmd = %w[bundle exec teaspoon] + teaspoon_arguments
-
-    run_test_cmd(cmd)
+    run_test_cmd(%W[
+      bundle exec teaspoon
+      --require=spec/teaspoon_env.rb
+      --format=documentation,junit>#{report_dir}/#{name}_js.xml
+    ])
   end
 
   def run_test_cmd(args)
     puts "Run: #{args.join(' ')}"
-    result = system(*args)
-    puts(result ? "Success" : "Failed")
-    result
-  end
-
-  def teaspoon_arguments
-    args = []
-
-    args << '--require=spec/teaspoon_env.rb'
-
-    if report_dir
-      FileUtils.mkdir_p("#{report_dir}/rspec")
-      args << "--format=documentation,junit>#{report_dir}/rspec/#{name}_js.xml"
-    else
-      args << '--format=documentation'
-    end
-
-    args
-  end
-
-  def rspec_arguments
-    args = []
-    args += %w[--format documentation --profile 10 --no-color]
-    if report_dir
-      args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/#{name}.xml]
-    end
-    args
+    system(*args).tap { puts(_1 ? "Success" : "Failed") }
   end
 
   def report_dir
-    ENV['CIRCLE_TEST_REPORTS']
-  end
-
-  # Change to subproject directory and execute block
-  #
-  # @return [void]
-  def chdir(&block)
-    Dir.chdir(ROOT.join(name), &block)
+    base_dir = Pathname(ENV['CIRCLE_TEST_REPORTS'] || ROOT.join("tmp/test-reports/#{@test_type}"))
+    base_dir.join('rspec').tap { mkdir_p _1 }
   end
 end
 
-exit Project.run_cli(ARGV)
+if ARGV.first # Run a single project
+  projects = Project.all.select { _1.name == ARGV.first }
+elsif ENV['CIRCLE_NODE_INDEX'] # Run projects on a CI node
+  projects = Project.weighted_projects(
+    node_total: Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1)),
+    node_index: Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0)),
+  )
+else # Run all projects
+  projects = Project.all
+end
+
+exit Project.run(projects)

--- a/bin/build-ci
+++ b/bin/build-ci
@@ -11,12 +11,7 @@ class Project
   NODE_INDEX = Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0))
 
   ROOT          = Pathname.pwd.freeze
-  VENDOR_BUNDLE = ROOT.join('vendor', 'bundle').freeze
 
-  BUNDLER_JOBS    = 4
-  BUNDLER_RETRIES = 3
-
-  DEFAULT_MODE = 'test'.freeze
 
   def initialize(name, test_type: :rspec, title: nil, weight:)
     @name = name
@@ -32,34 +27,6 @@ class Project
     new('core', weight: 220),
     new('sample', weight: 22)
   ].freeze
-
-  # Install subproject
-  #
-  # @raise [RuntimeError]
-  #   in case of failure
-  #
-  # @return [self]
-  #   otherwise
-  def self.install
-    bundle_check || bundle_install || fail('Cannot finish gem installation')
-  end
-
-  # Check if current bundle is already usable
-  #
-  # @return [Boolean]
-  def self.bundle_check
-    system("bundle", "check", "--path=#{VENDOR_BUNDLE}")
-  end
-  private_class_method :bundle_check
-
-  # Install the current bundle
-  #
-  # @return [Boolean]
-  #   the success of the installation
-  def self.bundle_install
-    system("bundle", "install", "--path=#{VENDOR_BUNDLE}", "--jobs=#{BUNDLER_JOBS}", "--retry=#{BUNDLER_RETRIES}")
-  end
-  private_class_method :bundle_check
 
   # Test subproject for passing its tests
   #


### PR DESCRIPTION
## Summary

I had to wrap my head around this script while trying to debug an issue that I only saw in the CI.
While doing that I started to realize that it was full of legacy code and that could be simplified a lot.

- Removed support for calling `bin/build-ci install` which hasn't been used in a while
- Separated the multi-project runner from the list of projects which can now be passed to `.run`
- Inlined a lot of small method that mostly create indirection without adding much value
- _extra: Finally was able to run it locally with ease and fix my issue, hooray 🎉_

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
