### PR TITLE
[Admin] Spike for data & configuration layer for tables

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -27,17 +27,10 @@
         icon: 'play-circle-line',
       },
     ],
-    columns: [
-      {
-        class_name: "w-10",
-        header: tag.span('aria-label': t('.product_image'), role: 'text'),
-        data: -> { image_column(_1) },
-      },
-      { header: :name, data: -> { name_column(_1) } },
-      { header: :status, data: -> { status_column(_1) } },
-      { header: :price, data: -> { price_column(_1) } },
-      { header: :stock, data: -> { stock_column(_1) } }
-     ]
+    columns: @columns,
+    column_classes: {
+      image: "w-10"
+    }
    )
   %>
 </div>

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -28,7 +28,11 @@
       },
     ],
     columns: [
-      { header: "", data: -> { image_column(_1) }, class_name: "w-10" },
+      {
+        class_name: "w-10",
+        header: tag.span('aria-label': t('.product_image'), role: 'text'),
+        data: -> { image_column(_1) },
+      },
       { header: :name, data: -> { name_column(_1) } },
       { header: :status, data: -> { status_column(_1) } },
       { header: :price, data: -> { price_column(_1) } },

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -7,6 +7,26 @@
 
   <%= render component("ui/table").new(
     page: @page,
+    batch_actions: [
+      {
+        display_name: t('.batch_actions.delete'),
+        action: solidus_admin.products_path,
+        method: :delete,
+        icon: 'delete-bin-7-line',
+      },
+      {
+        display_name: t('.batch_actions.discontinue'),
+        action: solidus_admin.discontinue_products_path,
+        method: :put,
+        icon: 'pause-circle-line',
+      },
+      {
+        display_name: t('.batch_actions.activate'),
+        action: solidus_admin.activate_products_path,
+        method: :put,
+        icon: 'play-circle-line',
+      },
+    ],
     columns: [
       { header: "", data: -> { image_column(_1) }, class_name: "w-10" },
       { header: :name, data: -> { name_column(_1) } },

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -1,34 +1,39 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
-  def initialize(page:)
+  def initialize(page:, columns: container["products.index"])
     @page = page
+    @columns = columns.map { _1.ensure_render_context(self) }
   end
 
-  def image_column(product)
-    image = product.gallery.images.first or return
+  def image_header
+    tag.span('aria-label': t(".product_image"), role: 'text')
+  end
+
+  def image_column(id, image)
+    image or return
 
     link_to(
       image_tag(image.url(:small), class: 'h-10 w-10 max-w-min'),
-      spree.edit_admin_product_path(product),
+      spree.edit_admin_product_path(id),
     )
   end
 
-  def name_column(product)
-    link_to product.name, spree.edit_admin_product_path(product)
+  def name_column(id, name)
+    link_to name, spree.edit_admin_product_path(id)
   end
 
-  def status_column(product)
-    if product.available?
+  def status_column(available)
+    if available
       component('ui/badge').new(name: t('.status.available'), color: :green)
     else
       component('ui/badge').new(name: t('.status.discontinued'), color: :red)
     end
   end
 
-  def stock_column(product)
+  def stock_column(on_hand, variants_count)
     stock_info =
-      case (on_hand = product.total_on_hand)
+      case on_hand
       when Float::INFINITY
         content_tag :span, t('.stock.in_stock', on_hand: t('.stock.infinity')), class: 'text-forest'
       when 1..Float::INFINITY
@@ -38,12 +43,12 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
       end
 
     variant_info =
-      t('.for_variants', count: product.variants.count)
+      t('.for_variants', count: variants_count)
 
     safe_join([stock_info, variant_info], ' ')
   end
 
-  def price_column(product)
-    product.master.display_price.to_html
+  def price_column(price)
+    price.to_html
   end
 end

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -3,7 +3,7 @@
 class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
   def initialize(page:, columns: container["products.index"])
     @page = page
-    @columns = columns.map { _1.ensure_render_context(self) }
+    @columns = columns.map { _1.ensure_render_context(self) }.sort_by(&:position)
   end
 
   def image_header

--- a/admin/app/components/solidus_admin/products/index/component.yml
+++ b/admin/app/components/solidus_admin/products/index/component.yml
@@ -1,4 +1,5 @@
 en:
+  product_image: 'Image'
   status:
     available: 'Available'
     discontinued: 'Discontinued'

--- a/admin/app/components/solidus_admin/products/index/component.yml
+++ b/admin/app/components/solidus_admin/products/index/component.yml
@@ -6,3 +6,7 @@ en:
     infinity: '∞'
     in_stock: '%{on_hand} in stock'
   for_variants: 'for %{count} variants'
+  batch_actions:
+    delete: 'Delete'
+    discontinue: 'Discontinue'
+    activate: 'Activate'

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -14,6 +14,8 @@
   </div>
 
   <% if @batch_actions %>
+    <%= form_tag '', id: batch_actions_form_id %>
+
     <div class="<%= toolbar_classes %>">
       <% @batch_actions.each do |batch_action| %>
         <%= render_batch_action_button(batch_action) %>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -25,7 +25,7 @@
 
       <div class="bg-white border-b border-gray-100 justify-start items-center gap-0 flex">
         <div class="py-3 px-4">
-          <%= render_header_cell(selectable_column.header) %>
+          <%= render_header_cell(selectable_column) %>
         </div>
 
         <div class="py-3 px-4">
@@ -39,7 +39,7 @@
   <table class="table-auto w-full border-collapse">
     <colgroup>
       <% @columns.each do |column| %>
-        <col class="<%= column.class_name %>">
+        <col class="<%= @column_classes[column.name] %>">
       <% end %>
     </colgroup>
 
@@ -49,7 +49,7 @@
     >
       <tr>
         <% @columns.each do |column| %>
-          <%= render_header_cell(column.header) %>
+          <%= render_header_cell(column) %>
         <% end %>
       </tr>
     </thead>
@@ -58,7 +58,7 @@
       <% @rows.each do |row| %>
         <tr class="border-b border-gray-100">
           <% @columns.each do |column| %>
-            <%= render_data_cell(column.data, row) %>
+            <%= render_data_cell(column, row) %>
           <% end %>
         </tr>
       <% end %>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -7,9 +7,19 @@
   "
   data-controller="<%= stimulus_id %>"
 >
-  <div class="h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex">
+  <% toolbar_classes = "h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex" %>
+
+  <div class="<%= toolbar_classes %>">
     <%= render component('ui/tab').new(text: "All", active: true, scheme: :secondary, href: "") %>
   </div>
+
+  <% if @batch_actions %>
+    <div class="<%= toolbar_classes %>">
+      <% @batch_actions.each do |batch_action| %>
+        <%= render_batch_action_button(batch_action) %>
+      <% end %>
+    </div>
+  <% end %>
 
   <table class="table-auto w-full border-collapse">
     <colgroup>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -19,6 +19,17 @@
         <%= render_batch_action_button(batch_action) %>
       <% end %>
     </div>
+
+    <div class="bg-white border-b border-gray-100 justify-start items-center gap-0 flex">
+      <div class="py-3 px-4">
+        <%= render_header_cell(selectable_column.header) %>
+      </div>
+
+      <div class="py-3 px-4">
+        <span>0</span>
+        <%= t('.rows_selected') %>.
+      </div>
+    </div>
   <% end %>
 
   <table class="table-auto w-full border-collapse">

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -9,27 +9,29 @@
 >
   <% toolbar_classes = "h-14 p-2 bg-white border-b border-gray-100 justify-start items-center gap-2 flex" %>
 
-  <div class="<%= toolbar_classes %>">
+  <div class="<%= toolbar_classes %>" data-<%= stimulus_id %>-target="scopesToolbar">
     <%= render component('ui/tab').new(text: "All", active: true, scheme: :secondary, href: "") %>
   </div>
 
   <% if @batch_actions %>
     <%= form_tag '', id: batch_actions_form_id %>
 
-    <div class="<%= toolbar_classes %>">
-      <% @batch_actions.each do |batch_action| %>
-        <%= render_batch_action_button(batch_action) %>
-      <% end %>
-    </div>
-
-    <div class="bg-white border-b border-gray-100 justify-start items-center gap-0 flex">
-      <div class="py-3 px-4">
-        <%= render_header_cell(selectable_column.header) %>
+    <div data-<%= stimulus_id %>-target="batchToolbar" class="hidden">
+      <div class="<%= toolbar_classes %>">
+        <% @batch_actions.each do |batch_action| %>
+          <%= render_batch_action_button(batch_action) %>
+        <% end %>
       </div>
 
-      <div class="py-3 px-4">
-        <span>0</span>
-        <%= t('.rows_selected') %>.
+      <div class="bg-white border-b border-gray-100 justify-start items-center gap-0 flex">
+        <div class="py-3 px-4">
+          <%= render_header_cell(selectable_column.header) %>
+        </div>
+
+        <div class="py-3 px-4">
+          <span data-<%= stimulus_id %>-target="selectedRowsCount">0</span>
+          <%= t('.rows_selected') %>.
+        </div>
       </div>
     </div>
   <% end %>
@@ -41,7 +43,10 @@
       <% end %>
     </colgroup>
 
-    <thead class="bg-gray-15 color-gray-100">
+    <thead
+      class="bg-gray-15 color-gray-100"
+      data-<%= stimulus_id %>-target="tableHeader"
+    >
       <tr>
         <% @columns.each do |column| %>
           <%= render_header_cell(column.header) %>

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["checkbox", "headerCheckbox", "batchToolbar", "scopesToolbar", "tableHeader", "selectedRowsCount"]
+
+  connect() {
+    this.mode = "default"
+
+    this.render()
+  }
+
+  selectRow(event) {
+    if (this.checkboxTargets.some((checkbox) => checkbox.checked)) {
+      this.mode = "batch"
+    } else {
+      this.mode = "default"
+    }
+
+    this.render()
+  }
+
+  selectAllRows(event) {
+    this.mode = event.target.checked ? "batch" : "default"
+    this.checkboxTargets.forEach((checkbox) => (checkbox.checked = event.target.checked))
+
+    this.render()
+  }
+
+  render() {
+    const selectedRows = this.checkboxTargets.filter((checkbox) => checkbox.checked)
+
+    this.batchToolbarTarget.classList.toggle("hidden", this.mode !== "batch")
+    this.scopesToolbarTarget.classList.toggle("hidden", this.mode !== "default")
+    this.tableHeaderTarget.classList.toggle("hidden", this.mode !== "default")
+
+    // Update the rows background color
+    this.checkboxTargets.filter((checkbox) => checkbox.classList.toggle('bg-gray-15', checkbox.checked))
+
+    // Update the selected rows count
+    this.selectedRowsCountTarget.textContent = `${selectedRows.length}`
+
+    // Update the header checkboxes
+    this.headerCheckboxTargets.forEach((checkbox) => {
+      checkbox.indeterminate = false
+      checkbox.checked = false
+
+      if (selectedRows.length === this.checkboxTargets.length) checkbox.checked = true
+      else if (selectedRows.length > 0) checkbox.indeterminate = true
+    })
+  }
+}

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -32,6 +32,14 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     )
   end
 
+  def render_batch_action_button(batch_action)
+    render component('ui/button').new(
+      icon: batch_action.icon,
+      text: batch_action.display_name,
+      scheme: :secondary,
+    )
+  end
+
   def render_cell(tag, cell, **attrs)
     # Allow component instances as cell content
     content_tag(tag, **attrs) do

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -27,6 +27,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           form: batch_actions_form_id,
           "data-action": "#{stimulus_id}#selectAllRows",
           "data-#{stimulus_id}-target": "headerCheckbox",
+          "aria-label": t('.select_all'),
         )
       },
       data: ->(data) {
@@ -36,6 +37,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           value: data.id,
           "data-action": "#{stimulus_id}#selectRow",
           "data-#{stimulus_id}-target": "checkbox",
+          "aria-label": t('.select_row'),
         )
       },
       class_name: 'w-[20px]',

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -81,11 +81,11 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
         @model_class.human_attribute_name(cell)
       when Proc
         cell.call
