### PR TITLE
4860-deprecate-and-remove-dashboards-code

### DIFF
--- a/backend/app/controllers/spree/admin/dashboards_controller.rb
+++ b/backend/app/controllers/spree/admin/dashboards_controller.rb
@@ -3,8 +3,9 @@
 module Spree
   module Admin
     class DashboardsController < BaseController
-      class << self
-         Spree.deprecator.warn "The Dashboards controller is deprecated. Please use the new admin dashboard."
+      before_action :deprecate
+      def deprecate
+        Spree.deprecator.warn "The #{self.class.name} is deprecated. If you still use dashboards, please copy all controllers and views from solidus_backend to your application."
       end
     end
   end

--- a/backend/app/controllers/spree/admin/dashboards_controller.rb
+++ b/backend/app/controllers/spree/admin/dashboards_controller.rb
@@ -3,6 +3,12 @@
 module Spree
   module Admin
     class DashboardsController < BaseController
+      class << self
+        ActiveSupport::Deprecation.warn(
+          "The Dashboard controller is deprecated." \
+          "Please update your source code."
+        )
+      end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/dashboards_controller.rb
+++ b/backend/app/controllers/spree/admin/dashboards_controller.rb
@@ -4,10 +4,7 @@ module Spree
   module Admin
     class DashboardsController < BaseController
       class << self
-        ActiveSupport::Deprecation.warn(
-          "The Dashboard controller is deprecated." \
-          "Please update your source code."
-        )
+         Spree.deprecator.warn "The Dashboards controller is deprecated. Please use the new admin dashboard."
       end
     end
   end

--- a/backend/app/views/spree/admin/dashboards/home.html.erb
+++ b/backend/app/views/spree/admin/dashboards/home.html.erb
@@ -1,2 +1,2 @@
 <%# Placeholder view for a home dashboard %>
-<% Spree.deprecator.warn "Using the #{@virtual_path.inspect} is deprecated, please use The new admin dashboard." %>
+<p><%= Spree.deprecator.warn "The Home view is deprecated, If you still use dashboards, please copy all controllers and views from solidus_backend to your application." %></p>

--- a/backend/app/views/spree/admin/dashboards/home.html.erb
+++ b/backend/app/views/spree/admin/dashboards/home.html.erb
@@ -1,1 +1,2 @@
 <%# Placeholder view for a home dashboard %>
+<% Spree.deprecator.warn "Using the #{@virtual_path.inspect} is deprecated, please use The new admin dashboard." %>

--- a/backend/spec/controllers/spree/admin/dashboards_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/dashboards_controller_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Spree::Admin::DashboardsController, type: :controller do
-    it 'emits a warning' do
-      expect(Spree.deprecator).to receive(:warn)
+    it 'displays a warning' do
+      expect(Spree.deprecator).to receive(:deprecate)
     end
 end

--- a/backend/spec/controllers/spree/admin/dashboards_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/dashboards_controller_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Spree::Admin::DashboardsController, type: :controller do
+    it 'emits a warning' do
+      expect(Spree.deprecator).to receive(:warn)
+    end
+end

--- a/backend/spec/views/spree/admin/shared/home_spec.rb
+++ b/backend/spec/views/spree/admin/shared/home_spec.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'spree/admin/dashboards/home', type: :view, partial_double_verification: false do
   it 'renders the home view' do
     render
-    expect(rendered).to match('The Home view is deprecated')
+
+    expect(rendered).to match /The Home view is deprecated/
   end
 end

--- a/backend/spec/views/spree/admin/shared/home_spec.rb
+++ b/backend/spec/views/spree/admin/shared/home_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'spree/admin/dashboards/home', type: :view, partial_double_verification: false do
+  it 'renders the home view' do
+    render
+    expect(rendered).to match('The Home view is deprecated')
+  end
+end

--- a/core/lib/spree/permission_sets/dashboard_display.rb
+++ b/core/lib/spree/permission_sets/dashboard_display.rb
@@ -9,6 +9,7 @@ module Spree
     # customizations.
     class DashboardDisplay < PermissionSets::Base
       def activate!
