### PR TITLE
[Admin] Construct base components for order creation in admin interface

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/index/component.html.erb
@@ -9,7 +9,7 @@
       <%= render component("ui/button").new(
         tag: :a,
         text: t('.create_order'),
-        href: spree.new_admin_order_path,
+        href: solidus_admin.new_order_path,
         icon: "add-line",
       ) %>
     </div>

--- a/admin/app/components/solidus_admin/orders/new/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/new/component.html.erb
@@ -1,0 +1,20 @@
+<div class="px-4 relative" data-controller="<%= stimulus_id %>">
+  <header class="py-6 flex items-center gap-4">
+    <%= render component("ui/button").new(
+      tag: :a,
+      title: t(".back"),
+      icon: "arrow-left-line",
+      scheme: :secondary,
+      href: solidus_admin.orders_path
+    ) %>
+    <h1 class="flex items-center gap-2">
+      <span class="body-title"><%= t(".create_order") %></span>
+    </h1>
+
+    <div class="ml-auto flex gap-2 items-center">
+      <%= render component("feedback").new %>
+      <%= render component("ui/button").new(tag: :button, scheme: :secondary, text: t(".discard"), form: form_id) %>
+      <%= render component("ui/button").new(tag: :button, text: t(".save"), form: form_id) %>
+    </div>
+  </header>
+</div>

--- a/admin/app/components/solidus_admin/orders/new/component.js
+++ b/admin/app/components/solidus_admin/orders/new/component.js
@@ -1,0 +1,5 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+
+}

--- a/admin/app/components/solidus_admin/orders/new/component.rb
+++ b/admin/app/components/solidus_admin/orders/new/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::New::Component < SolidusAdmin::BaseComponent
+  def initialize(order:)
+    @order = order
+  end
+
+  def form_id
+    @form_id ||= "#{stimulus_id}--form-#{@order.id}"
+  end
+end

--- a/admin/app/components/solidus_admin/orders/new/component.yml
+++ b/admin/app/components/solidus_admin/orders/new/component.yml
@@ -1,0 +1,6 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  create_order: Create Order
+  save: Save
+  discard: Discard

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -19,11 +19,15 @@ module SolidusAdmin
     end
 
     def new
-      Spree::Order.new(
+      @order = Spree::Order.new(
         created_by: current_solidus_admin_user,
         frontend_viewable: false,
         store_id: current_store.try(:id)
       )
+
+      respond_to do |format|
+        format.html { render component('orders/new').new(order: @order) }
+      end
     end
   end
 end

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -17,5 +17,13 @@ module SolidusAdmin
         format.html { render component('orders/index').new(page: @page) }
       end
     end
+
+    def new
+      Spree::Order.new(
+        created_by: current_solidus_admin_user,
+        frontend_viewable: false,
+        store_id: current_store.try(:id)
+      )
+    end
   end
 end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -13,5 +13,5 @@ SolidusAdmin::Engine.routes.draw do
       put :activate
     end
   end
-  resources :orders, only: :index
+  resources :orders, only: [:index, :new, :create]
 end

--- a/admin/spec/components/previews/solidus_admin/orders/new/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/orders/new/component_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# @component "orders/new"
+class SolidusAdmin::Orders::New::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template(locals: { order: Spree::Order.new })
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/orders/new/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/orders/new/component_preview/overview.html.erb
@@ -1,0 +1,3 @@
+<div class="mb-8">
+  <%= render current_component.new(order: order) %>
+</div>

--- a/admin/spec/components/solidus_admin/orders/new/component_spec.rb
+++ b/admin/spec/components/solidus_admin/orders/new/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::Orders::New::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

This PR lays the foundation for the `orders/new` component and integrates basic UI elements within `solidus_admin`.

- Used the component generator to create the `orders/new` component
- Incorporated an action to render the new component
- Header and UI buttons:
   - Added a header with `Save` and `Discard` buttons
   - The buttons are currently non-functional, serving as UI placeholders for upcoming feature integrations

<img width="1820" alt="Screenshot 2023-10-12 at 16 57 03" src="https://github.com/solidusio/solidus/assets/19948291/11077294-529d-4e50-882b-70e35596f407">



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
