### PR TITLE
Use bundler gem tasks instead of gem_release

### DIFF
--- a/.gem_release.yml
+++ b/.gem_release.yml
@@ -1,7 +1,0 @@
-bump:
-  recurse: false
-  file: 'core/lib/spree/core/version.rb'
-  message: Bump Solidus to %{version}
-
-release:
-  recurse: true

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ group :utils do
   gem 'rubocop', '~> 1', require: false
   gem 'rubocop-performance', '~> 1.4', require: false
   gem 'rubocop-rails', '~> 2.9', require: false
-  gem 'gem-release', require: false
 end
 
 gem 'rspec_junit_formatter', require: false, group: :ci

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler'
+require 'bundler/gem_tasks'
 
 task default: :spec
 
@@ -53,55 +54,21 @@ task :clean do
 end
 
 SOLIDUS_GEM_NAMES = %w[core api backend sample]
+GEM_TASKS_NAME = %w[build install]
 
-namespace :gem do
-  def version
-    require_relative 'core/lib/spree/core/version'
-    Spree.solidus_version
-  end
-
-  def for_each_gem
+GEM_TASKS_NAME.each do |task_name|
+  desc "Run rake gem:#{task} for each Solidus gem"
+  task task_name do
     SOLIDUS_GEM_NAMES.each do |gem_name|
-      print_title(gem_name)
-      yield "pkg/solidus_#{gem_name}-#{version}.gem"
-    end
-    print_title
-    yield "pkg/solidus-#{version}.gem"
-  end
-
-  desc "Build all solidus gems"
-  task :build do
-    pkgdir = File.expand_path('pkg', __dir__)
-    FileUtils.mkdir_p pkgdir
-
-    SOLIDUS_GEM_NAMES.each do |gem_name|
-      Dir.chdir(gem_name) do
-        sh "gem build solidus_#{gem_name}.gemspec"
-        mv "solidus_#{gem_name}-#{version}.gem", pkgdir
-      end
-    end
-
-    print_title
-    sh "gem build solidus.gemspec"
-    mv "solidus-#{version}.gem", pkgdir
-  end
-
-  desc "Install all solidus gems"
-  task install: :build do
-    for_each_gem do |gem_path|
-      Bundler.with_clean_env do
-        sh "gem install #{gem_path}"
-      end
+      cd(gem_name) { sh "rake #{task_name}" }
     end
   end
+end
 
-  desc "Release all gems to rubygems"
-  task release: :build do
-    sh "git tag -a -m \"Version #{version}\" v#{version}"
-
-    for_each_gem do |gem_path|
-      sh "gem push '#{gem_path}'"
-    end
+task :releasez do
+  require_relative 'core/lib/spree/core/version'
+  SOLIDUS_GEM_NAMES.each do |gem_name|
+    sh "gem push #{gem_name}/pkg/solidus_#{gem_name}-#{Spree.solidus_version}.gem"
   end
 end
 

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -5,6 +5,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/dummy_app/rake_tasks'
+require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new
 task default: :spec

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -4,6 +4,7 @@ require 'rubygems'
 require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
+require 'bundler/gem_tasks'
 
 require 'solidus_backend'
 require 'spree/testing_support/dummy_app/rake_tasks'

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -5,6 +5,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/dummy_app/rake_tasks'
+require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new
 task default: :spec

--- a/sample/Rakefile
+++ b/sample/Rakefile
@@ -4,6 +4,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/dummy_app/rake_tasks'
+require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new
 task default: :spec


### PR DESCRIPTION
## Summary

Now that we also have a solidus_admin that follows a different release track we need more control over what gems are released. `gem_release` has no such control available and simply has a configuration for recursing. Also all the features of `gem_relerase` regarding version numbers manipulation are no longer relevant as it all happens within GitHub actions using dev_tools.

Bundler gem tasks are now the standard for all our extensions and are a simpler, already available, tool that can be leveraged here as well.

<img width="767" alt="image" src="https://github.com/solidusio/solidus/assets/1051/b2245675-10e0-4b2f-9d78-7c7a11e471f1">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
