### PR TITLE
[Admin] Add account navigation component

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
@@ -1,0 +1,42 @@
+<nav class="mt-auto w-48"
+  data-controller="<%= stimulus_id %>"
+  data-<%= stimulus_id %>-active-class="bg-gray-25"
+  aria-label="<%= t('.account.account') %>"
+>
+  <ul data-<%= stimulus_id %>-target="links"
+    class="
+      hidden
+      p-2
+      body-small text-black
+      border border-gray-100 rounded-lg shadow-base
+    ">
+    <li class="h-8 flex items-center hover:bg-gray-25">
+      <%= link_to @account_path do %>
+        <%= icon_tag("user-3-line", class: "inline-block align-text-bottom w-[0.83rem] h-[1.09rem] mx-2 fill-current") %>
+        <%= t('.account.account') %>
+      <% end %>
+    </li>
+    <li class="h-8 flex items-center hover:bg-gray-25">
+      <%= link_to @logout_path, method: @logout_method do %>
+        <%= icon_tag("logout-box-line", class: "inline-block align-text-bottom w-[0.98rem] h-[1.04rem] mx-2 fill-current") %>
+        <%= t('.account.logout') %>
+      <% end %>
+    </li>
+  </ul>
+  <p data-action="
+    click-><%= stimulus_id %>#toggleLinks
+    "
+    data-<%= stimulus_id %>-target="button"
+    class="
+      flex gap-1.5
+      p-3 mt-2
+      body-small-bold text-gray-500
+      hover:bg-gray-25
+      cursor-pointer
+  ">
+    <%= icon_tag("user-smile-fill", class: "inline-block align-text-bottom shrink-0 w-6 h-6 rounded-[4.81rem] mr-[1.5] body-small fill-yellow bg-black") %>
+    <span class="overflow-hidden whitespace-nowrap text-ellipsis">
+      <%= @user_label %>
+    </span class="">
+  </p>
+</nav>

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.js
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["links", "button"]
+
+  static classes = ["active"]
+
+  // Toggle the visibility of the links and mark the button as active
+  toggleLinks() {
+    this.buttonTarget.classList.toggle(
+      this.activeClass,
+    )
+    this.linksTarget.classList.toggle("hidden")
+  }
+}

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Account navigation
+class SolidusAdmin::Sidebar::AccountNav::Component < SolidusAdmin::BaseComponent
+  # @param user_label [String]
+  # @param account_path [String]
+  # @param logout_path [String]
+  # @param logout_method [Symbol]
+  def initialize(user_label: "Alice Doe", account_path: "#", logout_path: "#", logout_method: :delete)
+    @user_label = user_label
+    @account_path = account_path
+    @logout_path = logout_path
+    @logout_method = logout_method
+  end
+end

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.yml
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.yml
@@ -1,0 +1,5 @@
+en:
+  account:
+    account: Account
+    logout: Logout
+    nav_label: Account

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -1,9 +1,9 @@
 <aside class="
+  flex flex-col
   border-r border-r-gray-100
   col-start-1 col-end-2
   lg:col-start-1 lg:col-end-3
   bg-gray-15
-  h-screen
   p-4
 ">
   <%= image_tag @logo_path, alt: "Solidus" %>
@@ -30,4 +30,5 @@
       <%= render @item_component.with_collection(items, fullpath: request.fullpath) %>
     </ul>
   </nav>
+  <%= render @account_nav_component.new %>
 </aside>

--- a/admin/app/components/solidus_admin/sidebar/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/component.rb
@@ -6,11 +6,13 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
     store:,
     logo_path: SolidusAdmin::Config.logo_path,
     items: container["main_nav_items"],
-    item_component: component("sidebar/item")
+    item_component: component("sidebar/item"),
+    account_nav_component: component("sidebar/account_nav")
   )
     @logo_path = logo_path
     @items = items
     @item_component = item_component
+    @account_nav_component = account_nav_component
     @store = store
   end
 

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -17,6 +17,7 @@
       grid grid-cols-4
       lg:grid-cols-12
       bg-gray-15
+      h-screen
     ">
       <%= render component("sidebar").new(store: current_store) %>
 

