### PR TITLE
[Admin] Fix Turbo issue with inconsistent form identifiers in Turbo frame

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -87,7 +87,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   def batch_actions_form_id
-    @batch_actions_form_id ||= "#{stimulus_id}--batch-actions-#{SecureRandom.hex}"
+    @batch_actions_form_id ||= "#{stimulus_id}--batch-actions"
   end
 
   def table_frame_id


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->


⚠️ See also [[Admin] Add external id param to enhance table component flexibility #5302](https://github.com/solidusio/solidus/pull/5302)

This PR will be closed with the mentioned one, but it's a good explanation of our issue in the table component.

-------

The `batch_actions_form_id` was generating a unique ID with `SecureRandom.hex` each time it was called.
This led to inconsistencies in form IDs within the turbo frame of our table.

This became problematic when the turbo frame was updated: The form, identified by a newly generated ID, was not recognized by the table turbo frame which knew only the original ID. Consequently, upon a form submission with an action, the payload didn't contain the expected record IDs.

To address this, we've removed the random element in ID generation.
We now generate a static ID using `"#{stimulus_id}--batch-actions"`: This ensures consistency of form ID within the Turbo-frame, enabling Turbo to handle form submissions and responses correctly.

However, the ideal solution would be to pass the IDs externally, thereby decoupling the ID generation from the table component and delegating this responsibility to the page rendering the component.
This approach would also prevent any potential issues that might arise from having multiple tables on the same page with identical IDs.
This improvement is something we aim to incorporate in the future updates.

**Before**

https://github.com/solidusio/solidus/assets/19948291/2fbccada-c2c3-4b4e-b564-e4f5785c35b1


**Now**

https://github.com/solidusio/solidus/assets/19948291/8cff45fe-08e6-4cd4-a791-34b6f1f8aea2


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
