### PR TITLE
Fix promotion code batch

### DIFF
--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -39,13 +39,15 @@ class ::Spree::PromotionCode::BatchBuilder
       new_codes = Array.new(max_codes_to_generate) { generate_random_code }.uniq
       codes_for_current_batch = get_unique_codes(new_codes)
 
-      codes_for_current_batch.each do |value|
+      codes_for_current_batch = codes_for_current_batch.map do |value|
         Spree::PromotionCode.create!(
           value: value,
           promotion: promotion,
           promotion_code_batch: promotion_code_batch
         )
-      end
+      rescue ActiveRecord::RecordInvalid
+        nil
+      end.compact
       created_codes += codes_for_current_batch.size
     end
   end

--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -30,7 +30,8 @@ class ::Spree::PromotionCode::BatchBuilder
   private
 
   def generate_random_codes
-    created_codes = 0
+    created_codes = promotion_code_batch.promotion_codes.count
+
     batch_size = @options[:batch_size]
 
     while created_codes < number_of_codes

--- a/core/spec/models/spree/promotion_code/batch_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/batch_builder_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
           expect(promotion.codes.size).to eq(number_of_codes)
         end
       end
+
+      context "when same promotion_codes are already present" do
+        before do
+          create_list(:promotion_code, 11, promotion: promotion, promotion_code_batch: promotion_code_batch)
+        end
+
+        it "creates only the missing promotion_codes" do
+          expect { subject.build_promotion_codes }.to change { promotion.codes.size }.by(39)
+        end
+      end
     end
   end
 

--- a/core/spec/models/spree/promotion_code/batch_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/batch_builder_spec.rb
@@ -72,6 +72,25 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
         subject.build_promotion_codes
         expect(promotion.codes.size).to eq(number_of_codes)
       end
+
+      context "when promotion_code creation returns an error" do
+        before do
+          @raise_exception = true
+          allow(Spree::PromotionCode).to receive(:create!) do
+            if @raise_exception
+              @raise_exception = false
+              raise(ActiveRecord::RecordInvalid)
+            else
+              create(:promotion_code, promotion: promotion)
+            end
+          end
+        end
+
+        it "creates the correct number of codes anyway" do
+          subject.build_promotion_codes
+          expect(promotion.codes.size).to eq(number_of_codes)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

When a new promotion with 2.5m new promo codes has created, it just generated about 250k promo codes and then stopped.

The PromotionBatch screen this error: Errored: #<ActiveRecord::RecordInvalid: Validation failed: Value has already been taken>

This PR rescues the exception raised by the Spree::PromotionCode creation and jumps to the next code to save, avoiding stopping the process completely.
The PR also adds the ability to restart the PromotionCodeBatch from the latest PromotionCodes created.

Fixes: https://github.com/solidusio/solidus/issues/5379

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
