### PR TITLE
[Admin] Add a label to the batch actions form to make it a landmark

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -87,7 +87,7 @@
     ) %>
   </div>
 
-  <div class="<%= toolbar_classes %>" data-<%= stimulus_id %>-target="batchToolbar">
+  <div class="<%= toolbar_classes %>" data-<%= stimulus_id %>-target="batchToolbar" aria-label="<%= t(".batch_actions") %>">
     <%= form_tag '', id: batch_actions_form_id %>
     <% @batch_actions.each do |batch_action| %>
       <%= render_batch_action_button(batch_action) %>

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -6,5 +6,6 @@ en:
   filter: 'Filter'
   search_placeholder: 'Search all %{resources}'
   refine_search: 'Refine Search'
+  batch_actions: Batch actions
   clear: Clear
   cancel: Cancel


### PR DESCRIPTION
## Summary

For a form to be a landmark and be announced by screen readers, it needs to have an associated accessible name. See
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/form_role:

> Using the <form> element will automatically communicate a section of content as a form landmark, if it is provided an accessible name.

Closes #5274

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
