### PR TITLE
[Backend] cleanup `MenuItems` generation

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -46,7 +46,7 @@ module Spree
       #   * :match_path can also be a callable that takes a request and determines whether the menu item is selected for the request.
       #   * :selected to explicitly control whether the tab is active
       def tab(*args, &block)
-        options = args.last.is_a?(Hash) ? args.pop : {}
+        options = args.last.is_a?(Hash) ? args.pop.dup : {}
         css_classes = Array(options[:css_class])
 
         if options.key?(:route)

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -46,7 +46,6 @@ module Spree
       #   * :match_path can also be a callable that takes a request and determines whether the menu item is selected for the request.
       #   * :selected to explicitly control whether the tab is active
       def tab(*args, &block)
-        block_content = capture(&block) if block_given?
         options = args.last.is_a?(Hash) ? args.pop : {}
         css_classes = Array(options[:css_class])
 
@@ -65,13 +64,6 @@ module Spree
         options[:url] ||= spree.send("admin_#{options[:label]}_path")
         label = t(options[:label], scope: [:spree, :admin, :tab])
 
-        if options[:icon]
-          link = link_to_with_icon(options[:icon], label, options[:url])
-          css_classes << 'tab-with-icon'
-        else
-          link = link_to(label, options[:url])
-        end
-
         options[:selected] ||=
           if options[:match_path].is_a? Regexp
             request.fullpath =~ options[:match_path]
@@ -85,6 +77,13 @@ module Spree
 
         css_classes << 'selected' if options[:selected]
 
+        if options[:icon]
+          link = link_to_with_icon(options[:icon], label, options[:url])
+          css_classes << 'tab-with-icon'
+        else
+          link = link_to(label, options[:url])
+        end
+        block_content = capture(&block) if block_given?
         content_tag('li', link + block_content.to_s, class: css_classes.join(' ') )
       end
 

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -45,7 +45,8 @@ module Spree
       #   * :route to override automatically determining the default route
       #   * :match_path as an alternative way to control when the tab is active, /products would match /admin/products, /admin/products/5/variants etc.
       #   * :match_path can also be a callable that takes a request and determines whether the menu item is selected for the request.
-      def tab(*args, &_block)
+      def tab(*args, &block)
+        block_content = capture(&block) if block_given?
         options = { label: args.first.to_s }
 
         if args.last.is_a?(Hash)
@@ -80,7 +81,7 @@ module Spree
         if options[:css_class]
           css_classes << options[:css_class]
         end
-        content_tag('li', link + (yield if block_given?), class: css_classes.join(' ') )
+        content_tag('li', link + block_content.to_s, class: css_classes.join(' ') )
       end
 
       def link_to_clone(resource, options = {})

--- a/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
@@ -1,3 +1,5 @@
+<% Spree::Deprecation.warn "Using the #{@virtual_path.inspect} partial is deprecated, please use MenuItem#children instead." %>
+
 <ul class="admin-subnav" data-hook="admin_product_sub_tabs">
   <% if can? :admin, Spree::Product %>
     <%= tab label: :products, match_path: '/products' %>

--- a/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
@@ -1,17 +1,17 @@
 <ul class="admin-subnav" data-hook="admin_product_sub_tabs">
   <% if can? :admin, Spree::Product %>
-    <%= tab :products, match_path: '/products' %>
+    <%= tab label: :products, match_path: '/products' %>
   <% end %>
   <% if can? :admin, Spree::OptionType %>
-    <%= tab :option_types, match_path: '/option_types' %>
+    <%= tab label: :option_types, match_path: '/option_types' %>
   <% end %>
   <% if can? :admin, Spree::Property %>
-    <%= tab :properties %>
+    <%= tab label: :properties %>
   <% end %>
   <% if can? :admin, Spree::Taxonomy %>
-    <%= tab :taxonomies %>
+    <%= tab label: :taxonomies %>
   <% end %>
   <% if can? :admin, Spree::Taxon %>
-    <%= tab :taxons, label: :display_order, match_path: '/taxons' %>
+    <%= tab url: spree.admin_taxons_path, label: :display_order, match_path: '/taxons' %>
   <% end %>
 </ul>

--- a/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
@@ -1,3 +1,5 @@
+<% Spree::Deprecation.warn "Using the #{@virtual_path.inspect} partial is deprecated, please use MenuItem#children instead." %>
+
 <ul class="admin-subnav" data-hook="admin_promotion_sub_tabs">
   <% if can? :admin, Spree::Promotion %>
     <%= tab label: :promotions %>

--- a/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
@@ -1,8 +1,8 @@
 <ul class="admin-subnav" data-hook="admin_promotion_sub_tabs">
   <% if can? :admin, Spree::Promotion %>
-    <%= tab :promotions %>
+    <%= tab label: :promotions %>
   <% end %>
   <% if can? :admin, Spree::PromotionCategory %>
-    <%= tab :promotion_categories %>
+    <%= tab label: :promotion_categories %>
   <% end %>
 </ul>

--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -1,3 +1,5 @@
+<% Spree::Deprecation.warn "Using the #{@virtual_path.inspect} partial is deprecated, please use MenuItem#children instead." %>
+
 <ul class="admin-subnav" data-hook="admin_settings_sub_tabs">
   <% if can?(:admin, Spree::Store) %>
     <%= tab label: :stores, url: spree.admin_stores_path %>

