### PR TITLE
[Admin] Add `order/show/summary` component

### DIFF
--- a/admin/app/components/solidus_admin/orders/show/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/component.html.erb
@@ -11,6 +11,7 @@
   <%= page_with_sidebar do %>
     <%= page_with_sidebar_main do %>
       <%= render component("orders/cart").new(order: @order) %>
+      <%= render component("orders/show/summary").new(order: @order) %>
     <% end %>
 
     <%= page_with_sidebar_aside do %>

--- a/admin/app/components/solidus_admin/orders/show/summary/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/summary/component.html.erb
@@ -1,0 +1,14 @@
+<div class="<%= stimulus_id %> w-full">
+  <%= render component('ui/panel').new(title: t('.summary')) do %>
+    <%= render component('ui/details_list').new(
+      items: [
+        { label: t('.subtotal'), value: number_to_currency(@order.item_total), class: 'font-semibold' },
+        { label: t('.taxes'), value: number_to_currency(@order.additional_tax_total) },
+        { label: t('.shipping'), value: number_to_currency(@order.shipment_total) },
+        { label: link_to(t('.add_promo_code'), '#', class: "body-link"), value: number_to_currency(@order.promo_total) },
+        { label: link_to(t('.adjustments'), '#', class: "body-link"), value: number_to_currency(@order.adjustment_total) },
+        { label: t('.total'), value: number_to_currency(@order.total), class: 'font-semibold' }
+      ]
+    ) %>
+  <% end %>
+</div>

--- a/admin/app/components/solidus_admin/orders/show/summary/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/summary/component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Summary::Component < SolidusAdmin::BaseComponent
+  def initialize(order:)
+    @order = order
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/summary/component.yml
+++ b/admin/app/components/solidus_admin/orders/show/summary/component.yml
@@ -1,0 +1,8 @@
+en:
+  summary: Summary
+  subtotal: Subtotal
+  taxes: Taxes
+  shipping: Shipping
+  add_promo_code: Add Promo Code
+  adjustments: Adjustments
+  total: Total

--- a/admin/app/components/solidus_admin/ui/details_list/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/details_list/component.html.erb
@@ -1,0 +1,10 @@
+<div class="<%= stimulus_id %>">
+  <ul class="text-sm">
+    <% @items.each do |item| %>
+      <li class="flex justify-between py-2 <%= item[:class] %>">
+        <span><%= item[:label] %></span>
+        <span><%= item[:value] %></span>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/admin/app/components/solidus_admin/ui/details_list/component.rb
+++ b/admin/app/components/solidus_admin/ui/details_list/component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::DetailsList::Component < SolidusAdmin::BaseComponent
+  def initialize(items:)
+    @items = items
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/orders/show/summary/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/orders/show/summary/component_preview.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# @component "orders/show/summary"
+class SolidusAdmin::Orders::Show::Summary::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    order = fake_order(item_total: 340, additional_tax_total: 10, shipment_total: 20, promo_total: 10, adjustment_total: 20)
+    render_with_template(locals: { order: order })
+  end
+
+  # @param item_total [Float]
+  # @param additional_tax_total [Float]
+  # @param shipment_total [Float]
+  # @param promo_total [Float]
+  # @param adjustment_total [Float]
+  def playground(item_total: 100, additional_tax_total: 10, shipment_total: 5, promo_total: 0, adjustment_total: 0)
+    fake_order = fake_order(
+      item_total: item_total,
+      additional_tax_total: additional_tax_total,
+      shipment_total: shipment_total,
+      promo_total: promo_total,
+      adjustment_total: adjustment_total
+    )
+
+    render current_component.new(order: fake_order)
+  end
+
+  private
+
+  def fake_order(item_total:, additional_tax_total:, shipment_total:, promo_total:, adjustment_total:)
+    order = Spree::Order.new
+
+    order.define_singleton_method(:item_total) { item_total }
+    order.define_singleton_method(:additional_tax_total) { additional_tax_total }
+    order.define_singleton_method(:shipment_total) { shipment_total }
+    order.define_singleton_method(:promo_total) { promo_total }
+    order.define_singleton_method(:adjustment_total) { adjustment_total }
+    order.define_singleton_method(:total) {
+      item_total.to_f + additional_tax_total.to_f + shipment_total.to_f - promo_total.to_f - adjustment_total.to_f
+    }
+
+    order
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/orders/show/summary/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/orders/show/summary/component_preview/overview.html.erb
@@ -1,0 +1,1 @@
+<%= render current_component.new(order: order) %>

