### PR TITLE
[Admin] add `ui/table` dummy scopes

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -9,6 +9,10 @@
   "
   data-controller="<%= stimulus_id %>"
 >
+  <div class="h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex">
+    <%= render component('ui/tab').new(text: "All", active: true, scheme: :secondary, href: "") %>
+  </div>
+
   <table class=" table-auto w-full border-collapse ">
     <colgroup>
       <% @columns.each do |column| %>


### PR DESCRIPTION
## Summary

This is preparatory to batch actions that will replace the "scopes" toolbar when activated.

<img width="1270" alt="image" src="https://github.com/solidusio/solidus/assets/1051/27d3aa2f-4cf1-4be4-ab6d-86fa45c6978b">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
