### PR TITLE
Call empty only on unshipped orders

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -46,7 +46,9 @@ module Spree
 
       def empty
         authorize! :update, @order, order_token
-        @order.empty!
+
+        @order.empty! unless @order.shipped?
+
         respond_with(@order, default_template: :show)
       end
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -399,6 +399,33 @@ describe "Order Details", type: :feature, js: true do
               expect(page).not_to have_selector('.fa-arrows-h')
               expect(page).not_to have_selector('.fa-trash')
             end
+
+            context 'and on the cart page the cart is emptied' do
+              it 'should show the empty cart page' do
+                order = create(:order_ready_to_ship)
+
+                visit spree.cart_admin_order_path(order)
+                order.fulfill!
+
+                ## simulate shipping order in another tab
+                shipment = order.shipments.first
+                order.shipping.ship(
+                  inventory_units: shipment.inventory_units,
+                  stock_location: shipment.stock_location,
+                  address: order.ship_address,
+                  shipping_method: shipment.shipping_method
+                )
+
+                click_on 'Empty Cart'
+
+                accept_alert 'Are you sure you want to delete this record?' do
+                  click_icon :ok
+                end
+
+                expect(page.current_path).to eq(spree.cart_admin_order_path(order))
+                expect(page).not_to have_content(order.line_items.first.variant.sku)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
## Summary

Fixes #4438.

The change triggers `@order.empty!` only when the shipping status is false.
The 500 is not triggered from the FE, but only from the BE. Nevertheless I tested manually for both cases.

**Notes:** 
1. I was not able to redirect to the Shipping action (`admin/order/xxxxxx/edit`), directions are welcome.
2. The test is failing on my local environment on interaction with the alert for confirming the emptying action. I am also not sure if that is the best location for the test itself. Please advise :) 

## Checklist
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- [x] II have added tests 