### PR TITLE
[Admin] Add a skip link

### DIFF
--- a/admin/app/components/solidus_admin/skip_link/component.rb
+++ b/admin/app/components/solidus_admin/skip_link/component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Skip to content link
+class SolidusAdmin::SkipLink::Component < SolidusAdmin::BaseComponent
+  # @param href [String] the href attribute for the skip link
+  def initialize(href:)
+    @href = href
+  end
+
+  def call
+    link_to t(".skip_link"),
+            @href,
+            class: %{
+              sr-only
+              focus:not-sr-only
+              inline-block
+              focus:p-2
+              focus:absolute
+              body-small
+              text-white
+              bg-black
+            }
+  end
+end

--- a/admin/app/components/solidus_admin/skip_link/component.yml
+++ b/admin/app/components/solidus_admin/skip_link/component.yml
@@ -1,0 +1,2 @@
+en:
+  skip_link: Skip to content

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -8,6 +8,7 @@
   </head>
 
   <body>
+    <%= render component("skip_link").new(href: "#main") %>
     <div class="fixed right-3 bottom-3 flex flex-col gap-3" role="alert">
       <% flash.each do |key, message| %>
         <%= render component("ui/toast").new(text: message, scheme: key == :error ? :error : :default) %>
@@ -22,7 +23,7 @@
     ">
       <%= render component("sidebar").new(store: current_store) %>
 
-      <main class="
+      <main id="main" class="
         col-start-2 col-end-4
         lg:col-start-3 lg:col-end-12
         py-6 px-4

--- a/admin/spec/components/previews/solidus_admin/skip_link/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/skip_link/component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# @component "skip_link"
+class SolidusAdmin::SkipLink::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  # Click on the "Preview" window area and press "Tab" to see the skip link
+  def overview
+    render current_component.new(href: "#")
+  end
+end

--- a/admin/spec/components/solidus_admin/skip_link/component_spec.rb
+++ b/admin/spec/components/solidus_admin/skip_link/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::SkipLink::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

This fulfills WCAG 2.0 guideline [2.4.1](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-skip) (Bypass Blocks) for the sidebar navigation in the admin interface, jumping to the main content area.

[screencast-localhost_3000-2023.07.21-10_10_05.webm](https://github.com/solidusio/solidus/assets/52650/ad168112-9bd0-48e6-b855-a84f1e1d049f)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
