### PR TITLE
Solidus legacy color hierarchy

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_hint.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_hint.scss
@@ -1,3 +1,7 @@
 .hint-tooltip {
   cursor: pointer;
+
+  i {
+    color: $color-dark-light;
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -129,7 +129,9 @@ $color-navbar-hover: $color-navbar !default;
 
       &::before,
       svg {
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         width: 18px;
         height: 18px;
         padding: 0;

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -122,7 +122,7 @@ $color-navbar-hover: $color-navbar !default;
       padding: 2px 12px;
       width: 100%;
       border-radius: $border-radius;
-      color: $color-primary;
+      color: $solidus-admin-gray-800;
       gap: 12px;
       display: flex;
       align-items: center;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -38,6 +38,7 @@ table {
         text-align: center;
         border-bottom: none;
         vertical-align: middle;
+        color: $color-dark-light;
 
         &:before {
           padding: 0;
@@ -111,6 +112,10 @@ table {
 
   th a {
     color: $color-dark;
+
+    &:hover {
+      color: $color-dark-light;
+    }
   }
 
   tbody {

--- a/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/themes/solidus_admin/_variables.scss
@@ -19,10 +19,10 @@ $color-dark-dark: $solidus-admin-gray-600;
 $color-dark-light: $solidus-admin-gray-500;
 $color-dark-accent: $solidus-admin-gray-200;
 
-$color-primary: $solidus-admin-black;
+$color-primary: $solidus-admin-gray-700;
 $color-primary-light: $solidus-admin-gray-100;
 
-$color-light: $solidus-admin-gray-15;
+$color-light: $solidus-admin-gray-25;
 $color-light-dark: $solidus-admin-gray-50;
 $color-light-accent: $solidus-admin-gray-100;
 
@@ -49,10 +49,10 @@ $color-navbar-active: $solidus-admin-solidus-red;
 $color-navbar-active-bg: $solidus-admin-gray-50;
 $color-navbar-submenu: $color-dark-light;
 $color-navbar-submenu-bg: $color-light;
-$color-navbar-submenu-active: $color-primary;
+$color-navbar-submenu-active: $solidus-admin-solidus-red;
 $color-navbar-footer: $color-dark;
 $color-navbar-footer-bg: $color-light;
-$color-navbar-footer-active: $color-primary;
+$color-navbar-footer-active: $solidus-admin-solidus-red;
 $color-icon-navbar: $color-dark-light;
 
 $color-navbar-hover-bg: $solidus-admin-gray-50;
@@ -61,7 +61,7 @@ $color-navbar-hover: $color-dark;
 // Basic Tabs colors
 $color-tab: $color-dark-light;
 $color-tab-bg: $color-light;
-$color-tab-border: $color-border;
+$color-tab-border: $color-light-accent;
 $color-tab-active: $color-primary;
 $color-tab-active-bg: $color-white;
 $color-tab-active-border: $color-white;
@@ -74,6 +74,7 @@ $color-error: $color-red;
 // Breadcrumb custom variable
 
 $breadcrumb-color: $color-dark-light;
+$breadcrumb-active-color: $color-dark;
 
 // Color for spinner
 $color-spinner: $color-white;
@@ -157,4 +158,14 @@ $main-header-height: 84px;
 $content-wrapper-bg: $color-white;
 $admin-body-bg: $color-white;
 
-$link-hover-color: $solidus-admin-solidus-red;
+// Links
+//--------------------------------------------------------------
+
+$link-color: $solidus-admin-blue;
+$link-hover-color: darken($solidus-admin-blue, 10%);
+
+// Pagination
+//--------------------------------------------------------------
+
+$pagination-color: $color-primary;
+$pagination-hover-color: $color-dark;


### PR DESCRIPTION
## Summary
When the Solidus Admin colors were extracted in a different file, we followed the color hierarchy of the New Solidus Admin Panel, in which the primary color is black. If this works in an admin panel where the UI has been updated, it creates issues on the Solidus Legacy version that loses its primary blue color.

In this PR, we have improved the color hierarchy for the Solidus Legacy version to facilitate user interactions.
e.g. understanding an element is clickable, having a hover effect on primary buttons, and keeping icons aligned on custom menu items.

| Before  | After |
| ------------- | ------------- |
| <img width="1269" alt="Screenshot 2023-10-20 at 18 42 13" src="https://github.com/solidusio/solidus/assets/46188345/e0574e87-244d-4636-9e66-a51ca8a00eb8"> | <img width="1264" alt="Screenshot 2023-10-23 at 14 45 09" src="https://github.com/solidusio/solidus/assets/46188345/3781d8c3-8b8b-4150-a9c5-20b9af3191f4"> |
| <img width="1269" alt="Screenshot 2023-10-20 at 18 10 49" src="https://github.com/solidusio/solidus/assets/46188345/4604d96a-c580-43dd-877b-5e0e48579f26"> | <img width="1266" alt="Screenshot 2023-10-23 at 14 45 29" src="https://github.com/solidusio/solidus/assets/46188345/541a4795-fc38-412d-a74b-76abe5e65cba"> |
| <img width="1266" alt="Screenshot 2023-10-23 at 14 46 58" src="https://github.com/solidusio/solidus/assets/46188345/b4a12b45-773c-4500-bbeb-a1466c87b8b9"> | <img width="1265" alt="Screenshot 2023-10-23 at 14 46 16" src="https://github.com/solidusio/solidus/assets/46188345/5191e562-16b4-484c-b82c-673c3863a50e"> | 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
