### PR TITLE
[Admin] Ensure labels are clickable by parameterizing ids

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/ransack_filter/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/ransack_filter/component.rb
@@ -26,7 +26,7 @@ class SolidusAdmin::UI::Table::RansackFilter::Component < SolidusAdmin::BaseComp
   def before_render
     @selections = @options.map.with_index do |(label, value), opt_index|
       Selection.new(
-        "#{stimulus_id}--#{label}-#{value}",
+        "#{stimulus_id}--#{label}-#{value}".parameterize,
         label,
         build(:attribute, @attribute, opt_index),
         build(:predicate, @predicate, opt_index),


### PR DESCRIPTION
## Summary

In certain instances within `SolidusAdmin::UI::Table::RansackFilter::Component`, labels were not clickable due to spaces in their associated IDs, which occurred when the label or option value contained spaces.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
