### PR TITLE
Use configurable promo adjuster in callback

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -132,6 +132,7 @@ module Spree
         eligible?
       end
     end
+    deprecate :calculate_eligibility, deprecator: Spree.deprecator
 
     private
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -788,10 +788,9 @@ module Spree
     end
 
     def ensure_promotions_eligible
-      adjustment_changed = all_adjustments.eligible.promotion.any? do |adjustment|
-        !adjustment.calculate_eligibility
-      end
-      if adjustment_changed
+      Spree::Config.promotion_adjuster_class.new(self).call
+
+      if promo_total_changed?
         restart_checkout_flow
         recalculate
         errors.add(:base, I18n.t('spree.promotion_total_changed_before_complete'))

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -128,6 +128,12 @@ RSpec.describe Spree::Adjustment, type: :model do
         let(:source) { promotion.actions.first! }
         let(:promotion) { create(:promotion, :with_line_item_adjustment, adjustment_rate: 7) }
 
+        around do |example|
+          Spree.deprecator.silence do
+            example.run
+          end
+        end
+
         context 'when the promotion is eligible' do
           it 'updates the adjustment' do
             expect { subject }.to change { adjustment.amount }.from(5).to(-7)


### PR DESCRIPTION
## Summary

This deprecates `Spree::Adjustment#calculate_eligibility` by refactoring `Spree::Order#ensure_promotions_eligible` to use the configurable promotion adjuster rather than `Spree::Adjustment#calculate_eligibility`.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- ✅ I have added automated tests to cover my changes. (Really I didn't add any because exisiting specs would catch misbehavior).
