### PR TITLE
[Admin] Extract a `ui/search_panel` component from `orders/cart`

### DIFF
--- a/admin/app/assets/stylesheets/solidus_admin/application.tailwind.css.erb
+++ b/admin/app/assets/stylesheets/solidus_admin/application.tailwind.css.erb
@@ -30,6 +30,10 @@
   .body-title {
     @apply font-sans font-semibold text-xl;
   }
+
+  .body-link {
+    @apply text-blue hover:underline;
+  }
 }
 
 <%= SolidusAdmin::Config.tailwind_stylesheets.map { File.read(_1) }.join("\n") %>

--- a/admin/app/components/solidus_admin/orders/cart/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/component.html.erb
@@ -9,14 +9,16 @@
   data-<%= stimulus_id %>-initial-text-value="<%= t('.initial') %>"
   data-<%= stimulus_id %>-empty-text-value="<%= t('.empty') %>"
 >
-  <%= render component('ui/panel').new do |panel| %>
+  <%= render component('ui/panel').new(title: t('.title')) do |panel| %>
+    <div class="border-gray-100 border-t -mx-6"></div>
     <div>
       <div class="peer">
-      <%= render component("ui/forms/search_field").new(
-        "data-action": "#{stimulus_id}#search focus->#{stimulus_id}#showResults #{stimulus_id}#showResults",
-        placeholder: t(".search_placeholder"),
-        "data-#{stimulus_id}-target": "searchField",
-      ) %>
+        <%= render component("ui/forms/search_field").new(
+          "data-action":
+            "#{stimulus_id}#search focus->#{stimulus_id}#showResults #{stimulus_id}#showResults",
+          placeholder: t(".search_placeholder"),
+          "data-#{stimulus_id}-target": "searchField"
+        ) %>
       </div>
 
       <%# results popover %>

--- a/admin/app/components/solidus_admin/orders/cart/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/component.html.erb
@@ -3,118 +3,77 @@
   data-controller="<%= stimulus_id %>"
   data-<%= stimulus_id %>-products-url-value="<%= solidus_admin.variants_for_order_path(@order) %>"
   data-action="
-    keydown-><%= stimulus_id %>#selectResult
+    <%= component('ui/search_panel').stimulus_id %>:search-><%= stimulus_id %>#search
+    <%= component('ui/search_panel').stimulus_id %>:submit-><%= stimulus_id %>#selectResult
   "
-  data-<%= stimulus_id %>-loading-text-value="<%= t('.loading') %>"
-  data-<%= stimulus_id %>-initial-text-value="<%= t('.initial') %>"
-  data-<%= stimulus_id %>-empty-text-value="<%= t('.empty') %>"
 >
-  <%= render component('ui/panel').new(title: t('.title')) do |panel| %>
-    <div class="border-gray-100 border-t -mx-6"></div>
-    <div>
-      <div class="peer">
-        <%= render component("ui/forms/search_field").new(
-          "data-action":
-            "#{stimulus_id}#search focus->#{stimulus_id}#showResults #{stimulus_id}#showResults",
-          placeholder: t(".search_placeholder"),
-          "data-#{stimulus_id}-target": "searchField"
-        ) %>
-      </div>
-
-      <%# results popover %>
-      <details class="px-6 relative overflow-visible">
-        <summary class="hidden"></summary>
-        <div
-          class="
-            absolute
-            left-0
-            top-2
-            bg-white
-            z-30
-            w-full
-            rounded-lg
-            shadow
-            border
-            border-gray-100
-            p-2
-            flex-col
-            gap-1
-            max-h-screen
-            overflow-y-auto
-          "
-          data-<%= stimulus_id %>-target="results"
-        >
-        </div>
-      </details>
-
-    </div>
-
-    <%# line items table %>
-    <div class="rounded-b-lg -mx-6 -mb-6 overflow-hidden">
-      <table class="table-auto w-full">
-        <thead>
+  <%= render component('ui/search_panel').new(
+    title: t('.title'),
+    search_placeholder: t('.search_placeholder'),
+    id: :order_cart,
+  ) do |panel| %>
+    <table class="table-auto w-full" <%= :hidden if @order.line_items.empty? %>>
+      <thead>
+        <tr class="border-gray-100 border-t">
+          <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none">Product</th>
+          <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none w-16">Quantity</th>
+          <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none w-16">Price</th>
+          <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none w-16"><span class="sr-only">Actions</span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @order.line_items.each do |line_item| %>
           <tr class="border-gray-100 border-t">
