### PR TITLE
Do not require active_storage/engine

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -6,7 +6,6 @@ require "action_view/railtie"
 require "active_job/railtie"
 require "active_model/railtie"
 require "active_record/railtie"
-require "active_storage/engine"
 require "sprockets/railtie"
 
 require 'active_support/deprecation'


### PR DESCRIPTION
## Summary

The activestorage adapter is optional and stores might use another attachment adapter (ie. paperclip). We do not have it as dependency in our `gemspec`.

Since bundler already requires activestorage if the store decided to use activestorage adapter (either via a direct dependency or the transient `rails` gem) we do not need to require it in our engine.

This removes a `LoadError` for stores/engines that do not use activestorage.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
