### PR TITLE
[Admin] Add text_area component

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/guidance/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/guidance/component.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# @api private
+class SolidusAdmin::UI::Forms::Guidance::Component < SolidusAdmin::BaseComponent
+  def initialize(field:, form:, hint:, errors:)
+    @field = field
+    @form = form
+    @hint = hint
+    @errors = errors || @form.object&.errors || raise(ArgumentError, <<~MSG
+      When the form builder is not bound to a model instance, you must pass an
+      errors Hash (`{ field_name: [errors] }`) to the component.
+    MSG
+    )
+  end
+
+  def call
+    return "" unless needed?
+
+    tag.div(class: "mt-2") do
+      hint_tag + error_tag
+    end
+  end
+
+  def hint_tag
+    return "".html_safe unless @hint
+
+    tag.p(id: hint_id, class: "body-tiny text-gray-500 peer-disabled:text-gray-300") do
+      @hint
+    end
+  end
+
+  def hint_id
+    "#{prefix}_hint"
+  end
+
+  def error_tag
+    return "".html_safe unless errors?
+
+    tag.p(id: error_id, class: "body-tiny text-red-400") do
+      @errors[@field].map do |error|
+        tag.span(class: "block") { error.capitalize }
+      end.reduce(&:+)
+    end
+  end
+
+  def errors?
+    @errors[@field].present?
+  end
+
+  def error_id
+    "#{prefix}_error"
+  end
+
+  def prefix
+    "#{@form.object_name}_#{@field}"
+  end
+
+  def aria_describedby
+    "#{hint_id if @hint} #{error_id if errors?}"
+  end
+
+  def needed?
+    @hint || errors?
+  end
+end

--- a/admin/app/components/solidus_admin/ui/forms/label/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/label/component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# @api private
+class SolidusAdmin::UI::Forms::Label::Component < SolidusAdmin::BaseComponent
+  def initialize(field:, form:)
+    @field = field
+    @form = form
+  end
+
+  def call
+    @form.label(@field, class: "block mb-0.5 body-tiny-bold")
+  end
+end

--- a/admin/app/components/solidus_admin/ui/forms/text_area/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/text_area/component.rb
@@ -1,32 +1,14 @@
 # frozen_string_literal: true
 
-class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponent
+class SolidusAdmin::UI::Forms::TextArea::Component < SolidusAdmin::BaseComponent
   SIZES = {
-    s: %w[leading-4 body-small],
-    m: %w[leading-6 body-small],
-    l: %w[leading-9 body-text]
-  }.freeze
-
-  TYPES = {
-    color: :color_field,
-    date: :date_field,
-    datetime: :datetime_field,
-    email: :email_field,
-    month: :month_field,
-    number: :number_field,
-    password: :password_field,
-    phone: :phone_field,
-    range: :range_field,
-    search: :search_field,
-    text: :text_field,
-    time: :time_field,
-    url: :url_field,
-    week: :week_field
+    s: %w[h-20 body-small],
+    m: %w[h-28 body-small],
+    l: %w[h-36 body-text]
   }.freeze
 
   # @param field [Symbol] the name of the field. Usually a model attribute.
   # @param form [ActionView::Helpers::FormBuilder] the form builder instance.
-  # @param type [Symbol] the type of the field. Defaults to `:text`.
   # @param size [Symbol] the size of the field: `:s`, `:m` or `:l`.
   # @param hint [String, null] helper text to display below the field.
   # @param errors [Hash, nil] a Hash of errors for the field. If `nil` and the
@@ -38,7 +20,6 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
   def initialize(
     field:,
     form:,
-    type: :text,
     size: :m,
     hint: nil,
     errors: nil,
@@ -48,10 +29,8 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
   )
     @field = field
     @form = form
-    @type = type
     @size = size
     @hint = hint
-    @type = type
     @attributes = attributes
     @errors = errors
     @label_component = label_component
@@ -72,8 +51,7 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
   end
 
   def field_tag(guidance)