+      else
+        cell
       end
 
-    cell_tag = cell.blank? ? :td : :th
-
-    render_cell(cell_tag, cell, class: <<~CLASSES)
+    render_cell(:th, cell, class: %w[
       border-b
       border-gray-100
       py-3
@@ -95,7 +95,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       text-3.5
       font-[600]
       line-[120%]
-    CLASSES
+    ].join(" "))
   end
 
   def render_data_cell(cell, data)
@@ -105,6 +105,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
         data.public_send(cell)
       when Proc
         cell.call(data)
+      else
+        cell
       end
 
     render_cell(:td, cell, class: "py-2 px-4")

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -3,8 +3,6 @@ require "solidus_admin/column"
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
-  attr_reader :model_class
-
   # @param page [GearedPagination::Page] The pagination page object.
   # @param path [Proc] A callable object that generates the path for pagination links.
   # @param columns [Array<Hash>] The array of column definitions.
@@ -39,7 +37,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           "aria-label": t('.select_row'),
         )
       },
-      render_context: self
+      render_context: self,
+      position: 0
     ).tap { |column| @column_classes[column.name] = 'w-[20px]' }
   end
 

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -25,6 +25,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       header: -> {
         component('ui/forms/checkbox').new(
           form: batch_actions_form_id,
+          "data-action": "#{stimulus_id}#selectAllRows",
+          "data-#{stimulus_id}-target": "headerCheckbox",
         )
       },
       data: ->(data) {
@@ -32,6 +34,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
           name: "id[]",
           form: batch_actions_form_id,
           value: data.id,
+          "data-action": "#{stimulus_id}#selectRow",
+          "data-#{stimulus_id}-target": "checkbox",
         )
       },
       class_name: 'w-[20px]',

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -16,6 +16,20 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     @pagination_component = pagination_component
     @model_class = page.records.model
     @rows = page.records
