### PR TITLE
Fix module resolution Issue with precompiled assets

### DIFF
--- a/admin/app/javascript/solidus_admin/controllers/index.js
+++ b/admin/app/javascript/solidus_admin/controllers/index.js
@@ -1,6 +1,6 @@
 // Import and register all your controllers from the importmap under controllers/*
 
-import { application } from "./application"
+import { application } from "solidus_admin/controllers/application"
 
 // Eager load all controllers defined in the import map under controllers/**/*_controller
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
@@ -10,5 +10,5 @@ eagerLoadControllersFrom("solidus_admin/controllers", application)
 // import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
 // lazyLoadControllersFrom("controllers", application)
 
-import { eagerLoadComponents } from "./components"
+import { eagerLoadComponents } from "solidus_admin/controllers/components"
 eagerLoadComponents(application, { under: "solidus_admin", suffix: "/component" })


### PR DESCRIPTION
## Summary

This PR resolves an issue where the production deployment of the Solidus admin interface at https://demo.solidus.io/ was breaking due to relative import paths in the `solidus_admin/controllers/index.js` file.

Observations:
- In development mode, with the `compile` setting set to `true`, everything was working as expected.
- In the production environment, with `compile` set to `false` and assets precompiled, the relative paths caused issues.

The root cause appears tied to how the production environment handles module resolution when assets are precompiled.

**Before**
<img width="1840" alt="Screenshot 2023-09-07 at 17 04 59" src="https://github.com/solidusio/solidus/assets/19948291/c7cabc5c-dba4-4841-b8cf-ada63b5b7c8b">


**After**
<img width="1840" alt="Screenshot 2023-09-07 at 17 06 52" src="https://github.com/solidusio/solidus/assets/19948291/62a4037c-6e96-4805-b172-99a47c2c7376">



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.

## Additional Information

After merging this into the `nebulab/admin` branch, the change will also be backported into the `admin/alpha/v1` branch to ensure consistency and functionality across versions.