### PR TITLE
[admin] Separate authorization from authentication

### DIFF
--- a/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/account_nav/component.html.erb
@@ -58,7 +58,7 @@
       <% end %>
     </li>
     <li class="h-8 flex items-center hover:bg-gray-25 rounded">
-      <%= link_to @logout_path, method: @logout_method, class: 'flex gap-2 items-center px-2' do %>
+      <%= button_to @logout_path, method: @logout_method, class: 'flex gap-2 items-center px-2' do %>
         <%= icon_tag("logout-box-line", class: "w-5 h-5 fill-current shrink") %>
         <span><%= t('.logout') %></span>
       <% end %>

--- a/admin/app/controllers/solidus_admin/accounts_controller.rb
+++ b/admin/app/controllers/solidus_admin/accounts_controller.rb
@@ -2,6 +2,8 @@
 
 module SolidusAdmin
   class AccountsController < SolidusAdmin::BaseController
+    skip_before_action :authorize_solidus_admin_user!
+
     def show
       redirect_to spree.edit_admin_user_path(current_solidus_admin_user)
     end

--- a/admin/app/controllers/solidus_admin/authentication_adapters/backend.rb
+++ b/admin/app/controllers/solidus_admin/authentication_adapters/backend.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusAdmin::AuthAdapters::Backend
+module SolidusAdmin::AuthenticationAdapters::Backend
   extend ActiveSupport::Concern
 
   included do

--- a/admin/app/controllers/solidus_admin/authentication_adapters/backend.rb
+++ b/admin/app/controllers/solidus_admin/authentication_adapters/backend.rb
@@ -11,20 +11,9 @@ module SolidusAdmin::AuthenticationAdapters::Backend
   private
 
   def authenticate_solidus_backend_user!
-    if respond_to?(:model_class, true) && model_class
-      record = model_class
-    else
-      record = controller_name.to_sym
-    end
-    authorize! :admin, record
-    authorize! action_name.to_sym, record
-  rescue CanCan::AccessDenied
-    instance_exec(&Spree::Admin::BaseController.unauthorized_redirect)
-  end
+    return if spree_current_user
 
-  # Needs to be overriden so that we use Spree's Ability rather than anyone else's.
-  def current_ability
-    @current_ability ||= Spree::Ability.new(spree_current_user)
+    instance_exec(&Spree::Admin::BaseController.unauthorized_redirect)
   end
 
   def store_location

--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -9,6 +9,7 @@ module SolidusAdmin
     include GearedPagination::Controller
 
     include SolidusAdmin::ControllerHelpers::Authentication
+    include SolidusAdmin::ControllerHelpers::Authorization
     include SolidusAdmin::ControllerHelpers::Locale
     include SolidusAdmin::ComponentsHelper
     include SolidusAdmin::AuthenticationAdapters::Backend if defined?(Spree::Backend)

--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -8,10 +8,10 @@ module SolidusAdmin
     include Spree::Core::ControllerHelpers::Store
     include GearedPagination::Controller
 
-    include SolidusAdmin::ControllerHelpers::Auth
+    include SolidusAdmin::ControllerHelpers::Authentication
     include SolidusAdmin::ControllerHelpers::Locale
     include SolidusAdmin::ComponentsHelper
-    include SolidusAdmin::AuthAdapters::Backend if defined?(Spree::Backend)
+    include SolidusAdmin::AuthenticationAdapters::Backend if defined?(Spree::Backend)
 
     layout 'solidus_admin/application'
     helper 'solidus_admin/components'

--- a/admin/app/controllers/solidus_admin/controller_helpers/authentication.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusAdmin::ControllerHelpers::Auth
+module SolidusAdmin::ControllerHelpers::Authentication
   extend ActiveSupport::Concern
 
   included do

--- a/admin/app/controllers/solidus_admin/controller_helpers/authorization.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/authorization.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module SolidusAdmin::ControllerHelpers::Authorization
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorize_solidus_admin_user!
+  end
+
+  private
+
+  def current_ability
+    @current_ability ||= Spree::Ability.new(current_solidus_admin_user)
+  end
+
+  def authorize_solidus_admin_user!
+    subject = authorization_subject
+
+    authorize! :admin, subject
+    authorize! action_name, subject
+  end
+
+  def authorization_subject
+    "Spree::#{controller_name.classify}".constantize
+  rescue NameError
+    raise NotImplementedError, "Couldn't infer the model class from the controller name, " \
+      "please implement `#{self.class}#authorization_subject`."
+  end
+end

--- a/admin/lib/solidus_admin/preview.rb
+++ b/admin/lib/solidus_admin/preview.rb
@@ -27,7 +27,7 @@ module SolidusAdmin::Preview
     extend ActiveSupport::Concern
 
     included do
-      include SolidusAdmin::ControllerHelpers::Auth
+      include SolidusAdmin::ControllerHelpers::Authentication
       helper ActionView::Helpers
       helper SolidusAdmin::ComponentsHelper
       helper_method :current_component

--- a/admin/spec/components/solidus_admin/sidebar/account_nav/component_spec.rb
+++ b/admin/spec/components/solidus_admin/sidebar/account_nav/component_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe SolidusAdmin::Sidebar::AccountNav::Component, type: :component do
 
       # Links are hidden within a <details> element
       expect(page).to have_link("Account", href: "/admin/account", visible: :any)
-      expect(page).to have_link("Logout", href: "/admin/logout", visible: :any)
-      expect(page.find_link("Logout", visible: :any)["data-method"]).to eq("delete")
+      within('form[action="/admin/logout"]') do
+        expect(page).to have_button("Logout", visible: :any)
+        expect(page).to have_css('input[type="hidden"][name="_method"][value="delete"]')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR disambiguates "auth" pulling "authorization" management out of the Spree::Backend adapter into its own module that is not tied to the authentication implementation of choice.

This makes the authentication backend adapter for SolidusAdmin have a slightly different behavior from the original one, but it should match when using the standard solidus_auth_devise (by default it requires authentication if authorization fails and no user is authenticated).

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