+
+    @columns.unshift selectable_column if batch_actions.present?
+  end
+
+  def selectable_column
+    @selectable_column ||= Column.new(
+      header: -> {
+        component('ui/forms/checkbox').new
+      },
+      data: ->(data) {
+        component('ui/forms/checkbox').new
+      },
+      class_name: 'w-[20px]',
+    )
   end
 
   def render_cell(tag, cell, **attrs)

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -23,17 +23,36 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   def selectable_column
     @selectable_column ||= Column.new(
       header: -> {
-        component('ui/forms/checkbox').new
+        component('ui/forms/checkbox').new(
+          form: batch_actions_form_id,
+        )
       },
       data: ->(data) {
-        component('ui/forms/checkbox').new
+        component('ui/forms/checkbox').new(
+          name: "id[]",
+          form: batch_actions_form_id,
+          value: data.id,
+        )
       },
       class_name: 'w-[20px]',
     )
   end
 
+  def batch_actions_form_id
+    @batch_actions_form_id ||= "#{stimulus_id}--batch-actions-#{SecureRandom.hex}"
+  end
+
   def render_batch_action_button(batch_action)
     render component('ui/button').new(
+      name: request_forgery_protection_token,
+      value: form_authenticity_token(form_options: {
+        action: batch_action.action,
+        method: batch_action.method,
+      }),
+      formaction: batch_action.action,
+      formmethod: batch_action.method,
+      form: batch_actions_form_id,
+      type: :submit,
       icon: batch_action.icon,
       text: batch_action.display_name,
       scheme: :secondary,

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -4,14 +4,15 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   # @param page [GearedPagination::Page] The pagination page object.
   # @param path [Proc] A callable object that generates the path for pagination links.
   # @param columns [Array<Hash>] The array of column definitions.
-  # @option columns [Symbol] :header The column header.
-  # @option columns [Symbol|Proc] :data The data accessor for the column.
+  # @option columns [Symbol|Proc|String] :header The column header.
+  # @option columns [Symbol|Proc|String] :data The data accessor for the column.
   # @option columns [String] :class_name (optional) The class name for the column.
   # @param pagination_component [Class] The pagination component class (default: component("ui/table/pagination")).
-  def initialize(page:, path: nil, columns: [], pagination_component: component("ui/table/pagination"))
+  def initialize(page:, path: nil, columns: [], batch_actions: [], pagination_component: component("ui/table/pagination"))
     @page = page
     @path = path
     @columns = columns.map { Column.new(**_1) }
+    @batch_actions = batch_actions.map { BatchAction.new(**_1) }
     @pagination_component = pagination_component
     @model_class = page.records.model
     @rows = page.records
@@ -83,5 +84,6 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   Column = Struct.new(:header, :data, :class_name, keyword_init: true)
-  private_constant :Column
+  BatchAction = Struct.new(:display_name, :icon, :action, :method, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+  private_constant :Column, :BatchAction
 end

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -1,3 +1,5 @@
 en:
   no_resources_found: "No %{resources} found"
   rows_selected: 'selected'
+  select_all: 'Select all'
+  select_row: 'Select row'

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -1,2 +1,3 @@
 en:
   no_resources_found: "No %{resources} found"
+  rows_selected: 'selected'

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class ProductsController < SolidusAdmin::BaseController
     def index
       set_page_and_extract_portion_from(
-        Spree::Product.order(created_at: :desc),
+        Spree::Product.order(created_at: :desc, id: :desc),
         per_page: SolidusAdmin::Config[:products_per_page]
       )
     end

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -8,5 +8,46 @@ module SolidusAdmin
         per_page: SolidusAdmin::Config[:products_per_page]
       )
     end
+
+    def destroy
+      @products = Spree::Product.where(id: params[:id])
+
+      Spree::Product.transaction do
+        @products.discard_all
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to products_path, status: :see_other
+    end
+
+    def discontinue
+      @products = Spree::Product.where(id: params[:id])
+
+      Spree::Product.transaction do
+        @products
+          .update_all(discontinue_on: Time.current)
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to products_path, status: :see_other
+    end
+
+    def activate
+      @products = Spree::Product.where(id: params[:id])
+
+      Spree::Product.transaction do
+        @products
+          .where.not(discontinue_on: nil)
+          .update_all(discontinue_on: nil)
+
+        @products
+          .where("available_on <= ?", Time.current)
+          .or(@products.where(available_on: nil))
+          .update_all(discontinue_on: nil)
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to products_path, status: :see_other
+    end
   end
 end

--- a/admin/config/locales/products.en.yml
+++ b/admin/config/locales/products.en.yml
@@ -1,0 +1,9 @@
+en:
+  solidus_admin:
+    products:
+      destroy:
+        success: "Products were successfully removed."
+      discontinue:
+        success: "Products were successfully discontinued."
+      activate:
+        success: "Products were successfully activated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -2,5 +2,11 @@
 
 SolidusAdmin::Engine.routes.draw do
   resource :account, only: :show
-  resources :products, only: :index
+  resources :products, only: :index do
+    collection do
+      delete :destroy
+      put :discontinue
+      put :activate
+    end
+  end
 end

--- a/admin/lib/solidus_admin/column.rb
+++ b/admin/lib/solidus_admin/column.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class Column
+    attr_reader :name, :header, :model_class_name
+
+    def initialize(
+      name:,
+      header:,
+      model_class_name: nil,
+      data: :itself,
+      renderer: ->(data) { send(:"#{name}_column", *data) },
+      header_renderer: lambda do
+        if respond_to?(:"#{name}_header")
+          send(:"#{name}_header")
+        else
+          model_class_name.constantize.human_attribute_name(header)
+        end
+      end,
+      render_context: nil
+    )
+      @name = name
+      @header = header
+      @data = data
+      @renderer = renderer
+      @header_renderer = header_renderer
+      @render_context = render_context
+      @model_class_name = model_class_name
+    end
+
+    def row_data(row)
+      case @data
+      when Symbol
+        row.send(@data)
+      when Proc
+        @data.call(row)
+      end
+    end
+
+    def render_data(row)
+      data = row_data(row)
+
+      @render_context.instance_exec(data, &@renderer)
+    end
+
+    def render_header
+      @render_context.instance_exec(&@header_renderer)
+    end
+
+    def ensure_render_context(render_context)
+      return self if @render_context
+
+      self.class.new(
+        name: @name,
+        header: @header,
+        data: @data,
+        renderer: @renderer,
+        header_renderer: @header_renderer,
+        model_class_name: @model_class_name,
+        render_context: render_context
+      )
+    end
+  end
+end

--- a/admin/lib/solidus_admin/column.rb
+++ b/admin/lib/solidus_admin/column.rb
@@ -2,11 +2,12 @@
 
 module SolidusAdmin
   class Column
-    attr_reader :name, :header, :model_class_name
+    attr_reader :name, :header, :model_class_name, :position
 
     def initialize(
       name:,
       header:,
+      position:,
       model_class_name: nil,
       data: :itself,
       renderer: ->(data) { send(:"#{name}_column", *data) },
@@ -21,6 +22,7 @@ module SolidusAdmin
     )
       @name = name
       @header = header
+      @position = position
       @data = data
       @renderer = renderer
       @header_renderer = header_renderer
@@ -57,6 +59,7 @@ module SolidusAdmin
         renderer: @renderer,
         header_renderer: @header_renderer,
         model_class_name: @model_class_name,
+        position: @position,
         render_context: render_context
       )
     end

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -2,6 +2,7 @@
 
 require 'spree/preferences/configuration'
 require 'solidus_admin/configuration/main_nav'
