### PR TITLE
[4.1] Use ActiveRecord's `.find_each` instead of `.each` whenever possible

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -339,3 +339,7 @@ Lint/MissingSuper:
   Exclude:
     - 'core/lib/spree/deprecation.rb' # this is a known class that doesn't require super
     - 'core/lib/spree/preferences/configuration.rb' # this class has no superclass defining `self.inherited`
+
+Rails/FindEach:
+  Exclude:
+    - 'db/migrate/**/*'

--- a/api/spec/requests/spree/api/checkouts_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_spec.rb
@@ -101,7 +101,7 @@ module Spree::Api
 
         # Regression Spec for https://github.com/spree/spree/issues/5389 and https://github.com/spree/spree/issues/5880
         it "can update addresses but not transition to delivery w/o shipping setup" do
-          Spree::ShippingMethod.all.each(&:destroy)
+          Spree::ShippingMethod.all.find_each(&:destroy)
           put spree.api_checkout_path(order),
             params: { order_token: order.guest_token, order: {
               bill_address_attributes: address,

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -90,7 +90,7 @@ describe "Order Details", type: :feature, js: true do
 
             product.stock_items.where.not(stock_location_id: stock_location_ids).discard_all
 
-            product.stock_items.where(stock_location_id: stock_location_ids).each do |stock_item|
+            product.stock_items.where(stock_location_id: stock_location_ids).find_each do |stock_item|
               stock_item.set_count_on_hand 1
             end
 

--- a/backend/spec/helpers/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/admin/base_helper_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Admin::BaseHelper, type: :helper do
     end
 
     it "should return a formatted date when date is present" do
-      date = "2013-08-14".to_time
+      date = Time.zone.parse("2013-08-14")
       expect(datepicker_field_value(date)).to eq("2013/08/14")
     end
   end

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -12,7 +12,7 @@ module Spree
   class ReimbursementTaxCalculator
     class << self
       def call(reimbursement)
-        reimbursement.return_items.includes(:inventory_unit).each do |return_item|
+        reimbursement.return_items.includes(:inventory_unit).find_each do |return_item|
           set_tax!(return_item)
         end
       end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -121,7 +121,7 @@ module Spree
 
     def ensure_one_default
       if default
-        Spree::StockLocation.where(default: true).where.not(id: id).each do |stock_location|
+        Spree::StockLocation.where(default: true).where.not(id: id).find_each do |stock_location|
           stock_location.default = false
           stock_location.save!
         end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -397,7 +397,7 @@ module Spree
     end
 
     def create_stock_items
-      StockLocation.where(propagate_all_variants: true).each do |stock_location|
+      StockLocation.where(propagate_all_variants: true).find_each do |stock_location|
         stock_location.propagate_variant(self)
       end
     end

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -9,7 +9,7 @@ def create_states(subregions, country)
 end
 
 ActiveRecord::Base.transaction do
-  Spree::Country.all.each do |country|
+  Spree::Country.all.find_each do |country|
     carmen_country = Carmen::Country.coded(country.iso)
     next unless carmen_country.subregions?
 

--- a/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
+++ b/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
@@ -17,7 +17,7 @@ class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
       t.timestamps
     end
 
-    StoreCreditUpdateReason.all.each do |update_reason|
+    StoreCreditUpdateReason.all.find_each do |update_reason|
       StoreCreditReason.create!(name: update_reason.name)
     end
 
@@ -45,7 +45,7 @@ class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
       end
     end
 
-    StoreCreditReason.all.each do |store_credit_reason|
+    StoreCreditReason.all.find_each do |store_credit_reason|
       StoreCreditUpdateReason.create!(name: store_credit_reason.name)
     end
 

--- a/core/db/migrate/20220317165036_set_promotions_with_any_policy_to_all_if_possible.rb
+++ b/core/db/migrate/20220317165036_set_promotions_with_any_policy_to_all_if_possible.rb
@@ -2,7 +2,7 @@
 
 class SetPromotionsWithAnyPolicyToAllIfPossible < ActiveRecord::Migration[5.2]
   def up
-    Spree::Promotion.where(match_policy: :any).includes(:promotion_rules).all.each do |promotion|
+    Spree::Promotion.where(match_policy: :any).includes(:promotion_rules).all.find_each do |promotion|
       if promotion.promotion_rules.length <= 1
         promotion.update!(match_policy: :all)
       else

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -45,7 +45,7 @@ module Spree
 
         def set_current_order
           if spree_current_user && current_order
-            spree_current_user.orders.by_store(current_store).incomplete.where('id != ?', current_order.id).each do |order|
+            spree_current_user.orders.by_store(current_store).incomplete.where('id != ?', current_order.id).find_each do |order|
               current_order.merge!(order, spree_current_user)
             end
           end

--- a/core/spec/models/spree/exchange_spec.rb
+++ b/core/spec/models/spree/exchange_spec.rb
@@ -54,7 +54,7 @@ module Spree
 
       context "when it cannot create shipments for all items" do
         before do
-          StockItem.where(variant_id: return_item.exchange_variant_id).each(&:destroy)
+          StockItem.where(variant_id: return_item.exchange_variant_id).find_each(&:destroy)
         end
 
         it 'raises an UnableToCreateShipments error' do

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -85,7 +85,7 @@ module Spree
         end
 
         it "sorts shipping rates by cost" do
-          ShippingMethod.all.each(&:destroy)
+          ShippingMethod.all.find_each(&:destroy)
           create(:shipping_method, cost: 5)
           create(:shipping_method, cost: 3)
           create(:shipping_method, cost: 4)
@@ -94,7 +94,7 @@ module Spree
         end
 
         context "general shipping methods" do
-          before { Spree::ShippingMethod.all.each(&:destroy) }
+          before { Spree::ShippingMethod.all.find_each(&:destroy) }
 
           context 'with a custom shipping calculator with no preference' do
             class Spree::Calculator::Shipping::NoPreferences < Spree::ShippingCalculator
@@ -168,7 +168,7 @@ module Spree
         end
 
         context "involves backend only shipping methods" do
-          before{ Spree::ShippingMethod.all.each(&:destroy) }
+          before{ Spree::ShippingMethod.all.find_each(&:destroy) }
           let!(:backend_method) { create(:shipping_method, available_to_users: false, cost: 0.00) }
           let!(:generic_method) { create(:shipping_method, cost: 5.00) }
 
@@ -183,7 +183,7 @@ module Spree
         end
 
         context "excludes shipping methods from other stores" do
-          before{ Spree::ShippingMethod.all.each(&:destroy) }
+          before{ Spree::ShippingMethod.all.find_each(&:destroy) }
 
           let!(:other_method) do
             create(

--- a/core/spec/models/spree/variant/vat_price_generator_spec.rb
+++ b/core/spec/models/spree/variant/vat_price_generator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Spree::Variant::VatPriceGenerator do
 
     # We need to remove the price for FR from the database so it is created in memory, and then run VatPriceGenerator twice to trigger the duplicate price issue.
     it "will not build duplicate prices on multiple runs" do
-      variant.prices.where(country_iso: "FR").each(&:destroy)
+      variant.prices.where(country_iso: "FR").find_each(&:destroy)
       variant.reload
       described_class.new(variant).run
       expect { subject }.not_to change { variant.prices.size }

--- a/sample/db/samples/product_option_types.rb
+++ b/sample/db/samples/product_option_types.rb
@@ -9,7 +9,7 @@ colored_clothes = [
   "Solidus T-Shirt", "Solidus Long Sleeve", "Solidus Women's T-Shirt"
 ]
 
-Spree::Product.all.each do |product|
+Spree::Product.all.find_each do |product|
   product.option_types = [size]
   product.option_types << color if colored_clothes.include?(product.name)
   product.save!

--- a/sample/db/samples/stock.rb
+++ b/sample/db/samples/stock.rb
@@ -7,7 +7,7 @@ location = Spree::StockLocation.first_or_create! name: 'default', address1: 'Exa
 location.active = true
 location.save!
 
-Spree::Variant.all.each do |variant|
+Spree::Variant.all.find_each do |variant|
   variant.stock_items.each do |stock_item|
     Spree::StockMovement.create(quantity: 10, stock_item: stock_item)
   end


### PR DESCRIPTION
## Summary

Backport of https://github.com/solidusio/solidus/pull/5380/ for v4.1