### PR TITLE
[Admin] Fix color applied to the hint of disabled form fields

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/guidance/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/guidance/component.rb
@@ -2,10 +2,11 @@
 
 # @api private
 class SolidusAdmin::UI::Forms::Guidance::Component < SolidusAdmin::BaseComponent
-  def initialize(field:, form:, hint:, errors:)
+  def initialize(field:, form:, hint:, errors:, disabled: false)
     @field = field
     @form = form
     @hint = hint
+    @disabled = disabled
     @errors = errors || @form.object&.errors || raise(ArgumentError, <<~MSG
       When the form builder is not bound to a model instance, you must pass an
       errors Hash (`{ field_name: [errors] }`) to the component.
@@ -24,9 +25,13 @@ class SolidusAdmin::UI::Forms::Guidance::Component < SolidusAdmin::BaseComponent
   def hint_tag
     return "".html_safe unless @hint
 
-    tag.p(id: hint_id, class: "body-tiny text-gray-500 peer-disabled:text-gray-300") do
+    tag.p(id: hint_id, class: "body-tiny #{hint_text_color_class}") do
       @hint
     end
+  end
+
+  def hint_text_color_class
+    @disabled ? "text-gray-300" : "text-gray-500"
   end
 
   def hint_id

--- a/admin/app/components/solidus_admin/ui/forms/text_area/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/text_area/component.rb
@@ -31,7 +31,7 @@ class SolidusAdmin::UI::Forms::TextArea::Component < SolidusAdmin::BaseComponent
     @form = form
     @size = size
     @hint = hint
-    @attributes = attributes
+    @attributes = HashWithIndifferentAccess.new(attributes)
     @errors = errors
     @label_component = label_component
     @guidance_component = guidance_component
@@ -42,7 +42,8 @@ class SolidusAdmin::UI::Forms::TextArea::Component < SolidusAdmin::BaseComponent
       field: @field,
       form: @form,
       hint: @hint,
-      errors: @errors
+      errors: @errors,
+      disabled: @attributes[:disabled]
     )
 
     tag.div(class: "mb-6") do
@@ -62,7 +63,6 @@ class SolidusAdmin::UI::Forms::TextArea::Component < SolidusAdmin::BaseComponent
 
   def field_classes(guidance)
     %w[
-      peer
       block px-3 py-4 w-full
       text-black
       bg-white border border-gray-300 rounded-sm

--- a/admin/app/components/solidus_admin/ui/forms/text_field/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/text_field/component.rb
@@ -52,7 +52,7 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
     @size = size
     @hint = hint
     @type = type
-    @attributes = attributes
+    @attributes = HashWithIndifferentAccess.new(attributes)
     @errors = errors
     @label_component = label_component
     @guidance_component = guidance_component
@@ -63,7 +63,8 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
       field: @field,
       form: @form,
       hint: @hint,
-      errors: @errors
+      errors: @errors,
+      disabled: @attributes[:disabled]
     )
 
     tag.div(class: "mb-6") do
@@ -84,7 +85,6 @@ class SolidusAdmin::UI::Forms::TextField::Component < SolidusAdmin::BaseComponen
 
   def field_classes(guidance)
     %w[
-      peer
       block px-3 py-1.5 w-full
       text-black
       bg-white border border-gray-300 rounded-sm


### PR DESCRIPTION
## Summary

As the hint is wrapped within a "div" that goes after the form field, the "peer" class applied on the field had no effect on the hint.

We break the coupling between the guidance component and the fields components by explicitly passing the "disabled" state to the former.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
