### PR TITLE
[Admin] Extract sidebar item's icon to a proper helper 

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -5,6 +5,23 @@ module SolidusAdmin
   class BaseComponent < ViewComponent::Base
     include SolidusAdmin::ContainerHelper
 
+    # Renders a remixincon svg.
+    #
+    # @param name [String] the name of the icon
+    # @option attrs [String] :class the class to add to the svg
+    # @return [String] the svg tag
+    # @see https://remixicon.com/
+    def icon_tag(name, **attrs)
+      href = image_path("solidus_admin/remixicon.symbol.svg") + "#ri-#{name}"
+      tag.svg(
+        class: attrs[:class],
+      ) do
+        tag.use(
+          "xlink:href": href
+        )
+      end
+    end
+
     def self.stimulus_id
       @stimulus_id ||= name.underscore
         .sub(/^solidus_admin\/(.*)\/component$/, '\1')

--- a/admin/app/components/solidus_admin/sidebar/item/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.rb
@@ -20,7 +20,7 @@ class SolidusAdmin::Sidebar::Item::Component < SolidusAdmin::BaseComponent
     common_classes = "inline-block w-[1.125rem] h-[1.125rem] mr-[0.68rem] body-small"
 
     return tag.span(class: common_classes) unless @item.icon
-    icon_tag(@item.icon, class: "#{common_classes} align-text-bottom fill-black group-hover:fill-red-500 group-[.active]:fill-red-500")
+    icon_tag(@item.icon, class: "#{common_classes} align-text-bottom fill-current")
   end
 
   def path

--- a/admin/app/components/solidus_admin/sidebar/item/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.rb
@@ -20,15 +20,7 @@ class SolidusAdmin::Sidebar::Item::Component < SolidusAdmin::BaseComponent
     common_classes = "inline-block w-[1.125rem] h-[1.125rem] mr-[0.68rem] body-small"
 
     return tag.span(class: common_classes) unless @item.icon
-
-    href = image_path("solidus_admin/remixicon.symbol.svg") + "#ri-#{@item.icon}"
-    tag.svg(
-      class: "#{common_classes} align-text-bottom fill-black group-hover:fill-red-500 group-[.active]:fill-red-500"
-    ) do
-      tag.use(
-        "xlink:href": href
-      )
-    end
+    icon_tag(@item.icon, class: "#{common_classes} align-text-bottom fill-black group-hover:fill-red-500 group-[.active]:fill-red-500")
   end
 
   def path

--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -3,6 +3,21 @@
 require "spec_helper"
 
 RSpec.describe SolidusAdmin::BaseComponent, type: :component do
+  describe "#icon_tag" do
+    it "renders a remixicon svg" do
+      component = mock_component do
+        def call
+          icon_tag("user-line")
+        end
+      end.new
+
+      render_inline(component)
+
+      svg = page.find("svg use")["xlink:href"]
+      expect(svg).to match(/#ri-user-line/)
+    end
+  end
+
   describe "#spree" do
     it "gives access to spree routing helpers" do
       allow(Spree::Core::Engine.routes.url_helpers).to receive(:foo_path).and_return("/foo/bar")

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -103,6 +103,7 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
+  config.include SolidusAdmin::ComponentHelpers, type: :component
 
   config.include Rails::Generators::Testing::Behaviour, type: :generator
   config.include FileUtils, type: :generator

--- a/admin/spec/support/solidus_admin/component_helpers.rb
+++ b/admin/spec/support/solidus_admin/component_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  module ComponentHelpers
+    # Mocks a component class with the given definition.
+    #
+    # @param definition [Proc] the component definition
+    # @example
+    #  mock_component do
+    #    def call
+    #      "Rendered"
+    #    end
+    #  end
+    def mock_component(&definition)
+      Class.new(SolidusAdmin::BaseComponent) do
+        # ViewComponent will complain if we don't fake a class name:
+        # @see https://github.com/ViewComponent/view_component/blob/5decd07842c48cbad82527daefa3fe9c65a4226a/lib/view_component/base.rb#L371
+        def self.name
+          "Foo"
+        end
+      end.tap { |klass| klass.class_eval(&definition) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We will use this `icon_tag` a lot, so it might make sense to extract it into a common place.

This PR also improves the sidebar's item fill color to use the [`fill-current`](https://v2.tailwindcss.com/docs/fill#usage) property, which is now the default. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