-            <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none">Product</th>
-            <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none w-16">Quantity</th>
-            <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none w-16">Price</th>
-            <th class="text-left body-small-bold text-gray-800 bg-gray-15 px-6 py-3 leading-none w-16"><span class="sr-only">Actions</span></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @order.line_items.each do |line_item| %>
-            <tr class="border-gray-100 border-t">
-              <td class="px-6 py-4">
-                <div class="flex gap-2 grow">
-                  <% variant = line_item.variant %>
-                  <%= render component("ui/thumbnail").new(
-                    src: (variant.images.first || variant.product.gallery.images.first)&.url(:small),
-                    alt: variant.name
-                  ) %>
-                  <div class="flex-col">
-                    <div class="leading-5 text-black body-small-bold"><%= variant.name %></div>
-                    <div class="leading-5 text-gray-500 body-small">
-                      SKU: <%= variant.sku %>
-                      <%= variant.options_text.presence&.prepend("- ") %>
-                    </div>
+            <td class="px-6 py-4">
+              <div class="flex gap-2 grow">
+                <% variant = line_item.variant %>
+                <%= render component("ui/thumbnail").new(
+                  src: (variant.images.first || variant.product.gallery.images.first)&.url(:small),
+                  alt: variant.name
+                ) %>
+                <div class="flex-col">
+                  <div class="leading-5 text-black body-small-bold"><%= variant.name %></div>
+                  <div class="leading-5 text-gray-500 body-small">
+                    SKU: <%= variant.sku %>
+                    <%= variant.options_text.presence&.prepend("- ") %>
                   </div>
                 </div>
-              </td>
-              <td class="px-6 py-4">
-                <%= form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), html: {
-                  "data-controller": "readonly-when-submitting"
-                }) do |f| %>
-                  <%= render component("ui/forms/input").new(
-                    name: "#{f.object_name}[quantity]",
-                    type: :number,
-                    value: line_item.quantity,
-                    "aria-label": "Quantity",
-                    min: 0,
-                    class: "!w-16 inline-block",
-                    "data-action": "input->#{stimulus_id}#updateLineItem",
-                  ) %>
-                  <% render component("ui/button").new(type: :submit, text: "Update", class: "inline-block") %>
-                <% end %>
-              </td>
-              <td class="px-6 py-4">
-                <span class="text-gray-500 body-small"><%= line_item.single_money.to_html %></span>
-              </td>
-              <td class="px-6 py-4 text-right">
-                <%= form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), method: :delete) do |f| %>
-                  <%= render component('ui/button').new(
-                    scheme: :ghost,
-                    size: :s,
-                    title: t("spree.delete"),
-                    icon: 'close-line',
-                    "data-controller": "confirm",
-                    "data-confirm-text-value": t("spree.are_you_sure"),
-                  ) %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-
+              </div>
+            </td>
+            <td class="px-6 py-4">
+              <%= form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), html: {
+                "data-controller": "readonly-when-submitting"
+              }) do |f| %>
+                <%= render component("ui/forms/input").new(
+                  name: "#{f.object_name}[quantity]",
+                  type: :number,
+                  value: line_item.quantity,
+                  "aria-label": "Quantity",
+                  min: 0,
+                  class: "!w-16 inline-block",
+                  "data-action": "input->#{stimulus_id}#updateLineItem",
+                ) %>
+                <% render component("ui/button").new(type: :submit, text: "Update", class: "inline-block") %>
+              <% end %>
+            </td>
+            <td class="px-6 py-4">
+              <span class="text-gray-500 body-small"><%= line_item.single_money.to_html %></span>
+            </td>
+            <td class="px-6 py-4 text-right">
+              <%= form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), method: :delete) do |f| %>
+                <%= render component('ui/button').new(
+                  scheme: :ghost,
+                  size: :s,
+                  title: t("spree.delete"),
+                  icon: 'close-line',
+                  "data-controller": "confirm",
+                  "data-confirm-text-value": t("spree.are_you_sure"),
+                ) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   <% end %>
 </div>

