### PR TITLE
[Admin] Add missing items to the main navigation

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/item/component.yml
+++ b/admin/app/components/solidus_admin/sidebar/item/component.yml
@@ -2,8 +2,18 @@ en:
   main_nav:
     orders: Orders
     products: Products
+    option_types: Option Types
+    property_types: Property Types
+    taxonomies: Taxonomies
+    taxons: Display Order
     promotions: Promotions
+    promotion_categories: Promotion Categories
     stock: Stock
     users: Users
     settings: Settings
-    option_types: Options
+    stores: Stores
+    payment_methods: Payments
+    tax_categories: Taxes
+    refund_reasons: Refunds and Returns
+    shipping_methods: Shipping
+    zones: Zones

--- a/admin/lib/solidus_admin/providers/main_nav.rb
+++ b/admin/lib/solidus_admin/providers/main_nav.rb
@@ -26,6 +26,21 @@ module SolidusAdmin
                   key: "option_types",
                   route: -> { spree.admin_option_types_path },
                   position: 10
+                },
+                {
+                  key: "property_types",
+                  route: -> { spree.admin_properties_path },
+                  position: 20
+                },
+                {
+                  key: "taxonomies",
+                  route: -> { spree.admin_taxonomies_path },
+                  position: 30
+                },
+                {
+                  key: "taxons",
+                  route: -> { spree.admin_taxons_path },
+                  position: 40
                 }
               ]
             )
@@ -34,7 +49,14 @@ module SolidusAdmin
             key: "promotions",
             route: -> { spree.admin_promotions_path },
             icon: "megaphone-line",
-            position: 30
+            position: 30,
+            children: [
+              {
+                key: "promotion_categories",
+                route: -> { spree.admin_promotion_categories_path },
+                position: 10
+              }
+            ]
           )
 
           main_nav.add(
@@ -55,7 +77,34 @@ module SolidusAdmin
             key: "settings",
             route: -> { spree.admin_stores_path },
             icon: "settings-line",
-            position: 60
+            position: 60,
+            children: [
+              {
+                key: "payment_methods",
+                route: -> { spree.admin_payment_methods_path },
+                position: 20
+              },
+              {
+                key: "tax_categories",
+                route: -> { spree.admin_tax_categories_path },
+                position: 30
+              },
+              {
+                key: "refund_reasons",
+                route: -> { spree.admin_refund_reasons_path },
+                position: 40
+              },
+              {
+                key: "shipping_methods",
+                route: -> { spree.admin_shipping_methods_path },
+                position: 50
+              },
+              {
+                key: "zones",
+                route: -> { spree.admin_zones_path },
+                position: 60
+              }
+            ]
           )
         end
 

--- a/admin/spec/components/solidus_admin/sidebar/item/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/item/component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SolidusAdmin::Sidebar::Item::Component, type: :component do
 
     render_inline(component)
 
-    expect(page).to have_content("Options")
+    expect(page).to have_content("Option Types")
   end
 
   it "syles top level items differently from nested items" do
@@ -54,7 +54,7 @@ RSpec.describe SolidusAdmin::Sidebar::Item::Component, type: :component do
     expect(
       page.find("a", text: "Products")[:class]
     ).not_to eq(
-      page.find("a", text: "Options")[:class]
+      page.find("a", text: "Option Types")[:class]
     )
   end
 


### PR DESCRIPTION
## Summary

This commit adds the missing items to the admin main navigation to bring it to parity with the old UI. We also update the option types label to keep using the old name, so there's no mismatch when changing UIs.

![screenshot-localhost_3000-2023 07 20-10_02_31](https://github.com/solidusio/solidus/assets/52650/4883e7b7-d5f8-4443-b4ee-4478ff27201d)

Ref. #5106 


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
