### PR TITLE
Prepare for the first rubygems release of SolidusAdmin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :backend do
 end
 
 group :admin do
+  gem 'solidus_admin', path: 'admin', require: false
   gem 'axe-core-rspec', '~> 4.7', require: false
   gem 'axe-core-capybara', '~> 4.7', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ task :clean do
   end
 end
 
-SOLIDUS_GEM_NAMES = %w[core api backend frontend sample]
+SOLIDUS_GEM_NAMES = %w[core api backend sample]
 
 namespace :gem do
   def version

--- a/Rakefile
+++ b/Rakefile
@@ -52,6 +52,8 @@ task :clean do
   end
 end
 
+SOLIDUS_GEM_NAMES = %w[core api backend frontend sample]
+
 namespace :gem do
   def version
     require_relative 'core/lib/spree/core/version'
@@ -59,7 +61,7 @@ namespace :gem do
   end
 
   def for_each_gem
-    %w(core api backend frontend sample).each do |gem_name|
+    SOLIDUS_GEM_NAMES.each do |gem_name|
       print_title(gem_name)
       yield "pkg/solidus_#{gem_name}-#{version}.gem"
     end
@@ -72,7 +74,7 @@ namespace :gem do
     pkgdir = File.expand_path('pkg', __dir__)
     FileUtils.mkdir_p pkgdir
 
-    %w(core api backend frontend sample).each do |gem_name|
+    SOLIDUS_GEM_NAMES.each do |gem_name|
       Dir.chdir(gem_name) do
         sh "gem build solidus_#{gem_name}.gemspec"
         mv "solidus_#{gem_name}-#{version}.gem", pkgdir

