### PR TITLE
[Admin] Fix user locale handling in SolidusAdmin

### DIFF
--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -5,13 +5,13 @@ require 'geared_pagination'
 module SolidusAdmin
   class BaseController < ApplicationController
     include ActiveStorage::SetCurrent
-    include ::SolidusAdmin::Auth
     include Spree::Core::ControllerHelpers::Store
     include Spree::Admin::SetsUserLanguageLocaleKey
+    include GearedPagination::Controller
 
+    include SolidusAdmin::ControllerHelpers::Auth
     include SolidusAdmin::AuthAdapters::Backend if defined?(Spree::Backend)
 
-    include ::GearedPagination::Controller
 
     before_action :set_locale
 

--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -6,28 +6,14 @@ module SolidusAdmin
   class BaseController < ApplicationController
     include ActiveStorage::SetCurrent
     include Spree::Core::ControllerHelpers::Store
-    include Spree::Admin::SetsUserLanguageLocaleKey
     include GearedPagination::Controller
 
     include SolidusAdmin::ControllerHelpers::Auth
+    include SolidusAdmin::ControllerHelpers::Locale
     include SolidusAdmin::AuthAdapters::Backend if defined?(Spree::Backend)
-
-
-    before_action :set_locale
 
     layout 'solidus_admin/application'
     helper 'solidus_admin/container'
     helper 'solidus_admin/layout'
-
-    private
-
-    def set_locale
-      if params[:switch_to_locale].to_s != session[set_user_language_locale_key].to_s
-        session[set_user_language_locale_key] = params[:switch_to_locale]
-        flash[:notice] = t('spree.locale_changed')
-      end
-
-      I18n.locale = session[set_user_language_locale_key] ? session[set_user_language_locale_key].to_sym : I18n.default_locale
-    end
   end
 end

--- a/admin/app/controllers/solidus_admin/controller_helpers/auth.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/auth.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusAdmin::Auth
+module SolidusAdmin::ControllerHelpers::Auth
   extend ActiveSupport::Concern
 
   included do

--- a/admin/app/controllers/solidus_admin/controller_helpers/locale.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/locale.rb
@@ -6,16 +6,27 @@ module SolidusAdmin::ControllerHelpers::Locale
 
   included do
     before_action :set_locale
+    before_action :update_user_locale
   end
 
   private
 
-  def set_locale
-    if params[:switch_to_locale].to_s != session[set_user_language_locale_key].to_s
-      session[set_user_language_locale_key] = params[:switch_to_locale]
-      flash[:notice] = t('spree.locale_changed')
-    end
+  def update_user_locale
+    requested_locale = params[:switch_to_locale] or return
 
-    I18n.locale = session[set_user_language_locale_key] ? session[set_user_language_locale_key].to_sym : I18n.default_locale
+    if requested_locale.to_sym != user_locale
+      session[set_user_language_locale_key] = requested_locale
+
+      flash[:notice] = t('spree.locale_changed')
+      redirect_to url_for(request.params.except(:switch_to_locale))
+    end
+  end
+
+  def user_locale
+    session[set_user_language_locale_key] || I18n.default_locale
+  end
+
+  def set_locale
+    I18n.locale = user_locale
   end
 end

--- a/admin/app/controllers/solidus_admin/controller_helpers/locale.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/locale.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SolidusAdmin::ControllerHelpers::Locale
+  extend ActiveSupport::Concern
+  include Spree::Admin::SetsUserLanguageLocaleKey
+
+  included do
+    before_action :set_locale
+  end
+
+  private
+
+  def set_locale
+    if params[:switch_to_locale].to_s != session[set_user_language_locale_key].to_s
+      session[set_user_language_locale_key] = params[:switch_to_locale]
+      flash[:notice] = t('spree.locale_changed')
+    end
+
+    I18n.locale = session[set_user_language_locale_key] ? session[set_user_language_locale_key].to_sym : I18n.default_locale
+  end
+end

--- a/admin/lib/solidus_admin/preview.rb
+++ b/admin/lib/solidus_admin/preview.rb
@@ -27,7 +27,7 @@ module SolidusAdmin::Preview
     extend ActiveSupport::Concern
 
     included do
-      include SolidusAdmin::Auth
+      include SolidusAdmin::ControllerHelpers::Auth
       helper ActionView::Helpers
       helper SolidusAdmin::ContainerHelper
       helper_method :current_component


### PR DESCRIPTION
## Summary

The current implementation was writing on the session key if the requested locale was empty and the session key was set.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