--- a/admin/app/components/solidus_admin/orders/cart/component.js
+++ b/admin/app/components/solidus_admin/orders/cart/component.js
@@ -1,92 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
-import { useClickOutside, useDebounce } from "stimulus-use"
-
-const QUERY_KEY = "q[name_or_variants_including_master_sku_cont]"
+import { useDebounce } from "stimulus-use"
 
 export default class extends Controller {
-  static targets = ["result", "results", "searchField"]
-  static values = {
-    results: String,
-    productsUrl: String,
-    loadingText: String,
-    initialText: String,
-    emptyText: String,
-  }
-  static debounces = [
-    {
-      name: "requestSubmitForLineItems",
-      wait: 500,
-    },
-    "search",
-  ]
-
-  get query() {
-    return this.searchFieldTarget.value
-  }
-
-  get selectedResult() {
-    // Keep the index within boundaries
-    if (this.selectedIndex < 0) this.selectedIndex = 0
-    if (this.selectedIndex >= this.resultTargets.length) this.selectedIndex = this.resultTargets.length - 1
-
-    return this.resultTargets[this.selectedIndex]
-  }
+  static values = { productsUrl: String }
+  static debounces = [{ name: "submitLineItems", wait: 500 }]
 
   connect() {
-    useClickOutside(this)
     useDebounce(this)
-
-    this.selectedIndex = 0
     this.lineItemsToBeSubmitted = []
-
-    if (this.query) {
-      this.showResults()
-      this.search()
-    }
   }
 
-  selectResult(event) {
-    switch (event.key) {
-      case "Enter":
-        event.preventDefault()
-        this.selectedResult?.click()
-        break
-      case "ArrowUp":
-        event.preventDefault()
-        this.selectedIndex -= 1
-        this.render()
-        break
-      case "ArrowDown":
-        event.preventDefault()
-        this.selectedIndex += 1
-        this.render()
-        break
-    }
-  }
-
-  clickOutside() {
-    this.openResults = false
-    this.render()
-  }
-
-  async search() {
-    const query = this.query
-
-    if (query) {
-      this.resultsValue = this.loadingTextValue
-      this.render()
-
-      this.resultsValue = (await (await fetch(`${this.productsUrlValue}?${QUERY_KEY}=${query}`)).text()) || this.emptyTextValue
-      this.render()
-    } else {
-      this.resultsValue = this.initialTextValue
-      this.render()
-    }
-  }
-
-  showResults() {
-    this.openResults = true
-    this.render()
+  async search({ detail: { query, controller } }) {
+    controller.resultsValue = await (
+      await fetch(`${this.productsUrlValue}?q[name_or_variants_including_master_sku_cont]=${query}`)
+    ).text()
   }
 
   updateLineItem(event) {
@@ -94,42 +21,17 @@ export default class extends Controller {
       this.lineItemsToBeSubmitted.push(event.currentTarget)
     }
 
-    this.requestSubmitForLineItems()
+    this.submitLineItems()
   }
 
   // This is a workaround to permit using debounce when needing to pass a parameter
-  requestSubmitForLineItems() {
-    this.lineItemsToBeSubmitted.forEach((lineItem) => {
-      lineItem.form.requestSubmit()
-    })
+  submitLineItems() {
+    this.lineItemsToBeSubmitted.forEach((lineItem) => lineItem.form.requestSubmit())
     this.lineItemsToBeSubmitted = []
   }
 
-  render() {
-    let resultsHtml = this.resultsValue
-
-    if (this.renderedHtml !== resultsHtml) {
-      this.renderedHtml = resultsHtml
-      this.resultsTarget.innerHTML = resultsHtml
-    }
-
-    if (this.openResults && resultsHtml && this.query) {
-      if (!this.resultsTarget.parentNode.open) this.selectedIndex = 0
-
-      for (const result of this.resultTargets) {
-        if (result === this.selectedResult) {
-          if (!result.hasAttribute("aria-selected") && result.scrollIntoViewIfNeeded) {
-            // This is a non-standard method, but it's supported by all major browsers
-            result.scrollIntoViewIfNeeded()
-          }
-          result.setAttribute("aria-selected", true)
-        } else {
-          result.removeAttribute("aria-selected")
-        }
-      }
-      this.resultsTarget.parentNode.open = true
-    } else {
-      this.resultsTarget.parentNode.open = false
-    }
+  selectResult(event) {
+    const form = event.detail.resultTarget.querySelector("form")
+    form.submit()
   }
 }

--- a/admin/app/components/solidus_admin/orders/cart/component.yml
+++ b/admin/app/components/solidus_admin/orders/cart/component.yml
@@ -3,6 +3,3 @@
 en:
   title: "Cart"
   search_placeholder: "Find a variant by name or SKU"
-  loading: "Loading..."
-  initial: "Type to search"
-  empty: "No results"

--- a/admin/app/components/solidus_admin/orders/cart/component.yml
+++ b/admin/app/components/solidus_admin/orders/cart/component.yml
@@ -1,6 +1,7 @@
 # Add your component translations here.
 # Use the translation in the example in your template with `t(".hello")`.
 en:
+  title: "Cart"
   search_placeholder: "Find a variant by name or SKU"
   loading: "Loading..."
   initial: "Type to search"

--- a/admin/app/components/solidus_admin/orders/cart/result/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/result/component.html.erb
@@ -1,34 +1,26 @@
-<%= form_for(@order.line_items.build(variant: @variant), url: solidus_admin.order_line_items_path(@order), method: :post, html: {
-  "data-controller": "readonly-when-submitting #{stimulus_id}",
-  "data-action": "click->#{stimulus_id}#submit",
-  "data-#{component('orders/cart').stimulus_id}-target": "result",
-  class: "
-    rounded
-    p-2
-    items-center
-    flex
-    hover:bg-gray-25
-    aria-selected:bg-gray-25
-    cursor-pointer
-  "
-}) do |f| %>
-  <%= hidden_field_tag("#{f.object_name}[variant_id]", @variant.id) %>
-  <div class="flex gap-2 grow">
-    <%= render component("ui/thumbnail").new(
-      src: @image&.url(:small),
-      alt: @variant.name
-    ) %>
-    <div class="flex-col">
-      <div class="leading-5 text-black body-small-bold"><%= @variant.name %></div>
-      <div class="leading-5 text-gray-500 body-small">
-        SKU:
-        <%= @variant.sku %>
-        <%= @variant.options_text.presence&.prepend("- ") %>
+<%= render component('ui/search_panel/result').new do %>
+  <%= form_for(@order.line_items.build(variant: @variant), url: solidus_admin.order_line_items_path(@order), method: :post, html: {
+    "data-controller": "readonly-when-submitting",
+    class: "flex items-center",
+  }) do |f| %>
+    <%= hidden_field_tag("#{f.object_name}[variant_id]", @variant.id) %>
+    <div class="flex gap-2 grow">
+      <%= render component("ui/thumbnail").new(
+        src: @image&.url(:small),
+        alt: @variant.name
+      ) %>
+      <div class="flex-col">
+        <div class="leading-5 text-black body-small-bold"><%= @variant.name %></div>
+        <div class="leading-5 text-gray-500 body-small">
+          SKU:
+          <%= @variant.sku %>
+          <%= @variant.options_text.presence&.prepend("- ") %>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex gap-2 items-center">
-    <span class="text-gray-500 body-small"><%= render component("products/stock").from_variant(@variant) %></span>
-    <span class="text-black body-small"><%= @variant.display_price.to_html %></span>
-  </div>
+    <div class="flex gap-2 items-center">
+      <span class="text-gray-500 body-small"><%= render component("products/stock").from_variant(@variant) %></span>
+      <span class="text-black body-small"><%= @variant.display_price.to_html %></span>
+    </div>
+  <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/orders/cart/result/component.js
+++ b/admin/app/components/solidus_admin/orders/cart/result/component.js
@@ -1,7 +1,0 @@
-import { Controller } from '@hotwired/stimulus'
-
-export default class extends Controller {
-  submit(event) {
-    event.currentTarget.requestSubmit()
-  }
-}

--- a/admin/app/components/solidus_admin/ui/badge/component.rb
+++ b/admin/app/components/solidus_admin/ui/badge/component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Badge::Component < SolidusAdmin::BaseComponent
-  include ViewComponent::InlineTemplate
-
   COLORS = {
     graphite_light: "text-black bg-graphite-light",
     red: 'text-red-500 bg-red-100',

--- a/admin/app/components/solidus_admin/ui/search_panel/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/search_panel/component.html.erb
@@ -1,0 +1,58 @@
+<div
+  data-controller="<%= stimulus_id %>"
+  class="w-full relative overflow-visible"
+  data-action="
+    keydown.up-><%= stimulus_id %>#selectPrev
+    keydown.down-><%= stimulus_id %>#selectNext
+    keydown.enter-><%= stimulus_id %>#selectResult
+  "
+  data-<%= stimulus_id %>-loading-text-value="<%= t('.loading') %>"
+  data-<%= stimulus_id %>-initial-text-value="<%= t('.initial') %>"
+  data-<%= stimulus_id %>-empty-text-value="<%= t('.empty') %>"
+>
+  <%= render component('ui/panel').new(**@panel_args) do |panel| %>
+    <div class="border-gray-100 border-t -mx-6"></div>
+    <div>
+      <div class="peer">
+        <%= render component("ui/forms/search_field").new(
+          id: "#{stimulus_id}--search-field--#{@id}",
+          placeholder: @search_placeholder,
+          "data-action": "
+            #{stimulus_id}#search
+            #{stimulus_id}#showResults
+          ",
+          "data-#{stimulus_id}-target": "searchField",
+        ) %>
+      </div>
+
+      <details class="px-6 relative overflow-visible">
+        <summary class="hidden"></summary>
+        <div
+          class="
+            absolute
+            left-0
+            top-2
+            bg-white
+            z-30
+            w-full
+            rounded-lg
+            shadow
+            border
+            border-gray-100
+            p-2
+            flex-col
+            gap-1
+            max-h-screen
+            overflow-y-auto
+          "
+          data-<%= stimulus_id %>-target="results"
+        >
+        </div>
+      </details>
+    </div>
+
+    <div class="rounded-b-lg -mx-6 -mb-6 overflow-hidden">
+      <%= content %>
+    </div>
+  <% end %>
+</div>

--- a/admin/app/components/solidus_admin/ui/search_panel/component.js
+++ b/admin/app/components/solidus_admin/ui/search_panel/component.js
@@ -1,0 +1,116 @@
+import { Controller } from "@hotwired/stimulus"
+import { useClickOutside, useDebounce } from "stimulus-use"
+
+export default class extends Controller {
+  static targets = ["result", "results", "searchField"]
+  static values = {
+    results: String,
+    loadingText: String,
+    initialText: String,
+    emptyText: String,
+  }
+  static debounces = ["search"]
+
+  get query() {
+    return this.searchFieldTarget.value
+  }
+
+  get selectedResult() {
+    // Keep the index within boundaries
+    if (this.selectedIndex < 0) this.selectedIndex = 0
+    if (this.selectedIndex >= this.resultTargets.length) this.selectedIndex = this.resultTargets.length - 1
+
+    return this.resultTargets[this.selectedIndex]
+  }
+
+  connect() {
+    useClickOutside(this)
+    useDebounce(this)
+
+    this.selectedIndex = 0
+
+    if (this.query) {
+      this.showResults()
+      this.search()
+    }
+  }
+
+  selectResult(event) {
+    event.preventDefault()
+    this.dispatch("submit", { detail: { resultTarget: this.selectedResult } })
+  }
+
+  clickedResult(event) {
+    this.selectedIndex = this.resultTargets.indexOf(event.currentTarget)
+    this.render()
+    this.selectResult(event)
+  }
+
+  selectPrev(event) {
+    event.preventDefault()
+    this.selectedIndex -= 1
+    this.render()
+  }
+
+  selectNext(event) {
+    event.preventDefault()
+    this.selectedIndex += 1
+    this.render()
+  }
+
+  clickOutside() {
+    this.openResults = false
+    this.render()
+  }
+
+  async search() {
+    const query = this.query
+
+    if (query) {
+      this.resultsValue = this.loadingTextValue
+      this.render()
+      this.dispatch("search", { detail: { query, controller: this } })
+    } else {
+      this.resultsValue = this.initialTextValue
+      this.render()
+    }
+  }
+
+  resultsValueChanged() {
+    this.selectedIndex = 0
+    this.render()
+  }
+
+  showResults() {
+    this.openResults = true
+    this.render()
+  }
+
+  render() {
+    let resultsHtml = this.resultsValue
+
+    if (this.renderedHtml !== resultsHtml) {
+      this.renderedHtml = resultsHtml
+      this.resultsTarget.innerHTML = resultsHtml
+    }
+
+    if (this.openResults && resultsHtml && this.query) {
+      if (!this.resultsTarget.parentNode.open) this.selectedIndex = 0
+
+      for (const result of this.resultTargets) {
+        if (result === this.selectedResult) {
+          if (!result.hasAttribute("aria-selected") && result.scrollIntoViewIfNeeded) {
+            // This is a non-standard method, but it's supported by all major browsers
+            result.scrollIntoViewIfNeeded()
+          }
+          result.setAttribute("aria-selected", true)
+        } else {
+          result.removeAttribute("aria-selected")
+        }
+      }
+      this.resultsTarget.parentNode.open = true
+    } else {
+      this.resultsTarget.parentNode.open = false
+    }
+  }
+}

--- a/admin/app/components/solidus_admin/ui/search_panel/component.rb
+++ b/admin/app/components/solidus_admin/ui/search_panel/component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::SearchPanel::Component < SolidusAdmin::BaseComponent
+  def initialize(search_placeholder: nil, id: nil, **panel_args)
+    @search_placeholder = search_placeholder
+    @panel_args = panel_args
+    @id = id
+  end
+end

--- a/admin/app/components/solidus_admin/ui/search_panel/component.yml
+++ b/admin/app/components/solidus_admin/ui/search_panel/component.yml
@@ -1,0 +1,4 @@
+en:
+  loading: "Loading..."
+  initial: "Type to search"
+  empty: "No results"

--- a/admin/app/components/solidus_admin/ui/search_panel/result/component.rb
+++ b/admin/app/components/solidus_admin/ui/search_panel/result/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::SearchPanel::Result::Component < SolidusAdmin::BaseComponent
+  def call
+    tag.div(
+      content,
+      class: "rounded p-2 hover:bg-gray-25 aria-selected:bg-gray-25 cursor-pointer",
+      "data-#{component('ui/search_panel').stimulus_id}-target": "result",
+      "data-action": "click->#{component('ui/search_panel').stimulus_id}#clickedResult",
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/search_panel/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/search_panel/component_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# @component "ui/search_panel"
+class SolidusAdmin::UI::SearchPanel::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/search_panel/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/search_panel/component_preview/overview.html.erb
@@ -1,0 +1,24 @@
+<div class="mb-8">
+  <h6 class="text-gray-500 mb-3 mt-0">
+    Default
+  </h6>
+
+  <script>
+    window.addEventListener('<%= current_component.stimulus_id %>:submit', (event) => {
+      alert(`selected: ${event.detail.resultTarget.innerText}`)
+    })
+    window.addEventListener('<%= current_component.stimulus_id %>:search', (event) => {
+      const {controller, query} = event.detail
+      const resultTemplate = `<%= render component('ui/search_panel/result').new.with_content("{{content}}") %>`
+      setTimeout(() => {
+        controller.resultsValue = [
+          resultTemplate.replace('{{content}}', `Result 1 for ${query}`),
+          resultTemplate.replace('{{content}}', `Result 2 for ${query}`),
+          resultTemplate.replace('{{content}}', `Result 3 for ${query}`),
+        ].join('')
+      }, 200);
+    })
+  </script>
+
+  <%= render current_component.new %>
+</div>

--- a/admin/spec/components/solidus_admin/ui/search_panel/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/search_panel/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::SearchPanel::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end

--- a/admin/spec/features/order_spec.rb
+++ b/admin/spec/features/order_spec.rb
@@ -15,7 +15,7 @@ describe "Order", type: :feature do
 
       expect(page).to have_content("Order R123456789")
 
-      search_field = find("[data-#{SolidusAdmin::Orders::Cart::Component.stimulus_id}-target='searchField']")
+      search_field = find("[data-#{SolidusAdmin::UI::SearchPanel::Component.stimulus_id}-target='searchField']")
       search_field.set "another"
 
       expect(page).not_to have_content("Just a product")


### PR DESCRIPTION
## Summary

Extract the generic part from the `orders/cart` component making it reusable for the customer search.
Might not be the last iteration of the generalizing process, but so far this is what we need for the customer search, this PR is itself extracted and isolated for reviewing purposes from the work on the customer picker.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
