### PR TITLE
Ensure `Spree::Country.available` and `Zone#country_list` consistently return AR relations

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -17,9 +17,11 @@ module Spree
     def self.available(restrict_to_zone: Spree::Config[:checkout_zone])
       checkout_zone = Zone.find_by(name: restrict_to_zone)
 
-      return checkout_zone.country_list if checkout_zone.try(:kind) == 'country'
-
-      all
+      if checkout_zone.try(:kind) == 'country'
+        checkout_zone.country_list
+      else
+        all
+      end
     end
 
     def <=>(other)

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -86,11 +86,11 @@ module Spree
 
     # convenience method for returning the countries contained within a zone
     def country_list
-      @countries ||= case kind
-                     when 'country' then zoneables
-                     when 'state' then zoneables.collect(&:country)
-                     else []
-                     end.flatten.compact.uniq
+      case kind
+      when 'country' then countries
+      when 'state' then Spree::Country.where(id: states.select(:id))
+      else Spree::Country.none
+      end
     end
 
     def <=>(other)

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -43,24 +43,28 @@ RSpec.describe Spree::Country, type: :model do
 
         context 'with no arguments' do
           it 'returns "Checkout Zone" countries' do
+            expect(described_class.available).to be_an(ActiveRecord::Relation)
             expect(described_class.available).to contain_exactly(united_states, canada)
           end
         end
 
         context 'setting nil as restricting zone' do
           it 'returns all countries' do
+            expect(described_class.available(restrict_to_zone: nil)).to be_an(ActiveRecord::Relation)
             expect(described_class.available(restrict_to_zone: nil)).to contain_exactly(united_states, canada, italy)
           end
         end
 
         context 'setting "Custom Zone" as restricting zone' do
           it 'returns "Custom Zone" countries' do
+            expect(described_class.available(restrict_to_zone: 'Custom Zone')).to be_an(ActiveRecord::Relation)
             expect(described_class.available(restrict_to_zone: 'Custom Zone')).to contain_exactly(united_states, italy)
           end
         end
 
         context 'setting "Checkout Zone" as restricting zone' do
           it 'returns "Checkout Zone" countries' do
+            expect(described_class.available(restrict_to_zone: 'Checkout Zone')).to be_an(ActiveRecord::Relation)
             expect(described_class.available(restrict_to_zone: 'Checkout Zone')).to contain_exactly(united_states, canada)
           end
         end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Spree::Zone, type: :model do
       before { country_zone.members.create(zoneable: country) }
 
       it 'should return a list of countries' do
+        expect(country_zone.country_list).to be_a(ActiveRecord::Relation)
         expect(country_zone.country_list).to eq([country])
       end
     end
@@ -67,7 +68,17 @@ RSpec.describe Spree::Zone, type: :model do
       before { state_zone.members.create(zoneable: state) }
 
       it 'should return a list of countries' do
+        expect(state_zone.country_list).to be_a(ActiveRecord::Relation)
         expect(state_zone.country_list).to eq([state.country])
+      end
+    end
+
+    context "when zone doesn't consist of either countries nor states" do
+      let(:zone) { create(:zone, name: 'Zone') }
+
+      it 'should return an empty list' do
+        expect(zone.country_list).to be_a(ActiveRecord::Relation)
+        expect(zone.country_list).to be_empty
       end
     end
   end


### PR DESCRIPTION

## Summary

Being able to depend on AR::Relation makes the methods more adaptable and efficient, allowing it to be embedded in other queries minimizing the roundtrips to the database.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
