### PR TITLE
Add dependent: :destroy to Spree::Order#order_promotions

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -104,7 +104,7 @@ module Spree
              foreign_key: :order_id,
              dependent: :destroy,
              inverse_of: :order
-    has_many :order_promotions, class_name: 'Spree::OrderPromotion'
+    has_many :order_promotions, class_name: 'Spree::OrderPromotion', dependent: :destroy
     has_many :promotions, through: :order_promotions
 
     # Payments

--- a/core/db/migrate/20231027084517_add_order_promotions_foreign_key.rb
+++ b/core/db/migrate/20231027084517_add_order_promotions_foreign_key.rb
@@ -1,0 +1,10 @@
+class AddOrderPromotionsForeignKey < ActiveRecord::Migration[7.0]
+  def up
+    Spree::OrderPromotion.left_joins(:order).where(spree_orders: { id: nil }).delete_all
+    add_foreign_key :spree_orders_promotions, :spree_orders, column: :order_id, validate: false, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :spree_orders_promotions, :spree_orders
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1818,4 +1818,18 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe "order deletion" do
+    let(:order) { create(:order) }
+    let(:promotion) { create(:promotion) }
+
+    subject { order.destroy }
+    before do
+      order.promotions << promotion
+    end
+
+    it "deletes join table entries when deleting an order" do
+      expect { subject }.to change { Spree::OrderPromotion.count }.from(1).to(0)
+    end
+  end
 end


### PR DESCRIPTION


## Summary

We found a lot of orphaned records in our database due to this missing dependent: :destroy.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
