### PR TITLE
Stop setting line items with quantity of zero

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -13,7 +13,7 @@ module Spree
         variant = Spree::Variant.find(params[:line_item][:variant_id])
         @line_item = @order.contents.add(
           variant,
-          params[:line_item][:quantity] || 1,
+          params[:line_item][:quantity].presence || 1,
           options: line_item_params[:options].to_h
         )
 

--- a/api/spec/requests/spree/api/line_items_spec.rb
+++ b/api/spec/requests/spree/api/line_items_spec.rb
@@ -95,11 +95,25 @@ module Spree::Api
         expect(response.status).to eq(201)
       end
 
-      it "default quantity to 1 if none is given" do
+      it "sets default quantity to 1 if none is given" do
         post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param } }
         expect(response.status).to eq(201)
         expect(json_response).to have_attributes(attributes)
         expect(json_response[:quantity]).to eq 1
+      end
+
+      it "sets default quantity to 1 if empty values are given" do
+        post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: '' } }
+        expect(response.status).to eq(201)
+        expect(json_response).to have_attributes(attributes)
+        expect(json_response[:quantity]).to eq 1
+      end
+
+      it "allows to explicitly set quantity to 0" do
+        post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: 0 } }
+        expect(response.status).to eq(201)
+        expect(json_response).to have_attributes(attributes)
+        expect(json_response[:quantity]).to eq 0
       end
 
       it "increases a line item's quantity if it exists already" do


### PR DESCRIPTION
## Summary

In order to order to be able to update LineItem's validations to stop allowing a quantity of zero, we need to remove code that saves LineItems with a quantity of 0 (or less which gets normalized to 0).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
