### PR TITLE
[4.0] Update pinned chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.3
+  browser-tools: circleci/browser-tools@1.4.6
   codecov: codecov/codecov@3.2.3
 
 executors:
@@ -58,8 +58,18 @@ commands:
   setup:
     steps:
       - checkout
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "118.0.5993.70"
+          replace-existing: true
+      - run:
+          name: Check chrome version
+          command: |
+            google-chrome --version
       - browser-tools/install-chromedriver
+      - run:
+          name: Check chromedriver version
+          command: |
+            chromedriver --version
       - run:
           name: "Lock dependencies"
           command: |


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.0`:
 - [Merge pull request #5459 from tvdeyen/revert-5367](https://github.com/solidusio/solidus/pull/5459)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)