### PR TITLE
Add foreign key constraint between order_promotions and promotions

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -14,7 +14,7 @@ module Spree
     has_many :promotion_actions, autosave: true, dependent: :destroy, inverse_of: :promotion
     alias_method :actions, :promotion_actions
 
-    has_many :order_promotions, class_name: "Spree::OrderPromotion"
+    has_many :order_promotions, class_name: "Spree::OrderPromotion", inverse_of: :promotion, dependent: :destroy
     has_many :orders, through: :order_promotions
 
     has_many :codes, class_name: "Spree::PromotionCode", inverse_of: :promotion, dependent: :destroy

--- a/core/db/migrate/20231031175215_add_promotion_order_promotion_foreign_key.rb
+++ b/core/db/migrate/20231031175215_add_promotion_order_promotion_foreign_key.rb
@@ -1,0 +1,10 @@
+class AddPromotionOrderPromotionForeignKey < ActiveRecord::Migration[7.0]
+  def up
+    Spree::OrderPromotion.left_joins(:promotion).where(spree_promotions: { id: nil }).delete_all
+    add_foreign_key :spree_orders_promotions, :spree_promotions, column: :promotion_id, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :spree_orders_promotions, :spree_orders
+  end
+end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -939,4 +939,20 @@ RSpec.describe Spree::Promotion, type: :model do
       expect(order.adjustment_total).to eq(-10)
     end
   end
+
+  describe "promotion deletion" do
+    subject { promotion.destroy! }
+
+    let(:promotion) { create(:promotion) }
+    let(:order) { create(:order) }
+
+    before do
+      order.promotions << promotion
+    end
+
+    it "destroys associated order promotions" do
+      expect(Spree::OrderPromotion.count).to eq(1)
+      expect { subject }.to change { Spree::OrderPromotion.count }.from(1).to(0)
+    end
+  end
 end


### PR DESCRIPTION


## Summary

When we delete a promotion, the associated `order_promotions` should also disappear.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- ✅ I have added automated tests to cover my changes.
