### PR TITLE
Extract a `products/stock` component

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -96,7 +96,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
   def status_column
     {
       header: :status,
-      data: ->(product) { component('products/status').new(product: product) }
+      data: ->(product) { component('products/status').from_product(product) }
     }
   end
 

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -103,22 +103,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
   def stock_column
     {
       header: :stock,
-      data: ->(product) do
-        stock_info =
-          case (on_hand = product.total_on_hand)
-          when Float::INFINITY
-            content_tag :span, t('.stock.in_stock', on_hand: t('.stock.infinity')), class: 'text-forest'
-          when 1..Float::INFINITY
-            content_tag :span, t('.stock.in_stock', on_hand: on_hand), class: 'text-forest'
-          else
-            content_tag :span, t('.stock.in_stock', on_hand: on_hand), class: 'text-red-500'
-          end
-
-        variant_info =
-          t('.for_variants', count: product.variants.count)
-
-        content_tag :div, safe_join([stock_info, variant_info], ' ')
-      end
+      data: ->(product) { component('products/stock').from_product(product) }
     }
   end
 

--- a/admin/app/components/solidus_admin/products/index/component.yml
+++ b/admin/app/components/solidus_admin/products/index/component.yml
@@ -1,10 +1,6 @@
 en:
   product_image: 'Image'
   add_product: 'Add Product'
-  stock:
-    infinity: '∞'
-    in_stock: '%{on_hand} in stock'
-  for_variants: 'for %{count} variants'
   batch_actions:
     delete: 'Delete'
     discontinue: 'Discontinue'

--- a/admin/app/components/solidus_admin/products/show/component.html.erb
+++ b/admin/app/components/solidus_admin/products/show/component.html.erb
@@ -9,7 +9,7 @@
     ) %>
     <h1 class="flex items-center gap-2">
       <span class="body-title"><%= @product.name %></span>
-      <%= render component("products/status").new(product: @product) %>
+      <%= render component("products/status").from_product(@product) %>
     </h1>
 
     <div class="ml-auto flex gap-2 items-center">

