### PR TITLE
CI: Skip install_solidus check on non-current version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,26 +268,33 @@ jobs:
       ruby: "3.0"
     steps:
       - checkout
-      - libvips
-
-      - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-      - run:
-          name: Ensure the correct PayPal is installed for SSF
-          command: |
-            cd /tmp/my_app
-            bundle list | grep 'solidus_paypal_commerce_platform (1.'
-
-      - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise --payment-method=stripe" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-
-      - install_dummy_app
-
-      - install_dummy_app: { extra_gems: "solidus_frontend" }
-      - run:
-          name: "Ensure solidus_frontend installer is run"
-          command: |
-            test -f /tmp/dummy_extension/spec/dummy/config/initializers/solidus_frontend.rb
+      - when:
+          condition:
+            or:
+              - equal: [main, << pipeline.git.branch >>]
+              - equal: [v4.2, << pipeline.git.branch >>]
+          steps:
+            - libvips
+            - install_solidus:
+                flags: "--sample=false --frontend=starter --authentication=devise"
+            - test_page:
+                expected_text: "The only eCommerce platform you’ll ever need."
+            - run:
+                name: Ensure the correct PayPal is installed for SSF
+                command: |
+                  cd /tmp/my_app
+                  bundle list | grep 'solidus_paypal_commerce_platform (1.'
+            - install_solidus:
+                flags: "--sample=false --frontend=starter --authentication=devise --payment-method=stripe"
+            - test_page:
+                expected_text: "The only eCommerce platform you’ll ever need."
+            - install_dummy_app
+            - install_dummy_app:
+                extra_gems: "solidus_frontend"
+            - run:
+                name: "Ensure solidus_frontend installer is run"
+                command: |
+                  test -f /tmp/dummy_extension/spec/dummy/config/initializers/solidus_frontend.rb
 
   test_solidus:
     parameters:


### PR DESCRIPTION
## Summary

The installer always uses the current released minor version (4.2 time writing this), but the check runs on all pipeline runs, wasting CI time and precious resources. Also it fails anyway, because of conflicting dependencies.

So, we only run the check on main and latest minor now.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
