### PR TITLE
[Admin] Remove redundant tailwindcss dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,10 +47,6 @@ group :backend do
   gem 'webrick', require: false
 end
 
-group :admin do
-  gem 'tailwindcss-rails', '~> 2.0', require: false
-end
-
 group :utils do
   gem 'pry'
   gem 'launchy', require: false


### PR DESCRIPTION
## Summary

Tailwindcss ended up being a runtime dependency for the admin in 8e7ae3fb. As it's already defined in the gemspec, there's no need to repeat it on the main Gemfile.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
