### PR TITLE
Fix error added when resetting order flow on an empty order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -522,7 +522,7 @@ module Spree
         state: 'cart',
         updated_at: Time.current
       )
-      self.next
+      self.next if line_items.any?
     end
 
     def refresh_shipment_rates

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -590,9 +590,16 @@ RSpec.describe Spree::Order, type: :model do
     end
 
     context "without line items" do
+      let(:order) { create(:order, state: "delivery", line_items: []) }
+
       it "updates the state column to cart" do
-        order = create(:order, state: "delivery")
         expect{ order.restart_checkout_flow }.to change{ order.state }.from("delivery").to("cart")
+      end
+
+      it "doesn't add errors to the order" do
+        order.restart_checkout_flow
+
+        expect(order.errors).to be_empty
       end
     end
   end


### PR DESCRIPTION
## Summary

https://github.com/solidusio/solidus/pull/4369 introduced a regression where when calling `Spree::Order#restart_checkout_flow` on an empty order, an error would be added to the order. That happened when calling `#next` and the validation failed because no line items were present.

We restore the previous behavior where we only try going to the `"address"` state if the order has line items.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