+require 'solidus_admin/configuration/products'
 
 module SolidusAdmin
   # Configuration for the admin interface.
@@ -86,6 +87,10 @@ module SolidusAdmin
       (@main_nav ||= MainNav.new).tap do
         yield(_1) if block_given?
       end
+    end
+
+    def products
+      @products ||= Products.new
     end
   end
 end

--- a/admin/lib/solidus_admin/configuration/products.rb
+++ b/admin/lib/solidus_admin/configuration/products.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'solidus_admin/configuration/products/index'
+
+module SolidusAdmin
+  class Configuration < Spree::Preferences::Configuration
+    class Products
+      def index
+        (@index ||= Index.new).tap do
+          yield(_1) if block_given?
+        end
+      end
+    end
+  end
+end

--- a/admin/lib/solidus_admin/configuration/products/index.rb
+++ b/admin/lib/solidus_admin/configuration/products/index.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "solidus_admin/container"
+require "solidus_admin/container_helper"
+require "solidus_admin/column"
+
+module SolidusAdmin
+  class Configuration < Spree::Preferences::Configuration
+    # Configuration for the products index table
+    class Products
+      class Index
+        class RenderContext
+          include ActionView::Helpers::TagHelper
+          include SolidusAdmin::ContainerHelper
+        end
+
+        NAMESPACE = "products.index"
+        private_constant :NAMESPACE
+
+        # @api private
+        def initialize(container: SolidusAdmin::Container)
+          @container = container
+        end
+
+        # Adds a new column to the products index table
+        #
+        # @return [SolidusAdmin::Column]
+        def add(name:, header:, data: nil, renderer: nil)
+          args = { name: name, header: header, model_class_name: "Spree::Product" }
+                 .tap { _1[:data] = data unless data.nil? }
+                 .tap { _1[:renderer] = renderer unless renderer.nil? }
+                 .tap { _1[:render_context] = render_context unless renderer.nil? }
+
+
+          column = Column.new(**args)
+
+          register(name, column) &&
+            resolve(name)
+        end
+
+        private
+
+        def register(key, column)
+          @container.register(
+            container_key(key),
+            column
+          )
+        end
+
+        def resolve(key)
+          @container.resolve(
+            container_key(key)
+          )
+        end
+
+        def container_key(key)
+          "#{NAMESPACE}#{@container.config.namespace_separator}#{key}"
+        end
+
+        def render_context
+          @render_context ||= RenderContext.new
+        end
+      end
+    end
+  end
+end

