### PR TITLE
[Admin] Fix solidus installation test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,11 +147,15 @@ commands:
       - run:
           name: "Cleanup & check rails version"
           command: |
+            sudo gem update --system
+            gem install bundler -v"~> 2.4"
             gem environment path
             rm -rf /tmp/my_app /tmp/.ruby-versions # cleanup previous runs
             rm -rf /tmp/my_app /tmp/.gems-versions # cleanup previous runs
 
             ruby -v >> /tmp/.ruby-versions
+            gem --version >> /tmp/.gems-versions
+            bundle --version >> /tmp/.gems-versions
             gem search -eq rails >> /tmp/.gems-versions # get the latest rails from rubygems
             gem search -eq solidus >> /tmp/.gems-versions # get the latest solidus from rubygems
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -159,7 +159,6 @@ module Solidus
     end
 
     def install_solidus_admin
-      bundle_command 'add solidus_admin' unless has_gem?('solidus_admin')
       generate 'solidus_admin:install'
     end
 

--- a/lib/solidus.rb
+++ b/lib/solidus.rb
@@ -3,4 +3,5 @@
 require 'solidus_core'
 require 'solidus_api'
 require 'solidus_backend'
+require 'solidus_admin'
 require 'solidus_sample'


### PR DESCRIPTION
## Summary

At some point adding the solidus_admin dependency stopped sourcing from the `path:` set for the `solidus` gem, causing bundler not to find it. Now we just require solidus_admin in `solidus.rb` consistently with the dependency being present in `solidus.gemspec`.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
