### PR TITLE
Configurable promotion handlers

### DIFF
--- a/api/app/controllers/spree/api/coupon_codes_controller.rb
+++ b/api/app/controllers/spree/api/coupon_codes_controller.rb
@@ -10,7 +10,7 @@ module Spree
         authorize! :update, @order, order_token
 
         @order.coupon_code = params[:coupon_code]
-        @handler = PromotionHandler::Coupon.new(@order).apply
+        @handler = Spree::Config.coupon_code_handler_class.new(@order).apply
 
         if @handler.successful?
           render 'spree/api/promotions/handler', status: 200
@@ -24,7 +24,7 @@ module Spree
         authorize! :update, @order, order_token
 
         @order.coupon_code = params[:id]
-        @handler = PromotionHandler::Coupon.new(@order).remove
+        @handler = Spree::Config.coupon_code_handler_class.new(@order).remove
 
         if @handler.successful?
           render 'spree/api/promotions/handler', status: 200

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -498,7 +498,7 @@ module Spree
     end
 
     def apply_shipping_promotions
-      Spree::PromotionHandler::Shipping.new(self).activate
+      Spree::Config.shipping_promotion_handler_class.new(self).activate
       recalculate
     end
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -365,6 +365,14 @@ module Spree
     #   Spree::OrderUpdater.
     class_name_attribute :order_recalculator_class, default: 'Spree::OrderUpdater'
 
+    # Allows providing a different coupon code handler.
+    # @!attribute [rw] coupon_code_handler_class
+    # @see Spree::PromotionHandler::Coupon
+    # @return [Class] an object that conforms to the API of
+    #   the standard coupon code handler class
+    #   Spree::PromotionHandler::Coupon.
+    class_name_attribute :coupon_code_handler_class, default: 'Spree::PromotionHandler::Coupon'
+
     # Allows providing your own Mailer for promotion code batch mailer.
     #
     # @!attribute [rw] promotion_code_batch_mailer_class

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -373,6 +373,14 @@ module Spree
     #   Spree::PromotionHandler::Coupon.
     class_name_attribute :coupon_code_handler_class, default: 'Spree::PromotionHandler::Coupon'
 
+    # Allows providing a different shipping promotion handler.
+    # @!attribute [rw] shipping_promotion_handler_class
+    # @see Spree::PromotionHandler::Shipping
+    # @return [Class] an object that conforms to the API of
+    #   the standard shipping promotion handler class
+    #   Spree::PromotionHandler::Coupon.
+    class_name_attribute :shipping_promotion_handler_class, default: 'Spree::PromotionHandler::Shipping'
+
     # Allows providing your own Mailer for promotion code batch mailer.
     #
     # @!attribute [rw] promotion_code_batch_mailer_class

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.coupon_code_handler_class).to eq Spree::PromotionHandler::Coupon
   end
 
+  it "uses promotion handler shipping class by default" do
+    expect(prefs.shipping_promotion_handler_class).to eq Spree::PromotionHandler::Shipping
+  end
+
   it "has a getter for the pricing options class provided by the variant price selector class" do
     expect(prefs.pricing_options_class).to eq Spree::Variant::PriceSelector.pricing_options_class
   end

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
   end
 
+  it "uses promotion handler coupon class by default" do
+    expect(prefs.coupon_code_handler_class).to eq Spree::PromotionHandler::Coupon
+  end
+
   it "has a getter for the pricing options class provided by the variant price selector class" do
     expect(prefs.pricing_options_class).to eq Spree::Variant::PriceSelector.pricing_options_class
   end


### PR DESCRIPTION
## Summary

We have four promotion handlers in the codebase, but only two are actually used: the promotion handler "coupon" and the promotion handler "shipping". If one chose to use a promotion system that works different from the stock Solidus one, these two promotion handlers must be configurable. 

See also https://github.com/friendlycart/solidus_friendly_promotions/pull/61 because this extension point does not exist yet.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- ✅ I have added automated tests to cover my changes.