--- a/admin/lib/solidus_admin/configuration/products/index.rb
+++ b/admin/lib/solidus_admin/configuration/products/index.rb
@@ -25,8 +25,8 @@ module SolidusAdmin
         # Adds a new column to the products index table
         #
         # @return [SolidusAdmin::Column]
-        def add(name:, header:, data: nil, renderer: nil)
-          args = { name: name, header: header, model_class_name: "Spree::Product" }
+        def add(name:, header:, data: nil, renderer: nil, position: 100)
+          args = { name: name, header: header, model_class_name: "Spree::Product", position: position }
                  .tap { _1[:data] = data unless data.nil? }
                  .tap { _1[:renderer] = renderer unless renderer.nil? }
                  .tap { _1[:render_context] = render_context unless renderer.nil? }

--- a/admin/lib/solidus_admin/engine.rb
+++ b/admin/lib/solidus_admin/engine.rb
@@ -70,5 +70,11 @@ module SolidusAdmin
 
       Container.start("main_nav")
     end
+
+    initializer "solidus_admin.products_index_provider" do
+      require "solidus_admin/providers/products/index"
+
+      Container.start("products.index")
+    end
   end
 end

--- a/admin/lib/solidus_admin/providers/products/index.rb
+++ b/admin/lib/solidus_admin/providers/products/index.rb
@@ -8,27 +8,32 @@ module SolidusAdmin
           columns.add(
             name: :image,
             header: :image,
-            data: -> { [_1.id, _1.gallery.images.first] }
+            data: -> { [_1.id, _1.gallery.images.first] },
+            position: 10
           )
           columns.add(
             name: :name,
             header: :name,
-            data: -> { [_1.id, _1.name] }
+            data: -> { [_1.id, _1.name] },
+            position: 20
           )
           columns.add(
             name: :status,
             header: :status,
-            data: -> { _1.available? }
+            data: -> { _1.available? },
+            position: 30
           )
           columns.add(
             name: :stock,
             header: :stock,
-            data: -> { [_1.total_on_hand, _1.variants.count] }
+            data: -> { [_1.total_on_hand, _1.variants.count] },
+            position: 40
           )
           columns.add(
             name: :price,
             header: :price,
-            data: -> { _1.master.display_price }
+            data: -> { _1.master.display_price },
+            position: 50
           )
         end
 

