### PR TITLE
[Admin] Improve a11y experience for product rows

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -9,9 +9,9 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
     image = product.gallery.images.first or return
 
     link_to(
-      image_tag(image.url(:small), class: 'h-10 w-10 max-w-min rounded border border-gray-100 '),
+      image_tag(image.url(:small), class: 'h-10 w-10 max-w-min rounded border border-gray-100', alt: ''),
       spree.edit_admin_product_path(product),
-      class: 'inline-flex overflow-hidden'
+      class: 'inline-flex overflow-hidden',
     )
   end
 

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -12,6 +12,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
       image_tag(image.url(:small), class: 'h-10 w-10 max-w-min rounded border border-gray-100', alt: ''),
       spree.edit_admin_product_path(product),
       class: 'inline-flex overflow-hidden',
+      tabindex: -1,
     )
   end
 


### PR DESCRIPTION
## Summary

Skip duplicate product link when tabbing through product rows. This way, when tabbing through the product rows, the user will not encounter the same link twice, as the link is already set for the product name.

[screencast-localhost_3000-2023.07.21-11_47_12.webm](https://github.com/solidusio/solidus/assets/52650/af6f2b42-3e88-46ad-8f77-48d861e7cdc8)

We also explicitly mark product images as decorative by giving an empty alt attribute.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
