### PR TITLE
Enhance product model with `variants_option_values` ransacker

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -131,8 +131,26 @@ module Spree
 
     alias :options :product_option_types
 
+    # The :variants_option_values ransacker filters Spree::Product based on
+    # variant option values ids.
+    #
+    # Usage:
+    # Spree::Product.ransack(
+    #   variants_option_values_in: [option_value_id1, option_value_id2]
+    # ).result
+    ransacker :variants_option_values, formatter: proc { |v|
+      if OptionValue.exists?(v)
+        joins(variants_including_master: :option_values)
+          .where(spree_option_values: { id: v })
+          .distinct
+          .select(:id).arel
+      end
+    } do |parent|
+      parent.table[:id]
+    end
+
     self.allowed_ransackable_associations = %w[stores variants_including_master master variants]
-    self.allowed_ransackable_attributes = %w[name slug]
+    self.allowed_ransackable_attributes = %w[name slug variants_option_values]
     self.allowed_ransackable_scopes = %i[available with_discarded with_all_variant_sku_cont with_kept_variant_sku_cont]
 
     # @return [Boolean] true if there are any variants


### PR DESCRIPTION
## Summary

This PR introduces a new [ransacker](https://activerecord-hackery.github.io/ransack/going-further/ransackers/), `variants_option_values`, to the `Spree::Product` model. 

The primary purpose of this ransacker is to enhance filtering capabilities within the admin interface.
[It facilitates combinate option type filtering with ransack](https://github.com/solidusio/solidus/pull/5376), allowing for more refined searches based on variant option values.

- Added a ransacker `variants_option_values` to enable searching based on product variants' option values.
- Updated `allowed_ransackable_attributes` to include `variants_option_values`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
