### PR TITLE
[Admin] Automatically test a11y in the new admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,11 @@ group :backend do
   gem 'webrick', require: false
 end
 
+group :admin do
+  gem 'axe-core-rspec', '~> 4.7', require: false
+  gem 'axe-core-capybara', '~> 4.7', require: false
+end
+
 group :utils do
   gem 'pry'
   gem 'launchy', require: false

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -1,8 +1,8 @@
 <div class="<%= stimulus_id %>">
   <header class="mb-6">
-    <div class="body-title">
+    <h1 class="body-title">
       <%= Spree::Product.model_name.human.pluralize %>
-    </div>
+    </h1>
   </header>
 
   <%= render component("ui/table").new(

--- a/admin/app/components/solidus_admin/sidebar/item/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.rb
@@ -61,7 +61,7 @@ class SolidusAdmin::Sidebar::Item::Component < SolidusAdmin::BaseComponent
   def nested_items
     return unless @item.children?
 
-    tag.nav(
+    tag.ul(
       class: nested_nav_active_classes
     ) do
       render self.class.with_collection(@item.children, url_helpers: @url_helpers, fullpath: @fullpath)

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -19,19 +19,7 @@
     <thead class="bg-gray-15 color-gray-100">
       <tr>
         <% @columns.each do |column| %>
-          <th
-            class="
-              border-b
-              border-gray-100
-              py-3
-              px-4
-              text-[#4f4f4f]
-              text-left
-              text-3.5
-              font-[600]
-              line-[120%]
-            "
-          ><%= render_header_cell(column.header) %></th>
+          <%= render_header_cell(column.header) %>
         <% end %>
       </tr>
     </thead>
@@ -40,7 +28,7 @@
       <% @rows.each do |row| %>
         <tr class="border-b border-gray-100">
           <% @columns.each do |column| %>
-            <td class="py-2 px-4 "><%= render_data_cell(column.data, row) %></td>
+            <%= render_data_cell(column.data, row) %>
           <% end %>
         </tr>
       <% end %>

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -7,12 +7,14 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     @columns = columns.map { Column.new(**_1) }
   end
 
-  def render_cell(cell)
+  def render_cell(tag, cell, **attrs)
     # Allow component instances as cell content
-    if cell.respond_to?(:render_in)
-      cell.render_in(self)
-    else
-      cell
+    content_tag(tag, **attrs) do
+      if cell.respond_to?(:render_in)
+        cell.render_in(self)
+      else
+        cell
+      end
     end
   end
 
@@ -25,7 +27,19 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
         cell.call
       end
 
-    render_cell(cell)
+    cell_tag = cell.blank? ? :td : :th
+
+    render_cell(cell_tag, cell, class: <<~CLASSES)
+      border-b
+      border-gray-100
+      py-3
+      px-4
+      text-[#4f4f4f]
+      text-left
+      text-3.5
+      font-[600]
+      line-[120%]
+    CLASSES
   end
 
   def render_data_cell(cell, data)
@@ -37,7 +51,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
         cell.call(data)
       end
 
-    render_cell(cell)
+    render_cell(:td, cell, class: "py-2 px-4")
   end
 
   Column = Struct.new(:header, :data, :class_name, keyword_init: true)

--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -4,5 +4,6 @@ module SolidusAdmin
   class BaseController < Spree::BaseController
     layout 'solidus_admin/application'
     helper 'solidus_admin/container'
+    helper 'solidus_admin/layout'
   end
 end

--- a/admin/app/helpers/solidus_admin/layout_helper.rb
+++ b/admin/app/helpers/solidus_admin/layout_helper.rb
@@ -3,6 +3,11 @@
 module SolidusAdmin
   # Helpers for the admin layout
   module LayoutHelper
+    # @return [Symbol]
+    def current_locale(backend: I18n)
+      backend.locale
+    end
+
     # @param store_name [String]
     # @param controller_name [String]
     # @return [String] HTML title

--- a/admin/app/helpers/solidus_admin/layout_helper.rb
+++ b/admin/app/helpers/solidus_admin/layout_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  # Helpers for the admin layout
+  module LayoutHelper
+    # @param store_name [String]
+    # @param controller_name [String]
+    # @return [String] HTML title
+    def solidus_admin_title(store_name: current_store.name, controller_name: controller.controller_name)
+      "#{store_name} - #{t("solidus_admin.#{controller_name}")}"
+    end
+  end
+end

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= current_locale %>">
   <head>
     <title><%= solidus_admin_title %></title>
     <%= stylesheet_link_tag "solidus_admin/application.css", "inter-font", "data-turbo-track": "reload" %>

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title><%= solidus_admin_title %></title>
     <%= stylesheet_link_tag "solidus_admin/application.css", "inter-font", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags "solidus_admin/application", shim: false, importmap: SolidusAdmin.importmap %>
   </head>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  solidus_admin:
+    products: Products

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -3,12 +3,13 @@
 require 'spec_helper'
 
 describe "Products", type: :feature do
-  it "lists products" do
+  it "lists products", :js do
     create(:product, name: "Just a product", price: 19.99)
 
     visit "/admin/products"
 
     expect(page).to have_content("Just a product")
     expect(page).to have_content("$19.99")
+    expect(page).to be_axe_clean
   end
 end

--- a/admin/spec/helpers/solidus_admin/layout_helper_spec.rb
+++ b/admin/spec/helpers/solidus_admin/layout_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::LayoutHelper, :helper do
+  describe '#solidus_admin_title' do
+    it "includes the store name" do
+      expect(
+        helper.solidus_admin_title(store_name: "My Store")
+      ).to include("My Store")
+    end
+
+    it "includes the translated controller base name" do
+      expect(
+        helper.solidus_admin_title(store_name: "My Store", controller_name: "orders")
+      ).to include("Orders")
+    end
+  end
+end

--- a/admin/spec/helpers/solidus_admin/layout_helper_spec.rb
+++ b/admin/spec/helpers/solidus_admin/layout_helper_spec.rb
@@ -3,6 +3,14 @@
 require "spec_helper"
 
 RSpec.describe SolidusAdmin::LayoutHelper, :helper do
+  describe '#current_locale' do
+    it "returns the current locale" do
+      expect(
+        helper.current_locale(backend: double(locale: :en))
+      ).to eq(:en)
+    end
+  end
+
   describe '#solidus_admin_title' do
     it "includes the store name" do
       expect(

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -77,6 +77,10 @@ require "rails/generators"
 require "rails/generators/app_base"
 require "rails/generators/testing/behaviour"
 
+# AXE - ACCESSIBILITY
+require 'axe-rspec'
+require 'axe-capybara'
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
## Summary

We use the [axe set of gems](https://github.com/dequelabs/axe-core-gems) to test for automatic testing of accessibility issues in the new admin. This commit adds the necessary gems and configuration to the admin Gemfile and spec_helper.rb files. It also adds a test to the products listing.

As accessibility testing requires javascript, which makes tests slow, we'll need to be selective about where we add these tests.

We're also fixing some accessibility issues we had so far. Please, check individual commits for more details.

Closes #5132

- Adds HTML titles to admin pages
- Fix accessibility for empty column headers in admin tables
- Fix HTML tag not specifying language in the admin
- Fix nested main menu items wrapped within "nav" instead of "ul"
- Add h1 to products index page

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
