### PR TITLE
[Admin] Add toggletip component

### DIFF
--- a/admin/app/components/solidus_admin/ui/toggletip/component.erb
+++ b/admin/app/components/solidus_admin/ui/toggletip/component.erb
@@ -1,0 +1,26 @@
+<div class="relative inline-block" data-controller="<%= stimulus_id %>">
+  <button
+    type="button"
+    class="block w-[1rem] h-[1rem]"
+    data-target="<%= stimulus_id %>.button"
+    data-action="<%= stimulus_id %>#toggle"
+    aria-label="<%= t('.get_help') %>"
+  >
+    <%=
+      icon_tag("question-fill", class: "w-[1rem] h-[1rem] #{icon_theme_classes}")
+    %>
+  </button>
+  <div
+    class="hidden absolute inline-block w-[9rem] px-[0.75rem] body-tiny-bold rounded z-10 <%= bubble_position_classes %> <%= bubble_theme_classes %>"
+    data-target="<%= stimulus_id %>.bubble"
+    data-content="<%= @guide %>"
+  >
+   <span
+     role="status"
+     class="relative block bg-inherit py-[0.5rem] <%= bubble_arrow_pseudo_element %>"
+     data-target="<%= stimulus_id %>.content"
+   >
+     <%= @guide %>
+   </span>
+  </div>
+</div>

--- a/admin/app/components/solidus_admin/ui/toggletip/component.js
+++ b/admin/app/components/solidus_admin/ui/toggletip/component.js
@@ -1,0 +1,46 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['button', 'bubble', 'content']
+
+  connect () {
+    // Progressive enhancement && a11y: the content is visible in plain HTML.
+    // We first remove it and then make it an aria-live region so users are
+    // updated when it's readded.
+    this.contentTarget.textContent = ''
+    this.contentTarget.setAttribute('role', 'status')
+
+    // Close the bubble when clicking outside of it or pressing escape.
+    document.addEventListener('click', (event) => {
+      if (!this.buttonTarget.contains(event.target) && !this.bubbleTarget.contains(event.target)) {
+        this.close()
+      }
+    })
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        this.close()
+      }
+    })
+  }
+
+  // Toggle the bubble when clicking the button. The content is added and
+  // remove every time so that the aria-live region is updated and users are
+  // notified..
+  toggle () {
+    if (this.bubbleTarget.classList.contains('hidden')) {
+      this.open()
+    } else {
+      this.close()
+    }
+  }
+
+  open () {
+    this.bubbleTarget.classList.remove('hidden')
+    this.contentTarget.textContent = this.bubbleTarget.dataset.content
+  }
+
+  close () {
+    this.bubbleTarget.classList.add('hidden')
+    this.contentTarget.textContent = ''
+  }
+}

--- a/admin/app/components/solidus_admin/ui/toggletip/component.rb
+++ b/admin/app/components/solidus_admin/ui/toggletip/component.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Toggletip::Component < SolidusAdmin::BaseComponent
+  # Icon size: 1rem
+  # Arrow size: 0.375rem
+  # Banner padding x: 0.75rem
+  POSITIONS = {
+    up: {
+      arrow: %w[before:top-0 before:left-1/2 before:translate-y-[-50%] before:translate-x-[-50%]],
+      bubble: %w[translate-x-[calc(-50%+(1rem/2))] translate-y-[calc(0.375rem/2)]]
+    },
+    up_right: {
+      arrow: %w[before:top-0 before:right-0 before:translate-y-[-50%]],
+      bubble: %w[translate-x-[calc(-100%+0.75rem+(1rem/2)+(0.375rem/2))] translate-y-[calc(0.375rem/2)]]
+    },
+    right: {
+      arrow: %w[before:top-1/2 before:right-0 before:translate-y-[-50%] before:translate-x-[0.93rem]],
+      bubble: %w[translate-x-[calc(-100%+(-0.375rem/2))] translate-y-[calc(-50%-(1rem/2))]]
+    },
+    down_right: {
+      arrow: %w[before:bottom-0 before:right-0 before:translate-y-[50%]],
+      bubble: %w[translate-x-[calc(-100%+0.75rem+(1rem/2)+(0.376rem/2))] translate-y-[calc(-100%-1rem-(0.375rem/2))]]
+    },
+    down: {
+      arrow: %w[before:bottom-0 before:left-1/2 before:translate-y-[50%] before:translate-x-[-50%]],
+      bubble: %w[translate-x-[calc(-50%+(1rem/2))] translate-y-[calc(-100%-1rem-(0.375rem/2))]]
+    },
+    down_left: {
+      arrow: %w[before:bottom-0 before:left-0 before:translate-y-[50%]],
+      bubble: %w[translate-x-[calc(-1rem/2)] translate-y-[calc(-100%-0.75rem-0.375rem)]]
+    },
+    left: {
+      arrow: %w[before:top-1/2 before:left-0 before:translate-y-[-50%] before:translate-x-[-0.93rem]],
+      bubble: %w[translate-x-[calc(1rem+(0.375rem/2))] translate-y-[calc(-50%-(1rem/2))]]
+    },
+    up_left: {
+      arrow: %w[before:top-0 before:left-0 before:translate-y-[-50%]],
+      bubble: %w[translate-x-[calc(-0.75rem+0.375rem)] translate-y-[calc(0.375rem/2)]]
+    },
+    none: {
+      arrow: %w[before:hidden],
+      bubble: %w[translate-x-[calc(-50%+0.75rem)]]
+    }
+  }.freeze
+
+  THEMES = {
+    light: {
+      icon: %w[fill-gray-500],
+      bubble: %w[text-gray-800 bg-gray-50]
+    },
+    dark: {
+      icon: %w[fill-gray-800],
+      bubble: %w[text-white bg-gray-800]
+    }
+  }.freeze
+
+  # @param guide [String] The toggletip text
+  # @param position [Symbol] The position of the arrow in relation to the
+  #   toggletip. The latter will be positioned accordingly in relation to the
+  #   help icon. Defaults to `:up`. See `POSITIONS` for available options.
+  # @param theme [Symbol] The theme of the toggletip. Defaults to `:light`. See
+  #   `THEMES` for available options.
+  def initialize(guide:, position: :up, theme: :light)
+    @guide = guide
+    @position = position
+    @theme = theme
+  end
+
+  def icon_theme_classes
+    THEMES.fetch(@theme)[:icon].join(" ")
+  end
+
+  def bubble_theme_classes
+    THEMES.fetch(@theme)[:bubble].join(" ")
+  end
+
+  def bubble_position_classes
+    POSITIONS.fetch(@position)[:bubble].join(" ")
+  end
+
+  def bubble_arrow_pseudo_element
+    (
+      [
+        "before:content['']",
+        "before:absolute",
+        "before:w-[0.375rem]",
+        "before:h-[0.375rem]",
+        "before:rotate-45",
+        "before:bg-inherit",
+      ] + POSITIONS.fetch(@position)[:arrow]
+    ).join(" ")
+  end
+end

