### PR TITLE
[v3.4] CI: Skip install_solidus check on non-current version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,45 +220,46 @@ jobs:
     executor: sqlite
     steps:
       - checkout
-      - libvips
-
-      - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-      - run:
-          name: Ensure the correct PayPal is installed for SSF
-          command: |
-            cd /tmp/my_app
-            bundle list | grep 'solidus_paypal_commerce_platform (1.'
-
-      - install_solidus: { flags: "--sample=false --frontend=starter --payment-method=braintree" }
-      - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
-      - run:
-          name: Ensure the correct Braintree is installed for SSF
-          command: |
-            cd /tmp/my_app
-            bundle list | grep 'solidus_braintree (3.'
-
-      - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
-      - test_page: { expected_text: "<title>Ruby on Rails" }
-
-      - install_solidus: { flags: "--sample=false --frontend=classic --authentication=custom" }
-      - test_page: { expected_text: "data-hook=" }
-      - run:
-          name: Ensure the correct PayPal is installed for SSF
-          command: |
-            cd /tmp/my_app
-            bundle list | grep 'solidus_paypal_commerce_platform (0.'
-
-      - run:
-          name: "Test `rake task: extensions:test_app`"
-          command: |
-            mkdir -p /tmp/dummy_extension
-            cd /tmp/dummy_extension
-            bundle init
-            bundle add rails sqlite3 --skip-install
-            bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
-            export LIB_NAME=set # dummy requireable file
-            bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
+      - when:
+          condition:
+            or:
+              - equal: [main, << pipeline.git.branch >>]
+              - equal: [v4.2, << pipeline.git.branch >>]
+          steps:
+            - libvips
+            - install_solidus: { flags: "--sample=false --frontend=starter --authentication=devise" }
+            - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
+            - run:
+                name: Ensure the correct PayPal is installed for SSF
+                command: |
+                  cd /tmp/my_app
+                  bundle list | grep 'solidus_paypal_commerce_platform (1.'
+            - install_solidus: { flags: "--sample=false --frontend=starter --payment-method=braintree" }
+            - test_page: { expected_text: "The only eCommerce platform you’ll ever need." }
+            - run:
+                name: Ensure the correct Braintree is installed for SSF
+                command: |
+                  cd /tmp/my_app
+                  bundle list | grep 'solidus_braintree (3.'
+            - install_solidus: { flags: "--sample=false --frontend=none --authentication=none" }
+            - test_page: { expected_text: "<title>Ruby on Rails" }
+            - install_solidus: { flags: "--sample=false --frontend=classic --authentication=custom" }
+            - test_page: { expected_text: "data-hook=" }
+            - run:
+                name: Ensure the correct PayPal is installed for SSF
+                command: |
+                  cd /tmp/my_app
+                  bundle list | grep 'solidus_paypal_commerce_platform (0.'
+            - run:
+                name: "Test `rake task: extensions:test_app`"
+                command: |
+                  mkdir -p /tmp/dummy_extension
+                  cd /tmp/dummy_extension
+                  bundle init
+                  bundle add rails sqlite3 --skip-install
+                  bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+                  export LIB_NAME=set # dummy requireable file
+                  bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
 
   test_solidus:
     parameters:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v3.4`:
 - [Merge pull request #5477 from tvdeyen/skip-install-check](https://github.com/solidusio/solidus/pull/5477)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)