-    @form.send(
-      field_helper,
+    @form.text_area(
       @field,
       class: field_classes(guidance),
       **field_aria_describedby_attribute(guidance),
@@ -85,7 +63,7 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
   def field_classes(guidance)
     %w[
       peer
-      block px-3 py-1.5 w-full
+      block px-3 py-4 w-full
       text-black
       bg-white border border-gray-300 rounded-sm
       hover:border-gray-500
@@ -93,10 +71,6 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
       focus:border-gray-500 focus:shadow-[0_0_0_2px_#bbb] focus-visible:outline-none
       disabled:bg-gray-50 disabled:text-gray-300
     ] + field_size_classes + field_error_classes(guidance) + Array(@attributes[:class]).compact
-  end
-
-  def field_helper
-    TYPES.fetch(@type)
   end
 
   def field_size_classes

--- a/admin/app/components/solidus_admin/ui/forms/text_field/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/text_field/component.rb
@@ -81,7 +81,7 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
     %w[
       peer
       block px-3 py-1.5 w-full
-      text-black text-black
+      text-black
       bg-white border border-gray-300 rounded-sm
       hover:border-gray-500
       placeholder:text-gray-400

--- a/admin/spec/components/previews/solidus_admin/ui/forms/text_area/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/text_area/component_preview.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# @component "ui/forms/text_area"
+class SolidusAdmin::UI::Forms::TextArea::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  # The text area component is used to render a textarea in a form.
+  #
+  # See the [`ui/forms/text_field`](../text_field) component for usage
+  # instructions.
+  def overview
+    dummy_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, urna eu aliquam ultricies, urna elit aliquam urna, eu aliquam urna elit euismod urna."
+    render_with_template(
+      locals: {
+        sizes: current_component::SIZES.keys,
+        variants: {
+          "empty" => {
+            value: nil, disabled: false, hint: nil, errors: {}
+          },
+          "filled" => {
+            value: dummy_text, disabled: false, hint: nil, errors: {}
+          },
+          "with_hint" => {
+            value: dummy_text, disabled: false, hint: "Max. 400 characters", errors: {}
+          },
+          "empty_with_error" => {
+            value: nil, disabled: false, hint: nil, errors: { "empty_with_error" => ["can't be blank"] }
+          },
+          "filled_with_error" => {
+            value: dummy_text, disabled: false, hint: nil, errors: { "filled_with_error" => ["is invalid"] }
+          },
+          "with_hint_and_error" => {
+            value: dummy_text, disabled: false, hint: "Max. 400 characters", errors: { "with_hint_and_error" => ["is invalid"] }
+          },
+          "empty_disabled" => {
+            value: nil, disabled: true, hint: nil, errors: {}
+          },
+          "filled_disabled" => {
+            value: dummy_text, disabled: true, hint: nil, errors: {}
+          },
+          "with_hint_disabled" => {
+            value: dummy_text, disabled: true, hint: "Max. 400 characters", errors: {}
+          }
+        }
+      }
+    )
+  end
+
+  # @param size select { choices: [s, m, l] }
+  # @param label text
+  # @param value text
+  # @param hint text
+  # @param errors text "Separate multiple errors with a comma"
+  # @param placeholder text
+  # @param disabled toggle
+  def playground(size: :m, label: "Description", value: nil, hint: nil, errors: "", placeholder: "Placeholder", disabled: false)
+    render_with_template(
+      locals: {
+        size: size.to_sym,
+        field: label,
+        value: value,
+        hint: hint,
+        errors: { label.dasherize => (errors.blank? ? [] : errors.split(",").map(&:strip)) },
+        placeholder: placeholder,
+        disabled: disabled
+      }
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/forms/text_area/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/text_area/component_preview/overview.html.erb
@@ -1,0 +1,34 @@
+<%= form_with(url: "#", scope: :overview, method: :get, class: "w-full") do |form| %>
+  <table>
+    <thead>
+      <tr>
+        <% sizes.each do |size| %>
+          <td class="px-3 py-1 text-gray-500 text-center body-text"><%= size.to_s.humanize %></td>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <%
+        variants.each_pair do |name, definition| %>
+          <tr>
+            <% sizes.each do |size| %>
+              <td class="px-3 py-1">
+                <%=
+                  render current_component.new(
+                    form: form,
+                    field: name,
+                    size: size,
+                    errors: definition[:errors],
+                    hint: definition[:hint],
+                    disabled: definition[:disabled],
+                    placeholder: "Placeholder",
+                    value: definition[:value]
+                  )
+                %>
+              </td>
+            <% end %>
+          </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/admin/spec/components/previews/solidus_admin/ui/forms/text_area/component_preview/playground.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/text_area/component_preview/playground.html.erb
@@ -1,0 +1,14 @@
+<%= form_with(url: "#", scope: :playground, method: :get, class: "w-60") do |form| %>
+  <%=
+    render current_component.new(
+      form: form,
+      size: size,
+      field: field,
+      value: value,
+      hint: hint,
+      errors: errors,
+      placeholder: placeholder,
+      disabled: disabled
+   )
+  %>
+<% end %>

--- a/admin/spec/components/previews/solidus_admin/ui/forms/text_field/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/text_field/component_preview.rb
@@ -81,7 +81,7 @@ class SolidusAdmin::UI::Forms::TextField::ComponentPreview < ViewComponent::Prev
   # @param label text
   # @param value text
   # @param hint text
-  # @param errors text (comma separated)
+  # @param errors text "Separate multiple errors with a comma"
   # @param placeholder text
   # @param disabled toggle
   def playground(size: :m, type: :text, label: "Name", value: nil, hint: nil, errors: "", placeholder: "Placeholder", disabled: false)

--- a/admin/spec/components/solidus_admin/ui/forms/guidance/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/guidance/component_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Forms::Guidance::Component, type: :component do
+  describe "#initialize" do
+    it "uses given errors when form is bound to a model" do
+      form = double("form", object: double("model", errors: {}))
+
+      component = described_class.new(form: form, field: :name, hint: nil, errors: { name: ["can't be blank"] })
+
+      expect(component.errors?).to be(true)
+    end
+
+    it "uses model errors when form is bound to a model and they are not given" do
+      form = double("form", object: double("model", errors: { name: ["can't be blank"] }))
+
+      component = described_class.new(form: form, field: :name, hint: nil, errors: nil)
+
+      expect(component.errors?).to be(true)
+    end
+
+    it "uses given errors when form is not bound to a model" do
+      form = double("form", object: nil)
+
+      component = described_class.new(form: form, field: :name, hint: nil, errors: { name: ["can't be blank"] })
+
+      expect(component.errors?).to be(true)
+    end
+
+    it "raises an error when form is not bound to a model and errors are not given" do
+      form = double("form", object: nil)
+
+      expect { described_class.new(form: form, field: :name, errors: nil) }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/admin/spec/components/solidus_admin/ui/forms/text_area/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/text_area/component_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe SolidusAdmin::UI::Forms::TextField::Component, type: :component do
+RSpec.describe SolidusAdmin::UI::Forms::TextArea::Component, type: :component do
   it "renders the overview preview" do
     render_preview(:overview)
   end

--- a/admin/spec/components/solidus_admin/ui/forms/text_field/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/text_field/component_spec.rb
@@ -5,6 +5,9 @@ require "spec_helper"
 RSpec.describe SolidusAdmin::UI::Forms::TextField::Component, type: :component do
   it "renders the overview preview" do
     render_preview(:overview)
+  end
+
+  it "renders the playground preview" do
     render_preview(:playground)
   end
 


### PR DESCRIPTION
## Summary

As the logic and styling for the associated label, hint and error messages are the same as for the text_field component, we extract it into a couple of new components: one for the label and one for the guidance (hint and error messages). These new components are marked as private, as they are not meant to be used directly (at least for now).

The original text_field component and the new text_area compose the new components but keep the responsibility of how to render the form inputs and which classes or attributes to use. We consider this approach more flexible than, for instance, using inheritance. Although it requires more code than just sharing a bunch of common styles, we keep them decoupled so they can change independently.

We stop short of creating another form element component wrapping new extracted pure input and textarea components. We can do that in the future if we need to.

The first three commits in this PR fix a couple of small issues in the text_field component.

Ref. #5329

![screenshot-localhost_3000-2023 08 18-11_51_32](https://github.com/solidusio/solidus/assets/52650/6d58f68c-e485-4c7a-a542-b39f3f803975)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
