### PR TITLE
Exclude Rails 7.1 from the installer in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,23 +156,23 @@ commands:
             ruby -v >> /tmp/.ruby-versions
             gem --version >> /tmp/.gems-versions
             bundle --version >> /tmp/.gems-versions
-            gem search -eq rails >> /tmp/.gems-versions # get the latest rails from rubygems
+            gem search -eq rails -v "~> 7" -v"< 7.1" >> /tmp/.gems-versions # get the latest rails from rubygems
             gem search -eq solidus >> /tmp/.gems-versions # get the latest solidus from rubygems
 
             cat /tmp/.ruby-versions
             cat /tmp/.gems-versions
       - restore_cache:
           keys:
-            - solidus-installer-v8-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
-            - solidus-installer-v8-{{ checksum "/tmp/.ruby-versions" }}-
+            - solidus-installer-v9-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+            - solidus-installer-v9-{{ checksum "/tmp/.ruby-versions" }}-
       - run:
           name: "Prepare the rails application"
           command: |
             cd /tmp
-            test -d my_app || gem install rails solidus
+            test -d my_app || (gem install rails -v "< 7.1" && gem install solidus)
             test -d my_app || rails new my_app --skip-git
       - save_cache:
-          key: solidus-installer-v8-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+          key: solidus-installer-v9-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
           paths:
             - /tmp/my_app
             - /home/circleci/.rubygems
@@ -220,7 +220,8 @@ commands:
             mkdir -p /tmp/dummy_extension
             cd /tmp/dummy_extension
             bundle init
-            bundle add rails sqlite3 <<parameters.extra_gems>> --skip-install
+            bundle add rails -v "< 7.1" --skip-install
+            bundle add sqlite3 <<parameters.extra_gems>> --skip-install
             bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
             export LIB_NAME=set # dummy requireable file
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'


### PR DESCRIPTION
## Summary

Prevent the installer from using Rails 7.1, ref: #5420.
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
