### PR TITLE
Fix the link to customization guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The storefront will be accessible at
 [http://localhost:3000/](http://localhost:3000/) and the admin can be found at
 [http://localhost:3000/admin/](http://localhost:3000/admin/).
 
-For information on how to customize your store, check out the [customization guides](https://guides.solidus.io/developers/customizations/overview.html).
+For information on how to customize your store, check out the [customization guides](https://guides.solidus.io/customization/customizing-your-storefront).
 
 ### Default Username/Password
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -101,4 +101,4 @@ unbundled bin/rails generate solidus:install --admin-preview --auto-accept $@
 echo "
 🚀 This app is intended for test purposes. If you're interested in running
 🚀 Solidus in production, visit:
-🚀 https://guides.solidus.io/developers/getting-started/first-time-installation"
+🚀 https://guides.solidus.io/getting-started/installing-solidus"


### PR DESCRIPTION
## Summary

The current link results in 404, change it to a proper place in the docs


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
