### PR TITLE
[Admin] Add a toggle for switching between legacy and new solidus admin 

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -16,11 +16,10 @@
     <%= render @icon_component.new(name: 'arrow-right-up-line', class: 'w-4 h-4 fill-gray-400') %>
   <% end %>
 
-  <div data-controller="main-nav">
-    <ul>
-      <%= render @item_component.with_collection(items, fullpath: request.fullpath) %>
-    </ul>
-  </div>
+  <ul>
+    <%= render @item_component.with_collection(items, fullpath: request.fullpath) %>
+  </ul>
+
   <div class="mt-auto">
     <%= render @account_nav_component.new(
       user_label: helpers.current_solidus_admin_user.email,

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -3,7 +3,7 @@
   bg-gray-15
   p-4
   w-full
-">
+" data-controller="<%= stimulus_id %>" data-<%= stimulus_id %>-cookie-value="solidus_admin">
   <%= link_to @store.url, class: "py-3 px-2 text-left flex mb-4" do %>
     <%= image_tag @logo_path, alt: t('.visit_store'), class: "max-h-7" %>
   <% end %>
@@ -21,6 +21,14 @@
   </ul>
 
   <div class="mt-auto">
+    <div class="group mb-3">
+      <label class="flex gap-3 items-center py-0.5 px-3 pb-0.5 rounded hover:text-red-500 hover:bg-gray-50 body-small-bold text-black cursor-pointer">
+        <%= t('solidus_admin.main_nav.legacy_label') %>
+        <div class="flex items-center">
+          <%= render @switch_component.new(size: :s, checked: false, 'data-action': "#{stimulus_id}#setCookie:prevent") %>
+        </div>
+      </label>
+    </div>
     <%= render @account_nav_component.new(
       user_label: helpers.current_solidus_admin_user.email,
       account_path: solidus_admin.account_path,

--- a/admin/app/components/solidus_admin/sidebar/component.js
+++ b/admin/app/components/solidus_admin/sidebar/component.js
@@ -1,7 +1,14 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  connect() {
-    console.log(`The main-nav has been loaded!`)
+  static values = {
+    cookie: String
+  }
+
+  setCookie(event) {
+    let value = !event.currentTarget.checked
+
+    document.cookie = `${this.cookieValue}=${value};`
+    location.reload()
   }
 }

--- a/admin/app/components/solidus_admin/sidebar/component.rb
+++ b/admin/app/components/solidus_admin/sidebar/component.rb
@@ -8,7 +8,8 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
     items: container["main_nav_items"],
     icon_component: component("ui/icon"),
     item_component: component("sidebar/item"),
-    account_nav_component: component("sidebar/account_nav")
+    account_nav_component: component("sidebar/account_nav"),
+    switch_component: component("ui/forms/switch")
   )
     @logo_path = logo_path
     @items = items
@@ -17,6 +18,7 @@ class SolidusAdmin::Sidebar::Component < SolidusAdmin::BaseComponent
     @icon_component = icon_component
     @item_component = item_component
     @account_nav_component = account_nav_component
+    @switch_component = switch_component
   end
 
   def items

--- a/admin/config/locales/main_nav.en.yml
+++ b/admin/config/locales/main_nav.en.yml
@@ -11,3 +11,5 @@ en:
       stock: Stock
       users: Users
       settings: Settings
+      legacy_label: Switch to legacy admin
+      admin_label: Switch to new admin

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -21,4 +21,22 @@ Spree.ready(function() {
   if (document.body.classList.contains('admin-nav-hidden')) {
     $(adminNavToggle).removeClass('fa-chevron-circle-left').addClass('fa-chevron-circle-right');
   }
+
+  let solidusAdminSwitch = document.querySelector("#solidus-admin-switch");
+
+  if (solidusAdminSwitch) {
+    let cookies = new Map(document.cookie.split(';').map((cookie) => cookie.trim().split('=')))
+    let label = document.querySelector("#solidus-admin-switch-label");
+
+    solidusAdminSwitch.checked = cookies.get("solidus_admin") === 'false'
+    label.textContent = solidusAdminSwitch.checked ? label.dataset.adminLabel : label.dataset.legacyLabel
+
+    solidusAdminSwitch.addEventListener("change", function(e) {
+      let value = !solidusAdminSwitch.checked;
+
+      document.cookie = `solidus_admin=${value}`;
+
+      location.reload();
+    });
+  }
 });

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -1,6 +1,7 @@
 $color-navbar-hover-bg: $color-navbar-bg !default;
 $color-navbar-hover: $color-navbar !default;
 @import "spree/backend/themes/solidus_admin/colors";
+@import 'spree/backend/components/switch_solidus_admin';
 
 .solidus-admin--nav {
   background-color: $color-light;

--- a/backend/app/assets/stylesheets/spree/backend/components/_switch_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_switch_solidus_admin.scss
@@ -1,0 +1,48 @@
+@import "spree/backend/themes/solidus_admin/colors";
+
+.solidus-admin--nav--switch {
+  appearance: none;
+	cursor: pointer;
+	width: 2.5rem;
+	height: 1.5rem;
+	background: $solidus-admin-gray-200;
+	display: block;
+	border-radius: 100px;
+	position: relative;
+
+  &:focus {
+    outline: 0;
+  }
+
+  &:hover {
+    background-color: $solidus-admin-gray-300;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0.125rem;
+    left: 0.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    background: #fff;
+    border-radius: 90px;
+    transition: 0.3s;
+  }
+
+  &:checked {
+    background: $solidus-admin-gray-500;
+    &:after {
+      left: 2.375rem;
+      transform: translatex(-100%);
+    }
+
+    &:hover {
+      background: $solidus-admin-gray-700;
+    }
+  }
+
+  &:active:after {
+    width: 1.5rem;
+  }
+}

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -34,6 +34,14 @@
   </nav>
 
   <footer class="solidus-admin--nav--section">
+    <ul class="solidus-admin--nav--menu">
+      <li class="tab-with-icon">
+        <label class="icon_link with-tip">
+          <span id="solidus-admin-switch-label" class="text" <%= tag.attributes('data-legacy-label': t('solidus_admin.main_nav.legacy_label'), 'data-admin-label': t('solidus_admin.main_nav.admin_label')) %>></span>
+          <span><input type="checkbox" id="solidus-admin-switch" class="solidus-admin--nav--switch"/></span>
+        </label>
+      </li>
+    </ul>
     <% if spree_current_user %>
       <details class="solidus-admin--nav--footer" aria-label="Account">
         <summary>


### PR DESCRIPTION
## Summary

### Using new admin - Switch to Legacy
<img width="1429" alt="Screen Shot 2023-08-08 at 12 57 53" src="https://github.com/solidusio/solidus/assets/31260493/7c9c0e45-2dad-420e-a403-8a262e9b5c3c">


### Using legacy admin - Switch to new
<img width="1427" alt="Screen Shot 2023-08-08 at 12 58 07" src="https://github.com/solidusio/solidus/assets/31260493/fe4ca8dd-7f8a-4ccb-a389-1d3c05e03342">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
