### PR TITLE
[Admin] Extract product status component

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -3,14 +3,13 @@
 class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
   def initialize(
     page:,
-    badge_component: component('ui/badge'),
+    status_component: component('products/status'),
     table_component: component('ui/table'),
     pagination_component: component('ui/table/pagination'),
     button_component: component("ui/button")
   )
     @page = page
-
-    @badge_component = badge_component
+    @status_component = status_component
     @table_component = table_component
     @button_component = button_component
     @pagination_component = pagination_component
@@ -100,13 +99,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
   def status_column
     {
       header: :status,
-      data: ->(product) do
-        if product.available?
-          @badge_component.new(name: t('.status.available'), color: :green)
-        else
-          @badge_component.new(name: t('.status.discontinued'), color: :red)
-        end
-      end
+      data: ->(product) { @status_component.new(product: product) }
     }
   end
 

--- a/admin/app/components/solidus_admin/products/index/component.yml
+++ b/admin/app/components/solidus_admin/products/index/component.yml
@@ -1,9 +1,6 @@
 en:
   product_image: 'Image'
   add_product: 'Add Product'
-  status:
-    available: 'Available'
-    discontinued: 'Discontinued'
   stock:
     infinity: '∞'
     in_stock: '%{on_hand} in stock'

--- a/admin/app/components/solidus_admin/products/status/component.rb
+++ b/admin/app/components/solidus_admin/products/status/component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Products::Status::Component < SolidusAdmin::BaseComponent
+  COLORS = {
+    available: :green,
+    discontinued: :red
+  }.freeze
+
+  # @param product [Spree::Product]
+  def initialize(product:, badge_component: component('ui/badge'))
+    @product = product
+    @badge_component = badge_component
+  end
+
+  def call
+    render @badge_component.new(
+      name: t(".#{status}"),
+      color: COLORS.fetch(status)
+    )
+  end
+
+  # @return [Symbol]
+  #   :available when the product is available
+  #   :discontinued when the product is not available
+  def status
+    if @product.available?
+      :available
+    else
+      :discontinued
+    end
+  end
+end

--- a/admin/app/components/solidus_admin/products/status/component.yml
+++ b/admin/app/components/solidus_admin/products/status/component.yml
@@ -1,0 +1,3 @@
+en:
+  available: 'Available'
+  discontinued: 'Discontinued'

--- a/admin/spec/components/previews/solidus_admin/products/status/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/products/status/component_preview.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# @component "products/status"
+class SolidusAdmin::Products::Status::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template(locals:
+      {
+        definitions: {
+          available: available_component,
+          discontinued: discontinued_component
+        }
+      })
+  end
+
+  private
+
+  def available_component
+    current_component.new(
+      product: Spree::Product.new(available_on: Time.current)
+    )
+  end
+
+  def discontinued_component
+    current_component.new(
+      product: Spree::Product.new(available_on: nil)
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/products/status/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/products/status/component_preview/overview.html.erb
@@ -1,0 +1,16 @@
+<table>
+  <thead>
+    <tr>
+      <% definitions.each_key do |status| %>
+        <th class="px-3 py-1 text-gray-500 text-center"><%= status.to_s.humanize %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <% definitions.each_value do |component| %>
+        <th class="px-3 py-1"><%= render component %></th>
+      <% end %>
+    </tr>
+  </tbody>
+</table>

--- a/admin/spec/components/solidus_admin/products/status/component_spec.rb
+++ b/admin/spec/components/solidus_admin/products/status/component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::Products::Status::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+
+  describe "#status" do
+    it "returns :available when the product is available" do
+      product = Spree::Product.new(available_on: Time.current)
+
+      component = described_class.new(product: product)
+
+      expect(component.status).to eq(:available)
+    end
+
+    it "returns :discontinued when the product is not available" do
+      product = Spree::Product.new(available_on: nil)
+
+      component = described_class.new(product: product)
+
+      expect(component.status).to eq(:discontinued)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We'll need the same logic in the product forms, so we need to extract it to a component.

Ref. #5329

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
