### PR TITLE
Restore using `MenuItem#sections` for matching paths

### DIFF
--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -13,31 +13,31 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
 
   describe '#match_path?' do
     it 'matches a string using the admin path prefix' do
-      described_class.new(match_path: '/stock_items')
+      subject = described_class.new(match_path: '/stock_items')
       request = double(ActionDispatch::Request, fullpath: '/admin/stock_items/1/edit')
 
-      expect(subject.match_path?(request)).to be true
+      expect(subject.match_path?(request)).to be_truthy
     end
 
     it 'matches a proc accepting the request object' do
       request = double(ActionDispatch::Request, fullpath: '/foo/bar/baz')
       subject = described_class.new(match_path: -> { _1.fullpath.include? '/bar/' })
 
-      expect(subject.match_path?(request)).to be true
+      expect(subject.match_path?(request)).to be_truthy
     end
 
     it 'matches a regexp' do
-      described_class.new(match_path: %r{/bar/})
+      subject = described_class.new(match_path: %r{/bar/})
       request = double(ActionDispatch::Request, fullpath: '/foo/bar/baz')
 
-      expect(subject.match_path?(request)).to be true
+      expect(subject.match_path?(request)).to be_truthy
     end
 
     it 'matches the item url as the fullpath prefix' do
-      described_class.new(url: '/foo/bar')
+      subject = described_class.new(url: '/foo/bar')
       request = double(ActionDispatch::Request, fullpath: '/foo/bar/baz')
 
-      expect(subject.match_path?(request)).to be true
+      expect(subject.match_path?(request)).to be_truthy
     end
   end
 

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
 
       expect(subject.match_path?(request)).to be_truthy
     end
+
+    it 'matches the item on the (deprecated) sections against the controller name' do
+      allow(Spree.deprecator).to receive(:warn).with(a_string_matching(/icon/))
+      allow(Spree.deprecator).to receive(:warn).with(a_string_matching(/sections/))
+
+      subject = described_class.new([:foo, :bar], :baz_icon)
+      matching_request = double(
+        ActionDispatch::Request,
+        controller_class: double(ActionController::Base, controller_name: 'bar'),
+        fullpath: '/qux',
+      )
+      other_request = double(
+        ActionDispatch::Request,
+        controller_class: double(ActionController::Base, controller_name: 'baz'),
+        fullpath: '/qux',
+      )
+
+      expect(subject.match_path?(matching_request)).to be true
+      expect(subject.match_path?(other_request)).to be false
+    end
   end
 
   describe "#url" do


### PR DESCRIPTION
## Summary

Using sections for matching the path was originally done inside the #tab helper, when the responsibility was moved to MenuItem this use-case was lost. Not anymore.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
