### PR TITLE
[Admin] Make account navigation accessible

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
@@ -1,29 +1,9 @@
-<nav class="mt-auto w-48"
+<nav class="flex flex-col-reverse w-48 mt-auto"
   data-controller="<%= stimulus_id %>"
   data-<%= stimulus_id %>-active-class="bg-gray-25"
   aria-label="<%= t('.account.account') %>"
 >
-  <ul data-<%= stimulus_id %>-target="links"
-    class="
-      hidden
-      p-2
-      body-small text-black
-      border border-gray-100 rounded-lg shadow-base
-    ">
-    <li class="h-8 flex items-center hover:bg-gray-25">
-      <%= link_to @account_path do %>
-        <%= icon_tag("user-3-line", class: "inline-block align-text-bottom w-[0.83rem] h-[1.09rem] mx-2 fill-current") %>
-        <%= t('.account.account') %>
-      <% end %>
-    </li>
-    <li class="h-8 flex items-center hover:bg-gray-25">
-      <%= link_to @logout_path, method: @logout_method do %>
-        <%= icon_tag("logout-box-line", class: "inline-block align-text-bottom w-[0.98rem] h-[1.04rem] mx-2 fill-current") %>
-        <%= t('.account.logout') %>
-      <% end %>
-    </li>
-  </ul>
-  <p data-action="
+  <button data-action="
     click-><%= stimulus_id %>#toggleLinks
     "
     data-<%= stimulus_id %>-target="button"
@@ -37,6 +17,30 @@
     <%= icon_tag("user-smile-fill", class: "inline-block align-text-bottom shrink-0 w-6 h-6 rounded-[4.81rem] mr-[1.5] body-small fill-yellow bg-black") %>
     <span class="overflow-hidden whitespace-nowrap text-ellipsis">
       <%= @user_label %>
-    </span class="">
-  </p>
+    </span>
+  </button>
+  <ul data-<%= stimulus_id %>-target="links"
+    class="
+      hidden
+      p-2
+      body-small text-black
+      border border-gray-100 rounded-lg shadow-base
+    ">
+    <li class="h-8 flex items-center hover:bg-gray-25">
+      <%= link_to @account_path do %>
+        <%= icon_tag("user-3-line", class: "inline-block align-text-bottom w-[0.83rem] h-[1.09rem] mx-2 fill-current") %>
+        <%= t('.account.account') %>
+      <% end %>
+    </li>
+    <li class="h-8 flex items-center hover:bg-gray-25"
+      data-action="
+        focusout-><%= stimulus_id %>#hideLinks
+      "
+    >
+      <%= link_to @logout_path, method: @logout_method do %>
+        <%= icon_tag("logout-box-line", class: "inline-block align-text-bottom w-[0.98rem] h-[1.04rem] mx-2 fill-current") %>
+        <%= t('.account.logout') %>
+      <% end %>
+    </li>
+  </ul>
 </nav>

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
@@ -7,6 +7,7 @@
     click-><%= stimulus_id %>#toggleLinks
     "
     data-<%= stimulus_id %>-target="button"
+    aria-expanded="false" aria-controls="account-menu"
     class="
       flex gap-1.5
       p-3 mt-2
@@ -20,6 +21,7 @@
     </span>
   </button>
   <ul data-<%= stimulus_id %>-target="links"
+    id="account-menu"
     class="
       hidden
       p-2

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.js
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.js
@@ -12,4 +12,12 @@ export default class extends Controller {
     )
     this.linksTarget.classList.toggle("hidden")
   }
+
+  // Hide the links and mark the button as inactive
+  hideLinks() {
+    this.buttonTarget.classList.remove(
+      this.activeClass,
+    )
+    this.linksTarget.classList.add("hidden")
+  }
 }

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.js
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.js
@@ -5,19 +5,33 @@ export default class extends Controller {
 
   static classes = ["active"]
 
-  // Toggle the visibility of the links and mark the button as active
   toggleLinks() {
+    // Toggle button's active state
     this.buttonTarget.classList.toggle(
       this.activeClass,
     )
+    // Toggle aria-expanded state
+    this.buttonTarget.setAttribute(
+      "aria-expanded",
+      this.buttonTarget.classList.contains(
+        this.activeClass,
+      ),
+    )
+    // Toggle links' visibility
     this.linksTarget.classList.toggle("hidden")
   }
 
-  // Hide the links and mark the button as inactive
   hideLinks() {
+    // Remove button's active state
     this.buttonTarget.classList.remove(
       this.activeClass,
     )
+    // Set aria-expanded to false
+    this.buttonTarget.setAttribute(
+      "aria-expanded",
+      "false"
+    )
+    // Hide the links
     this.linksTarget.classList.add("hidden")
   }
 }


### PR DESCRIPTION
## Summary

We make it browsable by keyboard. We transform the user name to button so it can be focused and activated by the keyboard. We also render it before the links in the DOM so the next tab will focus on the first link. We close the dropdown when the focus leaves the last item.

We also make it more friendly for screen readers by using the `aria-expanded`
attribute to tell screen readers if the menu is expanded or not.

[screencast-localhost_3000-2023.07.21-08_59_43.webm](https://github.com/solidusio/solidus/assets/52650/f57ab54a-038d-40b5-ac8f-2b898de78333)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
