### PR TITLE
Fix wrong translation key in pagination component

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/pagination/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/pagination/component.yml
@@ -1,3 +1,3 @@
 en:
   next: Next
-  prev: Previous
+  previous: Previous


### PR DESCRIPTION
## Summary

Fixes https://github.com/solidusio/solidus/discussions/5319#discussioncomment-6764927

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
