### PR TITLE
Enhance log message for Bogus payments

### DIFF
--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -29,39 +29,44 @@ module Spree
 
     def authorize(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
+      message_detail = " - #{__method__}"
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'D' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'D' })
       else
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, { message: FAILURE_MESSAGE }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE  + message_detail, { message: FAILURE_MESSAGE + message_detail }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
+      message_detail = " - #{__method__}"
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'M' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'M' })
       else
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, message: FAILURE_MESSAGE + message_detail, test: true)
       end
     end
 
     def credit(_money, _credit_card, _response_code, _options = {})
-      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+      message_detail = " - #{__method__}"
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     def capture(_money, authorization, _gateway_options)
+      message_detail = " - #{__method__}"
       if authorization == '12345'
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true)
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true)
       else
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, error: FAILURE_MESSAGE, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, error: FAILURE_MESSAGE + message_detail, test: true)
       end
     end
 
     def void(_response_code, _credit_card, options = {})
+      message_detail = " - #{__method__}"
       if options[:originator].completed?
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE)
       else
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE)
       end
     end
 

--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -33,7 +33,7 @@ module Spree
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
         ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'D' })
       else
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE  + message_detail, { message: FAILURE_MESSAGE + message_detail }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, { message: FAILURE_MESSAGE + message_detail }, test: true)
       end
     end
 

--- a/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
@@ -8,26 +8,32 @@ module Spree
     end
 
     def authorize(_money, credit_card, _options = {})
+      message_detail = " - #{__method__}"
+
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, { message: FAILURE_MESSAGE }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, { message: FAILURE_MESSAGE }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
+      message_detail = " - #{__method__}"
+
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, message: FAILURE_MESSAGE, test: true)
       end
     end
 
     def void(_response_code, options = {})
+      message_detail = " - #{__method__}"
+
       if options[:originator].completed?
-        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE)
       else
-        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE + message_detail, {}, test: true, authorization: AUTHORIZATION_CODE)
       end
     end
   end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Spree::Refund, type: :model do
       expect { subject }.to change { refund.perform_response }.from(nil)
 
       expect(refund.perform_response).to be_a(ActiveMerchant::Billing::Response)
-      expect(refund.perform_response.message).to eq(Spree::PaymentMethod::BogusCreditCard::SUCCESS_MESSAGE)
+      expect(refund.perform_response.message).to include(Spree::PaymentMethod::BogusCreditCard::SUCCESS_MESSAGE)
     end
 
     it "sets a transaction_id" do


### PR DESCRIPTION
## Summary

Fixes #4867.

For both bogus_credit_card and simple_bogus_credit_card, identifies the method from which the message is being created and adds that information to the log.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
