### PR TITLE
[Admin] Fix the checkbox when `focus` and `checked` are active

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/checkbox/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/checkbox/component.rb
@@ -16,20 +16,25 @@ class SolidusAdmin::UI::Forms::Checkbox::Component < SolidusAdmin::BaseComponent
       type: 'checkbox',
       class: "
         #{SIZES.fetch(@size)}
+        form-checkbox
         cursor-pointer
         disabled:cursor-not-allowed
 
         bg-white rounded border border-2 border-gray-300
         hover:border-gray-700
+        focus:ring focus:ring-gray-300 focus:ring-0.5 focus:bg-white focus:ring-offset-0
+        active:ring active:ring-gray-300 active:ring-0.5
         disabled:border-gray-300
-
-        checked:border-gray-700 checked:bg-gray-700 checked:text-white
-        checked:hover:border-gray-500 checked:hover:bg-gray-500
-        checked:disabled:border-gray-300 checked:disabled:bg-gray-300
 
         indeterminate:border-gray-700 indeterminate:bg-gray-700 indeterminate:text-white
         indeterminate:hover:border-gray-500 indeterminate:hover:bg-gray-500
+        indeterminate:focus:bg-gray-700
         indeterminate:disabled:border-gray-300 indeterminate:disabled:bg-gray-300
+
+        checked:border-gray-700 checked:bg-gray-700 checked:text-white
+        checked:hover:border-gray-500 checked:hover:bg-gray-500
+        checked:focus:bg-gray-700
+        checked:disabled:border-gray-300 checked:disabled:bg-gray-300
       ",
       **@attributes,
     )

--- a/admin/config/solidus_admin/tailwind.config.js.erb
+++ b/admin/config/solidus_admin/tailwind.config.js.erb
@@ -78,7 +78,7 @@ module.exports = {
     },
   },
   plugins: [
-    require('@tailwindcss/forms'),
+    require('@tailwindcss/forms')({ strategy: 'class' }),
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
     require('@tailwindcss/container-queries'),


### PR DESCRIPTION
## Summary

### Before

<img width="181" alt="image" src="https://github.com/solidusio/solidus/assets/1051/8bc4ff29-13e2-47f0-9ef3-63c8f2651bfa">

h/t @waiting-for-dev https://github.com/solidusio/solidus/pull/5180#issuecomment-1639962938

### After

<img width="69" alt="image" src="https://github.com/solidusio/solidus/assets/1051/683aa438-dc48-42b1-9151-e083ea6ffdb5">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