--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -1,26 +1,26 @@
 <ul class="admin-subnav" data-hook="admin_settings_sub_tabs">
   <% if can?(:admin, Spree::Store) %>
-    <%= tab :stores, label: :stores, url: spree.admin_stores_path %>
+    <%= tab label: :stores, url: spree.admin_stores_path %>
   <% end %>
 
   <% if can?(:admin, Spree::PaymentMethod) %>
-    <%= tab :payments, url: spree.admin_payment_methods_path %>
+    <%= tab label: :payments, url: spree.admin_payment_methods_path %>
   <% end %>
 
   <% if can?(:admin, Spree::TaxCategory) || can?(:admin, Spree::TaxRate) %>
-    <%= tab :taxes, url: spree.admin_tax_categories_path, match_path: %r(tax_categories|tax_rates) %>
+    <%= tab label: :taxes, url: spree.admin_tax_categories_path, match_path: %r(tax_categories|tax_rates) %>
   <% end %>
 
   <% if can?(:admin, Spree::RefundReason) || can?(:admin, Spree::ReimbursementType) ||
     can?(:show, Spree::ReturnReason) || can?(:show, Spree::AdjustmentReason) %>
-    <%= tab :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons|store_credit_reasons) %>
+    <%= tab label: :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons|store_credit_reasons) %>
   <% end %>
 
   <% if can?(:admin, Spree::ShippingMethod) || can?(:admin, Spree::ShippingCategory) || can?(:admin, Spree::StockLocation) %>
-    <%= tab :shipping, url: spree.admin_shipping_methods_path, match_path: %r(shipping_methods|shipping_categories|stock_locations) %>
+    <%= tab label: :shipping, url: spree.admin_shipping_methods_path, match_path: %r(shipping_methods|shipping_categories|stock_locations) %>
   <% end %>
 
   <% if can?(:admin, Spree::Zone) %>
-    <%= tab :zones, url: spree.admin_zones_path %>
+    <%= tab label: :zones, url: spree.admin_zones_path %>
   <% end %>
 </ul>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -5,10 +5,23 @@
         icon: menu_item.icon,
         label: menu_item.label,
         url: menu_item.url,
-        match_path: menu_item.match_path,
+        selected: menu_item.match_path?(request) || menu_item.children.any? { _1.match_path?(request) },
       ) do
     %>
-      <%- render partial: menu_item.partial if menu_item.partial %>
+      <% if menu_item.render_partial? %>
+        <%- render partial: menu_item.partial %>
+      <% elsif menu_item.children.present? %>
+        <ul class="admin-subnav" data-hook="<%= menu_item.data_hook %>">
+          <%- menu_item.children.each do |child| %>
+            <%= tab(
+              icon: child.icon,
+              label: child.label,
+              url: child.url,
+              selected: child.match_path?(request),
+            ) if instance_exec(&child.condition) %>
+          <% end %>
+        </ul>
+      <% end %>
     <%- end %>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,5 +1,5 @@
 <% Spree::Backend::Config.menu_items.sort_by { |item| item.position || Float::INFINITY }.each do |menu_item| %>