--- a/admin/lib/solidus_admin/providers/products/index.rb
+++ b/admin/lib/solidus_admin/providers/products/index.rb
@@ -1,0 +1,41 @@
+require "solidus_admin/container"
+
+module SolidusAdmin
+  module Providers
+    Container.register_provider("products.index") do
+      start do
+        SolidusAdmin::Config.products.index do |columns|
+          columns.add(
+            name: :image,
+            header: :image,
+            data: -> { [_1.id, _1.gallery.images.first] }
+          )
+          columns.add(
+            name: :name,
+            header: :name,
+            data: -> { [_1.id, _1.name] }
+          )
+          columns.add(
+            name: :status,
+            header: :status,
+            data: -> { _1.available? }
+          )
+          columns.add(
+            name: :stock,
+            header: :stock,
+            data: -> { [_1.total_on_hand, _1.variants.count] }
+          )
+          columns.add(
+            name: :price,
+            header: :price,
+            data: -> { _1.master.display_price }
+          )
+        end
+
+        container.register("products.index") do
+          Container.within_namespace("products.index")
+        end
+      end
+    end
+  end
+end

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -12,4 +12,48 @@ describe "Products", type: :feature do
     expect(page).to have_content("$19.99")
     expect(page).to be_axe_clean
   end
+
+  it "can delete multiple products at once", js: true do
+    create(:product, name: "Just a product", price: 19.99)
+    create(:product, name: "Another product", price: 29.99)
+
+    visit "/admin/products"
+    find('main tbody tr:nth-child(2)').find('input').check
+    click_button "Delete"
+
+    expect(page).to have_content("Products were successfully removed.", wait: 5)
+    expect(page).not_to have_content("Just a product")
+    expect(page).to have_content("Another product")
+    expect(Spree::Product.count).to eq(1)
+  end
+
+  it "can discontinue and (re)activate multiple products at once", js: true do
+    create(:product, name: "Just a product", price: 19.99)
+    create(:product, name: "Another product", price: 29.99)
+
+    visit "/admin/products"
+    find('main tbody tr:nth-child(2)').find('input').check
+    click_button "Discontinue"
+
+    expect(page).to have_content("Products were successfully discontinued.", wait: 5)
+    within('main tbody tr:nth-child(2)') {
+      expect(page).to have_content("Just a product")
+      expect(page).to have_content("Discontinued")
+      expect(page).not_to have_content("Available")
+    }
+    within('main tbody tr:nth-child(1)') {
+      expect(page).to have_content("Another product")
+      expect(page).not_to have_content("Discontinued")
+      expect(page).to have_content("Available")
+    }
+
+    find('main tbody tr:nth-child(2)').find('input').check
+    click_button "Activate"
+
+    expect(page).to have_content("Products were successfully activated.", wait: 5)
+    expect(page).to have_content("Just a product")
+    expect(page).to have_content("Another product")
+    expect(page).not_to have_content("Discontinued")
+    expect(page).to have_content("Available").twice
+  end
 end


