### PR TITLE
Add `aria-label` attribute to main navigation in the sidebar component

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -25,7 +25,7 @@
       <%= @store.url %>
     </p>
   <% end %>
-  <nav data-controller="main-nav" class="mt-2">
+  <nav data-controller="main-nav" class="mt-2" aria-label="main-nav">
     <ul>
       <%= render @item_component.with_collection(items, fullpath: request.fullpath) %>
     </ul>


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

Fix failed specs in products_spec.rb by adding aria-label to sidebar navigation.
The `aria-label` attribute is set to "main-nav" to provide an accessible label for the main navigation section of the page.
https://dequeuniversity.com/rules/axe/4.7/landmark-unique?application=axeAPI

<img width="1138" alt="Screenshot 2023-07-17" src="https://github.com/solidusio/solidus/assets/19948291/71d47283-74a7-4295-85de-d38d5594c1c8">



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
