### PR TITLE
[Admin] Fix the legacy switcher not working on different paths

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/component.js
+++ b/admin/app/components/solidus_admin/sidebar/component.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   setCookie(event) {
     let value = !event.currentTarget.checked
 
-    document.cookie = `${this.cookieValue}=${value};`
+    document.cookie = `${this.cookieValue}=${value}; Path=/`
     location.reload()
   }
 }

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -34,7 +34,7 @@ Spree.ready(function() {
     solidusAdminSwitch.addEventListener("change", function(e) {
       let value = !solidusAdminSwitch.checked;
 
-      document.cookie = `solidus_admin=${value}`;
+      document.cookie = `solidus_admin=${value}; Path=/ `;
 
       location.reload();
     });


### PR DESCRIPTION
## Summary

As the cookie was set relative to the path where the switcher was clicked, it created as many cookies as paths where the switcher was clicked. That was causing the switcher to not work when a previous cookie was also encompassing the current path.

To reproduce (in Chrome):

1. Initiate the sandbox application (new admin is on by default).
2. Go to the product creation page. It falls back to the legacy admin but the switcher is still on the new admin.
3. Click on the switcher to go back to the legacy admin. It works. The cookie is set for `/admin/products` to `false`.
4. Go to the product listing. Switch again to the new admin. It sets the cookie for `/admin` to `true`, but as the `/admin/products` cookie also applies and takes precedence, the new route is not taken into account.

Before:

[screencast-localhost_3000-2023.08.29-14_17_47.webm](https://github.com/solidusio/solidus/assets/52650/b3ada85a-126e-46b7-a724-739b86915c29)

After:

[screencast-localhost_3000-2023.08.29-14_49_24.webm](https://github.com/solidusio/solidus/assets/52650/658cde7a-d663-4712-8604-47a28d927f33)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
