### PR TITLE
Rails 7.1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,10 +358,10 @@ workflows:
       # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
       - test_solidus:
           name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
-          matrix: { parameters: { rails: ['7.0'], ruby: ['3.0'], database: ['mysql'], paperclip: [true] } }
+          matrix: { parameters: { rails: ['7.0', '7.1'], ruby: ['3.0'], database: ['mysql'], paperclip: [true] } }
       - test_solidus:
           name: *name
-          matrix: { parameters: { rails: ['7.0'], ruby: ['3.1'], database: ['postgres'], paperclip: [false] } }
+          matrix: { parameters: { rails: ['7.0', '7.1'], ruby: ['3.1'], database: ['postgres'], paperclip: [false] } }
       - test_solidus:
           name: *name
-          matrix: { parameters: { rails: ['7.0'], ruby: ['3.2'], database: ['sqlite'], paperclip: [false] } }
+          matrix: { parameters: { rails: ['7.0', '7.1'], ruby: ['3.2'], database: ['sqlite'], paperclip: [false] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ commands:
             ruby -v >> /tmp/.ruby-versions
             gem --version >> /tmp/.gems-versions
             bundle --version >> /tmp/.gems-versions
-            gem search -eq rails -v "~> 7" -v"< 7.1" >> /tmp/.gems-versions # get the latest rails from rubygems
+            gem search -eq rails -v "~> 7" -v "< 7.2" >> /tmp/.gems-versions # get the latest rails from rubygems
             gem search -eq solidus >> /tmp/.gems-versions # get the latest solidus from rubygems
 
             cat /tmp/.ruby-versions

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec require: false
 
 # rubocop:disable Bundler/DuplicatedGem
-if ENV['RAILS_VERSION'] == 'master'
+if ENV['RAILS_VERSION'] == 'main'
   gem 'rails', github: 'rails', require: false
 else
   gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ end
 group :admin do
   gem 'solidus_admin', path: 'admin', require: false
   gem 'tailwindcss-rails', '~> 2.0', require: false
-  gem 'axe-core-rspec', '~> 4.7', require: false
-  gem 'axe-core-capybara', '~> 4.7', require: false
+  gem 'axe-core-rspec', '~> 4.8', require: false
+  gem 'axe-core-capybara', '~> 4.8', require: false
 end
 
 group :lint do

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'mysql2', '~> 0.5.0', require: false if dbs.match?(/all|mysql/)
 gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
 
-gem 'database_cleaner', '~> 1.3', require: false
+gem 'database_cleaner', '~> 2.0', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false
 gem 'rspec-rails', '~> 4.0.1', require: false
 gem 'rspec-retry', '~> 0.6.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec require: false
 if ENV['RAILS_VERSION'] == 'main'
   gem 'rails', github: 'rails', require: false
 else
-  gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0.2', require: false
+  gem 'rails', ENV['RAILS_VERSION'] || '~> 7.1.0', require: false
 end
 # rubocop:enable Bundler/DuplicatedGem
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
 
 gem 'database_cleaner', '~> 2.0', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false
-gem 'rspec-rails', '~> 4.0.1', require: false
+gem 'rspec-rails', '~> 6.0.3', require: false
 gem 'rspec-retry', '~> 0.6.2', require: false
 gem 'simplecov', require: false
 gem 'simplecov-cobertura', require: false

--- a/admin/config/initializers/view_component.rb
+++ b/admin/config/initializers/view_component.rb
@@ -6,8 +6,8 @@ if Rails.env.development? || Rails.env.test?
   Rails.application.config.view_component.instrumentation_enabled = true
   Rails.application.config.view_component.use_deprecated_instrumentation_name = false
 
-  bold = ActiveSupport::LogSubscriber::BOLD
-  clear = ActiveSupport::LogSubscriber::CLEAR
+  bold  = "\e[1m"
+  clear = "\e[0m"
 
   ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
     next unless args.last[:name].starts_with?("SolidusAdmin::")

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -83,7 +83,7 @@ require "view_component/system_test_helpers"
 require "rails/version"
 require "rails/generators"
 require "rails/generators/app_base"
-require "rails/generators/testing/behaviour"
+require "rails/generators/testing/behavior"
 
 # AXE - ACCESSIBILITY
 require 'axe-rspec'
@@ -119,7 +119,7 @@ RSpec.configure do |config|
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include SolidusAdmin::ComponentHelpers, type: :component
 
-  config.include Rails::Generators::Testing::Behaviour, type: :generator
+  config.include Rails::Generators::Testing::Behavior, type: :generator
   config.include FileUtils, type: :generator
   config.before type: :generator do
     self.generator_class = described_class

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -4,8 +4,8 @@ module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
       before_action :initialize_order_events
-      before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm]
-      around_action :lock_order, only: [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
+      before_action :load_order, only: [:edit, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm]
+      around_action :lock_order, only: [:advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
       respond_to :html

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -28,8 +28,10 @@ module Spree
 
     self.allowed_ransackable_attributes = %w[name]
 
-    scope :with_values, ->(attributes) do
-      where(value_attributes(attributes))
+    unless ActiveRecord::Relation.method_defined? :with_values # Rails 7.1+
+      scope :with_values, ->(attributes) do
+        where(value_attributes(attributes))
+      end
     end
 
     # @return [Address] an address with default attributes

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -21,9 +21,6 @@ module Spree
 
     scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
 
-    # needed for some of the ActiveMerchant gateways (eg. SagePay)
-    alias_attribute :brand, :cc_type
-
     # Taken from ActiveMerchant
     # https://github.com/activemerchant/active_merchant/blob/2f2acd4696e8de76057b5ed670b9aa022abc1187/lib/active_merchant/billing/credit_card_methods.rb#L5
     CARD_TYPES = {
@@ -94,6 +91,12 @@ module Spree
       else type
       end
     end
+
+    # needed for some of the ActiveMerchant gateways (eg. SagePay)
+    alias_attribute :brand, :cc_type
+
+    # Rails 7.1+ won't use the custom setter with alias_attribute
+    alias_method :brand=, :cc_type=
 
     # Sets the last digits field based on the assigned credit card number.
     def set_last_digits

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -72,11 +72,15 @@ module Spree
 
     # Customer info
     belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
+
     belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address', optional: true
-    alias_attribute :billing_address, :bill_address
+    alias_method :billing_address, :bill_address
+    alias_method :billing_address=, :bill_address=
 
     belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address', optional: true
-    alias_attribute :shipping_address, :ship_address
+    alias_method :shipping_address, :ship_address
+    alias_method :shipping_address=, :ship_address=
+
     alias_attribute :ship_total, :shipment_total
 
     belongs_to :store, class_name: 'Spree::Store', optional: true

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Spree::Preference < Spree::Base
-  serialize :value
+  serialize :value, coder: YAML
 
   validates :key, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
 end

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -67,7 +67,7 @@ module Spree
     scope :exchange_processed, -> { where.not(exchange_inventory_unit: nil) }
     scope :exchange_required, -> { exchange_requested.where(exchange_inventory_unit: nil) }
 
-    serialize :acceptance_status_errors
+    serialize :acceptance_status_errors, coder: YAML
 
     delegate :eligible_for_return?, :requires_manual_intervention?, to: :validator
     delegate :variant, to: :inventory_unit

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -18,8 +18,7 @@ module Spree
     delegate :name, :tax_category, :tax_category_id, to: :shipping_method
     delegate :code, to: :shipping_method, prefix: true
     alias_attribute :amount, :cost
-
-    alias_method :total_before_tax, :amount
+    alias_attribute :total_before_tax, :cost
 
     extend DisplayMoney
     money_methods :amount

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -18,7 +18,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = false # Should be :none for Rails 7.1+
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -21,6 +21,8 @@ require 'paperclip'
 require 'ransack'
 require 'state_machines-activerecord'
 
+require_relative './ransack_4_1_patch'
+
 # This is required because ActiveModel::Validations#invalid? conflicts with the
 # invalid state of a Payment. In the future this should be removed.
 StateMachines::Machine.ignore_method_conflicts = true

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -67,12 +67,14 @@ module Spree
       end
 
       # Load in mailer previews for apps to use in development.
-      initializer "spree.core.action_mailer.set_preview_path", after: "action_mailer.set_configs" do |app|
-        original_preview_path = app.config.action_mailer.preview_path
-        solidus_preview_path = Spree::Core::Engine.root.join 'lib/spree/mailer_previews'
+      initializer "spree.core.action_mailer.set_preview_path", after: "action_mailer.set_autoload_paths" do
+        solidus_preview_path = Spree::Core::Engine.root.join("lib/spree/mailer_previews")
 
-        app.config.action_mailer.preview_path = "{#{original_preview_path},#{solidus_preview_path}}"
-        ActionMailer::Base.preview_path = app.config.action_mailer.preview_path
+        if ActionMailer::Base.respond_to? :preview_paths # Rails 7.1+
+          ActionMailer::Base.preview_paths << solidus_preview_path.to_s
+        else
+          ActionMailer::Base.preview_path = "{#{ActionMailer::Base.preview_path},#{solidus_preview_path}}"
+        end
       end
 
       initializer "spree.deprecator" do |app|

--- a/core/lib/spree/preferences/persistable.rb
+++ b/core/lib/spree/preferences/persistable.rb
@@ -7,7 +7,13 @@ module Spree
 
       included do
         include Spree::Preferences::Preferable
-        serialize :preferences, Hash
+
+        if method(:serialize).parameters.include?([:key, :type]) # Rails 7.1+
+          serialize :preferences, type: Hash, coder: YAML
+        else
+          serialize :preferences, Hash, coder: YAML
+        end
+
         after_initialize :initialize_preference_defaults
       end
 

--- a/core/lib/spree/ransack_4_1_patch.rb
+++ b/core/lib/spree/ransack_4_1_patch.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "ransack/version"
+
+return unless Ransack::VERSION.start_with?("4.1.")
+
+module RansackNodeConditionPatch
+  private
+
+  # Waiting for https://github.com/activerecord-hackery/ransack/pull/1468
+  def casted_array?(predicate)
+    predicate.is_a?(Arel::Nodes::Casted) && predicate.value.is_a?(Array)
+  end
+
+  Ransack::Nodes::Condition.prepend(self)
+end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -63,7 +63,7 @@ module DummyApp
 
     # Make debugging easier:
     config.consider_all_requests_local = true
-    config.action_dispatch.show_exceptions = false
+    config.action_dispatch.show_exceptions = false # Should be :none for Rails 7.1+
     config.active_support.deprecation = :stderr
     config.log_level = :debug
 

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -82,7 +82,11 @@ module DummyApp
     config.secret_key_base = 'SECRET_TOKEN'
 
     # Set the preview path within the dummy app:
-    config.action_mailer.preview_path = File.expand_path('dummy_app/mailer_previews', __dir__)
+    if ActionMailer::Base.respond_to? :preview_paths # Rails 7.1+
+      config.action_mailer.preview_paths << File.expand_path('dummy_app/mailer_previews', __dir__)
+    else
+      config.action_mailer.preview_path = File.expand_path('dummy_app/mailer_previews', __dir__)
+    end
 
     config.active_record.dump_schema_after_migration = false
 

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -87,17 +87,15 @@ module DummyApp
     config.active_record.dump_schema_after_migration = false
 
     # Configure active storage to use storage within tmp folder
-    unless (ENV['DISABLE_ACTIVE_STORAGE'] == 'true')
-      initializer 'solidus.active_storage' do
-        config.active_storage.service_configurations = {
-          test: {
-            service: 'Disk',
-            root: Rails.root.join('tmp', 'storage')
-          }
+    initializer 'solidus.active_storage' do
+      config.active_storage.service_configurations = {
+        test: {
+          service: 'Disk',
+          root: Rails.root.join('tmp', 'storage')
         }
-        config.active_storage.service = :test
-        config.active_storage.variant_processor = ENV.fetch('ACTIVE_STORAGE_VARIANT_PROCESSOR', :vips).to_sym
-      end
+      }
+      config.active_storage.service = :test
+      config.active_storage.variant_processor = ENV.fetch('ACTIVE_STORAGE_VARIANT_PROCESSOR', :vips).to_sym
     end
 
     # Avoid issues if an old spec/dummy still exists

--- a/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
+++ b/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
@@ -38,10 +38,7 @@ namespace :db do
     # railties:install:migrations and then db:migrate.
     # Migrations should be run one directory at a time
     ActiveRecord::Migrator.migrations_paths.each do |path|
-      ActiveRecord::MigrationContext.new(
-        [path],
-        ActiveRecord::SchemaMigration
-      ).migrate
+      ActiveRecord::MigrationContext.new([path]).migrate
     end
 
     ActiveRecord::Base.clear_cache!

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
   s.add_dependency 'psych', ['>= 4.0.1', '< 5.0']
-  s.add_dependency 'ransack', '~> 2.0'
+  s.add_dependency 'ransack', '~> 4.0'
   s.add_dependency 'sprockets-rails'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
   s.add_dependency 'omnes', '~> 0.2.2'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 7.0', '< 7.1']
+    s.add_dependency rails_dep, ['>= 7.0', '< 7.2']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Spree::BaseHelper, type: :helper do
       expect(html.css(".notice").text).to eq("ok")
       expect(html.css(".foo").text).to be_empty
       expect(html.css(".bar").text).to be_empty
-      expect(helper.output_buffer).to eq("<div class=\"flash notice\">ok</div>")
+      expect(helper.output_buffer.to_s).to eq("<div class=\"flash notice\">ok</div>")
     end
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
           path: '/api'
         })
         get :index
-        expect(response.headers["Set-Cookie"]).to match(/domain=\.test\.host; path=\/api/)
+        expect(response.headers["Set-Cookie"]).to match(/domain=(\.)?test\.host; path=\/api/)
       end
 
       it 'never overwrites httponly' do

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -294,7 +294,9 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
       end
 
       it "with string, encryption key provided as env variable" do
-        expect(ENV).to receive(:[]).with("SOLIDUS_PREFERENCES_MASTER_KEY").and_return("VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!")
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("SOLIDUS_PREFERENCES_MASTER_KEY").and_return("VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!")
+        expect(Spree::Encryptor).to receive(:new).with("VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!").and_call_original
 
         config_class_a.preference :secret, :encrypted_string
 

--- a/sample/db/samples/orders.rb
+++ b/sample/db/samples/orders.rb
@@ -7,14 +7,15 @@ payment_method = Spree::PaymentMethod::Check.first!
 store = Spree::Store.first!
 
 orders = []
+
 orders << Spree::Order.create!(
   number: "R123456789",
   email: "spree@example.com",
   item_total: 150.95,
   adjustment_total: 150.95,
   total: 301.90,
-  shipping_address: Spree::Address.first,
-  billing_address: Spree::Address.last
+  ship_address: Spree::Address.first,
+  bill_address: Spree::Address.last
 )
 
 orders << Spree::Order.create!(
@@ -23,8 +24,8 @@ orders << Spree::Order.create!(
   item_total: 15.95,
   adjustment_total: 15.95,
   total: 31.90,
-  shipping_address: Spree::Address.first,
-  billing_address: Spree::Address.last
+  ship_address: Spree::Address.first,
+  bill_address: Spree::Address.last
 )
 
 orders[0].line_items.create!(


### PR DESCRIPTION
## Summary

Preparation for supporting Rails 7.1. Very much work in progress, although it looks like the changes needed are minimal so far. The sandbox is running successfully, there are some failing specs that need to be addressed. 

- [x] https://github.com/activerecord-hackery/ransack/issues/1420 
- [x] Add support to Circle to run Rails from edge
- [x] Add support to Circle to run Rails 7.1
- [x] Fix all the specs
- [x] Fix or document all deprecation warnings for 7.1
- [x] Use Rails 7.1 for installer tests on CircleCI

One of the current RSpec errors are related to this https://github.com/rails/rails/issues/49591 and it looks that this will be fixed in the upcoming Rails 7.1.2 release.

Ransack is pain still. The custom predicates with formatters is failing hard currently:

`core/app/models/spree/product.rb`:

```ruby
# The :variants_option_values ransacker filters Spree::Product based on
    # variant option values ids.
    #
    # Usage:
    # Spree::Product.ransack(
    #   variants_option_values_in: [option_value_id1, option_value_id2]
    # ).result
    ransacker :variants_option_values, formatter: proc { |v|
      if OptionValue.exists?(v)
        joins(variants_including_master: :option_values)
          .where(spree_option_values: { id: v })
          .distinct
          .select(:id).arel
      end
    } do |parent|
      parent.table[:id]
    end
```

```
1) Spree::Product ransacker :variants_option_values filters products based on option values of their variants
     Failure/Error: result = Spree::Product.ransack(variants_option_values_in: [option_value_1.id]).result
     
     NoMethodError:
       undefined method `value' for #<Arel::SelectManager:0x00000001160b22c0 @ast=#<Ar
```
Figuring out where this value method call used to be. 

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
