### PR TITLE
Improve automatic backport flow

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,3 @@
+{
+  "prTitle": "[{{targetBranch}}] {{sourcePullRequest.title}}"
+}

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,3 +1,4 @@
 {
-  "prTitle": "[{{targetBranch}}] {{sourcePullRequest.title}}"
+  "prTitle": "[{{targetBranch}}] {{sourcePullRequest.title}}",
+  "copySourcePRLabels": true
 }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,7 +18,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v8.9.3
+        uses: sqren/backport-github-action@v9.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-


### PR DESCRIPTION
## Summary

### Make automatic backporting PRs take the title from the original one

Up until now, the title of the backporting PRs was the name of the merge commit, which is not very readable. This commit builds the title from the original PR title and the target branch, e.g.:

    [v4.2] Fix some bug

This is now possible thanks to upstream's recent changes. See https://github.com/sqren/backport/issues/455 for details.

### Automatically copy labels from original PR to backported PRs

None of the automatically generated PRs for backports can trigger the labeler flow, which resulted in them not being added to the automatic release notes unless manual work was done to update the labels. The reason is that an action in a workflow can't trigger another action, and that's by design. As referenced in [an issue from the `create-pull-request` project](https://github.com/peter-evans/create-pull-request/issues/48):

> An action in a workflow run can't trigger a new workflow run. For example, if an action pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

On that issue, there's also a reference from a response from GH support:

> This is a deliberate decision by the Actions team in order to prevent accidental "infinite loop" situations, and as an anti-abuse measure.  You will be able to work around this using a Personal Access Token in place of the provided token. As this needs to be explicitly provided it will remove any potential for possible abuse, so we recommend using this method when needing to create a pull request.

As said, we could work around that by using a personal token, which could be scoped to the `solidusio/solidus` repository. However, we don't think that would be a good idea because of security & practical concerns.

Thanks to upstream work in the backporter tool [2] we can now copy the labels from the original PR to the backported PRs, avoiding the need for manual work.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
