### PR TITLE
Redefine the release task skipping tag creation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,10 +54,9 @@ task :clean do
 end
 
 SOLIDUS_GEM_NAMES = %w[core api backend sample]
-GEM_TASKS_NAME = %w[build install]
 
-GEM_TASKS_NAME.each do |task_name|
-  desc "Run rake gem:#{task} for each Solidus gem"
+%w[build install].each do |task_name|
+  desc "Run rake #{task} for each Solidus gem"
   task task_name do
     SOLIDUS_GEM_NAMES.each do |gem_name|
       cd(gem_name) { sh "rake #{task_name}" }
@@ -65,10 +64,12 @@ GEM_TASKS_NAME.each do |task_name|
   end
 end
 
-task :releasez do
-  require_relative 'core/lib/spree/core/version'
+# We need to redefine release task to skip creating and pushing git tag
+Rake::Task["release"].clear
+desc "Build and push solidus gems to RubyGems"
+task "release" => ["build", "release:guard_clean", "release:rubygem_push"] do
   SOLIDUS_GEM_NAMES.each do |gem_name|
-    sh "gem push #{gem_name}/pkg/solidus_#{gem_name}-#{Spree.solidus_version}.gem"
+    cd(gem_name) { sh "rake release:rubygem_push" }
   end
 end
 


### PR DESCRIPTION
## Summary

The tag creation is handled by GitHub Actions and thus doesn't need to happen while releasing the gems.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
