### PR TITLE
Update backend configuration for solidus `v4.2`

### DIFF
--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -16,7 +16,7 @@ module Spree
 
     # @!attribute [rw] theme
     #   @return [String] Default admin theme name
-    versioned_preference :theme, :string, initial_value: 'classic', boundaries: { "4.1.0.a" => "solidus_admin" }
+    versioned_preference :theme, :string, initial_value: 'classic', boundaries: { "4.2.0" => "solidus_admin" }
 
     def theme_path(user_theme = nil)
       user_theme ? themes.fetch(user_theme.to_sym) : themes.fetch(theme.to_sym)
@@ -25,8 +25,7 @@ module Spree
     # @!attribute [rw] admin_updated_navbar
     #   @return [Boolean] Should the updated navbar be used in admin (default: +false+)
     #
-    # TODO: Update boundaries before merging to `main`
-    versioned_preference :admin_updated_navbar, :boolean, initial_value: false, boundaries: { "4.1.0.a" => true }
+    versioned_preference :admin_updated_navbar, :boolean, initial_value: false, boundaries: { "4.2.0" => true }
 
     preference :frontend_product_path,
       :proc,
@@ -40,7 +39,7 @@ module Spree
 
     # @!attribute [rw] prefer_menu_item_partials
     #   @return [Boolean] Whether or not to prefer menu item partials when both a partial and children are present.
-    preference :prefer_menu_item_partials, :boolean, default: false
+    versioned_preference :prefer_menu_item_partials, :boolean, initial_value: true, boundaries: { "4.2.0" => false }
 
     autoload :ORDER_TABS, 'spree/backend_configuration/deprecated_tab_constants'
     autoload :PRODUCT_TABS, 'spree/backend_configuration/deprecated_tab_constants'


### PR DESCRIPTION
## Summary

The `backend_configuration.rb` file had preferences still pointing to `Solidus v4.1.0.a`.

This PR updates the references to `Solidus v4.2.0` to ensure the correct versioned preferences are loaded.

From v4.2.0:
- the default theme preference is `'solidus_admin'`
- the updated admin navbar is enabled
- do not prioritize menu item partials when both a partial and children exist

Below v4.2.0:
- the theme is `'classic'`
- the old admin navbar is used
- the system prioritizes menu item partials in the same scenario

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