### PR DESCRIPTION
## Summary

**This PR is a proof of concept on adding a data and configuration layer on top of the table rendering. It's not meant to be merged, and it serves as a way to understand tradeoffs**

Currently, users need to replace a given table-based component in order to add a column. For instance, adding the `discontinue_on` column to the products table could look like this:

```ruby
# app/components/my_application/solidus_admin/products/component.rb
class MyApplication::SolidusAdmin::Products::Component < ::SolidusAdmin::Products::Component
  def columns
    super + [{
      header: :disconue_on,
      data: ->{ discontinue_on_column(_1) }
    }]
  end
  
  def discontinue_on_column(product)
    tag.span(class: "text-bold") { product.discontiue_on }
  end
end
```

The above code requires the user to know the internals of the table component. It has the potential to make use of any available method in it, making the new component brittle against future upgrades.

An interface that allows adding columns from outside would be more flexible and less brittle. This proof of concept shows how that could look like:

```ruby
# config/initializers/solidus_admin.rb
SolidusAdmin::Config.products.index do |columns|
  columns.add(
    name: :discontinue_on,
    header: :discontinue_on,
    renderer: ->(product) { tag.span(class: "text-bold") { product.discontiue_on } },
    position: 100
  )
end
```

It's important to notice that the `renderer` lambda is not executed in the context of the table component, which would expose the same kind of problems as the previous example, only making the experience more user-friendly. Instead, the available context is defined in `SolidusAdmin::Configuration::Products::Index::RenderContext`. The current version only gives access to Rails' tag helpers and SolidusAdmin's helpers to render other components, but it could be better tailored or even made configurable.

