### PR TITLE
set_position conflicts with acts_as_list

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -73,7 +73,6 @@ module Spree
     validates_uniqueness_of :sku, allow_blank: true, case_sensitive: true, conditions: -> { where(deleted_at: nil) }, if: :enforce_unique_sku?
 
     after_create :create_stock_items
-    after_create :set_position
     after_create :set_master_out_of_stock, unless: :is_master?
 
     after_save :clear_in_stock_cache
@@ -404,10 +403,6 @@ module Spree
 
     def build_vat_prices
       Spree::Config.variant_vat_prices_generator_class.new(self).run
-    end
-
-    def set_position
-      update_column(:position, product.variants.maximum(:position).to_i + 1)
     end
 
     def in_stock_cache_key

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -574,6 +574,16 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
+  describe 'acts_as_list' do
+    it 'sets variant position by acts_as_list' do
+      expect(variant.product.master.position).to eq 1
+      expect(variant.position).to eq 2
+
+      multi_variant = create(:variant, product: variant.product)
+      expect(multi_variant.position).to eq 3
+    end
+  end
+
   describe '#in_stock?' do
     before do
       stub_spree_preferences(track_inventory_levels: true)

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -574,14 +574,6 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
-  # Regression test for https://github.com/spree/spree/issues/2744
-  describe "set_position" do
-    it "sets variant position after creation" do
-      variant = create(:variant)
-      expect(variant.position).to_not be_nil
-    end
-  end
-
   describe '#in_stock?' do
     before do
       stub_spree_preferences(track_inventory_levels: true)


### PR DESCRIPTION
## Summary

Fixes #5508

Remove set_position callback


I thought about changing the test as in this diff, but decided to just remove it since this is just testing acts_as_list.

```diff
diff --git a/core/spec/models/spree/variant_spec.rb b/core/spec/models/spree/variant_spec.rb
index 84cab17c1f..7246a74e60 100644
--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -574,11 +574,13 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
-  # Regression test for https://github.com/spree/spree/issues/2744
-  describe "set_position" do
-    it "sets variant position after creation" do
-      variant = create(:variant)
-      expect(variant.position).to_not be_nil
+  describe "acts_as_list" do
+    it "sets variant position by acts_as_list" do
+      expect(variant.product.master.position).to eq 1
+      expect(variant.position).to eq 2
+
+      multi_variant = create(:variant, product: variant.product)
+      expect(multi_variant.position).to eq 3
     end
   end
 ```
## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
