### PR TITLE
Fix offense after RuboCop 1.56

### DIFF
--- a/core/spec/models/spree/preferences/statically_configurable_spec.rb
+++ b/core/spec/models/spree/preferences/statically_configurable_spec.rb
@@ -14,7 +14,7 @@ module Spree
         end
 
         def [](key)
-          return @preferences if key == :preferences
+          @preferences if key == :preferences
         end
       end
     end


### PR DESCRIPTION
## Summary

Rubocop 1.56 fixed a false negative for `Style/RedundantReturn` cop.

See https://github.com/rubocop/rubocop/issues/12106

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