--- a/admin/app/components/solidus_admin/products/status/component.rb
+++ b/admin/app/components/solidus_admin/products/status/component.rb
@@ -1,31 +1,23 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::Products::Status::Component < SolidusAdmin::BaseComponent
-  COLORS = {
+  STATUSES = {
     available: :green,
     discontinued: :red
   }.freeze
 
-  # @param product [Spree::Product]
-  def initialize(product:)
-    @product = product
+  def self.from_product(product)
+    new(status: product.available? ? :available : :discontinued)
+  end
+
+  def initialize(status:)
+    @status = status
   end
 
   def call
     render component('ui/badge').new(
-      name: t(".#{status}"),
-      color: COLORS.fetch(status)
+      name: t(".#{@status}"),
+      color: STATUSES.fetch(@status)
     )
-  end
-
-  # @return [Symbol]
-  #   :available when the product is available
-  #   :discontinued when the product is not available
-  def status
-    if @product.available?
-      :available
-    else
-      :discontinued
-    end
   end
 end

--- a/admin/app/components/solidus_admin/products/stock/component.rb
+++ b/admin/app/components/solidus_admin/products/stock/component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Products::Stock::Component < SolidusAdmin::BaseComponent
+  def self.from_product(product)
+    new(
+      on_hand: product.total_on_hand,
+      variants_count: product.variants.count,
+    )
+  end
+
+  def initialize(on_hand:, variants_count:)
+    @on_hand = on_hand
+    @variants_count = variants_count
+  end
+
+  def call
+    stock_info =
+      case @on_hand
+      when Float::INFINITY
+        tag.span t('.stock.in_stock', on_hand: t('.stock.infinity')), class: 'text-forest'
+      when 1..Float::INFINITY
+        tag.span t('.stock.in_stock', on_hand: @on_hand), class: 'text-forest'
+      else
+        tag.span t('.stock.in_stock', on_hand: @on_hand), class: 'text-red-500'
+      end
+
+    variant_info = t('.for_variants', count: @variants_count)
+
+    tag.div safe_join([stock_info, variant_info], ' ')
+  end
+end

--- a/admin/app/components/solidus_admin/products/stock/component.yml
+++ b/admin/app/components/solidus_admin/products/stock/component.yml
@@ -1,0 +1,5 @@
+en:
+  stock:
+    infinity: '∞'
+    in_stock: '%{on_hand} in stock'
+  for_variants: 'for %{count} variants'

--- a/admin/spec/components/previews/solidus_admin/products/status/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/products/status/component_preview.rb
@@ -5,26 +5,6 @@ class SolidusAdmin::Products::Status::ComponentPreview < ViewComponent::Preview
   include SolidusAdmin::Preview
 
   def overview
-    render_with_template(locals:
-      {
-        definitions: {
-          available: available_component,
-          discontinued: discontinued_component
-        }
-      })
-  end
-
-  private
-
-  def available_component
-    current_component.new(
-      product: Spree::Product.new(available_on: Time.current)
-    )
-  end
-
-  def discontinued_component
-    current_component.new(
-      product: Spree::Product.new(available_on: nil)
-    )
+    render_with_template
   end
 end

--- a/admin/spec/components/previews/solidus_admin/products/status/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/products/status/component_preview/overview.html.erb
@@ -1,16 +1,15 @@
-<table>
-  <thead>
-    <tr>
-      <% definitions.each_key do |status| %>
-        <th class="px-3 py-1 text-gray-500 text-center"><%= status.to_s.humanize %></th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <% definitions.each_value do |component| %>
-        <th class="px-3 py-1"><%= render component %></th>
-      <% end %>
-    </tr>
-  </tbody>
-</table>
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Available
+  </h6>
+
+  <%= render current_component.new(status: :available) %>
+</div>
+
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Discontinued
+  </h6>
+
+  <%= render current_component.new(status: :discontinued) %>
+</div>

--- a/admin/spec/components/previews/solidus_admin/products/stock/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/products/stock/component_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# @component "products/stock"
+class SolidusAdmin::Products::Stock::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/products/stock/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/products/stock/component_preview/overview.html.erb
@@ -1,0 +1,31 @@
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    In Stock
+  </h6>
+
+  <%= render current_component.new(on_hand: 32, variants_count: 12) %>
+</div>
+
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Infinite stock
+  </h6>
+
+  <%= render current_component.new(on_hand: Float::INFINITY, variants_count: 12) %>
+</div>
+
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Out of stock
+  </h6>
+
+  <%= render current_component.new(on_hand: 0, variants_count: 12) %>
+</div>
+
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Negative stock
+  </h6>
+
+  <%= render current_component.new(on_hand: -10, variants_count: 12) %>
+</div>

--- a/admin/spec/components/solidus_admin/products/status/component_spec.rb
+++ b/admin/spec/components/solidus_admin/products/status/component_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe SolidusAdmin::Products::Status::Component, type: :component do
     it "returns :available when the product is available" do
       product = Spree::Product.new(available_on: Time.current)
 
-      component = described_class.new(product: product)
+      render_inline described_class.from_product(product)
 
-      expect(component.status).to eq(:available)
+      expect(rendered_content).to have_text("Available")
     end
 
     it "returns :discontinued when the product is not available" do
       product = Spree::Product.new(available_on: nil)
 
-      component = described_class.new(product: product)
+      render_inline described_class.from_product(product)
 
-      expect(component.status).to eq(:discontinued)
+      expect(rendered_content).to have_text("Discontinued")
     end
   end
 end

--- a/admin/spec/components/solidus_admin/products/stock/component_spec.rb
+++ b/admin/spec/components/solidus_admin/products/stock/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::Products::Stock::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

<img width="337" alt="image" src="https://github.com/solidusio/solidus/assets/1051/18fc6b03-ee5e-4718-98e5-315b44c66d60">

Both the stock and status component now accept basic values in the initializer and have an alternative `from_product` constructor that will get those basic values from a Spree::Product object.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
