### PR TITLE
[Admin] Make pagination accessible

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/pagination/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.html.erb
@@ -3,24 +3,24 @@
     <ul class="flex items-center">
       <li>
         <% if @page.first? %>
-          <span class="<%= link_classes(rounded: :left) %>">
-            <%= icon_tag("arrow-left-s-line", class: "fill-current text-grey-400 w-5 h-5") %>
+          <span class="<%= link_classes(rounded: :left) %>", "aria-label"=<%= t(".prev") %>, "aria-disabled"=true>
+            <%= icon_tag("arrow-left-s-line", class: "fill-current text-grey-400 w-5 h-5", "aria-hidden" => true) %>
           </span>
         <% else %>
-          <%= link_to @path.call(@page.number - 1), class: link_classes(rounded: :left) do %>
-            <%= icon_tag("arrow-left-s-line", class: "w-5 h-5") %>
+          <%= link_to @path.call(@page.number - 1), class: link_classes(rounded: :left), "aria-label" => t(".prev") do %>
+            <%= icon_tag("arrow-left-s-line", class: "w-5 h-5", "aria-hidden" => true) %>
           <% end %>
         <% end %>
       </li>
 
       <li>
         <% if @page.last? %>
-          <span class="<%= link_classes(rounded: :right) %>">
-            <%= icon_tag("arrow-right-s-line", class: "fill-current text-grey-400 w-5 h-5") %>
+          <span class="<%= link_classes(rounded: :right) %>", "aria-label"=<%= t(".next") %>, "aria-disabled"=true>
+            <%= icon_tag("arrow-right-s-line", class: "fill-current text-grey-400 w-5 h-5", "aria-hidden" => true) %>
           </span>
         <% else %>
-          <%= link_to @path.call(@page.next_param), class: link_classes(rounded: :right) do %>
-            <%= icon_tag("arrow-right-s-line", class: "w-5 h-5") %>
+          <%= link_to @path.call(@page.next_param), class: link_classes(rounded: :right), "aria-label" => t(".next") do %>
+            <%= icon_tag("arrow-right-s-line", class: "w-5 h-5", "aria-hidden" => true) %>
           <% end %>
         <% end %>
       </li>

--- a/admin/app/components/solidus_admin/ui/table/pagination/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.yml
@@ -1,0 +1,3 @@
+en:
+  next: Next
+  prev: Previous


### PR DESCRIPTION
## Summary

We label the pagination icon wrappers with "aria-label", while hiding the icon itself to screen readers. We also mark as "aria-disable"'d when the first/last page is reached.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