--- a/admin/config/solidus_admin/tailwind.config.js.erb
+++ b/admin/config/solidus_admin/tailwind.config.js.erb
@@ -73,6 +73,7 @@ module.exports = {
       },
       boxShadow: {
         sm: '0px 1px 2px 0px rgba(0, 0, 0, 0.04)',
+        base: '0px 4px 8px 0px rgba(0, 0, 0, 0.08), 0px 2px 4px -1px rgba(0, 0, 0, 0.04)'
       },
     },
   },

--- a/admin/spec/components/previews/solidus_admin/sidebar/account_nav/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/sidebar/account_nav/component_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# @component "sidebar/account_nav"
+class SolidusAdmin::Sidebar::AccountNav::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+
+  # @param user_label text
+  def playground(user_label: "Alice Doe")
+    render_with_template(
+      locals: {
+        user_label: user_label
+      }
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/sidebar/account_nav/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/sidebar/account_nav/component_preview/overview.html.erb
@@ -1,0 +1,16 @@
+<div class="flex h-screen">
+  <div class="flex h-4/5">
+    <div class="self-end">
+      <%= render current_component.new(
+        user_label: "Alice Doe"
+      ) %>
+    </div>
+  </div>
+  <div class="flex h-4/5">
+    <div class="self-end">
+      <%= render current_component.new(
+        user_label: "Alice Supercalifragilisticexpialidocious"
+      ) %>
+    </div>
+  </div>
+</div>

--- a/admin/spec/components/previews/solidus_admin/sidebar/account_nav/component_preview/playground.html.erb
+++ b/admin/spec/components/previews/solidus_admin/sidebar/account_nav/component_preview/playground.html.erb
@@ -1,0 +1,9 @@
+<div class="flex h-screen">
+  <div class="flex h-4/5">
+    <div class="self-end">
+      <%= render current_component.new(
+        user_label: user_label
+      ) %>
+    </div>
+  </div>
+</div>

--- a/admin/spec/components/solidus_admin/sidebar/account_nav/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/account_nav/component_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::Sidebar::AccountNav::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+
+  it "renders link to the account" do
+    component = described_class.new(
+      account_path: "/admin/account"
+    )
+
+    render_inline(component)
+
+    expect(page).to have_link("Account", href: "/admin/account")
+  end
+
+  it "renders link to logout" do
+    component = described_class.new(
+      logout_path: "/admin/logout"
+    )
+
+    render_inline(component)
+
+    expect(page).to have_link("Logout", href: "/admin/logout")
+  end
+
+  it "renders user lanel" do
+    component = described_class.new(
+      user_label: "Alice"
+    )
+
+    render_inline(component)
+
+    expect(page).to have_content("Alice")
+  end
+end

--- a/admin/spec/components/solidus_admin/sidebar/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/component_spec.rb
@@ -39,4 +39,21 @@ RSpec.describe SolidusAdmin::Sidebar::Component, type: :component do
 
     expect(page).to have_css("nav[data-controller='main-nav']")
   end
+
+  it "renders the account nav component" do
+    account_nav_component = mock_component do
+      def call
+        "account nav"
+      end
+    end
+    component = described_class.new(
+      store: build(:store),
+      items: [],
+      account_nav_component: account_nav_component
+    )
+
+    render_inline(component)
+
+    expect(page).to have_content("account nav")
+  end
 end


### PR DESCRIPTION
## Summary

It's not still fully functional, as authentication is not yet in place. For now, we use dummy data to show the component.

We extract the helper to render SVG remix icons as we need to reuse it.

We're also changing the layout so the main element occupies the full height of the viewport. That fixes an issue where the sidebar wasn't filling it due to being in a shorter container.

![screenshot-localhost_3000-2023 07 12-12_07_42](https://github.com/solidusio/solidus/assets/52650/8b905b74-5be5-4c58-9ff0-72ca54bd5a3c)

[screencast-localhost_3000-2023.07.12-12_06_52.webm](https://github.com/solidusio/solidus/assets/52650/90f8cd07-753c-44d0-8d38-17df7f25b82d)


Closes #5106 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
