### PR TITLE
SolidusAdmin `products/stock` component fixes

### DIFF
--- a/admin/app/components/solidus_admin/products/stock/component.rb
+++ b/admin/app/components/solidus_admin/products/stock/component.rb
@@ -26,6 +26,6 @@ class SolidusAdmin::Products::Stock::Component < SolidusAdmin::BaseComponent
 
     variant_info = t('.for_variants', count: @variants_count)
 
-    tag.div safe_join([stock_info, variant_info], ' ')
+    tag.span safe_join([stock_info, variant_info], ' ')
   end
 end

--- a/admin/app/components/solidus_admin/products/stock/component.rb
+++ b/admin/app/components/solidus_admin/products/stock/component.rb
@@ -8,6 +8,13 @@ class SolidusAdmin::Products::Stock::Component < SolidusAdmin::BaseComponent
     )
   end
 
+  def self.from_variant(variant)
+    new(
+      on_hand: variant.total_on_hand,
+      variants_count: nil,
+    )
+  end
+
   def initialize(on_hand:, variants_count:)
     @on_hand = on_hand
     @variants_count = variants_count
@@ -24,7 +31,7 @@ class SolidusAdmin::Products::Stock::Component < SolidusAdmin::BaseComponent
         tag.span t('.stock.in_stock', on_hand: @on_hand), class: 'text-red-500'
       end
 
-    variant_info = t('.for_variants', count: @variants_count)
+    variant_info = t('.for_variants', count: @variants_count) if @variants_count
 
     tag.span safe_join([stock_info, variant_info], ' ')
   end

--- a/admin/spec/components/solidus_admin/products/stock/component_spec.rb
+++ b/admin/spec/components/solidus_admin/products/stock/component_spec.rb
@@ -6,4 +6,30 @@ RSpec.describe SolidusAdmin::Products::Stock::Component, type: :component do
   it "renders the overview preview" do
     render_preview(:overview)
   end
+
+  describe ".from_variant" do
+    it "has an empty variants count" do
+      allow(described_class).to receive(:new)
+
+      described_class.from_variant(instance_double(Spree::Variant, total_on_hand: 123))
+
+      expect(described_class).to have_received(:new).with(
+        on_hand: 123,
+        variants_count: nil,
+      )
+    end
+  end
+
+  describe ".from_product" do
+    it "has an empty variants count" do
+      allow(described_class).to receive(:new)
+
+      described_class.from_product(instance_double(Spree::Product, total_on_hand: 123, variants: []))
+
+      expect(described_class).to have_received(:new).with(
+        on_hand: 123,
+        variants_count: 0,
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- add tests for `.from_products`
- add `.from_variant` tu support stock information for a single variant


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