+          ActiveSupport::Deprecation.warn('The Spree::PermissionSets::DashboardDisplay module is being deprecated.  Please use the new admin dashboard.')
           can [:admin, :home], :dashboards
       end
     end

--- a/core/lib/spree/permission_sets/dashboard_display.rb
+++ b/core/lib/spree/permission_sets/dashboard_display.rb
@@ -9,7 +9,8 @@ module Spree
     # customizations.
     class DashboardDisplay < PermissionSets::Base
       def activate!
-          ActiveSupport::Deprecation.warn('The Spree::PermissionSets::DashboardDisplay module is being deprecated.  Please use the new admin dashboard.')
+          Spree.deprecator.warn "The Spree::PermissionSets::DashboardDisplay module is deprecated. " \
+            "Please use the new admin dashboard."
           can [:admin, :home], :dashboards
       end
     end

--- a/core/lib/spree/permission_sets/dashboard_display.rb
+++ b/core/lib/spree/permission_sets/dashboard_display.rb
@@ -9,8 +9,8 @@ module Spree
     # customizations.
     class DashboardDisplay < PermissionSets::Base
       def activate!
-          Spree.deprecator.warn "The Spree::PermissionSets::DashboardDisplay module is deprecated. " \
-            "Please use the new admin dashboard."
+          Spree.deprecator.warn "The #{self.class.name} module is deprecated. " \
+            "If you still use dashboards, please copy all controllers and views from #{self.class.name} to your application."
           can [:admin, :home], :dashboards
       end
     end

--- a/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
 
   context "when activated" do
     before do
+      ActiveSupport::Deprecation.warn('The dashboard_display_spec.rb test is being deprecated.  Please update your source code.')
       described_class.new(ability).activate!
     end
 
@@ -18,6 +19,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
   end
 
   context "when not activated" do
+    ActiveSupport::Deprecation.warn('The dashboard_display_spec.rb test is being deprecated.  Please update your source code.')
     it { is_expected.not_to be_able_to(:admin, :dashboards) }
     it { is_expected.not_to be_able_to(:home, :dashboards) }
   end

--- a/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
 
   context "when activated" do
     before do
-      ActiveSupport::Deprecation.warn('The dashboard_display_spec.rb test is being deprecated.  Please update your source code.')
+      Spree.Deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
       described_class.new(ability).activate!
     end
 
@@ -19,7 +19,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
   end
 
   context "when not activated" do
-    ActiveSupport::Deprecation.warn('The dashboard_display_spec.rb test is being deprecated.  Please update your source code.')
+    Spree.Deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
     it { is_expected.not_to be_able_to(:admin, :dashboards) }
     it { is_expected.not_to be_able_to(:home, :dashboards) }
   end

--- a/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
 
   context "when activated" do
     before do
-      Spree.Deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
+      Spree.deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
       described_class.new(ability).activate!
     end
 
@@ -19,7 +19,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
   end
 
   context "when not activated" do
-    Spree.Deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
+    Spree.deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
     it { is_expected.not_to be_able_to(:admin, :dashboards) }
     it { is_expected.not_to be_able_to(:home, :dashboards) }
   end


### PR DESCRIPTION
## Summary


  Fixes #4860 
  This PR adds deprecation warnings to the following views and controllers:

-   [DashboardsController](https://github.com/solidusio/solidus/blob/main/backend/app/controllers/spree/admin/dashboards_controller.rb)
- [Home View](https://github.com/solidusio/solidus/blob/main/backend/app/views/spree/admin/dashboards/home.html.erb)
- [Dashboards Display](https://github.com/solidusio/solidus/blob/main/core/lib/spree/permission_sets/dashboard_display.rb)
- [Dashboards Display Spec](https://github.com/solidusio/solidus/blob/main/core/spec/models/spree/permission_sets/dashboard_display_spec.rb)



