### PR TITLE
[Admin] Fix the layout and sidebar styling

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -18,7 +18,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
     image = product.gallery.images.first or return
 
     link_to(
-      image_tag(image.url(:small), class: 'h-10 w-10 max-w-min rounded border border-gray-100', alt: ''),
+      image_tag(image.url(:small), class: 'h-10 w-10 max-w-min rounded border border-gray-100', alt: product.name),
       spree.edit_admin_product_path(product),
       class: 'inline-flex overflow-hidden',
       tabindex: -1,

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -5,7 +5,7 @@
   w-full
 ">
   <%= link_to @store.url, class: "py-3 px-2 text-left flex" do %>
-    <%= image_tag @logo_path, alt: "", class: "max-h-7" %>
+    <%= image_tag @logo_path, alt: t('.visit_store'), class: "max-h-7" %>
   <% end %>
 
   <%= link_to @store.url, class: "flex mt-4 mb-2 px-2 py-1.5 border border-gray-100 rounded-sm shadow-sm" do %>

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -1,8 +1,5 @@
 <aside class="
   flex flex-col
-  border-r border-r-gray-100
-  col-start-1 col-end-2
-  lg:col-start-1 lg:col-end-3
   bg-gray-15
   p-8
 ">

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -1,26 +1,21 @@
 <aside class="
   flex flex-col
   bg-gray-15
-  p-8
+  p-4
+  w-full
 ">
-  <%= image_tag @logo_path, alt: "", class: "py-3 px-2" %>
-  <%= link_to @store.url,
-        class: "
-          block
-          mt-4 px-2 py-0.5
-          border border-gray-100 rounded-sm shadow-sm
-          bg-arrow-right-up-line bg-right-top bg-no-repeat bg-origin-content
-        " do %>
-    <p class="
-      body-small-bold text-black
-    ">
-      <%= @store.name %>
-    </p>
-    <p class="
-      body-tiny text-gray-500
-    ">
-      <%= @store.url %>
-    </p>
+  <%= link_to @store.url, class: "py-3 px-2 text-left flex" do %>
+    <%= image_tag @logo_path, alt: "", class: "max-h-7" %>
+  <% end %>
+
+  <%= link_to @store.url, class: "flex mt-4 mb-2 px-2 py-1.5 border border-gray-100 rounded-sm shadow-sm" do %>
+    <div class="flex-grow">
+      <p class="body-small-bold text-black"><%= @store.name %></p>
+      <p class="body-tiny text-gray-500"><%= @store.url %></p>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M10.6693 6.27614L4.93158 12.0139L3.98877 11.0711L9.7265 5.33333H4.66932V4H12.0026V11.3333H10.6693V6.27614Z" fill="#A3A3A3"/>
+    </svg>
   <% end %>
   <nav data-controller="main-nav" class="mt-2">
     <ul>

--- a/admin/app/components/solidus_admin/sidebar/component.yml
+++ b/admin/app/components/solidus_admin/sidebar/component.yml
@@ -1,0 +1,2 @@
+en:
+  visit_store: Visit your store

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -7,7 +7,7 @@
     <%= javascript_importmap_tags "solidus_admin/application", shim: false, importmap: SolidusAdmin.importmap %>
   </head>
 
-  <body>
+  <body class="bg-gray-15">
     <%= render component("skip_link").new(href: "#main") %>
     <div class="fixed right-3 bottom-3 flex flex-col gap-3" role="alert">
       <% flash.each do |key, message| %>
@@ -15,19 +15,12 @@
       <% end %>
     </div>
 
-    <div class="
-      grid grid-cols-4
-      lg:grid-cols-12
-      bg-gray-15
-      h-screen
-    ">
-      <%= render component("sidebar").new(store: current_store) %>
+    <div class="flex gap-0 h-screen">
+      <div class="flex min-w-[240px] border-r border-r-gray-100">
+        <%= render component("sidebar").new(store: current_store) %>
+      </div>
 
-      <main id="main" class="
-        col-start-2 col-end-4
-        lg:col-start-3 lg:col-end-12
-        py-6 px-4
-      ">
+      <main id="main" class="flex-grow">
         <%= yield %>
       </main>
     </div>

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -2,7 +2,7 @@ $color-navbar-hover-bg: $color-navbar-bg !default;
 $color-navbar-hover: $color-navbar !default;
 
 .solidus-admin--nav {
-  background-color: $color-white;
+  background-color: $color-light;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -14,6 +14,7 @@ $color-navbar-hover: $color-navbar !default;
   display: flex;
   flex-direction: column;
   max-height: 100vh;
+  border-right: $color-light-accent 1px solid;
 
   @media print {
     display: none
@@ -51,11 +52,11 @@ $color-navbar-hover: $color-navbar !default;
   }
 
   &--store-link {
-    display: block;
+    display: flex;
     width: 100%;
     border: $border-color 1px solid;
     border-radius: $border-radius;
-    padding: 6px (8px - 1px);
+    padding: 6px 8px;
     text-align: left;
 
     &:hover {
@@ -70,14 +71,17 @@ $color-navbar-hover: $color-navbar !default;
     }
 
     &--name {
+      line-height: 24px;
       font-size: 14px;
-      font-weight: bold;
+      font-weight: 600;
       color: $color-dark;
       display: block;
     }
 
     &--url {
+      line-height: 20px;
       font-size: 12px;
+      font-weight: 400;
       color: $color-dark-light;
       display: block;
     }
@@ -97,9 +101,9 @@ $color-navbar-hover: $color-navbar !default;
       margin: 0;
       display: block;
       font-size: 14px;
-      line-height: 16.8px;
+      line-height: 24px;
       font-weight: 600;
-      padding: 8px 12px;
+      padding: 2px 12px;
       width: 100%;
       border-radius: $border-radius;
       color: $color-primary;
@@ -107,7 +111,7 @@ $color-navbar-hover: $color-navbar !default;
       &::before {
         margin-right: 12px;
         display: inline-block;
-        width: 16px;
+        width: 18px;
         padding: 0;
       }
 

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -7,9 +7,13 @@
     <%- end %>
 
     <%= link_to "//#{default_store.url}", target: '_blank', class: 'solidus-admin--nav--store-link' do %>
-      <i class='fa fa-external-link' title="<%= t("spree.back_to_store") %>"></i>
-      <span class="solidus-admin--nav--store-link--name"><%= default_store.name %></span>
-      <span class="solidus-admin--nav--store-link--url"><%= default_store.url %></span>
+      <div style="flex-grow: 1">
+        <span class="solidus-admin--nav--store-link--name"><%= default_store.name %></span>
+        <span class="solidus-admin--nav--store-link--url"><%= default_store.url %></span>
+      </div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M10.6693 6.27614L4.93158 12.0139L3.98877 11.0711L9.7265 5.33333H4.66932V4H12.0026V11.3333H10.6693V6.27614Z" fill="#A3A3A3"/>
+      </svg>
     <% end %>
   </header>
 


### PR DESCRIPTION
## Summary

- share the same width, let's setup a grid and responsiveness when we're don't need to switch between the two admins
- adjust the spacing of the logo and store link to match

The best way to test this is to open two tabs and switch between them, the upper part of the sidebar should not show any difference

| solidus_admin | solidus_backend |
|--------|--------|
| <img width="909" alt="image" src="https://github.com/solidusio/solidus/assets/1051/dc47056a-fbcc-4250-8ebe-41dc1aaaf0b2"> | <img width="909" alt="image" src="https://github.com/solidusio/solidus/assets/1051/4c071c18-bd3f-4f56-8867-1c022355d1f9"> | 

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