-  <% if instance_exec(&menu_item.condition) %>
+  <% if menu_item.render_in?(self) %>
     <%=
       tab(
         icon: menu_item.icon,
@@ -18,7 +18,7 @@
               label: child.label,
               url: child.url,
               selected: child.match_path?(request),
-            ) if instance_exec(&child.condition) %>
+            ) if child.render_in?(self) %>
           <% end %>
         </ul>
       <% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -4,7 +4,7 @@
       tab(
         icon: menu_item.icon,
         label: menu_item.label,
-        url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url,
+        url: menu_item.url,
         match_path: menu_item.match_path,
       ) do
     %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -2,7 +2,6 @@
   <% if instance_exec(&menu_item.condition) %>
     <%=
       tab(
-        *menu_item.sections,
         icon: menu_item.icon,
         label: menu_item.label,
         url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url,

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,4 +1,4 @@
-<% Spree::Backend::Config.menu_items.sort_by { |item| item.position || Float::INFINITY }.each do |menu_item| %>
+<% Spree::Backend::Config.menu_items.each do |menu_item| %>
   <% if menu_item.render_in?(self) %>
     <%=
       tab(

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -53,9 +53,12 @@ module Spree
     #
     # Spree::Backend::Config.configure do |config|
     #   config.menu_items << config.class::MenuItem.new(
-    #     [:section],
-    #     'icon-name',
-    #     url: 'https://solidus.io/'
+    #     label: :my_reports,
+    #     icon: 'file-text-o', # see https://fontawesome.com/v4/icons/
+    #     url: :my_admin_reports_path,
+    #     condition: -> { can?(:admin, MyReports) },
+    #     partial: 'spree/admin/shared/my_reports_sub_menu',
+    #     match_path: '/reports',
     #   )
     # end
     #
@@ -75,45 +78,49 @@ module Spree
     def menu_items
       @menu_items ||= [
         MenuItem.new(
-          ORDER_TABS,
-          'shopping-cart',
+          label: :orders,
+          icon: 'shopping-cart',
           condition: -> { can?(:admin, Spree::Order) },
+          match_path: %r{/(#{ORDER_TABS.join('|')})},
           position: 0
         ),
         MenuItem.new(
-          PRODUCT_TABS,
-          'th-large',
+          label: :products,
+          icon: 'th-large',
           condition: -> { can?(:admin, Spree::Product) },
+          match_path: %r{/(#{PRODUCT_TABS.join('|')})},
           partial: 'spree/admin/shared/product_sub_menu',
           position: 1
         ),
         MenuItem.new(
-          PROMOTION_TABS,
-          'bullhorn',
+          label: :promotions,
+          icon: 'bullhorn',
+          match_path: %r{/(#{PROMOTION_TABS.join('|')})},
           partial: 'spree/admin/shared/promotion_sub_menu',
           condition: -> { can?(:admin, Spree::Promotion) },
           url: :admin_promotions_path,
           position: 2
         ),
         MenuItem.new(
-          STOCK_TABS,
-          'cubes',
-          condition: -> { can?(:admin, Spree::StockItem) },
           label: :stock,
+          icon: 'cubes',
+          match_path: %r{/(#{STOCK_TABS.join('|')})},
+          condition: -> { can?(:admin, Spree::StockItem) },
           url: :admin_stock_items_path,
-          match_path: '/stock_items',
           position: 3
         ),
         MenuItem.new(
-          USER_TABS,
-          'user',
+          label: :users,
+          icon: 'user',
+          match_path: %r{/(#{USER_TABS.join('|')})},
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
           url: :admin_users_path,
           position: 4
         ),
         MenuItem.new(
-          CONFIGURATION_TABS,
-          'wrench',
+          label: :settings,
+          icon: 'wrench',
+          match_path: %r{/(#{CONFIGURATION_TABS.join('|')})},
           condition: -> {
             can?(:admin, Spree::Store) ||
             can?(:admin, Spree::AdjustmentReason) ||
@@ -128,7 +135,6 @@ module Spree
             can?(:admin, Spree::ReturnReason) ||
             can?(:admin, Spree::Zone)
           },
-          label: :settings,
           partial: 'spree/admin/shared/settings_sub_menu',
           url: :admin_stores_path,
           position: 5

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -32,22 +32,12 @@ module Spree
         }
       }
 
-    ORDER_TABS         ||= [:orders, :payments, :creditcard_payments,
-                            :shipments, :credit_cards, :return_authorizations,
-                            :customer_returns, :adjustments, :customer_details]
-    PRODUCT_TABS       ||= [:products, :option_types, :properties,
-                            :variants, :product_properties, :taxonomies,
-                            :taxons]
-    CONFIGURATION_TABS ||= [:stores, :tax_categories,
-                            :tax_rates, :zones,
-                            :payment_methods, :shipping_methods,
-                            :shipping_categories, :stock_locations,
-                            :refund_reasons, :reimbursement_types,
-                            :return_reasons, :adjustment_reasons,
-                            :store_credit_reasons]
-    PROMOTION_TABS     ||= [:promotions, :promotion_categories]
-    STOCK_TABS         ||= [:stock_items]
-    USER_TABS          ||= [:users, :store_credits]
+    autoload :ORDER_TABS, 'spree/backend_configuration/deprecated_tab_constants'
+    autoload :PRODUCT_TABS, 'spree/backend_configuration/deprecated_tab_constants'
+    autoload :CONFIGURATION_TABS, 'spree/backend_configuration/deprecated_tab_constants'
+    autoload :PROMOTION_TABS, 'spree/backend_configuration/deprecated_tab_constants'
+    autoload :STOCK_TABS, 'spree/backend_configuration/deprecated_tab_constants'
+    autoload :USER_TABS, 'spree/backend_configuration/deprecated_tab_constants'
 
     # Items can be added to the menu by using code like the following:
     #
@@ -81,21 +71,39 @@ module Spree
           label: :orders,
           icon: 'shopping-cart',
           condition: -> { can?(:admin, Spree::Order) },
-          match_path: %r{/(#{ORDER_TABS.join('|')})},
+          match_path: %r{/(
+            adjustments|
+            credit_cards|
+            creditcard_payments|
+            customer_details|
+            customer_returns|
+            orders|
+            payments|
+            return_authorizations|
+            shipments
+          )}x,
           position: 0
         ),
         MenuItem.new(
           label: :products,
           icon: 'th-large',
           condition: -> { can?(:admin, Spree::Product) },
-          match_path: %r{/(#{PRODUCT_TABS.join('|')})},
+          match_path: %r{/(
+            option_types|
+            product_properties|
+            products|
+            properties|
+            taxonomies|
+            taxons|
+            variants
+          )}x,
           partial: 'spree/admin/shared/product_sub_menu',
           position: 1
         ),
         MenuItem.new(
           label: :promotions,
           icon: 'bullhorn',
-          match_path: %r{/(#{PROMOTION_TABS.join('|')})},
+          match_path: %r{/(promotions|promotion_categories)},
           partial: 'spree/admin/shared/promotion_sub_menu',
           condition: -> { can?(:admin, Spree::Promotion) },
           url: :admin_promotions_path,
@@ -104,7 +112,7 @@ module Spree
         MenuItem.new(
           label: :stock,
           icon: 'cubes',
-          match_path: %r{/(#{STOCK_TABS.join('|')})},
+          match_path: %r{/(stock_items)},
           condition: -> { can?(:admin, Spree::StockItem) },
           url: :admin_stock_items_path,
           position: 3
@@ -112,7 +120,7 @@ module Spree
         MenuItem.new(
           label: :users,
           icon: 'user',
-          match_path: %r{/(#{USER_TABS.join('|')})},
+          match_path: %r{/(users|store_credits)},
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
           url: :admin_users_path,
           position: 4
@@ -120,7 +128,21 @@ module Spree
         MenuItem.new(
           label: :settings,
           icon: 'wrench',
-          match_path: %r{/(#{CONFIGURATION_TABS.join('|')})},
+          match_path: %r{/(
+            adjustment_reasons|
+            payment_methods|
+            refund_reasons|
+            reimbursement_types|
+            return_reasons|
+            shipping_categories|
+            shipping_methods|
+            stock_locations|
+            store_credit_reasons|
+            stores|
+            tax_categories|
+            tax_rates|
+            zones
+          )}x,
           condition: -> {
             can?(:admin, Spree::Store) ||
             can?(:admin, Spree::AdjustmentReason) ||

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -58,11 +58,6 @@ module Spree
     #
     # @!attribute menu_items
     #   @return [Array<Spree::BackendConfiguration::MenuItem>]
-    #
-    # Positioning can be determined by setting the position attribute to
-    # an Integer or nil. Menu Items will be rendered with smaller lower values
-    # first and higher values last. A position value of nil will cause the menu
-    # item to be rendered at the end of the list.
     attr_writer :menu_items
 
     # Return the menu items which should be drawn in the menu
@@ -86,14 +81,12 @@ module Spree
             return_authorizations|
             shipments
           )}x,
-          position: 0
         ),
         MenuItem.new(
           label: :products,
           icon: 'th-large',
           condition: -> { can?(:admin, Spree::Product) },
           partial: 'spree/admin/shared/product_sub_menu',
-          position: 1,
           data_hook: :admin_product_sub_tabs,
           children: [
             MenuItem.new(
@@ -129,7 +122,6 @@ module Spree
           condition: -> { can?(:admin, Spree::Promotion) },
           url: :admin_promotions_path,
           data_hook: :admin_promotion_sub_tabs,
-          position: 2,
           children: [
             MenuItem.new(
               label: :promotions,
@@ -147,7 +139,6 @@ module Spree
           match_path: %r{/(stock_items)},
           condition: -> { can?(:admin, Spree::StockItem) },
           url: :admin_stock_items_path,
-          position: 3,
         ),
         MenuItem.new(
           label: :users,
@@ -155,7 +146,6 @@ module Spree
           match_path: %r{/(users|store_credits)},
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
           url: :admin_users_path,
-          position: 4,
         ),
         MenuItem.new(
           label: :settings,
@@ -164,7 +154,6 @@ module Spree
           partial: 'spree/admin/shared/settings_sub_menu',
           condition: -> { can? :admin, Spree::Store },
           url: :admin_stores_path,
-          position: 5,
           children: [
             MenuItem.new(
               label: :stores,

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -32,6 +32,10 @@ module Spree
         }
       }
 
+    # @!attribute [rw] prefer_menu_item_partials
+    #   @return [Boolean] Whether or not to prefer menu item partials when both a partial and children are present.
+    preference :prefer_menu_item_partials, :boolean, default: false
+
     autoload :ORDER_TABS, 'spree/backend_configuration/deprecated_tab_constants'
     autoload :PRODUCT_TABS, 'spree/backend_configuration/deprecated_tab_constants'
     autoload :CONFIGURATION_TABS, 'spree/backend_configuration/deprecated_tab_constants'
@@ -98,7 +102,34 @@ module Spree
             variants
           )}x,
           partial: 'spree/admin/shared/product_sub_menu',
-          position: 1
+          position: 1,
+          data_hook: :admin_product_sub_tabs,
+          children: [
+            MenuItem.new(
+              label: :products,
+              condition: -> { can? :admin, Spree::Product },
+              match_path: '/products',
+            ),
+            MenuItem.new(
+              label: :option_types,
+              condition: -> { can? :admin, Spree::OptionType },
+              match_path: '/option_types',
+            ),
+            MenuItem.new(
+              label: :properties,
+              condition: -> { can? :admin, Spree::Property },
+            ),
+            MenuItem.new(
+              label: :taxonomies,
+              condition: -> { can? :admin, Spree::Taxonomy },
+            ),
+            MenuItem.new(
+              url: :admin_taxons_path,
+              condition: -> { can? :admin, Spree::Taxon },
+              label: :display_order,
+              match_path: '/taxons',
+            ),
+          ],
         ),
         MenuItem.new(
           label: :promotions,
@@ -107,7 +138,18 @@ module Spree
           partial: 'spree/admin/shared/promotion_sub_menu',
           condition: -> { can?(:admin, Spree::Promotion) },
           url: :admin_promotions_path,
-          position: 2
+          data_hook: :admin_promotion_sub_tabs,
+          position: 2,
+          children: [
+            MenuItem.new(
+              label: :promotions,
+              condition: -> { can?(:admin, Spree::Promotion) },
+            ),
+            MenuItem.new(
+              label: :promotion_categories,
+              condition: -> { can?(:admin, Spree::PromotionCategory) },
+            ),
+          ],
         ),
         MenuItem.new(
           label: :stock,
@@ -115,7 +157,7 @@ module Spree
           match_path: %r{/(stock_items)},
           condition: -> { can?(:admin, Spree::StockItem) },
           url: :admin_stock_items_path,
-          position: 3
+          position: 3,
         ),
         MenuItem.new(
           label: :users,
@@ -123,7 +165,7 @@ module Spree
           match_path: %r{/(users|store_credits)},
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
           url: :admin_users_path,
-          position: 4
+          position: 4,
         ),
         MenuItem.new(
           label: :settings,
@@ -143,6 +185,7 @@ module Spree
             tax_rates|
             zones
           )}x,
+          data_hook: :admin_settings_sub_tabs,
           condition: -> {
             can?(:admin, Spree::Store) ||
             can?(:admin, Spree::AdjustmentReason) ||
@@ -159,7 +202,52 @@ module Spree
           },
           partial: 'spree/admin/shared/settings_sub_menu',
           url: :admin_stores_path,
-          position: 5
+          position: 5,
+          children: [
+            MenuItem.new(
+              label: :stores,
+              condition: -> { can? :admin, Spree::Store },
+              url: :admin_stores_path,
+            ),
+            MenuItem.new(
+              label: :payments,
+              condition: -> { can? :admin, Spree::PaymentMethod },
+              url: :admin_payment_methods_path,
+            ),
+
+            MenuItem.new(
+              label: :taxes,
+              condition: -> { can?(:admin, Spree::TaxCategory) || can?(:admin, Spree::TaxRate) },
+              url: :admin_tax_categories_path,
+              match_path: %r(tax_categories|tax_rates),
+            ),
+            MenuItem.new(
+              label: :checkout,
+              condition: -> {
+                can?(:admin, Spree::RefundReason) ||
+                can?(:admin, Spree::ReimbursementType) ||
+                can?(:show, Spree::ReturnReason) ||
+                can?(:show, Spree::AdjustmentReason)
+              },
+              url: :admin_refund_reasons_path,
+              match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons|store_credit_reasons)
+            ),
+            MenuItem.new(
+              label: :shipping,
+              condition: -> {
+                can?(:admin, Spree::ShippingMethod) ||
+                  can?(:admin, Spree::ShippingCategory) ||
+                  can?(:admin, Spree::StockLocation)
+              },
+              url: :admin_shipping_methods_path,
+              match_path: %r(shipping_methods|shipping_categories|stock_locations),
+            ),
+            MenuItem.new(
+              label: :zones,
+              condition: -> { can?(:admin, Spree::Zone) },
+              url: :admin_zones_path,
+            ),
+          ],
         )
       ]
     end

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -92,15 +92,6 @@ module Spree
           label: :products,
           icon: 'th-large',
           condition: -> { can?(:admin, Spree::Product) },
-          match_path: %r{/(
-            option_types|
-            product_properties|
-            products|
-            properties|
-            taxonomies|
-            taxons|
-            variants
-          )}x,
           partial: 'spree/admin/shared/product_sub_menu',
           position: 1,
           data_hook: :admin_product_sub_tabs,
@@ -134,7 +125,6 @@ module Spree
         MenuItem.new(
           label: :promotions,
           icon: 'bullhorn',
-          match_path: %r{/(promotions|promotion_categories)},
           partial: 'spree/admin/shared/promotion_sub_menu',
           condition: -> { can?(:admin, Spree::Promotion) },
           url: :admin_promotions_path,
@@ -170,37 +160,9 @@ module Spree
         MenuItem.new(
           label: :settings,
           icon: 'wrench',
-          match_path: %r{/(
-            adjustment_reasons|
-            payment_methods|
-            refund_reasons|
-            reimbursement_types|
-            return_reasons|
-            shipping_categories|
-            shipping_methods|
-            stock_locations|
-            store_credit_reasons|
-            stores|
-            tax_categories|
-            tax_rates|
-            zones
-          )}x,
           data_hook: :admin_settings_sub_tabs,
-          condition: -> {
-            can?(:admin, Spree::Store) ||
-            can?(:admin, Spree::AdjustmentReason) ||
-            can?(:admin, Spree::PaymentMethod) ||
-            can?(:admin, Spree::RefundReason) ||
-            can?(:admin, Spree::ReimbursementType) ||
-            can?(:admin, Spree::ShippingCategory) ||
-            can?(:admin, Spree::ShippingMethod) ||
-            can?(:admin, Spree::StockLocation) ||
-            can?(:admin, Spree::TaxCategory) ||
-            can?(:admin, Spree::TaxRate) ||
-            can?(:admin, Spree::ReturnReason) ||
-            can?(:admin, Spree::Zone)
-          },
           partial: 'spree/admin/shared/settings_sub_menu',
+          condition: -> { can? :admin, Spree::Store },
           url: :admin_stores_path,
           position: 5,
           children: [

--- a/backend/lib/spree/backend_configuration/deprecated_tab_constants.rb
+++ b/backend/lib/spree/backend_configuration/deprecated_tab_constants.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+Spree::Deprecation.warn(
+  "Spree::BackendConfiguration::*_TABS is deprecated. Please use Spree::BackendConfiguration::MenuItem(match_path:) instead."
+)
+
+Spree::BackendConfiguration::ORDER_TABS ||= [
+  :orders, :payments, :creditcard_payments,
+  :shipments, :credit_cards, :return_authorizations,
+  :customer_returns, :adjustments, :customer_details
+]
+Spree::BackendConfiguration::PRODUCT_TABS ||= [
+  :products, :option_types, :properties,
+  :variants, :product_properties, :taxonomies,
+  :taxons
+]
+Spree::BackendConfiguration::PROMOTION_TABS ||= [
+  :promotions, :promotion_categories
+]
+Spree::BackendConfiguration::STOCK_TABS ||= [
+  :stock_items
+]
+Spree::BackendConfiguration::USER_TABS ||= [
+  :users, :store_credits
+]
+Spree::BackendConfiguration::CONFIGURATION_TABS ||= [
+  :stores, :tax_categories,
+  :tax_rates, :zones,
+  :payment_methods, :shipping_methods,
+  :shipping_categories, :stock_locations,
+  :refund_reasons, :reimbursement_types,
+  :return_reasons, :adjustment_reasons,
+  :store_credit_reasons
+]

--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -21,7 +21,7 @@ module Spree
       #   menu item.
       # @param partial [String] A partial to draw within this menu item for use
       #   in declaring a submenu
-      # @param url [String] A url where this link should send the user to
+      # @param url [String|Symbol] A url where this link should send the user to or a Symbol representing a route name
       # @param position [Integer] The position in which the menu item should render
       #   nil will cause the item to render last
       # @param match_path [String, Regexp, callable] (nil) If the {url} to determine the active tab is ambigous
@@ -59,9 +59,19 @@ module Spree
       def url
         if @url.respond_to?(:call)
           @url.call
+        elsif @url.is_a?(Symbol)
+          spree.public_send(@url)
+        elsif @url.nil?
+          spree.send("admin_#{@label}_path")
         else
           @url
         end
+      end
+
+      private
+
+      def spree
+        Spree::Core::Engine.routes.url_helpers
       end
     end
   end

--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -11,7 +11,9 @@ module Spree
       end
       deprecate sections: :label, deprecator: Spree::Deprecation
 
-      attr_accessor :position
+      attr_accessor :position # rubocop:disable Layout/EmptyLinesAroundAttributeAccessor
+      deprecate position: nil, deprecator: Spree::Deprecation
+      deprecate "position=": nil, deprecator: Spree::Deprecation
 
       # @param icon [String] The icon to draw for this menu item
       # @param condition [Proc] A proc which returns true if this menu item
@@ -21,8 +23,6 @@ module Spree
       #   menu item.
       # @param children [Array<Spree::BackendConfiguration::MenuItem>] An array
       # @param url [String|Symbol] A url where this link should send the user to or a Symbol representing a route name
-      # @param position [Integer] The position in which the menu item should render
-      #   nil will cause the item to render last
       # @param match_path [String, Regexp, callable] (nil) If the {url} to determine the active tab is ambigous
       #   you can pass a String, Regexp or callable to identify this menu item. The callable
       #   accepts a request object and returns a Boolean value.
@@ -60,9 +60,10 @@ module Spree
         @partial = partial
         @children = children
         @url = url
-        @position = position
         @data_hook = data_hook
         @match_path = match_path
+
+        self.position = position if position # Use the setter to deprecate
       end
 
       def render_in?(view_context)

--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -65,6 +65,11 @@ module Spree
         @match_path = match_path
       end
 
+      def render_in?(view_context)
+        view_context.instance_exec(&@condition) ||
+          children.any? { |child| child.render_in?(view_context) }
+      end
+
       def render_partial?
         return false if partial.blank?
 

--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -56,12 +56,24 @@ module Spree
         @match_path = match_path
       end
 
+      def match_path?(request)
+        if match_path.is_a? Regexp
+          request.fullpath =~ match_path
+        elsif match_path.respond_to?(:call)
+          match_path.call(request)
+        elsif match_path
+          request.fullpath.starts_with?("#{spree.admin_path}#{match_path}")
+        else
+          request.fullpath.to_s.starts_with?(url.to_s)
+        end
+      end
+
       def url
         if @url.respond_to?(:call)
           @url.call
         elsif @url.is_a?(Symbol)
           spree.public_send(@url)
-        elsif @url.nil?
+        elsif @url.nil? && @label
           spree.send("admin_#{@label}_path")
         else
           @url

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -8,26 +8,33 @@ describe Spree::Admin::NavigationHelper, type: :helper do
   end
 
   describe "#tab" do
-    context "creating an admin tab" do
+    context "deprecated usage", :silence_deprecations do
+      it "should capitalize the first letter of each word in the tab's label (deprecated)", :silence_deprecations do
+        subject = helper.tab(:orders)
+        expect(subject).to include("Orders")
+      end
+
+      it "should be selected if the controller matches" do
+        allow(controller).to receive(:controller_name).and_return("orders")
+        expect(helper.tab(:orders)).to include('class="selected"')
+      end
+
+      it "should not be selected if the controller does not match" do
+        allow(controller).to receive(:controller_name).and_return("bonobos")
+        expect(helper.tab(:orders)).not_to include('class="selected"')
+      end
+    end
+
+    context "creating an admin tab", :focus do
       it "should capitalize the first letter of each word in the tab's label" do
-        admin_tab = helper.tab(:orders)
+        admin_tab = helper.tab(label: :orders)
         expect(admin_tab).to include("Orders")
       end
     end
 
     describe "selection" do
       context "when match_path option is not supplied" do
-        subject(:tab) { helper.tab(:orders) }
-
-        it "should be selected if the controller matches" do
-          allow(controller).to receive(:controller_name).and_return("orders")
-          expect(subject).to include('class="selected"')
-        end
-
-        it "should not be selected if the controller does not match" do
-          allow(controller).to receive(:controller_name).and_return("bonobos")
-          expect(subject).not_to include('class="selected"')
-        end
+        subject(:tab) { helper.tab(label: :orders) }
 
         it "should be selected if the current path" do
           allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/admin/orders"))
@@ -47,30 +54,30 @@ describe Spree::Admin::NavigationHelper, type: :helper do
 
         it "should be selected if the fullpath matches" do
           allow(controller).to receive(:controller_name).and_return("bonobos")
-          tab = helper.tab(:orders, match_path: '/orders')
+          tab = helper.tab(label: :orders, match_path: '/orders')
           expect(tab).to include('class="selected"')
         end
 
         it "should be selected if the fullpath matches a regular expression" do
           allow(controller).to receive(:controller_name).and_return("bonobos")
-          tab = helper.tab(:orders, match_path: /orders$|orders\//)
+          tab = helper.tab(label: :orders, match_path: /orders$|orders\//)
           expect(tab).to include('class="selected"')
         end
 
         it "should not be selected if the fullpath does not match" do
           allow(controller).to receive(:controller_name).and_return("bonobos")
-          tab = helper.tab(:orders, match_path: '/shady')
+          tab = helper.tab(label: :orders, match_path: '/shady')
           expect(tab).not_to include('class="selected"')
         end
 
         it "should not be selected if the fullpath does not match a regular expression" do
           allow(controller).to receive(:controller_name).and_return("bonobos")
-          tab = helper.tab(:orders, match_path: /shady$|shady\//)
+          tab = helper.tab(label: :orders, match_path: /shady$|shady\//)
           expect(tab).not_to include('class="selected"')
         end
 
         context "when the match_path is a callable" do
-          subject { helper.tab(:orders, match_path: match_path) }
+          subject { helper.tab(label: :orders, match_path: match_path) }
 
           context "when the callable returns false" do
             let(:match_path) { ->(_request) { false } }
@@ -88,7 +95,7 @@ describe Spree::Admin::NavigationHelper, type: :helper do
     end
 
     it "should accept a block of content to append" do
-      admin_tab = helper.tab(:orders){ 'foo' }
+      admin_tab = helper.tab(label: :orders){ 'foo' }
       expect(admin_tab).to end_with("foo</li>")
     end
   end

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -23,6 +23,15 @@ describe Spree::Admin::NavigationHelper, type: :helper do
         allow(controller).to receive(:controller_name).and_return("bonobos")
         expect(helper.tab(:orders)).not_to include('class="selected"')
       end
+
+      it "supports a :route option" do
+        without_partial_double_verification do
+          allow(helper).to receive(:admin_orders_path).and_return("/admin/orders")
+        end
+        expect(Spree::Deprecation).to receive(:warn)
+          .with("Passing a route to #tab is deprecated. Please pass a url instead.")
+        expect(helper.tab(label: :orders, route: :admin_orders)).to include('href="/admin/orders"')
+      end
     end
 
     context "creating an admin tab", :focus do

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
 
     context "when url is a symbol" do
       let(:url) { :admin_promotions_path }
-      it { is_expected.to eq(:admin_promotions_path) }
+      it "treats it as a route name" do
+        is_expected.to eq("/admin/promotions")
+      end
     end
 
     context "if url is a lambda" do

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Spree::BackendConfiguration::MenuItem do
   describe '#match_path' do
     subject do
-      described_class.new([], nil, match_path: '/stock_items').match_path
+      described_class.new(match_path: '/stock_items').match_path
     end
 
     it 'can be read' do
@@ -14,14 +14,14 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
   end
 
   describe "#url" do
-    subject { described_class.new([], nil, url: url).url }
+    subject { described_class.new(url: url).url }
 
     context "if url is a string" do
       let(:url) { "/admin/promotions" }
       it { is_expected.to eq("/admin/promotions") }
     end
 
-    context "if url is a symbol" do
+    context "when url is a symbol" do
       let(:url) { :admin_promotions_path }
       it { is_expected.to eq(:admin_promotions_path) }
     end
@@ -31,6 +31,22 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
       let(:url) { -> { route_proxy.my_path } }
 
       it { is_expected.to eq("/admin/friendly_promotions") }
+    end
+  end
+
+  describe "deprecated behavior" do
+    describe "passing `sections` and `icon` sequentially" do
+      it "warns about the deprecation" do
+        expect(Spree::Deprecation).to receive(:warn).with(a_string_matching(/sections/))
+        expect(Spree::Deprecation).to receive(:warn).with(a_string_matching(/icon/))
+
+        described_class.new([:foo, :bar], 'icon')
+      end
+
+      it "raises ArgumentError when providing the wrong number of sequential arguments" do
+        expect { described_class.new([:foo, :bar], 'icon', 'baz') }.to raise_error(ArgumentError)
+        expect { described_class.new([:foo, :bar]) }.to raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -3,13 +3,33 @@
 require 'spec_helper'
 
 RSpec.describe Spree::BackendConfiguration::MenuItem do
-  describe '#match_path' do
-    subject do
-      described_class.new(match_path: '/stock_items').match_path
+  describe '#match_path?' do
+    it 'matches a string using the admin path prefix' do
+      described_class.new(match_path: '/stock_items')
+      request = double(ActionDispatch::Request, fullpath: '/admin/stock_items/1/edit')
+
+      expect(subject.match_path?(request)).to be true
     end
 
-    it 'can be read' do
-      is_expected.to eq('/stock_items')
+    it 'matches a proc accepting the request object' do
+      request = double(ActionDispatch::Request, fullpath: '/foo/bar/baz')
+      subject = described_class.new(match_path: -> { _1.fullpath.include? '/bar/' })
+
+      expect(subject.match_path?(request)).to be true
+    end
+
+    it 'matches a regexp' do
+      described_class.new(match_path: %r{/bar/})
+      request = double(ActionDispatch::Request, fullpath: '/foo/bar/baz')
+
+      expect(subject.match_path?(request)).to be true
+    end
+
+    it 'matches the item url as the fullpath prefix' do
+      described_class.new(url: '/foo/bar')
+      request = double(ActionDispatch::Request, fullpath: '/foo/bar/baz')
+
+      expect(subject.match_path?(request)).to be true
     end
   end
 

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 
 RSpec.describe Spree::BackendConfiguration::MenuItem do
+  describe '#children' do
+    it 'is the replacement for the deprecated #partial method' do
+      expect(Spree::Deprecation).to receive(:warn).with(a_string_matching(/partial/))
+
+      described_class.new(partial: 'foo')
+    end
+  end
+
   describe '#match_path?' do
     it 'matches a string using the admin path prefix' do
       described_class.new(match_path: '/stock_items')

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Spree::BackendConfiguration do
 
       # Regression for https://github.com/solidusio/solidus/issues/2950
       it 'has match_path set to /stock_items' do
-        expect(stock_menu_item.match_path).to eq('/stock_items')
+        expect(stock_menu_item.match_path).to eq(%r{/(stock_items)})
       end
     end
 

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -116,4 +116,14 @@ RSpec.describe Spree::BackendConfiguration do
       expect{ subject.theme_path(:bar) }.to raise_error(KeyError)
     end
   end
+
+  describe "deprecated behavior" do
+    describe "loading *_TABS constants" do
+      it "warns about the deprecation" do
+        expect(Spree::Deprecation).to receive(:warn).with(a_string_matching(/Spree::BackendConfiguration::\*_TABS is deprecated\./))
+
+        described_class::ORDER_TABS
+      end
+    end
+  end
 end

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -23,20 +23,18 @@ RSpec.describe Spree::BackendConfiguration do
       let(:menu_item) { subject.find { |item| item.label == :settings } }
       let(:view) { double("view") }
 
-      it 'is shown if any of its submenus are present' do
-        allow(view).to receive(:can?).and_return(true, false)
+      describe '#render_in?' do
+        it 'is shown if any of its submenus are present' do
+          allow(view).to receive(:can?).and_return(true, false)
 
-        result = view.instance_exec(&menu_item.condition)
+          expect(menu_item.render_in?(view)).to eq(true)
+        end
 
-        expect(result).to eq(true)
-      end
+        it 'is not shown if none of its submenus are present' do
+          expect(view).to receive(:can?).exactly(13).times.and_return(false)
 
-      it 'is not shown if none of its submenus are present' do
-        expect(view).to receive(:can?).exactly(12).times.and_return(false)
-
-        result = view.instance_exec(&menu_item.condition)
-
-        expect(result).to eq(false)
+          expect(menu_item.render_in?(view)).to eq(false)
+        end
       end
     end
   end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -45,6 +45,7 @@ require 'spree/testing_support/precompiled_assets'
 require 'spree/testing_support/translations'
 require 'spree/testing_support/job_helpers'
 require 'spree/testing_support/blacklist_urls'
+require 'spree/testing_support/silence_deprecations'
 
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -57,9 +57,12 @@ Spree::Backend::Config.configure do |config|
   # a new menu item:
   #
   # config.menu_items << config.class::MenuItem.new(
-  #   [:section],
-  #   'icon-name',
-  #   url: 'https://solidus.io/'
+  #   label: :my_reports,
+  #   icon: 'file-text-o', # see https://fontawesome.com/v4/icons/
+  #   url: :my_admin_reports_path,
+  #   condition: -> { can?(:admin, MyReports) },
+  #   partial: 'spree/admin/shared/my_reports_sub_menu',
+  #   match_path: '/reports',
   # )
 
   # Custom frontend product path


### PR DESCRIPTION
## Summary

Remove `#sections` that was probably introduced in order to generate the submenu and later became just a way to check if the MenuItem was "selected" or not.

This paves the way for replacing the second level navigation partials with a list of children items.

The `tab` helper is also updated and uses explicit `label:` and `match_path:` options instead of the initial list of sections.

## `MenuItem#position` replacement

`MenuItem#position` is deprecated and can be replaced by reordering menu items explicitly in the backend config:

```rb
products_menu = config.menu_items.find { _1.label == :products }
config.menu_items.insert(0, config.menu_items.delete(products_menu))
```

or

```rb
config.menu_items.sort_by! { %i[products orders settings promotions].index(_1.label) }
```

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).


The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
