### PR TITLE
Pin the version of chrome to install until the ORB is fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,9 @@ commands:
   setup:
     steps:
       - checkout
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.198"
+          replace-existing: true
       - browser-tools/install-chromedriver
       - run:
           name: "Lock dependencies"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,10 @@ commands:
             ruby -v > .ruby-version
       - restore_cache:
           keys:
-            - solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}
-            - solidus-gems-v3-{{checksum ".ruby-version"}}-main
-            - solidus-gems-v3-{{checksum ".ruby-version"}}
+            - solidus-gems-v4-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - solidus-gems-v4-{{checksum ".ruby-version"}}-{{ .Branch }}
+            - solidus-gems-v4-{{checksum ".ruby-version"}}-main
+            - solidus-gems-v4-{{checksum ".ruby-version"}}
 
       - run: |
           bundle config set path 'vendor/bundle'
@@ -82,7 +82,7 @@ commands:
           bundle clean
 
       - save_cache:
-          key: solidus-gems-v3-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: solidus-gems-v4-{{checksum ".ruby-version"}}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 
@@ -159,8 +159,8 @@ commands:
             cat /tmp/.gems-versions
       - restore_cache:
           keys:
-            - solidus-installer-v7-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
-            - solidus-installer-v7-{{ checksum "/tmp/.ruby-versions" }}-
+            - solidus-installer-v8-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+            - solidus-installer-v8-{{ checksum "/tmp/.ruby-versions" }}-
       - run:
           name: "Prepare the rails application"
           command: |
@@ -168,7 +168,7 @@ commands:
             test -d my_app || gem install rails solidus
             test -d my_app || rails new my_app --skip-git
       - save_cache:
-          key: solidus-installer-v7-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+          key: solidus-installer-v8-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
           paths:
             - /tmp/my_app
             - /home/circleci/.rubygems


### PR DESCRIPTION
Ref:
- https://github.com/CircleCI-Public/browser-tools-orb/pull/72
- https://stackoverflow.com/a/77013753

Once merged I'll immediately open a revert PR for the first commit so we'll make sure we don't stay on chrome v114 forever.

## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
