### PR TITLE
[Admin] Use blank alt attribute for the decorative logo

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -6,7 +6,7 @@
   bg-gray-15
   p-8
 ">
-  <%= image_tag @logo_path, alt: "Solidus", class: "py-3 px-2" %>
+  <%= image_tag @logo_path, alt: "", class: "py-3 px-2" %>
   <%= link_to @store.url,
         class: "
           block


### PR DESCRIPTION
## Summary

The image is purely decorative, as the store name is already present just below it. This avoids screen readers from noisily repeating the store name twice.

As [Success Criterion 1.1.1 states](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all), there are exceptions to providing text alternatives for non-text content, one of which is:

> Decoration, Formatting, Invisible: If non-text content is pure decoration, is used only for visual formatting, or is not presented to users, then it is implemented in a way that it can be ignored by assistive technology.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
