### PR TITLE
[Admin] Add fieldset component

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/fieldset/component.erb
+++ b/admin/app/components/solidus_admin/ui/forms/fieldset/component.erb
@@ -1,0 +1,4 @@
+<%= tag.fieldset(**fieldset_html_attributes) do %>
+  <%= legend_and_toggletip_tags %>
+  <%= content %>
+<% end %>

--- a/admin/app/components/solidus_admin/ui/forms/fieldset/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/fieldset/component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Forms::Fieldset::Component < SolidusAdmin::BaseComponent
+  # @param legend [String, nil] The legend of the fieldset.
+  # @param fieldset_attributes [Hash] Attributes to pass to the fieldset tag.
+  # @param legend_attributes [Hash, nil] Attributes to pass to the legend tag.
+  # @param toggletip_attributes [Hash, nil] Attributes to pass to a toggletip
+  #   component that will be rendered after the legend.
+  def initialize(
+    legend: nil,
+    attributes: {},
+    legend_attributes: {},
+    toggletip_attributes: {},
+    toggletip_component: component("ui/toggletip")
+  )
+    @legend = legend
+    @attributes = attributes
+    @legend_attributes = legend_attributes
+    @toggletip_attributes = toggletip_attributes
+    @toggletip_component = toggletip_component
+  end
+
+  def fieldset_html_attributes
+    {
+      class: fieldset_classes,
+      **@attributes.except(:class)
+    }
+  end
+
+  def fieldset_classes
+    %w[p-6 mb-6 border border-gray-100 rounded-lg] + Array(@attributes[:class]).compact
+  end
+
+  def legend_and_toggletip_tags
+    return "" unless @legend || @toggletip_attributes.any?
+
+    tag.div(class: "flex mb-4") do
+      legend_tag + toggletip_tag
+    end
+  end
+
+  def legend_tag
+    return "".html_safe unless @legend
+
+    tag.legend(@legend, **legend_html_attributes)
+  end
+
+  def legend_html_attributes
+    {
+      class: legend_classes,
+      **@legend_attributes.except(:class)
+    }
+  end
+
+  def legend_classes
+    %w[body-title mr-2] + Array(@legend_attributes[:class]).compact
+  end
+
+  def toggletip_tag
+    return "" unless @toggletip_attributes.any?
+
+    tag.div do
+      render @toggletip_component.new(**@toggletip_attributes)
+    end
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/forms/fieldset/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/fieldset/component_preview.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# @component "ui/forms/fieldset"
+class SolidusAdmin::UI::Forms::Fieldset::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  # The fieldset component is used to render a set of fields in a form.
+  #
+  # In its most basic form, it wraps the yielded content in a fieldset tag:
+  #
+  # ```erb
+  # <%= render components('ui/forms/fieldset').new do %>
+  #   <%= # ... %>
+  # <% end %>
+  # ```
+  #
+  # The legend of the fieldset can be set with the `legend` option:
+  #
+  # ```erb
+  # <%= render components('ui/forms/fieldset').new(
+  #   legend: "My fieldset"
+  # ) do %>
+  #   <%= # ... %>
+  # <% end %>
+  # ```
+  #
+  # Lastly, a toggletip can be added to the legend with the
+  # `toggletip_attributes`, which will be passed to the [toggletip
+  # component](../../toggletip):
+  #
+  # ```erb
+  # <%= render components('ui/forms/fieldset').new(
+  #   legend: "My fieldset",
+  #   toggletip_attributes: {
+  #     guide: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  #     position: :right
+  #   }
+  # ) do %>
+  #  <%= # ... %>
+  # <% end %>
+  # ```
+  def overview
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/forms/fieldset/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/fieldset/component_preview/overview.html.erb
@@ -1,0 +1,48 @@
+<%= form_with(url: "#", scope: :overview, method: :get, class: "w-full") do |form| %>
+  <div class="flex gap-4">
+    <div class="flex-1">
+      <%= render current_component.new do %>
+        <%=
+          render component('ui/forms/text_field').new(
+            field: :name,
+            form: form,
+            errors: {}
+          )
+        %>
+      <% end %>
+    </div>
+    <div class="flex-1">
+      <%= render current_component.new(legend: "Legend") do %>
+        <%=
+          render component('ui/forms/text_field').new(
+            field: :name,
+            form: form,
+            errors: {}
+          )
+        %>
+      <% end %>
+    </div>
+    <div class="flex-1">
+      <%= render current_component.new(toggletip_attributes: { guide: "Lorem ipsum dolor est." }) do %>
+        <%=
+          render component('ui/forms/text_field').new(
+            field: :name,
+            form: form,
+            errors: {}
+          )
+        %>
+      <% end %>
+    </div>
+    <div class="flex-1">
+      <%= render current_component.new(legend: "Legend & tip", toggletip_attributes: { guide: "Lorem ipsum dolor est.", position: :left, theme: :dark }) do %>
+        <%=
+          render component('ui/forms/text_field').new(
+            field: :name,
+            form: form,
+            errors: {}
+          )
+        %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/admin/spec/components/solidus_admin/ui/forms/fieldset/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/fieldset/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Forms::Fieldset::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

Add admin's fieldset component

The fieldset component just wraps a group of fields (or, actually, any content) within a fieldset tag. It optionally accepts a legend text and a toggletip component.

Ref. #5329

![screenshot-localhost_3000-2023 08 25-16_04_14](https://github.com/solidusio/solidus/assets/52650/f085fa51-67ac-4896-aaaa-9898d476ded0)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
