### PR TITLE
[Admin] Hide decorative svg from screen readers

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -14,7 +14,7 @@ module SolidusAdmin
     def icon_tag(name, **attrs)
       href = image_path("solidus_admin/remixicon.symbol.svg") + "#ri-#{name}"
       tag.svg(
-        class: attrs[:class],
+        **attrs
       ) do
         tag.use(
           "xlink:href": href

--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
@@ -15,7 +15,7 @@
       hover:bg-gray-25
       cursor-pointer
   ">
-    <%= icon_tag("user-smile-fill", class: "inline-block align-text-bottom shrink-0 w-6 h-6 rounded-[4.81rem] mr-[1.5] body-small fill-yellow bg-black") %>
+    <%= icon_tag("user-smile-fill", class: "inline-block align-text-bottom shrink-0 w-6 h-6 rounded-[4.81rem] mr-[1.5] body-small fill-yellow bg-black", "aria-hidden" => "true") %>
     <span class="overflow-hidden whitespace-nowrap text-ellipsis">
       <%= @user_label %>
     </span>
@@ -30,7 +30,7 @@
     ">
     <li class="h-8 flex items-center hover:bg-gray-25">
       <%= link_to @account_path do %>
-        <%= icon_tag("user-3-line", class: "inline-block align-text-bottom w-[0.83rem] h-[1.09rem] mx-2 fill-current") %>
+        <%= icon_tag("user-3-line", class: "inline-block align-text-bottom w-[0.83rem] h-[1.09rem] mx-2 fill-current", "aria-hidden"=>true) %>
         <%= t('.account.account') %>
       <% end %>
     </li>
@@ -40,7 +40,7 @@
       "
     >
       <%= link_to @logout_path, method: @logout_method do %>
-        <%= icon_tag("logout-box-line", class: "inline-block align-text-bottom w-[0.98rem] h-[1.04rem] mx-2 fill-current") %>
+        <%= icon_tag("logout-box-line", class: "inline-block align-text-bottom w-[0.98rem] h-[1.04rem] mx-2 fill-current", "aria-hidden"=>true) %>
         <%= t('.account.logout') %>
       <% end %>
     </li>

--- a/admin/app/components/solidus_admin/sidebar/item/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.rb
@@ -25,7 +25,7 @@ class SolidusAdmin::Sidebar::Item::Component < SolidusAdmin::BaseComponent
     common_classes = "inline-block w-[1.125rem] h-[1.125rem] mr-[0.68rem] body-small"
 
     return tag.span(class: common_classes) unless @item.icon
-    icon_tag(@item.icon, class: "#{common_classes} align-text-bottom fill-current")
+    icon_tag(@item.icon, class: "#{common_classes} align-text-bottom fill-current", "aria-hidden" => true)
   end
 
   def path


### PR DESCRIPTION
## Summary

By using the `aria-hidden` attribute, we can hide the svg from screen readers.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
