### PR TITLE
[Admin] add a `ui/button` component

### DIFF
--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
+  SIZES = {
+    s: %w[
+      h-7 px-1.5 py-1
+      text-xs font-semibold leading-none
+    ],
+    m: %w[
+      h-9 px-3 py-1.5
+      text-sm font-semibold leading-none
+    ],
+    l: %w[
+      h-12 px-4 py-2
+      text-base font-semibold leading-none
+    ],
+  }
+
+  SCHEMES = {
+    primary: %w[
+      text-white bg-black rounded
+      hover:text-white hover:bg-gray-600
+      active:text-white active:bg-gray-800
+      focus:text-white focus:bg-gray-700
+      disabled:text-gray-400 disabled:bg-gray-100 disabled:cursor-not-allowed
+    ],
+    secondary: %w[
+      text-gray-700 bg-white border border-1 rounded border-gray-200
+      hover:bg-gray-50
+      active:bg-gray-100
+      focus:bg-gray-50
+      disabled:text-gray-300 disabled:bg-white border-gray-200 disabled:cursor-not-allowed
+    ],
+    ghost: %w[
+      text-gray-700 bg-transparent rounded
+      hover:bg-gray-50
+      active:bg-gray-100
+      focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
+      disabled:text-gray-300 disabled:bg-transparent border-gray-300 disabled:cursor-not-allowed
+    ],
+  }
+
+  def initialize(text: nil, class_name: nil, size: :m, scheme: :primary, **attributes)
+    @text = text
+    @attributes = attributes
+
+    @class_name = [
+      class_name,
+      'justify-start items-center gap-1 inline-flex',
+      SIZES.fetch(size.to_sym),
+      SCHEMES.fetch(scheme.to_sym),
+    ].join(' ')
+  end
+
+  def call
+    content_tag(:button, @text, class: @class_name, **@attributes)
+  end
+end

--- a/admin/lib/generators/solidus_admin/component/templates/component_preview_overview.html.erb
+++ b/admin/lib/generators/solidus_admin/component/templates/component_preview_overview.html.erb
@@ -3,5 +3,5 @@
     Scenario 1
   </h6>
 
-  <%%= render component.new<%= preview_signature %> %>
+  <%%= render current_component.new<%= preview_signature %> %>
 </div>

--- a/admin/spec/components/previews/solidus_admin/ui/button/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/button/component_preview.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# @component "ui/button"
+class SolidusAdmin::UI::Button::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  # @param text text
+  def overview(text: "Button")
+    render_with_template locals: { text: text }
+  end
+
+  # @param size select { choices: [s, m, l] }
+  # @param scheme select { choices: [primary, secondary, ghost] }
+  # @param text text
+  def playground(size: :m, scheme: :primary, text: "Button")
+    render component("ui/button").new(size: size, scheme: scheme, text: text)
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/button/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/button/component_preview/overview.html.erb
@@ -1,0 +1,27 @@
+<% current_component::SCHEMES.keys.each do |scheme| %>
+  <div class="mb-8">
+    <h6 class="text-gray-500 mb-3 mt-0">
+      <%= scheme.to_s.humanize %>
+    </h6>
+
+    <table>
+      <tr>
+        <td></td>
+        <% current_component::SIZES.keys.each do |size| %>
+          <td class="px-3 py-1 text-gray-500 text-center text-[16px]"><%= size.to_s.humanize %></td>
+        <% end %>
+      </tr>
+      <% %i[default disabled].each do |state| %>
+        <tr>
+          <td class="font-bold px-3 py-1"><%= state.to_s.humanize %></td>
+          <% current_component::SIZES.keys.each do |size| %>
+            <td class="px-3 py-1 text-center">
+              <%= render current_component.new(size: size, scheme: scheme, text: text, disabled: state == :disabled) %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </table>
+
+  </div>
+<% end %>

--- a/admin/spec/components/solidus_admin/ui/button/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/button/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Button::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end

--- a/admin/spec/generator/solidus_admin/component_generator_spec.rb
+++ b/admin/spec/generator/solidus_admin/component_generator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SolidusAdmin::ComponentGenerator, type: :generator do
         .and include(%{# @param baz text})
 
       expect(engine_path('spec/components/previews/solidus_admin/ui/foo/component_preview/overview.html.erb').read)
-        .to include(%{<%= render component.new(bar: "bar", baz: "baz") %>})
+        .to include(%{<%= render current_component.new(bar: "bar", baz: "baz") %>})
     end
   end
 


### PR DESCRIPTION
## Summary

<img width="1195" alt="image" src="https://github.com/solidusio/solidus/assets/1051/4d752e27-67dc-4f13-a268-1d3bb4fbe099">

The icons are not yet supported, but will be added in a follow up PR.


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
