### PR TITLE
[Admin] Make the toast component accessible

### DIFF
--- a/admin/app/components/solidus_admin/ui/toast/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/toast/component.html.erb
@@ -6,8 +6,11 @@
   data-controller="<%= stimulus_id %>"
   data-<%= stimulus_id %>-closing-class="transform opacity-0 transition duration-500"
   data-<%= stimulus_id %>-transition-value="500"
+  role="dialog"
+  aria-label="<%= t(".#{@scheme}_label") %>"
+  aria-live="polite"
 >
-  <%= icon_tag(@icon, class: 'inline-block w-[1.125rem] h-[1.125rem] mr-3 fill-current') if @icon %>
+  <%= icon_tag(@icon, class: 'inline-block w-[1.125rem] h-[1.125rem] mr-3 fill-current', "aria-hidden" => true) if @icon %>
 
   <p class="inline-block body-tiny-bold"><%= @text %></p>
 
@@ -15,7 +18,9 @@
     class="inline-block ml-3 align-text-bottom"
     title="<%= t('.close_text') %>"
     data-action="<%= stimulus_id %>#close"
+    aria-label="<%= t('.close_text') %>"
+    data-target="<%= stimulus_id %>.closeButton"
   >
-    <%= icon_tag('close-line', class: "w-[1.125rem] h-[1.125rem] fill-current") %>
+    <%= icon_tag('close-line', class: "w-[1.125rem] h-[1.125rem] fill-current", "aria-hidden" => true) %>
   </button>
 </div>

--- a/admin/app/components/solidus_admin/ui/toast/component.js
+++ b/admin/app/components/solidus_admin/ui/toast/component.js
@@ -1,8 +1,14 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
+  static targets = ['closeButton']
   static classes = ['closing']
   static values = { transition: Number }
+
+  connect () {
+    // Give focus to the close button
+    this.closeButtonTarget.focus();
+  }
 
   close () {
     this.element.classList.add(...this.closingClasses);

--- a/admin/app/components/solidus_admin/ui/toast/component.yml
+++ b/admin/app/components/solidus_admin/ui/toast/component.yml
@@ -1,2 +1,4 @@
 en:
+  default_label: Information
+  error_label: Error
   close_text: "Close"


### PR DESCRIPTION
## Summary

We mark it as a polite dialog. When rendered, we move focus to the close button so it can be quickly dismissed with the keyboard.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
