### PR TITLE
[Admin] Use `ui/button` for the pagination component

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -17,6 +17,10 @@
 
   <%= render @table_component.new(
     page: @page,
+    footer: render(@pagination_component.new(
+      prev_link: @page.first? ? nil : solidus_admin.products_path(page: @page.number - 1),
+      next_link: @page.last? ? nil : solidus_admin.products_path(page: @page.number + 1)
+    )),
     batch_actions: [
       {
         display_name: t('.batch_actions.delete'),

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -5,6 +5,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
     page:,
     badge_component: component('ui/badge'),
     table_component: component('ui/table'),
+    pagination_component: component('ui/table/pagination'),
     button_component: component("ui/button")
   )
     @page = page
@@ -12,6 +13,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
     @badge_component = badge_component
     @table_component = table_component
     @button_component = button_component
+    @pagination_component = pagination_component
   end
 
   def image_column(product)

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -78,6 +78,17 @@
       <% end %>
     </tbody>
 
-    <%= render_table_footer %>
+    <% if @footer.present? %>
+      <tfoot>
+        <tr>
+          <td colspan="<%= @columns.size %>" class="py-4">
+            <div class="flex justify-center">
+              <%= @footer %>
+            </div>
+          </td>
+        </tr>
+      </tfoot>
+    <% end %>
+
   </table>
 </div>

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -2,7 +2,6 @@
 
 class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   # @param page [GearedPagination::Page] The pagination page object.
-  # @param path [Proc] A callable object that generates the path for pagination links.
   #
   # @param columns [Array<Hash>] The array of column definitions.
   # @option columns [Symbol|Proc|#to_s] :header The column header.
@@ -15,28 +14,27 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   # @option batch_actions [String] :action The batch action path.
   # @option batch_actions [String] :method The batch action HTTP method for the provided path.
   #
-  # @param pagination_component [Class] The pagination component class (default: component("ui/table/pagination")).
+  # @param footer [String] The content for the footer, e.g. pagination links.
+  #
   # @param checkbox_componnent [Class] The checkbox component class (default: component("ui/forms/checkbox")).
   # @param button_component [Class] The button component class (default: component("ui/button")).
   # @param tab_component [Class] The tab component class (default: component("ui/tab")).
   def initialize(
     page:,
-    path: nil,
     columns: [],
     batch_actions: [],
-    pagination_component: component("ui/table/pagination"),
+    footer: nil,
     checkbox_componnent: component("ui/forms/checkbox"),
     button_component: component("ui/button"),
     tab_component: component("ui/tab")
   )
     @page = page
-    @path = path
     @columns = columns.map { Column.new(**_1) }
     @batch_actions = batch_actions.map { BatchAction.new(**_1) }
     @model_class = page.records.model
     @rows = page.records
+    @footer = footer
 
-    @pagination_component = pagination_component
     @checkbox_componnent = checkbox_componnent
     @button_component = button_component
     @tab_component = tab_component
@@ -129,24 +127,6 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     cell = cell.render_in(self) if cell.respond_to?(:render_in)
 
     content_tag(:td, content_tag(:div, cell, class: "flex items-center gap-1.5"), class: "py-2 px-4 h-10 vertical-align-middle leading-none")
-  end
-
-  def render_table_footer
-    if @pagination_component
-      tag.tfoot do
-        tag.tr do
-          tag.td(colspan: @columns.size, class: "py-4") do
-            tag.div(class: "flex justify-center") do
-              render_pagination_component
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def render_pagination_component
-    @pagination_component.new(page: @page, path: @path).render_in(self)
   end
 
   Column = Struct.new(:header, :data, :class_name, keyword_init: true)

--- a/admin/app/components/solidus_admin/ui/table/pagination/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.html.erb
@@ -2,24 +2,24 @@
   <nav aria-label="pagination">
     <ul class="flex items-center">
       <li>
-        <% if @page.first? %>
+        <% if @prev_link.blank? %>
           <span class="<%= link_classes(rounded: :left) %>", "aria-label"=<%= t(".prev") %>, "aria-disabled"=true>
             <%= icon_tag("arrow-left-s-line", class: "fill-current text-grey-400 w-5 h-5") %>
           </span>
         <% else %>
-          <%= link_to @path.call(@page.number - 1), class: link_classes(rounded: :left), "aria-label" => t(".prev") do %>
+          <%= link_to @prev_link, class: link_classes(rounded: :left), "aria-label" => t(".prev") do %>
             <%= icon_tag("arrow-left-s-line", class: "w-5 h-5") %>
           <% end %>
         <% end %>
       </li>
 
       <li>
-        <% if @page.last? %>
+        <% if @next_link.blank? %>
           <span class="<%= link_classes(rounded: :right) %>", "aria-label"=<%= t(".next") %>, "aria-disabled"=true>
             <%= icon_tag("arrow-right-s-line", class: "fill-current text-grey-400 w-5 h-5") %>
           </span>
         <% else %>
-          <%= link_to @path.call(@page.next_param), class: link_classes(rounded: :right), "aria-label" => t(".next") do %>
+          <%= link_to @next_link, class: link_classes(rounded: :right), "aria-label" => t(".next") do %>
             <%= icon_tag("arrow-right-s-line", class: "w-5 h-5") %>
           <% end %>
         <% end %>

--- a/admin/app/components/solidus_admin/ui/table/pagination/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.html.erb
@@ -1,29 +1,24 @@
-<div>
-  <nav aria-label="pagination">
-    <ul class="flex items-center">
-      <li>
-        <% if @prev_link.blank? %>
-          <span class="<%= link_classes(rounded: :left) %>", "aria-label"=<%= t(".prev") %>, "aria-disabled"=true>
-            <%= icon_tag("arrow-left-s-line", class: "fill-current text-grey-400 w-5 h-5") %>
-          </span>
-        <% else %>
-          <%= link_to @prev_link, class: link_classes(rounded: :left), "aria-label" => t(".prev") do %>
-            <%= icon_tag("arrow-left-s-line", class: "w-5 h-5") %>
-          <% end %>
-        <% end %>
-      </li>
-
-      <li>
-        <% if @next_link.blank? %>
-          <span class="<%= link_classes(rounded: :right) %>", "aria-label"=<%= t(".next") %>, "aria-disabled"=true>
-            <%= icon_tag("arrow-right-s-line", class: "fill-current text-grey-400 w-5 h-5") %>
-          </span>
-        <% else %>
-          <%= link_to @next_link, class: link_classes(rounded: :right), "aria-label" => t(".next") do %>
-            <%= icon_tag("arrow-right-s-line", class: "w-5 h-5") %>
-          <% end %>
-        <% end %>
-      </li>
-    </ul>
-  </nav>
-</div>
+<nav aria-label="pagination" class="flex items-center">
+  <%= render component('ui/button').new(
+    icon: 'arrow-left-s-line',
+    class: 'rounded-tr-none rounded-br-none border-r-0',
+    scheme: :secondary,
+    size: :s,
+    tag: :a,
+    href: @prev_link,
+    'aria-disabled': @prev_link.blank?,
+    rel: 'prev',
+    text: content_tag(:span, t('.previous'), class: 'sr-only'),
+  ) -%>
+  <%= render component('ui/button').new(
+    icon: 'arrow-right-s-line',
+    class: 'rounded-tl-none rounded-bl-none',
+    scheme: :secondary,
+    size: :s,
+    tag: :a,
+    href: @next_link,
+    'aria-disabled': @next_link.blank?,
+    rel: 'next',
+    text: content_tag(:span, t('.next'), class: 'sr-only'),
+  ) %>
+</nav>

--- a/admin/app/components/solidus_admin/ui/table/pagination/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.rb
@@ -11,30 +11,4 @@ class SolidusAdmin::UI::Table::Pagination::Component < SolidusAdmin::BaseCompone
   def render?
     @prev_link.present? || @next_link.present?
   end
-
-  def link_classes(rounded: nil)
-    classes = %w[
-      flex
-      items-center
-      justify-center
-      px-2
-      h-10
-      ml-0
-      leading-tight
-      text-gray-500
-      bg-white
-      border
-      border-gray-300
-      hover:bg-gray-100
-      hover:text-gray-700
-      dark:bg-gray-800
-      dark:border-gray-700
-      dark:text-gray-400
-      dark:hover:bg-gray-700
-      dark:hover:text-white
-    ]
-    classes << 'rounded-l-lg' if rounded == :left
-    classes << 'rounded-r-lg' if rounded == :right
-    classes.join(' ')
-  end
 end

--- a/admin/app/components/solidus_admin/ui/table/pagination/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Table::Pagination::Component < SolidusAdmin::BaseComponent
-  # @param page [GearedPagination::Page] The Geared Pagination page object
-  # @param path [Proc] (optional) A callable object that generates the path,
-  #                         e.g. ->(page_number){ products_path(page: page_number) }
-  def initialize(page:, path: nil)
-    @page = page
-    @path = path || default_path
+  # @param prev_link [String] The link to the previous page.
+  # @param next_link [String] The link to the next page.
+  def initialize(prev_link: nil, next_link: nil)
+    @prev_link = prev_link
+    @next_link = next_link
   end
 
-  def default_path
-    model_name = @page.records.model.model_name.param_key
-    lambda { |page_number| send("#{model_name.pluralize}_path", page: page_number) }
+  def render?
+    @prev_link.present? || @next_link.present?
   end
 
   def link_classes(rounded: nil)

--- a/admin/lib/solidus_admin/preview.rb
+++ b/admin/lib/solidus_admin/preview.rb
@@ -28,6 +28,7 @@ module SolidusAdmin::Preview
 
     included do
       helper ActionView::Helpers
+      helper SolidusAdmin::ContainerHelper
       helper_method :current_component
     end
 

--- a/admin/spec/components/previews/solidus_admin/ui/button/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/button/component_preview.rb
@@ -18,6 +18,10 @@ class SolidusAdmin::UI::Button::ComponentPreview < ViewComponent::Preview
     render component("ui/button").new(size: size, scheme: scheme, text: text, icon: icon.presence)
   end
 
+  def group
+    render_with_template
+  end
+
   private
 
   def icon_options

--- a/admin/spec/components/previews/solidus_admin/ui/button/component_preview/group.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/button/component_preview/group.html.erb
@@ -1,0 +1,18 @@
+<%= render current_component.new(
+  tag: :a,
+  rel: 'prev',
+  href: '#',
+  icon: 'arrow-left-s-line',
+  class: 'rounded-tr-none rounded-br-none border-r-0',
+  scheme: :secondary,
+  size: :s
+) -%>
+<%= render current_component.new(
+  tag: :a,
+  rel: 'next',
+  icon: 'arrow-right-s-line',
+  class: 'rounded-tl-none rounded-bl-none',
+  scheme: :secondary,
+  size: :s,
+  'aria-disabled': true
+) %>

--- a/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
@@ -23,16 +23,6 @@ class SolidusAdmin::UI::Table::ComponentPreview < ViewComponent::Preview
       model_class
     end
 
-    render component("ui/table").new(
-      page: page,
-      path: ->(_page_number) { "#" },
-      columns: [
-        { header: :id, data: -> { _1.id.to_s } },
-        { header: :name, data: :name },
-        { header: -> { "Availability at #{Time.current}" }, data: -> { "#{time_ago_in_words _1.available_on} ago" } },
-        { header: -> { component("ui/badge").new(name: "$$$") }, data: -> { component("ui/badge").new(name: _1.display_price, color: :green) } },
-        { header: "Generated at", data: Time.current.to_s },
-      ]
-    )
+    render_with_template(locals: { page: page, rows: rows })
   end
 end

--- a/admin/spec/components/previews/solidus_admin/ui/table/component_preview/simple.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/component_preview/simple.html.erb
@@ -1,0 +1,11 @@
+<%= render current_component.new(
+  page: page,
+  path: ->(_page_number) { "#" },
+  columns: [
+    { header: :id, data: -> { _1.id.to_s } },
+    { header: :name, data: :name },
+    { header: -> { "Availability at #{Time.current}" }, data: -> { "#{time_ago_in_words _1.available_on} ago" } },
+    { header: -> { component("ui/badge").new(name: "$$$") }, data: -> { component("ui/badge").new(name: _1.display_price, color: :green) } },
+    { header: "Generated at", data: Time.current.to_s },
+  ]
+) %>

--- a/admin/spec/components/previews/solidus_admin/ui/table/component_preview/simple.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/component_preview/simple.html.erb
@@ -1,6 +1,9 @@
 <%= render current_component.new(
   page: page,
-  path: ->(_page_number) { "#" },
+  footer: render(component("ui/table/pagination").new(
+    prev_link: nil,
+    next_link: '#2',
+  )),
   columns: [
     { header: :id, data: -> { _1.id.to_s } },
     { header: :name, data: :name },

--- a/admin/spec/components/previews/solidus_admin/ui/table/pagination/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/pagination/component_preview.rb
@@ -5,32 +5,15 @@ class SolidusAdmin::UI::Table::Pagination::ComponentPreview < ViewComponent::Pre
   include SolidusAdmin::Preview
 
   def overview
-    render_with_template(
-      locals: {
-        page: page_proc,
-        path: path_proc
-      }
-    )
+    render_with_template
   end
 
-  # @param left toggle
-  # @param right toggle
-  def playground(left: false, right: false)
+  # @param prev_link
+  # @param next_link
+  def playground(prev_link: '#1', next_link: '#2')
     render current_component.new(
-      page: page_proc.call(left, right),
-      path: path_proc
+      prev_link: prev_link.presence,
+      next_link: next_link.presence,
     )
-  end
-
-  private
-
-  def page_proc
-    lambda { |left, right|
-      Struct.new(:number, :next_param, :first?, :last?).new(1, '#', !left, !right)
-    }
-  end
-
-  def path_proc
-    ->(_page_number) { "#" }
   end
 end

--- a/admin/spec/components/previews/solidus_admin/ui/table/pagination/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/pagination/component_preview/overview.html.erb
@@ -1,16 +1,16 @@
 <table>
-  <% [
-    { title: 'Default', left: true, right: true },
-    { title: 'Left', left: true, right: false },
-    { title: 'Right', left: false, right: true },
-    { title: 'Disabled', left: false, right: false }
-  ].each do |config| %>
+  <% {
+    'Default': ['#1', '#2'],
+    'Left': ['#1', nil],
+    'Right': [nil, '#2'],
+    'Disabled': [nil, nil],
+  }.each do |title, (left, right)| %>
     <tr>
-      <td class="font-bold px-3 py-1"><%= config[:title] %></td>
+      <td class="font-bold px-3 py-1"><%= title %></td>
       <td class="px-3 py-1 text-center">
         <%= render current_component.new(
-          page: page.call(config[:left], config[:right]),
-          path: path
+          prev_link: (left && "#1"),
+          next_link: (right && "#2"),
         ) %>
       </td>
     </tr>

--- a/admin/spec/components/solidus_admin/ui/button/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/button/component_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe SolidusAdmin::UI::Button::Component, type: :component do
-  it "renders the overview preview" do
+  it "renders previews" do
+    render_preview(:playground)
     render_preview(:overview)
+    render_preview(:group)
   end
 end


### PR DESCRIPTION
## Summary

Depends on:
- https://github.com/solidusio/solidus/pull/5287
- https://github.com/solidusio/solidus/pull/5284

Please review only the last 4 commits 👀.

The implementation was simplified and now the responsibility of generating the links has been moved outside of the component. Generating the link turned out to be much simpler if don within the `products/index` component. The pagination component won't render if both links are blank.

<img width="1363" alt="image" src="https://github.com/solidusio/solidus/assets/1051/65a1e21b-f5e0-4f04-a815-fa0dc0f42280">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
