### PR TITLE
[Admin] connect flash messages to the `ui/toast` component

### DIFF
--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -5,19 +5,28 @@
     <%= stylesheet_link_tag "solidus_admin/application.css", "inter-font", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags "solidus_admin/application", shim: false, importmap: SolidusAdmin.importmap %>
   </head>
-  <body class="
-    grid grid-cols-4
-    lg:grid-cols-12
-    bg-gray-15
-  ">
-    <%= render component("sidebar").new(store: current_store) %>
 
-    <main class="
-      col-start-2 col-end-4
-      lg:col-start-3 lg:col-end-12
-      py-6 px-4
+  <body>
+    <div class="fixed right-3 bottom-3 flex flex-col gap-3">
+      <% flash.each do |key, message| %>
+        <%= render component("ui/toast").new(text: message, scheme: key == :error ? :error : :default) %>
+      <% end %>
+    </div>
+
+    <div class="
+      grid grid-cols-4
+      lg:grid-cols-12
+      bg-gray-15
     ">
-      <%= yield %>
-    </main>
+      <%= render component("sidebar").new(store: current_store) %>
+
+      <main class="
+        col-start-2 col-end-4
+        lg:col-start-3 lg:col-end-12
+        py-6 px-4
+      ">
+        <%= yield %>
+      </main>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- If multiple messages are present they'll stack on top of each other.
- Based on #5236, please review just the last commit

<img width="1260" alt="image" src="https://github.com/solidusio/solidus/assets/1051/2fcb0580-445d-4d6f-89fb-8fbef22fbf8d">


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
