### PR TITLE
[Admin] Fix `ui/table/toolbar` & restore `clearSearch` & Streamline `feedback` rendering

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/index/component.html.erb
@@ -5,7 +5,6 @@
     </h1>
 
     <div class="ml-auto flex gap-2 items-center">
-      <%= render component("feedback").new %>
       <%= render component("ui/button").new(
         tag: :a,
         text: t('.create_order'),

--- a/admin/app/components/solidus_admin/orders/new/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/new/component.html.erb
@@ -5,7 +5,6 @@
     <%= page_header_title t(".create_order") %>
 
     <%= page_header_actions do %>
-      <%= render component("feedback").new %>
       <%= render component("ui/button").new(tag: :button, scheme: :secondary, text: t(".discard"), form: form_id) %>
       <%= render component("ui/button").new(tag: :button, text: t(".save"), form: form_id) %>
     <% end %>

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -2,7 +2,6 @@
   <%= page_header do %>
     <%= page_header_title title %>
     <%= page_header_actions do %>
-      <%= render component("feedback").new %>
       <%= render component("ui/button").new(
         tag: :a,
         text: t('.add_product'),

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -45,6 +45,11 @@ export default class extends Controller {
     this.searchFormTarget.requestSubmit()
   }
 
+  clearSearch() {
+    this.searchFieldTarget.value = ''
+    this.search()
+  }
+
   cancelSearch() {
     this.clearSearch()
 

--- a/admin/app/components/solidus_admin/ui/table/toolbar/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/toolbar/component.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Table::Toolbar::Component < SolidusAdmin::BaseComponent
-  erb_template <<~ERB
-    <div class="
-      h-14 p-2 bg-white border-b border-gray-100
-      justify-start items-center gap-2
-      visible:flex hidden:hidden
-      rounded-t-lg
-    ">
-      <%= content %>
-    </div>
-  ERB
+  def initialize(**options)
+    @options = options
+  end
+
+  def call
+    tag.div(
+      content,
+      **@options,
+      class: "
+        h-14 p-2 bg-white border-b border-gray-100
+        justify-start items-center gap-2
+        visible:flex hidden:hidden
+        rounded-t-lg
+        #{@options[:class]}
+      "
+    )
+  end
 end


### PR DESCRIPTION
## Summary

This PR addresses three fixes:
1. Updated the `ui/table/toolbar` component to support additional parameters correctly.
2. Restored the previously removed `clearSearch` function, ensuring the search functionality works as expected.
3. Removed a redundant rendering of the `feedback` component in the Orders and Products tables, leveraging the `page_header_actions` helper: https://github.com/solidusio/solidus/pull/5445.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
