### PR TITLE
Extract the table search field to a component

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/input/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/input/component.rb
@@ -32,6 +32,7 @@ class SolidusAdmin::UI::Forms::Input::Component < SolidusAdmin::BaseComponent
     datetime-local
     month
     week
+    search
     time
   ]).freeze
 

--- a/admin/app/components/solidus_admin/ui/forms/search_field/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/search_field/component.html.erb
@@ -1,0 +1,20 @@
+<label
+  data-controller="<%= stimulus_id %>"
+  class="items-center gap-1 p-0 inline-flex w-full justify-start relative"
+>
+  <%= render component("ui/icon").new(
+    name: "search-line",
+    class: "w-[1.4em] h-[1.4em] fill-gray-500 absolute ml-3",
+  ) %>
+  <%= render component("ui/forms/input").new(**@attributes) %>
+  <button
+    class="absolute right-0 mr-3 peer-placeholder-shown:hidden"
+    data-action="<%= stimulus_id %>#clear"
+    aria-label="<%= t('.clear') %>"
+  >
+    <%= render component("ui/icon").new(
+      name: "close-circle-fill",
+      class: "w-[1.4em] h-[1.4em] fill-gray-500"
+    ) %>
+  </button>
+</label>

--- a/admin/app/components/solidus_admin/ui/forms/search_field/component.js
+++ b/admin/app/components/solidus_admin/ui/forms/search_field/component.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input"]
+
+  clear() {
+    this.inputTarget.value = ""
+  }
+}

--- a/admin/app/components/solidus_admin/ui/forms/search_field/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/search_field/component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Forms::SearchField::Component < SolidusAdmin::BaseComponent
+  def initialize(**attributes)
+    @attributes = attributes
+    @attributes[:type] ||= :search
+    @attributes[:class] = "search-cancel:appearance-none peer !px-10 #{@attributes[:class]}"
+    @attributes[:"data-#{stimulus_id}-target"] = "input"
+  end
+end

--- a/admin/app/components/solidus_admin/ui/forms/search_field/component.yml
+++ b/admin/app/components/solidus_admin/ui/forms/search_field/component.yml
@@ -1,0 +1,2 @@
+en:
+  clear: Clear

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -31,25 +31,13 @@
           "data-action": "input->#{stimulus_id}#search change->#{stimulus_id}#search",
         },
       ) do |form| %>
-        <label class="items-center gap-1 p-0 inline-flex w-full justify-start relative">
-          <%= render component("ui/icon").new(name: 'search-line', class: "w-[1.4em] h-[1.4em] fill-gray-500 absolute ml-3") %>
-          <input
-            name="<%= "#{@search_param}[#{@search_key}]" %>"
-            value="<%= params.dig(@search_param, @search_key) %>"
-            type="search"
-            placeholder="<%= t('.search_placeholder', resources: resource_plural_name) %>"
-            class="peer w-full placeholder:text-gray-400 py-1.5 px-10 bg-white rounded border border-gray-300 search-cancel:appearance-none"
-            data-<%= stimulus_id %>-target="searchField"
-            aria-label="<%= t('.search_placeholder', resources: resource_plural_name) %>"
-          >
-          <button
-            class="absolute right-0 mr-3 peer-placeholder-shown:hidden"
-            data-action="<%= stimulus_id %>#clearSearch"
-            aria-label="<%= t('.clear') %>"
-          >
-            <%= render component("ui/icon").new(name: 'close-circle-fill', class: "w-[1.4em] h-[1.4em] fill-gray-500") %>
-          </button>
-        </label>
+        <%= render component('ui/forms/search_field').new(
+          name: "#{@search_param}[#{@search_key}]",
+          value: params.dig(@search_param, @search_key),
+          placeholder: t('.search_placeholder', resources: resource_plural_name),
+          "data-#{stimulus_id}-target": "searchField",
+          "aria-label": t('.search_placeholder', resources: resource_plural_name)
+        ) %>
       <% end %>
 
       <div class="ml-4">

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -45,11 +45,6 @@ export default class extends Controller {
     this.searchFormTarget.requestSubmit()
   }
 
-  clearSearch() {
-    this.searchFieldTarget.value = ''
-    this.search()
-  }
-
   cancelSearch() {
     this.clearSearch()
 

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -7,5 +7,4 @@ en:
   search_placeholder: 'Search all %{resources}'
   refine_search: 'Refine Search'
   batch_actions: Batch actions
-  clear: Clear
   cancel: Cancel

--- a/admin/spec/components/previews/solidus_admin/ui/forms/search_field/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/search_field/component_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# @component "ui/forms/search_field"
+class SolidusAdmin::UI::Forms::SearchField::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/forms/search_field/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/search_field/component_preview/overview.html.erb
@@ -1,0 +1,7 @@
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Default
+  </h6>
+
+  <%= render current_component.new %>
+</div>

--- a/admin/spec/components/solidus_admin/ui/forms/search_field/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/search_field/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Forms::SearchField::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

<img width="1122" alt="image" src="https://github.com/solidusio/solidus/assets/1051/2a17876c-8bae-433a-8a8e-f74104ae40dc">


Uses `ui/forms/input` under the hood, inheriting from it full styling.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
