### PR TITLE
[Admin] Ensure `action_name` is passed as symbol for `cancancan` authorization

### DIFF
--- a/admin/app/controllers/solidus_admin/controller_helpers/authorization.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/authorization.rb
@@ -17,7 +17,7 @@ module SolidusAdmin::ControllerHelpers::Authorization
     subject = authorization_subject
 
     authorize! :admin, subject
-    authorize! action_name, subject
+    authorize! action_name.to_sym, subject
   end
 
   def authorization_subject

--- a/admin/app/controllers/solidus_admin/controller_helpers/authorization.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/authorization.rb
@@ -5,6 +5,10 @@ module SolidusAdmin::ControllerHelpers::Authorization
 
   included do
     before_action :authorize_solidus_admin_user!
+
+    rescue_from CanCan::AccessDenied do
+      render 'unauthorized', status: :forbidden
+    end
   end
 
   private

--- a/admin/app/views/solidus_admin/base/unauthorized.html.erb
+++ b/admin/app/views/solidus_admin/base/unauthorized.html.erb
@@ -1,0 +1,4 @@
+<div class="p-4">
+  <h1 class="text-3xl font-semibold text-solidusRed mb-4"><%= t('solidus_admin.errors.authorization.access_denied.title') %></h1>
+  <p class="text-lg text-gray-700"><%= t('solidus_admin.errors.authorization.access_denied.description') %></p>
+</div>

--- a/admin/config/locales/errors.en.yml
+++ b/admin/config/locales/errors.en.yml
@@ -1,0 +1,7 @@
+en:
+  solidus_admin:
+    errors:
+      authorization:
+        access_denied:
+          title: "Access Denied"
+          description: "You are not authorized to access this page."

--- a/admin/spec/controllers/solidus_admin/base_controller_spec.rb
+++ b/admin/spec/controllers/solidus_admin/base_controller_spec.rb
@@ -15,9 +15,21 @@ describe SolidusAdmin::BaseController, type: :controller do
       allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 
-    it "redirects to unauthorized" do
+    it "redirects to unauthorized for no user" do
       get :index
       expect(response).to redirect_to '/unauthorized'
+    end
+
+    context "with a user without update permission" do
+      before do
+        user = create(:user, email: 'user@example.com')
+        allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(user)
+      end
+
+      it "redirects to unauthorized" do
+        get :index
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

In the context of implementing permissions in the Solidus Demo, we identified that `action_name` in string format doesn't align with CanCanCan's `authorize!` method expectations.

It needs to be in symbol format to be processed correctly.
This change ensures our authorization logic functions as intended even for the new solidus admin views.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