--- a/admin/README.md
+++ b/admin/README.md
@@ -22,3 +22,10 @@ bin/rails admin g solidus_admin:component foo
       create  app/components/solidus_admin/foo/component.js
       create  spec/components/solidus_admin/foo/component_spec.rb
 ```
+
+## Releasing
+
+1. Update the version in `lib/solidus_admin/version.rb`
+2. Commit the changes with the message `Release v1.2.3`
+3. `cd admin; bundle exec rake release`
+4. Manually release on GitHub

--- a/admin/Rakefile
+++ b/admin/Rakefile
@@ -16,3 +16,6 @@ DummyApp::RakeTasks.new(
 )
 
 task test_app: 'db:reset'
+
+# Namespace release tags, e.g. 'solidus_admin/v1.2.3'
+Bundler::GemHelper.tag_prefix = 'solidus_admin/'

--- a/admin/Rakefile
+++ b/admin/Rakefile
@@ -5,6 +5,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/dummy_app/rake_tasks'
+require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new
 task default: :spec

--- a/admin/app/components/solidus_admin/sidebar/component.html.erb
+++ b/admin/app/components/solidus_admin/sidebar/component.html.erb
@@ -23,7 +23,7 @@
   <div class="mt-auto">
     <div class="group mb-3">
       <label class="flex gap-3 items-center py-0.5 px-3 pb-0.5 rounded hover:text-red-500 hover:bg-gray-50 body-small-bold text-black cursor-pointer">
-        <%= t('solidus_admin.main_nav.legacy_label') %>
+        <%= t('spree.navigation.switch_to_legacy') %>
         <div class="flex items-center">
           <%= render component("ui/forms/switch").new(size: :s, checked: false, 'data-action': "#{stimulus_id}#setCookie:prevent") %>
         </div>

--- a/admin/config/locales/main_nav.en.yml
+++ b/admin/config/locales/main_nav.en.yml
@@ -11,5 +11,3 @@ en:
       stock: Stock
       users: Users
       settings: Settings
-      legacy_label: Switch to legacy admin
-      admin_label: Switch to new admin

--- a/admin/lib/solidus_admin/version.rb
+++ b/admin/lib/solidus_admin/version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/core/version'
-
 module SolidusAdmin
-  VERSION = Spree.solidus_version
+  VERSION = "0.0.1"
 end

--- a/admin/solidus_admin.gemspec
+++ b/admin/solidus_admin.gemspec
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require_relative '../core/lib/spree/core/version'
+require_relative './lib/solidus_admin/version'
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'solidus_admin'
-  s.version     = Spree.solidus_version
+  s.version     = SolidusAdmin::VERSION
   s.summary     = 'Admin interface for the Solidus e-commerce framework.'
   s.description = s.summary
 
@@ -25,8 +26,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'geared_pagination', '~> 1.1'
   s.add_dependency 'importmap-rails', '~> 1.2', '>= 1.2.1'
-  s.add_dependency 'solidus_backend', s.version
-  s.add_dependency 'solidus_core', s.version
+  s.add_dependency 'solidus_backend', Spree.solidus_version
+  s.add_dependency 'solidus_core', Spree.solidus_version
   s.add_dependency 'stimulus-rails', '~> 1.2'
   s.add_dependency 'tailwindcss-rails', '~> 2.0'
   s.add_dependency 'turbo-rails', '~> 1.4'

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -30,8 +30,8 @@
               <span
                 id="solidus-admin-switch-label"
                 class="text"
-                data-legacy-label="<%= 'solidus_admin.main_nav.legacy_label'.then { t(_1, default: t(_1, locale: :en)) } %>"
-                data-admin-label="<%= 'solidus_admin.main_nav.admin_label'.then { t(_1, default: t(_1, locale: :en)) } %>"
+                data-legacy-label="<%= 'spree.navigation.switch_to_legacy'.then { t(_1, default: t(_1, locale: :en)) } %>"
+                data-admin-label="<%= 'spree.navigation.switch_to_solidus_admin'.then { t(_1, default: t(_1, locale: :en)) } %>"
               ></span>
               <span><input type="checkbox" id="solidus-admin-switch" class="solidus-admin--nav--switch"/></span>
             </label>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1790,6 +1790,9 @@ en:
     name_contains: Name Contains
     name_on_card: Name on card
     name_or_sku: Name or SKU (enter at least first 4 characters of product name)
+    navigation:
+      switch_to_legacy: Switch to legacy admin
+      switch_to_solidus_admin: Switch to new admin
     negative_movement_absent_item: Cannot create negative movement for absent stock item.
     new: New
     new_adjustment: New Adjustment

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -34,6 +34,7 @@ module Solidus
     class_option :seed, type: :boolean, default: true, banner: 'Load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations and seeds must be run)'
     class_option :active_storage, type: :boolean, default: true, banner: 'Install ActiveStorage as image attachments handler for products and taxons'
+    class_option :admin_preview, type: :boolean, default: true, desc: 'Install the admin preview'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string
@@ -159,6 +160,10 @@ module Solidus
     end
 
     def install_solidus_admin
+      return unless options[:admin_preview]
+
+      say_status :installing, "SolidusAdmin", :blue
+      bundle_command 'add solidus_admin'
       generate 'solidus_admin:install'
     end
 

--- a/lib/solidus.rb
+++ b/lib/solidus.rb
@@ -3,5 +3,4 @@
 require 'solidus_core'
 require 'solidus_api'
 require 'solidus_backend'
-require 'solidus_admin'
 require 'solidus_sample'

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0.0'
   s.required_rubygems_version = '>= 1.8.23'
 
-  s.add_dependency 'solidus_admin'
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0.0'
   s.required_rubygems_version = '>= 1.8.23'
 
-  s.add_dependency 'solidus_admin', s.version
+  s.add_dependency 'solidus_admin'
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version


### PR DESCRIPTION
## Summary

We're going to release solidus_admin as v0.0.x and tags will be namespaced as `solidus_admin/0.0.x`. 
Releases will be handled manually using Bundler's helpers.

Once SolidusAdmin is ready to take over we'll link it to the main solidus version number and will jump directly to v4.x or v5 or whatever the version will be.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
