### PR TITLE
Reorganize simple stock coordinator for improve debugging

### DIFF
--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -22,39 +22,65 @@ module Spree
     class SimpleCoordinator
       attr_reader :order
 
+      # @api private
+      attr_reader :inventory_units, :splitters, :stock_locations,
+        :filtered_stock_locations, :inventory_units_by_variant, :desired,
+        :availability, :allocator, :packages
+
       def initialize(order, inventory_units = nil)
         @order = order
         @inventory_units =
           inventory_units || Spree::Config.stock.inventory_unit_builder_class.new(order).units
         @splitters = Spree::Config.environment.stock_splitters
 
-        filtered_stock_locations = Spree::Config.stock.location_filter_class.new(Spree::StockLocation.all, @order).filter
+        @filtered_stock_locations = Spree::Config.stock.location_filter_class.new(load_stock_locations, order).filter
         sorted_stock_locations = Spree::Config.stock.location_sorter_class.new(filtered_stock_locations).sort
         @stock_locations = sorted_stock_locations
 
         @inventory_units_by_variant = @inventory_units.group_by(&:variant)
-        @desired = Spree::StockQuantities.new(@inventory_units_by_variant.transform_values(&:count))
+        @desired = Spree::StockQuantities.new(inventory_units_by_variant.transform_values(&:count))
         @availability = Spree::Stock::Availability.new(
-          variants: @desired.variants,
-          stock_locations: @stock_locations
+          variants: desired.variants,
+          stock_locations: stock_locations
         )
 
-        @allocator = Spree::Config.stock.allocator_class.new(@availability)
+        @allocator = Spree::Config.stock.allocator_class.new(availability)
       end
 
       def shipments
-        @shipments ||= build_shipments
+        @shipments ||= begin
+          @packages = build_packages
+          shipments = build_shipments
+
+          # Make sure we don't add the proposed shipments to the order
+          order.shipments = order.shipments - shipments
+
+          shipments
+        end
       end
 
       private
 
+      def load_stock_locations
+        Spree::StockLocation.all
+      end
+
       def build_shipments
+        # Turn the Stock::Packages into a Shipment with rates
+        packages.map do |package|
+          shipment = package.shipment = package.to_shipment
+          shipment.shipping_rates = Spree::Config.stock.estimator_class.new.shipping_rates(package)
+          shipment
+        end
+      end
+
+      def build_packages
         # Allocate any available on hand inventory and remaining desired inventory from backorders
-        on_hand_packages, backordered_packages, leftover = @allocator.allocate_inventory(@desired)
+        on_hand_packages, backordered_packages, leftover = allocator.allocate_inventory(desired)
 
         raise Spree::Order::InsufficientStock.new(items: leftover.quantities) unless leftover.empty?
 
-        packages = @stock_locations.map do |stock_location|
+        packages = stock_locations.map do |stock_location|
           # Combine on_hand and backorders into a single package per-location
           on_hand = on_hand_packages[stock_location.id] || Spree::StockQuantities.new
           backordered = backordered_packages[stock_location.id] || Spree::StockQuantities.new
@@ -71,19 +97,7 @@ module Spree
         end.compact
 
         # Split the packages
-        packages = split_packages(packages)
-
-        # Turn the Stock::Packages into a Shipment with rates
-        shipments = packages.map do |package|
-          shipment = package.shipment = package.to_shipment
-          shipment.shipping_rates = Spree::Config.stock.estimator_class.new.shipping_rates(package)
-          shipment
-        end
-
-        # Make sure we don't add the proposed shipments to the order
-        order.shipments = order.shipments - shipments
-
-        shipments
+        split_packages(packages)
       end
 
       def split_packages(initial_packages)
@@ -96,7 +110,7 @@ module Spree
       def get_units(quantities)
         # Change our raw quantities back into inventory units
         quantities.flat_map do |variant, quantity|
-          @inventory_units_by_variant[variant].shift(quantity)
+          inventory_units_by_variant[variant].shift(quantity)
         end
       end
     end


### PR DESCRIPTION
## Summary

This is all about making it easier for a developer to debug issues when they get the dreaded

```
     Failure/Error: order.next!

     StateMachines::InvalidTransition:
       Cannot transition state via :next from :address (Reason(s): We are unable to calculate shipping rates for the selected items.)
```

The first step we wanted to take was to make the instance variables accessible to the developer. A developer's journey to this issue is likely going to be discovering `Spree::Order#create_proposed_shipments` is what's failing. Then discovering that it builds an instance of this class. After that, they're going to want to start looking into the data that is set. Since they're all instance variables, they would likely want to be able to access some of the data.

However, what the developer will soon realize is that it's the shipping rates that are holding back the shipments from being validated. So the real issue likely lies in an empty array being returned from:

```ruby
shipment.shipping_rates = Spree::Config.stock.estimator_class.new.shipping_rates(package)
```

If this is the issue, we'll want them to be able to easily recreate the packages the same way the class builds the packages. We've reorchestrated how the packages are built into a `build_packages` method and stored it there. I've also taken the time to simplify what `build_shipments` does so they can utilize that code as well.

One other issue I noticed was that there was a global `Spree::StockLocation.all`. In a normal store, there will likely not be many, but in a marketplace, there could be thousands - so let's give them a method to easily make that code more intelligent if needed.

I hope this work also makes it easier for the developer to extend this class.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
