### PR TITLE
[Admin] Mark the current link in the main nav for accessibility

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/item/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.html.erb
@@ -6,7 +6,9 @@
       hover:text-red-500 hover:bg-gray-50
       <%= link_active_classes %>
       <%= link_level_classes %>
-    ">
+    "
+    aria-current="<%= aria_current %>"
+  >
       <%= icon %>
       <%= name %>
   </a>

--- a/admin/app/components/solidus_admin/sidebar/item/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/item/component.rb
@@ -71,4 +71,8 @@ class SolidusAdmin::Sidebar::Item::Component < SolidusAdmin::BaseComponent
   def active?
     @item.active?(@url_helpers, @fullpath)
   end
+
+  def aria_current
+    @item.current?(@url_helpers, @fullpath) ? "page" : "false"
+  end
 end

--- a/admin/lib/solidus_admin/main_nav_item.rb
+++ b/admin/lib/solidus_admin/main_nav_item.rb
@@ -73,17 +73,31 @@ module SolidusAdmin
       end
     end
 
+    # Returns whether the item should be marked as current
+    #
+    # An item is considered the current one if its base path (that is, the path
+    # without any query parameters) matches the given full path.
+    #
+    # @param url_helpers [#solidus_admin, #spree] context object giving access
+    #  to url helpers
+    # @param fullpath [String] the full path of the current request
+    # @return [Boolean]
+    def current?(url_helpers, fullpath)
+      path(url_helpers) == fullpath.gsub(/\?.*$/, '')
+    end
+
     # Returns whether the item should be marked as active
     #
-    # An item is considered active if its base path (that is, the path without
-    # any query parameters) matches the given full path.
+    # An item is considered active when it is the current item or any of its
+    # children is active.
     #
     # @param url_helpers [#solidus_admin, #spree] context object giving access
     #   to url helpers
     # @param fullpath [String] the full path of the current request
     # @return [Boolean]
+    # @see #current?
     def active?(url_helpers, fullpath)
-      (path(url_helpers) == fullpath.gsub(/\?.*$/, '')) ||
+      current?(url_helpers, fullpath) ||
         children.any? { |child| child.active?(url_helpers, fullpath) }
     end
   end

--- a/admin/spec/solidus_admin/main_nav_item_spec.rb
+++ b/admin/spec/solidus_admin/main_nav_item_spec.rb
@@ -91,13 +91,13 @@ RSpec.describe SolidusAdmin::MainNavItem do
     end
   end
 
-  describe "#active?" do
+  describe "#current?" do
     it "returns true when the path matches the current request path" do
       item = described_class.new(key: "foo", route: :foo_path, position: 1)
       url_helpers = url_helpers(solidus_admin: { foo_path: "/foo" })
 
       expect(
-        item.active?(url_helpers, "/foo")
+        item.current?(url_helpers, "/foo")
       ).to be(true)
     end
 
@@ -106,11 +106,42 @@ RSpec.describe SolidusAdmin::MainNavItem do
       url_helpers = url_helpers(solidus_admin: { foo_path: "/foo" })
 
       expect(
-        item.active?(url_helpers, "/foo?bar=baz")
+        item.current?(url_helpers, "/foo?bar=baz")
       ).to be(true)
     end
 
     it "returns false when the path does not match the current request base path" do
+      item = described_class.new(key: "foo", route: :foo_path, position: 1)
+      url_helpers = url_helpers(solidus_admin: { foo_path: "/foo" })
+
+      expect(
+        item.current?(url_helpers, "/bar")
+      ).to be(false)
+    end
+  end
+
+  describe "#active?" do
+    it "returns true when it's the current item" do
+      item = described_class.new(key: "foo", route: :foo_path, position: 1)
+      url_helpers = url_helpers(solidus_admin: { foo_path: "/foo" })
+
+      expect(
+        item.active?(url_helpers, "/foo")
+      ).to be(true)
+    end
+
+    it "returns true when one of its children is active" do
+      item = described_class.new(
+        key: "foo", route: :foo_path, position: 1, children: [described_class.new(key: "bar", route: :bar_path, position: 1)]
+      )
+      url_helpers = url_helpers(solidus_admin: { foo_path: "/foo", bar_path: "/bar" })
+
+      expect(
+        item.active?(url_helpers, "/bar")
+      ).to be(true)
+    end
+
+    it "returns false otherwise" do
       item = described_class.new(key: "foo", route: :foo_path, position: 1)
       url_helpers = url_helpers(solidus_admin: { foo_path: "/foo" })
 


### PR DESCRIPTION
## Summary

By using the [`aria-current` attribute](https://w3c.github.io/aria/#aria-current) we can mark the current link in the main nav as active for screen readers.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