--- a/admin/spec/components/previews/solidus_admin/ui/details_list/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/details_list/component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# @component "ui/details_list"
+class SolidusAdmin::UI::DetailsList::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+
+  # @param items select { choices: [[Order details, './data/example1.json'], [Product details, './data/example2.json'], [Account details, './data/example3.json']] }
+  def playground(items: './data/example1.json')
+    parsed_items = JSON.parse(
+      File.read(File.join(__dir__, items)),
+      symbolize_names: true
+    )
+
+    render current_component.new(items: parsed_items)
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/details_list/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/details_list/component_preview/overview.html.erb
@@ -1,0 +1,10 @@
+<%= render current_component.new(
+  items: [
+    { label: 'Subtotal', value: '€90.00', class: 'font-semibold' },
+    { label: 'Taxes', value: '€0.00' },
+    { label: 'Shipping', value: '€0.00' },
+    { label: link_to('Add promo code', '#', class: "body-link"), value: '€0.00' },
+    { label: link_to('Adjustments', '#', class: "body-link"), value: '€0.00' },
+    { label: 'Total', value: '€90.00', class: 'font-semibold' }
+  ]
+) %>

--- a/admin/spec/components/previews/solidus_admin/ui/details_list/data/example1.json
+++ b/admin/spec/components/previews/solidus_admin/ui/details_list/data/example1.json
@@ -1,0 +1,6 @@
+[
+  { "label": "Subtotal", "value": "€120.00", "class": "font-semibold" },
+  { "label": "Discount", "value": "€20.00", "class": "text-red-500" },
+  { "label": "Shipping", "value": "€5.00" },
+  { "label": "Total", "value": "€105.00", "class": "font-bold" }
+]

--- a/admin/spec/components/previews/solidus_admin/ui/details_list/data/example2.json
+++ b/admin/spec/components/previews/solidus_admin/ui/details_list/data/example2.json
@@ -1,0 +1,6 @@
+[
+  { "label": "Weight", "value": "2kg" },
+  { "label": "Dimensions", "value": "10x20x30 cm" },
+  { "label": "Color", "value": "Red", "class": "text-red-500" },
+  { "label": "Material", "value": "Aluminum" }
+]

--- a/admin/spec/components/previews/solidus_admin/ui/details_list/data/example3.json
+++ b/admin/spec/components/previews/solidus_admin/ui/details_list/data/example3.json
@@ -1,0 +1,6 @@
+[
+  { "label": "Name", "value": "John Doe" },
+  { "label": "Membership", "value": "Gold", "class": "font-semibold" },
+  { "label": "Points", "value": "1500" },
+  { "label": "Account Status", "value": "Deactivated", "class": "text-red-500" }
+]

--- a/admin/spec/components/solidus_admin/orders/show/summary/component_spec.rb
+++ b/admin/spec/components/solidus_admin/orders/show/summary/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::Orders::Show::Summary::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end

--- a/admin/spec/components/solidus_admin/ui/details_list/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/details_list/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::DetailsList::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

<img width="1589" alt="Screenshot 2023-11-16 at 11 18 06" src="https://github.com/solidusio/solidus/assets/19948291/4a4e4f67-11aa-406e-8db7-585ccb75a322">
<img width="1728" alt="Screenshot 2023-11-17 at 12 30 44" src="https://github.com/solidusio/solidus/assets/19948291/6f602ee7-fdc4-42f5-8f17-63bb5e0eb5d6">
<img width="1840" alt="Screenshot 2023-11-17 at 12 31 11" src="https://github.com/solidusio/solidus/assets/19948291/832bc99f-7e4a-46e6-9d4e-5554eaed0ee7">


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