### Implementation

The `SolidusAdmin::Column` object has been extracted from within the table component. It accepts a `render_context` as an argument, which is set, in the example, to the products component for the columns defined from within the `solidus_admin` engine, and to the constrained `SolidusAdmin::Configuration::Products::Index::RenderContext` for user-defined columns.

To render a column cell, the `SolidusAdmin::Column` object calls the `renderer` lambda in the context of the defined `render_context`. By default, the `renderer` calls a `:"#{column_name}_column"` method on the context, which is leveraged by the `solidus_admin` components. Users can instead define their renderers. The `renderer` lambda takes as an argument the result of extracting data from every row, which is specified by the `data` parameter in `SolidusAdmin::Column`. By default, that's the complete row, but it can be trimmed down via a proc for a better separation of concerns.

For now, the behavior to render a column header is similar but with assumptions about the associated model class. Especially this part should not be seen as definitive, as it would still need a lot of refinements.

The component previews haven't been updated and are not working for now.

### Future work

In the case of this one moving forward, we should work on:

- Bringing the data definitions within the components sidecar directory.
- Better handling of column headers.
- New API to remove columns or modify the rendering for the ones already present.
- Tweakings the render context that is bound.

### Tradeoffs

Good:

- More flexibility for users.
- It gives us more license to treat some parts of table components as black boxes.
- The API can be used to add columns in any position, which is not that easy to do with the current implementation.
- The interface could easily be extended to also remove columns or modify the rendering of existing ones.

Bad:

- Adds a lot of complexity to tables (a lot of indirections).
- Makes contributions harder, as everything is much more abstracted.
