### PR TITLE
[Admin] add a `ui/toast` component

### DIFF
--- a/admin/app/components/solidus_admin/ui/toast/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/toast/component.html.erb
@@ -1,0 +1,21 @@
+<div
+  class="
+    rounded inline-block px-3 py-2
+    <%= SCHEMES.fetch(@scheme.to_sym) %>
+  "
+  data-controller="<%= stimulus_id %>"
+  data-<%= stimulus_id %>-closing-class="transform opacity-0 transition duration-500"
+  data-<%= stimulus_id %>-transition-value="500"
+>
+  <%= icon_tag(@icon, class_names: 'inline-block mr-3') if @icon %>
+
+  <p class="inline-block body-tiny-bold"><%= @text %></p>
+
+  <button
+    class="inline-block ml-3 align-text-bottom"
+    title="<%= t('.close_text') %>"
+    data-action="<%= stimulus_id %>#close"
+  >
+    <%= icon_tag('close-line') %>
+  </button>
+</div>

--- a/admin/app/components/solidus_admin/ui/toast/component.js
+++ b/admin/app/components/solidus_admin/ui/toast/component.js
@@ -1,0 +1,11 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static classes = ['closing']
+  static values = { transition: Number }
+
+  close () {
+    this.element.classList.add(...this.closingClasses);
+    setTimeout(() => this.element.remove(), this.transitionValue)
+  }
+}

--- a/admin/app/components/solidus_admin/ui/toast/component.rb
+++ b/admin/app/components/solidus_admin/ui/toast/component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Toast::Component < SolidusAdmin::BaseComponent
+  SCHEMES = {
+    default: %w[
+      bg-gray-800 text-white
+    ],
+    error: %w[
+      bg-red-500 text-white
+    ],
+  }
+
+  def initialize(text:, icon: nil, scheme: :default)
+    @text = text
+    @icon = icon
+    @scheme = scheme.to_sym
+  end
+
+  def icon_tag(icon, class_names: nil)
+    href = image_path("solidus_admin/remixicon.symbol.svg") + "#ri-#{icon}"
+    tag.svg(
+      class: "w-[1.125rem] h-[1.125rem] fill-current #{class_names}",
+    ) do
+      tag.use(
+        "xlink:href": href
+      )
+    end
+  end
+end

--- a/admin/app/components/solidus_admin/ui/toast/component.yml
+++ b/admin/app/components/solidus_admin/ui/toast/component.yml
@@ -1,0 +1,2 @@
+en:
+  close_text: "Close"

--- a/admin/spec/components/previews/solidus_admin/ui/toast/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/toast/component_preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# @component "ui/toast"
+class SolidusAdmin::UI::Toast::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+
+  # @param scheme select { choices: [default, error] }
+  # @param text text
+  # @param icon text
+  def playground(text: "Toast", scheme: :default, icon: "checkbox-circle-fill")
+    render component("ui/toast").new(text: text, scheme: scheme, icon: icon)
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/toast/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/toast/component_preview/overview.html.erb
@@ -1,0 +1,15 @@
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Default
+  </h6>
+
+  <%= render current_component.new(scheme: :default, text: 'Product Saved', icon: 'checkbox-circle-fill') %>
+</div>
+
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Error
+  </h6>
+
+  <%= render current_component.new(scheme: :error, text: 'Server Error', icon: 'error-warning-fill') %>
+</div>

--- a/admin/spec/components/solidus_admin/ui/toast/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/toast/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Toast::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

This component represents a sort of light notification that we want to display instead of the flash message in some cases. 

Still in draft because I need to address typography and the icon on the left.

<img width="1789" alt="Screenshot 2023-07-12 at 10 49 38@2x" src="https://github.com/solidusio/solidus/assets/167946/ecae1844-3710-4f3c-bf5d-526862444938">


https://github.com/solidusio/solidus/assets/167946/69c63134-076f-403a-b1a9-e1d458e3d048


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