--- a/admin/app/components/solidus_admin/ui/toggletip/component.yml
+++ b/admin/app/components/solidus_admin/ui/toggletip/component.yml
@@ -1,0 +1,2 @@
+en:
+  get_help: "Get help"

--- a/admin/spec/components/previews/solidus_admin/ui/toggletip/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/toggletip/component_preview.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# @component "ui/toggletip"
+class SolidusAdmin::UI::Toggletip::ComponentPreview < ViewComponent::Preview
+  DUMMY_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template(
+      locals: {
+        guide: DUMMY_TEXT,
+        positions: current_component::POSITIONS.keys,
+        themes: current_component::THEMES.keys
+      }
+    )
+  end
+
+  # @param guide text
+  # @param position select :position_options
+  # @param theme select :theme_options
+  def playground(guide: DUMMY_TEXT, position: :up, theme: :light)
+    render_with_template(
+      locals: {
+        guide: guide,
+        position: position,
+        theme: theme
+      }
+    )
+  end
+
+  private
+
+  def position_options
+    current_component::POSITIONS.keys
+  end
+
+  def theme_options
+    current_component::THEMES.keys
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/toggletip/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/toggletip/component_preview/overview.html.erb
@@ -1,0 +1,21 @@
+<table class="w-full">
+  <legend class="body-title text-center">Click us</legend>
+  <tr>
+    <th class="w-[10%]"></th>
+    <% themes.each do |theme| %>
+      <th class="px-3 py-1 text-gray-500 text-center"><%= theme.to_s.humanize %></th>
+    <% end %>
+  </tr>
+  <% positions.each do |position| %>
+    <tr>
+      <td class="font-bold px-3 py-1"><%= position.to_s.humanize %></td>
+      <% themes.each do |theme| %>
+        <td class="py-3">
+          <div class="flex justify-center">
+            <%= render current_component.new(guide: guide, theme: theme, position: position) %>
+          </div>
+        </td>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/admin/spec/components/previews/solidus_admin/ui/toggletip/component_preview/playground.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/toggletip/component_preview/playground.html.erb
@@ -1,0 +1,10 @@
+<legend class="body-title text-center">Click me</legend>
+<div class="flex flex-wrap justify-center content-center h-screen">
+  <%=
+    render current_component.new(
+      guide: guide,
+      position: position,
+      theme: theme
+    )
+  %>
+</div>

--- a/admin/spec/components/solidus_admin/ui/toggletip/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/toggletip/component_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Toggletip::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+
+  it "renders the playground preview" do
+    render_preview(:playground)
+  end
+end


### PR DESCRIPTION
## Summary

The toggletip component is composed of an info icon which, when clicked or focused+enter, displays a bubble with a message.

The CSS to correctly display the toggletip and its speech-bubble-style arrow is quite complex, so we leave the maths inlined to better understandings of the values.

We use a "button" role on the info icon instead of surrounding it with an actual button element because we found the latter to break the positioning of the speech bubble.

For the chosen name and a11y concerns, we've taken inspiration from https://inclusive-components.design/tooltips-toggletips/#inclusivetoggletips. TL;DR: it's not good to use a regular "aria-describedby" attribute, as
that would make the text read out in advance. Instead, we build a clickable control that renders the text on a live region so users are notified. For progressive enhancement concerns, we render the text upfront. We use JS to hide it and then add the status role to get notifications from that moment on.

Ref. #5329

[screencast-localhost_3000-2023.08.25-12_31_44.webm](https://github.com/solidusio/solidus/assets/52650/dd3fcd96-2773-486c-b779-1dc34c55324a)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
