### PR TITLE
Add activestorage as dependency

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -6,6 +6,7 @@ require "action_view/railtie"
 require "active_job/railtie"
 require "active_model/railtie"
 require "active_record/railtie"
+require "active_storage/engine"
 require "sprockets/railtie"
 
 require 'active_support/deprecation'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   %w[
     actionmailer actionpack actionview activejob activemodel activerecord
-    activesupport railties
+    activestorage activesupport railties
   ].each do |rails_dep|
     s.add_dependency rails_dep, ['>= 7.0', '< 7.1']
   end


### PR DESCRIPTION
## Summary

We use `ActiveStorage::Current` in our BaseControllers since a3119d560c7575e41fbaa05cc090738e6b9e83e4 but we never depended on it.

For stores never having activestorage as dependency this was breaking.

This reverts #5450

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
