### PR TITLE
Skip ActionCable for Dummy Apps

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -44,6 +44,7 @@ module Spree
       opts[:skip_yarn] = true
       opts[:skip_bootsnap] = true
       opts[:skip_javascript] = true
+      opts[:skip_action_cable] = true
 
       puts "Generating dummy Rails application..."
       invoke Rails::Generators::AppGenerator,


### PR DESCRIPTION

## Summary

We don't really use ActionCable for anything as far as I know. Having it makes installing Turbo/Stimulus in extensions harder.

The installer for Turbo will look for a Gemfile in `Rails.root`, which is not there in case of the dummy app, and fail. If, however, `config/cable.yml` can't be found, the Turbo installer succeeds with a message that Turbo is installed, just without the broadcasting feature (which is alright for most apps I believe).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
