### PR TITLE
Prevent hard-errors when VatPriceGenerator is invoked without a defau…

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -46,6 +46,8 @@ module Spree
     end
 
     def net_amount
+      return nil unless amount
+
       amount / (1 + sum_of_vat_amounts)
     end
 

--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -25,6 +25,7 @@ module Spree
       def run
         # Early return if there is no VAT rates in the current store.
         return if !variant.tax_category || variant_vat_rates.empty?
+        return unless variant.default_price.net_amount
 
         country_isos_requiring_price.each do |country_iso|
           # Don't re-create the default price


### PR DESCRIPTION
Guard against exceptions when calling `Price#net_amount` without a price.

Skip trying to calculate foreign prices in `VatPriceGenerator` when the `default_price` does not have an amount set.

Because the `VatPriceGenerator` is invoked in a `before_validate` hook when creating a product, this can lead to exceptions when an admin tries to create a product without specifying a price (and there are non-default countries for which a price needs to be calculated).

This PR allows the validations to run without raising exceptions so the admin can see the validation errors.

