### PR TITLE
[Admin] Add external id param to enhance table component flexibility

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -16,6 +16,7 @@
   </header>
 
   <%= render @table_component.new(
+    id: 'products-list',
     model_class: Spree::Product,
     rows: @page.records,
     search_key: SolidusAdmin::Config[:product_search_key],

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
+  # @param id [String] A unique identifier for the table component.
   # @param model_class [ActiveModel::Translation] The model class used for translations.
   # @param rows [Array] The collection of objects that will be passed to columns for display.
   # @param search_key [Symbol] The key for searching.
@@ -32,6 +33,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   # @param icon_component [Class] The icon component class (default: component("ui/icon")).
   # @param tab_component [Class] The tab component class (default: component("ui/tab")).
   def initialize(
+    id:,
     model_class:,
     rows:,
     search_key:,
@@ -50,6 +52,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     @columns = columns.map { Column.new(**_1) }
     @batch_actions = batch_actions.map { BatchAction.new(**_1) }
     @filters = filters.map { Filter.new(**_1) }
+    @id = id
     @model_class = model_class
     @rows = rows
     @search_key = search_key
@@ -95,15 +98,15 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   def batch_actions_form_id
-    @batch_actions_form_id ||= "#{stimulus_id}--batch-actions-#{SecureRandom.hex}"
+    @batch_actions_form_id ||= "#{stimulus_id}--batch-actions-#{@id}"
   end
 
   def table_frame_id
-    @table_frame_id ||= "#{stimulus_id}--table-frame"
+    @table_frame_id ||= "#{stimulus_id}--table-frame-#{@id}"
   end
 
   def search_form_id
-    @search_form_id ||= "#{stimulus_id}--search-form"
+    @search_form_id ||= "#{stimulus_id}--search-form-#{@id}"
   end
 
   def render_batch_action_button(batch_action)

--- a/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
@@ -13,6 +13,7 @@ class SolidusAdmin::UI::Table::ComponentPreview < ViewComponent::Preview
   # All these ways to header and data cells can be mixed and matched.
   def simple
     render current_component.new(
+      id: 'simple-list',
       model_class: Spree::Product,
       rows: Array.new(10) { |n|
         Spree::Product.new(id: n, name: "Product #{n}", price: n * 10.0, available_on: n.days.ago)


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

Depends on:
- https://github.com/solidusio/solidus/pull/5296

Closes:
- https://github.com/solidusio/solidus/pull/5301

In order to resolve issues with ID inconsistencies and improve the flexibility of our table component, we've introduced a mechanism to pass external IDs to the table component.

This change has allowed us to use a consistent ID across multiple elements within the table including the batch action form, Turbo-frame, and search form.
By passing the ID externally, we've ensured that the page rendering the component has full control over ID generation.

This not only resolves the previous issue of Turbo not recognizing the new identifiers, but it also prevents potential conflicts when multiple tables are present on the same page.

For more details, see [[Admin] Fix Turbo issue with inconsistent form identifiers in Turbo frame #5301](https://github.com/solidusio/solidus/pull/5301)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
