### PR TITLE
[admin] Add the `danger` scheme to the `ui/button` component

### DIFF
--- a/admin/app/components/solidus_admin/products/show/component.html.erb
+++ b/admin/app/components/solidus_admin/products/show/component.html.erb
@@ -165,8 +165,7 @@
         <%= render component("ui/button").new(
           tag: :button,
           text: t(".delete"),
-          scheme: :secondary,
-          class: "border-red-500 text-red-500 hover:bg-red-500 hover:text-white",
+          scheme: :danger,
           "data-action": "click->#{stimulus_id}#confirmDelete",
           "data-#{stimulus_id}-message-param": t(".delete_confirmation"),
         ) %>

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -35,23 +35,23 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
       active:text-white active:bg-gray-800
       focus:text-white focus:bg-gray-700
       disabled:text-gray-400 disabled:bg-gray-100 disabled:cursor-not-allowed
-      aria-disabled:text-gray-400 aria-disabled:bg-gray-100 aria-disabled:cursor-not-allowed
+      aria-disabled:text-gray-400 aria-disabled:bg-gray-100 aria-disabled:aria-disabled:cursor-not-allowed
     ],
     secondary: %w[
       text-gray-700 bg-white border border-1 border-gray-200
       hover:bg-gray-50
       active:bg-gray-100
       focus:bg-gray-50
-      disabled:text-gray-300 disabled:bg-white border-gray-200 disabled:cursor-not-allowed
-      aria-disabled:text-gray-300 aria-disabled:bg-white border-gray-200 aria-disabled:cursor-not-allowed
+      disabled:text-gray-300 disabled:bg-white disabled:cursor-not-allowed
+      aria-disabled:text-gray-300 aria-disabled:bg-white aria-disabled:cursor-not-allowed
     ],
     ghost: %w[
       text-gray-700 bg-transparent
       hover:bg-gray-50
       active:bg-gray-100
       focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
-      disabled:text-gray-300 disabled:bg-transparent border-gray-300 disabled:cursor-not-allowed
-      aria-disabled:text-gray-300 aria-disabled:bg-transparent border-gray-300 aria-disabled:cursor-not-allowed
+      disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
+      aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed
     ],
   }
 
@@ -70,6 +70,7 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
 
     @attributes[:class] = [
       'justify-start items-center justify-center gap-1 inline-flex rounded',
+      'focus:ring focus:ring-gray-300 focus:ring-0.5 focus:bg-white focus:ring-offset-0 [&:focus-visible]:outline-none',
       SIZES.fetch(size.to_sym),
       (TEXT_PADDINGS.fetch(size.to_sym) if @text),
       SCHEMES.fetch(scheme.to_sym),

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -45,6 +45,14 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
       disabled:text-gray-300 disabled:bg-white disabled:cursor-not-allowed
       aria-disabled:text-gray-300 aria-disabled:bg-white aria-disabled:cursor-not-allowed
     ],
+    danger: %w[
+      text-red-500 bg-white border border-1 border-red-500
+      hover:bg-red-500 hover:border-red-600 hover:text-white
+      active:bg-red-600 active:border-red-700 active:text-white
+      focus:bg-red-50 focus:bg-red-500 focus:border-red-600 focus:text-white
+      disabled:text-red-300 disabled:bg-white disabled:border-red-200 disabled:cursor-not-allowed
+      aria-disabled:text-red-300 aria-disabled:bg-white aria-disabled:border-red-200 aria-disabled:cursor-not-allowed
+    ],
     ghost: %w[
       text-gray-700 bg-transparent
       hover:bg-gray-50


### PR DESCRIPTION
## Summary

<img width="570" alt="image" src="https://github.com/solidusio/solidus/assets/1051/d84e150d-4a3f-46ad-8058-022b2ee7003a">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
