### PR TITLE
[admin] Add scopes and controller helpers for `ui/table`

### DIFF
--- a/admin/app/components/solidus_admin/layout/navigation/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/component.html.erb
@@ -4,14 +4,14 @@
   p-4
   w-full
 " data-controller="<%= stimulus_id %>" data-<%= stimulus_id %>-cookie-value="solidus_admin">
-  <%= link_to @store.url, class: "py-3 px-2 text-left flex mb-4" do %>
+  <%= link_to spree.admin_path, class: "py-3 px-2 text-left flex mb-4" do %>
     <%= image_tag @logo_path, alt: t('.visit_store'), class: "max-h-7" %>
   <% end %>
 
-  <%= link_to @store.url, target: :_blank, class: "flex mb-4 px-2 py-1.5 border border-gray-100 rounded-sm shadow-sm" do %>
+  <%= link_to @store_url, target: :_blank, class: "flex mb-4 px-2 py-1.5 border border-gray-100 rounded-sm shadow-sm" do %>
     <div class="flex-grow">
       <p class="body-small-bold text-black"><%= @store.name %></p>
-      <p class="body-tiny text-gray-500"><%= @store.url %></p>
+      <p class="body-tiny text-gray-500"><%= @store_url %></p>
     </div>
     <%= render component("ui/icon").new(name: 'arrow-right-up-line', class: 'w-4 h-4 fill-gray-400') %>
   <% end %>

--- a/admin/app/components/solidus_admin/layout/navigation/component.rb
+++ b/admin/app/components/solidus_admin/layout/navigation/component.rb
@@ -15,6 +15,12 @@ class SolidusAdmin::Layout::Navigation::Component < SolidusAdmin::BaseComponent
     @store = store
   end
 
+  def before_render
+    url = @store.url
+    url = "https://#{url}" unless url.start_with?("http")
+    @store_url = url
+  end
+
   def items
     @items.sort_by(&:position)
   end

--- a/admin/app/components/solidus_admin/orders/index/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/index/component.html.erb
@@ -32,6 +32,7 @@
       searchbar_key: SolidusAdmin::Config[:order_search_key],
       url: solidus_admin.orders_path(scope: params[:scope]),
       filters: filters,
+      scopes: scopes,
     },
   ) %>
 </div>

--- a/admin/app/components/solidus_admin/orders/index/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/index/component.html.erb
@@ -16,16 +16,22 @@
 
   <%= render component('ui/table').new(
     id: 'orders-list',
-    model_class: Spree::Order,
-    rows: @page.records,
-    row_fade: row_fade,
-    row_url: ->(order) { spree.edit_admin_order_path(order) },
-    search_key: SolidusAdmin::Config[:order_search_key],
-    search_url: solidus_admin.orders_path,
-    batch_actions: batch_actions,
-    filters: filters,
-    columns: columns,
-    prev_page_link: prev_page_link,
-    next_page_link: next_page_link,
+    data: {
+      class: Spree::Order,
+      rows: @page.records,
+      fade: row_fade,
+      url: ->(order) { spree.edit_admin_order_path(order) },
+      batch_actions: batch_actions,
+      columns: columns,
+      prev: prev_page_link,
+      next: next_page_link,
+    },
+    search: {
+      name: :q,
+      value: params[:q],
+      searchbar_key: SolidusAdmin::Config[:order_search_key],
+      url: solidus_admin.orders_path(scope: params[:scope]),
+      filters: filters,
+    },
   ) %>
 </div>

--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -102,6 +102,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::BaseComponent
   def columns
     [
       number_column,
+      state_column,
       date_column,
       customer_column,
       total_column,
@@ -120,6 +121,21 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::BaseComponent
         else
           content_tag :div, order.number
         end
+      end
+    }
+  end
+
+  def state_column
+    {
+      header: :state,
+      data: ->(order) do
+        color = {
+          'complete' => :green,
+          'returned' => :red,
+          'canceled' => :blue,
+          'cart' => :graphite_light,
+        }[order.state] || :yellow
+        component('ui/badge').new(name: order.state.humanize, color: color)
       end
     }
   end

--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -23,6 +23,16 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::BaseComponent
     []
   end
 
+  def scopes
+    [
+      { label: t('.scopes.complete'), name: 'completed', default: true },
+      { label: t('.scopes.in_progress'), name: 'in_progress' },
+      { label: t('.scopes.returned'), name: 'returned' },
+      { label: t('.scopes.canceled'), name: 'canceled' },
+      { label: t('.scopes.all_orders'), name: 'all' },
+    ]
+  end
+
   def filters
     [
       {

--- a/admin/app/components/solidus_admin/orders/index/component.yml
+++ b/admin/app/components/solidus_admin/orders/index/component.yml
@@ -15,3 +15,9 @@ en:
   date:
     formats:
       short: '%d %b %y'
+  scopes:
+    all_orders: All
+    canceled: Canceled
+    complete: Complete
+    returned: Returned
+    in_progress: In Progress

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -28,6 +28,7 @@
       url: solidus_admin.products_path,
       searchbar_key: SolidusAdmin::Config[:product_search_key],
       filters: filters,
+      scopes: scopes,
     },
   ) %>
 <% end %>

--- a/admin/app/components/solidus_admin/products/index/component.html.erb
+++ b/admin/app/components/solidus_admin/products/index/component.html.erb
@@ -13,15 +13,21 @@
 
   <%= render component('ui/table').new(
     id: 'products-list',
-    model_class: Spree::Product,
-    rows: @page.records,
-    row_url: ->(product) { solidus_admin.product_path(product) },
-    search_key: SolidusAdmin::Config[:product_search_key],
-    search_url: solidus_admin.products_path,
-    batch_actions: batch_actions,
-    filters: filters,
-    columns: columns,
-    prev_page_link: prev_page_link,
-    next_page_link: next_page_link,
+    data: {
+      class: Spree::Product,
+      rows: @page.records,
+      url: ->(product) { solidus_admin.product_path(product) },
+      prev: prev_page_link,
+      next: next_page_link,
+      columns: columns,
+      batch_actions: batch_actions,
+    },
+    search: {
+      name: :q,
+      value: params[:q],
+      url: solidus_admin.products_path,
+      searchbar_key: SolidusAdmin::Config[:product_search_key],
+      filters: filters,
+    },
   ) %>
 <% end %>

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -59,6 +59,13 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::BaseComponent
     end
   end
 
+  def scopes
+    [
+      { name: :all, label: t('.scopes.all'), default: true },
+      { name: :deleted, label: t('.scopes.deleted') },
+    ]
+  end
+
   def columns
     [
       image_column,

--- a/admin/app/components/solidus_admin/products/index/component.yml
+++ b/admin/app/components/solidus_admin/products/index/component.yml
@@ -7,3 +7,6 @@ en:
     activate: 'Activate'
   filters:
     with_deleted: Include deleted
+  scopes:
+    all: All
+    deleted: Deleted

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -34,32 +34,32 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
       hover:text-white hover:bg-gray-600
       active:text-white active:bg-gray-800
       focus:text-white focus:bg-gray-700
-      disabled:text-gray-400 disabled:bg-gray-100 disabled:cursor-not-allowed
-      aria-disabled:text-gray-400 aria-disabled:bg-gray-100 aria-disabled:aria-disabled:cursor-not-allowed
+      disabled:text-gray-400 disabled:bg-gray-100
+      aria-disabled:text-gray-400 aria-disabled:bg-gray-100
     },
     secondary: %{
       text-gray-700 bg-white border border-1 border-gray-200
       hover:bg-gray-50
       active:bg-gray-100
       focus:bg-gray-50
-      disabled:text-gray-300 disabled:bg-white disabled:cursor-not-allowed
-      aria-disabled:text-gray-300 aria-disabled:bg-white aria-disabled:cursor-not-allowed
+      disabled:text-gray-300 disabled:bg-white
+      aria-disabled:text-gray-300 aria-disabled:bg-white
     },
     danger: %{
       text-red-500 bg-white border border-1 border-red-500
       hover:bg-red-500 hover:border-red-600 hover:text-white
       active:bg-red-600 active:border-red-700 active:text-white
       focus:bg-red-50 focus:bg-red-500 focus:border-red-600 focus:text-white
-      disabled:text-red-300 disabled:bg-white disabled:border-red-200 disabled:cursor-not-allowed
-      aria-disabled:text-red-300 aria-disabled:bg-white aria-disabled:border-red-200 aria-disabled:cursor-not-allowed
+      disabled:text-red-300 disabled:bg-white disabled:border-red-200
+      aria-disabled:text-red-300 aria-disabled:bg-white aria-disabled:border-red-200
     },
     ghost: %{
       text-gray-700 bg-transparent
       hover:bg-gray-50
       active:bg-gray-100
       focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
-      disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
-      aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed
+      disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300
+      aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300
     },
   }
 

--- a/admin/app/components/solidus_admin/ui/tab/component.rb
+++ b/admin/app/components/solidus_admin/ui/tab/component.rb
@@ -23,11 +23,11 @@ class SolidusAdmin::UI::Tab::Component < SolidusAdmin::BaseComponent
         hover:bg-gray-75 hover:text-gray-700
         focus:bg-gray-25 focus:text-gray-700
 
-        active:bg-gray-50 active:text-black
+        active:bg-gray-75 active:text-black
         aria-current:bg-gray-50 aria-current:text-black
 
-        disabled:bg-gray-100 disabled:text-gray-400
-        aria-disabled:bg-gray-100 aria-disabled:text-gray-400
+        disabled:bg-gray-75 disabled:text-gray-400
+        aria-disabled:bg-gray-75 aria-disabled:text-gray-400
       ],
       SIZES.fetch(@size.to_sym),
       @attributes.delete(:class),

--- a/admin/app/components/solidus_admin/ui/tab/component.rb
+++ b/admin/app/components/solidus_admin/ui/tab/component.rb
@@ -7,7 +7,8 @@ class SolidusAdmin::UI::Tab::Component < SolidusAdmin::BaseComponent
     l: %w[h-12 px-4 body-text-bold],
   }
 
-  def initialize(text:, size: :m, current: false, disabled: false, **attributes)
+  def initialize(text:, tag: :a, size: :m, current: false, disabled: false, **attributes)
+    @tag = tag
     @text = text
     @size = size
     @attributes = attributes
@@ -35,7 +36,7 @@ class SolidusAdmin::UI::Tab::Component < SolidusAdmin::BaseComponent
 
   def call
     content_tag(
-      :a,
+      @tag,
       @text,
       **@attributes
     )

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -20,7 +20,6 @@
         html: {
           id: search_form_id,
           class: 'flex-grow',
-          "data-turbo-frame": table_frame_id,
           "data-turbo-action": "replace",
           "data-#{stimulus_id}-target": "searchForm",
           "data-action": "input->#{stimulus_id}#search change->#{stimulus_id}#search",
@@ -87,83 +86,81 @@
     <% end %>
   <% end %>
 
-  <%= turbo_frame_tag table_frame_id, target: "_top" do %>
-    <table class="table-fixed w-full border-collapse">
-      <colgroup>
-        <% @data.columns.each do |column| %>
-          <col <%= tag.attributes(**column.col) if column.col %>">
-        <% end %>
-      </colgroup>
+  <table class="table-fixed w-full border-collapse">
+    <colgroup>
+      <% @data.columns.each do |column| %>
+        <col <%= tag.attributes(**column.col) if column.col %>">
+      <% end %>
+    </colgroup>
 
+    <thead
+      class="bg-gray-15 text-gray-700 text-left text-small"
+      data-<%= stimulus_id %>-target="defaultHeader"
+    >
+      <tr>
+        <% @data.columns.each do |column| %>
+          <%= render_header_cell(column.header) %>
+        <% end %>
+      </tr>
+    </thead>
+
+    <% if @data.batch_actions %>
       <thead
-        class="bg-gray-15 text-gray-700 text-left text-small"
-        data-<%= stimulus_id %>-target="defaultHeader"
+        data-<%= stimulus_id %>-target="batchHeader"
+        class="bg-white color-black text-xs leading-none text-left"
+        hidden
       >
         <tr>
-          <% @data.columns.each do |column| %>
-            <%= render_header_cell(column.header) %>
-          <% end %>
+          <%= render_header_cell(selectable_column.header) %>
+          <%= render_header_cell(content_tag(:div, safe_join([
+            content_tag(:span, "0", "data-#{stimulus_id}-target": "selectedRowsCount"),
+            " #{t('.rows_selected')}.",
+          ])), colspan: @data.columns.count - 1) %>
         </tr>
       </thead>
+    <% end %>
 
-      <% if @data.batch_actions %>
-        <thead
-          data-<%= stimulus_id %>-target="batchHeader"
-          class="bg-white color-black text-xs leading-none text-left"
-          hidden
+    <tbody class="bg-white text-3.5 line-[150%] text-black">
+      <% @data.rows.each do |row| %>
+        <tr
+          class="border-b border-gray-100 last:border-0 hover:bg-gray-50 cursor-pointer <%= 'bg-gray-15 text-gray-700' if @data.fade&.call(row) %>"
+          <% if @data.url %>
+            data-action="click-><%= stimulus_id %>#rowClicked"
+            data-<%= stimulus_id %>-url-param="<%= @data.url.call(row) %>"
+          <% end %>
         >
-          <tr>
-            <%= render_header_cell(selectable_column.header) %>
-            <%= render_header_cell(content_tag(:div, safe_join([
-              content_tag(:span, "0", "data-#{stimulus_id}-target": "selectedRowsCount"),
-              " #{t('.rows_selected')}.",
-            ])), colspan: @data.columns.count - 1) %>
-          </tr>
-        </thead>
+          <% @data.columns.each do |column| %>
+            <%= render_data_cell(column, row) %>
+          <% end %>
+        </tr>
       <% end %>
 
-      <tbody class="bg-white text-3.5 line-[150%] text-black">
-        <% @data.rows.each do |row| %>
-          <tr
-            class="border-b border-gray-100 last:border-0 hover:bg-gray-50 cursor-pointer <%= 'bg-gray-15 text-gray-700' if @data.fade&.call(row) %>"
-            <% if @data.url %>
-              data-action="click-><%= stimulus_id %>#rowClicked"
-              data-<%= stimulus_id %>-url-param="<%= @data.url.call(row) %>"
-            <% end %>
+      <% if @data.rows.empty? && @data.plural_name %>
+        <tr>
+          <td
+            colspan="<%= @data.columns.size %>"
+            class="text-center py-4 text-3.5 line-[150%] text-black bg-white rounded-b-lg"
           >
-            <% @data.columns.each do |column| %>
-              <%= render_data_cell(column, row) %>
-            <% end %>
-          </tr>
-        <% end %>
-
-        <% if @data.rows.empty? && @data.plural_name %>
-          <tr>
-            <td
-              colspan="<%= @data.columns.size %>"
-              class="text-center py-4 text-3.5 line-[150%] text-black bg-white rounded-b-lg"
-            >
-              <%= t('.no_resources_found', resources: @data.plural_name) %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-
-      <% if @data.prev || @data.next %>
-        <tfoot>
-          <tr>
-            <td colspan="<%= @data.columns.size %>" class="py-4 bg-white rounded-b-lg border-t border-gray-100">
-              <div class="flex justify-center">
-                <%= render component('ui/table/pagination').new(
-                  prev_link: @data.prev,
-                  next_link: @data.next
-                ) %>
-              </div>
-            </td>
-          </tr>
-        </tfoot>
+            <%= t('.no_resources_found', resources: @data.plural_name) %>
+          </td>
+        </tr>
       <% end %>
+    </tbody>
 
-    </table>
-  <% end %>
+    <% if @data.prev || @data.next %>
+      <tfoot>
+        <tr>
+          <td colspan="<%= @data.columns.size %>" class="py-4 bg-white rounded-b-lg border-t border-gray-100">
+            <div class="flex justify-center">
+              <%= render component('ui/table/pagination').new(
+                prev_link: @data.prev,
+                next_link: @data.next
+              ) %>
+            </div>
+          </td>
+        </tr>
+      </tfoot>
+    <% end %>
+
+  </table>
 </div>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -26,6 +26,7 @@
           "data-action": "input->#{stimulus_id}#search change->#{stimulus_id}#search",
         },
       ) do |form| %>
+        <%= hidden_field_tag scope_param_name, current_scope_name %>
         <%= render component('ui/forms/search_field').new(
           name: "#{@search_param}[#{@search_key}]",
           value: params.dig(@search_param, @search_key),
@@ -54,7 +55,19 @@
 
     <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "scopesToolbar", hidden: initial_mode != "scopes") do %>
       <div class="flex-grow">
-        <%= render component("ui/tab").new(text: "All", current: true, href: "") %>
+        <%= form_with(url: @search_url, method: :get) do %>
+          <% @scopes.each do |scope| %>
+            <%= render component("ui/tab").new(
+              tag: :button,
+              type: :submit,
+              text: scope.label,
+              current: current_scope_name == scope.name.to_s,
+              name: scope_param_name,
+              value: scope.name,
+            ) %>
+            <%#= render component("ui/tab").new(text: scope.label, current: current, href: scope.path) %>
+          <% end %>
+        <% end %>
       </div>
 
       <%= render component("ui/button").new(

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -15,7 +15,7 @@
   <div role="search">
     <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "searchToolbar", hidden: initial_mode != "search") do %>
       <%= form_with(
-        url: @search_url,
+        url: @search.url,
         method: :get,
         html: {
           id: search_form_id,
@@ -26,13 +26,15 @@
           "data-action": "input->#{stimulus_id}#search change->#{stimulus_id}#search",
         },
       ) do |form| %>
-        <%= hidden_field_tag scope_param_name, current_scope_name %>
+        <%= hidden_field_tag @search.scope_param_name, @search.current_scope.name if @search.scopes.present? %>
         <%= render component('ui/forms/search_field').new(
-          name: "#{@search_param}[#{@search_key}]",
-          value: params.dig(@search_param, @search_key),
-          placeholder: t('.search_placeholder', resources: resource_plural_name),
+          name: @search.searchbar_param_name,
+          value: @search.value[@search.searchbar_key],
+          placeholder: t('.search_placeholder', resources: @data.plural_name),
+          "aria-label": t('.search_placeholder', resources: @data.plural_name),
           "data-#{stimulus_id}-target": "searchField",
-          "aria-label": t('.search_placeholder', resources: resource_plural_name),
+          "data-turbo-permanent": "true",
+          id: "#{stimulus_id}-search-field-#{@id}",
         ) %>
       <% end %>
 
@@ -45,9 +47,9 @@
       </div>
     <% end %>
 
-    <% if @filters.any? %>
+    <% if @search.filters.any? %>
       <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "filterToolbar", hidden: initial_mode != "search") do %>
-        <% @filters.each_with_index do |filter, index| %>
+        <% @search.filters.each_with_index do |filter, index| %>
           <%= render_ransack_filter_dropdown(filter, index) %>
         <% end %>
       <% end %>
@@ -55,17 +57,16 @@
 
     <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "scopesToolbar", hidden: initial_mode != "scopes") do %>
       <div class="flex-grow">
-        <%= form_with(url: @search_url, method: :get) do %>
-          <% @scopes.each do |scope| %>
+        <%= form_with(url: @search.url, method: :get) do %>
+          <% @search.scopes.each do |scope| %>
             <%= render component("ui/tab").new(
               tag: :button,
               type: :submit,
               text: scope.label,
-              current: current_scope_name == scope.name.to_s,
-              name: scope_param_name,
+              current: scope == @search.current_scope,
+              name: @search.scope_param_name,
               value: scope.name,
             ) %>
-            <%#= render component("ui/tab").new(text: scope.label, current: current, href: scope.path) %>
           <% end %>
         <% end %>
       </div>
@@ -81,7 +82,7 @@
 
   <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "batchToolbar", role: "toolbar", "aria-label": t(".batch_actions"), hidden: true) do %>
     <%= form_tag '', id: batch_actions_form_id %>
-    <% @batch_actions.each do |batch_action| %>
+    <% @data.batch_actions.each do |batch_action| %>
       <%= render_batch_action_button(batch_action) %>
     <% end %>
   <% end %>
@@ -89,7 +90,7 @@
   <%= turbo_frame_tag table_frame_id, target: "_top" do %>
     <table class="table-fixed w-full border-collapse">
       <colgroup>
-        <% @columns.each do |column| %>
+        <% @data.columns.each do |column| %>
           <col <%= tag.attributes(**column.col) if column.col %>">
         <% end %>
       </colgroup>
@@ -99,13 +100,13 @@
         data-<%= stimulus_id %>-target="defaultHeader"
       >
         <tr>
-          <% @columns.each do |column| %>
+          <% @data.columns.each do |column| %>
             <%= render_header_cell(column.header) %>
           <% end %>
         </tr>
       </thead>
 
-      <% if @batch_actions %>
+      <% if @data.batch_actions %>
         <thead
           data-<%= stimulus_id %>-target="batchHeader"
           class="bg-white color-black text-xs leading-none text-left"
@@ -116,46 +117,46 @@
             <%= render_header_cell(content_tag(:div, safe_join([
               content_tag(:span, "0", "data-#{stimulus_id}-target": "selectedRowsCount"),
               " #{t('.rows_selected')}.",
-            ])), colspan: @columns.count - 1) %>
+            ])), colspan: @data.columns.count - 1) %>
           </tr>
         </thead>
       <% end %>
 
       <tbody class="bg-white text-3.5 line-[150%] text-black">
-        <% @rows.each do |row| %>
+        <% @data.rows.each do |row| %>
           <tr
-            class="border-b border-gray-100 last:border-0 hover:bg-gray-50 cursor-pointer <%= 'bg-gray-15 text-gray-700' if @row_fade&.call(row) %>"
-            <% if @row_url %>
+            class="border-b border-gray-100 last:border-0 hover:bg-gray-50 cursor-pointer <%= 'bg-gray-15 text-gray-700' if @data.fade&.call(row) %>"
+            <% if @data.url %>
               data-action="click-><%= stimulus_id %>#rowClicked"
-              data-<%= stimulus_id %>-url-param="<%= @row_url.call(row) %>"
+              data-<%= stimulus_id %>-url-param="<%= @data.url.call(row) %>"
             <% end %>
           >
-            <% @columns.each do |column| %>
+            <% @data.columns.each do |column| %>
               <%= render_data_cell(column, row) %>
             <% end %>
           </tr>
         <% end %>
 
-        <% if @rows.empty? && @model_class %>
+        <% if @data.rows.empty? && @data.plural_name %>
           <tr>
             <td
-              colspan="<%= @columns.size %>"
+              colspan="<%= @data.columns.size %>"
               class="text-center py-4 text-3.5 line-[150%] text-black bg-white rounded-b-lg"
             >
-              <%= t('.no_resources_found', resources: resource_plural_name) %>
+              <%= t('.no_resources_found', resources: @data.plural_name) %>
             </td>
           </tr>
         <% end %>
       </tbody>
 
-      <% if @prev_page_link || @next_page_link %>
+      <% if @data.prev || @data.next %>
         <tfoot>
           <tr>
-            <td colspan="<%= @columns.size %>" class="py-4 bg-white rounded-b-lg border-t border-gray-100">
+            <td colspan="<%= @data.columns.size %>" class="py-4 bg-white rounded-b-lg border-t border-gray-100">
               <div class="flex justify-center">
                 <%= render component('ui/table/pagination').new(
-                  prev_link: @prev_page_link,
-                  next_link: @next_page_link
+                  prev_link: @data.prev,
+                  next_link: @data.next
                 ) %>
               </div>
             </td>

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -6,13 +6,14 @@
   "
   data-controller="<%= stimulus_id %>"
   data-<%= stimulus_id %>-selected-row-class="bg-gray-15"
+  data-<%= stimulus_id %>-mode-value="<%= initial_mode %>"
   data-action="
     <%= component("ui/table/ransack_filter").stimulus_id %>:search-><%= stimulus_id %>#search
     <%= component("ui/table/ransack_filter").stimulus_id %>:showSearch-><%= stimulus_id %>#showSearch
   "
 >
   <div role="search">
-    <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "searchToolbar") do %>
+    <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "searchToolbar", hidden: initial_mode != "search") do %>
       <%= form_with(
         url: @search_url,
         method: :get,
@@ -30,7 +31,7 @@
           value: params.dig(@search_param, @search_key),
           placeholder: t('.search_placeholder', resources: resource_plural_name),
           "data-#{stimulus_id}-target": "searchField",
-          "aria-label": t('.search_placeholder', resources: resource_plural_name)
+          "aria-label": t('.search_placeholder', resources: resource_plural_name),
         ) %>
       <% end %>
 
@@ -44,14 +45,14 @@
     <% end %>
 
     <% if @filters.any? %>
-      <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "filterToolbar") do %>
+      <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "filterToolbar", hidden: initial_mode != "search") do %>
         <% @filters.each_with_index do |filter, index| %>
           <%= render_ransack_filter_dropdown(filter, index) %>
         <% end %>
       <% end %>
     <% end %>
 
-    <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "scopesToolbar") do %>
+    <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "scopesToolbar", hidden: initial_mode != "scopes") do %>
       <div class="flex-grow">
         <%= render component("ui/tab").new(text: "All", current: true, href: "") %>
       </div>
@@ -65,7 +66,7 @@
     <% end %>
   </div>
 
-  <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "batchToolbar", role: "toolbar", "aria-label": t(".batch_actions")) do %>
+  <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "batchToolbar", role: "toolbar", "aria-label": t(".batch_actions"), hidden: true) do %>
     <%= form_tag '', id: batch_actions_form_id %>
     <% @batch_actions.each do |batch_action| %>
       <%= render_batch_action_button(batch_action) %>

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -29,12 +29,6 @@ export default class extends Controller {
     this.search = debounce(this.search.bind(this), 200)
   }
 
-  connect() {
-    if (this.searchFieldTarget.value !== "") this.modeValue = "search"
-
-    this.render()
-  }
-
   showSearch(event) {
     this.modeValue = "search"
     this.render()
@@ -51,10 +45,18 @@ export default class extends Controller {
   }
 
   cancelSearch() {
-    this.clearSearch()
+    this.resetFilters()
+    this.search()
+  }
 
-    this.modeValue = "scopes"
-    this.render()
+  resetFilters() {
+    if (!this.hasFilterToolbarTarget) return
+
+    for (const fieldset of this.filterToolbarTarget.querySelectorAll('fieldset')) {
+      fieldset.setAttribute('disabled', true)
+    }
+    this.searchFieldTarget.setAttribute('disabled', true)
+    this.searchFormTarget.submit()
   }
 
   selectRow(event) {

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -132,4 +132,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     ")
   end
 
+
+  def initial_mode
+    @initial_mode ||= params.dig(@search_param, @search_key) ? "search" : "scopes"
+  end
 end

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -7,36 +7,53 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   Scope = Struct.new(:name, :label, :default, keyword_init: true)
   private_constant :BatchAction, :Column, :Filter, :Scope
 
-  Data = Struct.new(:rows, :class, :url, :prev, :next, :columns, :fade, :batch_actions, keyword_init: true) # rubocop:disable Lint/StructNewOverride
-  Search = Struct.new(:name, :value, :url, :searchbar_key, :filters, :scopes, keyword_init: true)
+  class Data < Struct.new(:rows, :class, :url, :prev, :next, :columns, :fade, :batch_actions, keyword_init: true) # rubocop:disable Lint/StructNewOverride,Style/StructInheritance
+    def initialize(**args)
+      super
+
+      self.columns = columns.map { |column| Column.new(wrap: false, **column) }
+      self.batch_actions = batch_actions.to_a.map { |action| BatchAction.new(**action) }
+    end
+
+    def plural_name
+      self[:class].model_name.human.pluralize if self[:class]
+    end
+  end
+
+  class Search < Struct.new(:name, :value, :url, :searchbar_key, :filters, :scopes, keyword_init: true) # rubocop:disable Style/StructInheritance
+    def initialize(**args)
+      super
+
+      self.filters = filters.to_a.map { |filter| Filter.new(**filter) }
+      self.scopes = scopes.to_a.map { |scope| Scope.new(**scope) }
+    end
+
+    def current_scope
+      scopes.find { |scope| scope.name.to_s == value[:scope].presence } || default_scope
+    end
+
+    def default_scope
+      scopes.find(&:default)
+    end
+
+    def scope_param_name
+      "#{name}[scope]"
+    end
+
+    def searchbar_param_name
+      "#{name}[#{searchbar_key}]"
+    end
+
+    def value
+      super || {}
+    end
+  end
 
   def initialize(id:, data:, search: nil)
     @id = id
     @data = Data.new(**data)
+    @data.columns.unshift selectable_column if @data.batch_actions.present?
     @search = Search.new(**search)
-
-    # Data
-    @columns = @data.columns.map { Column.new(wrap: true, **_1) }
-    @columns.unshift selectable_column if @data.batch_actions.present?
-    @batch_actions = @data.batch_actions&.map { BatchAction.new(**_1) }
-    @model_class = data[:class]
-    @rows = @data.rows
-    @row_fade = @data.fade
-    @row_url = @data.url
-    @prev_page_link = @data.prev
-    @next_page_link = @data.next
-
-    # Search
-    @filters = @search.filters.map { Filter.new(**_1) }
-    @scopes = @search.scopes.map { Scope.new(**_1) }
-    @search_param = @search.name
-    @search_params = @search.value
-    @search_key = @search.searchbar_key
-    @search_url = @search.url
-  end
-
-  def resource_plural_name
-    @model_class.model_name.human.pluralize
   end
 
   def selectable_column
@@ -95,7 +112,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   def render_ransack_filter_dropdown(filter, index)
     render component("ui/table/ransack_filter").new(
       presentation: filter.presentation,
-      search_param: @search_param,
+      search_param: @search.name,
       combinator: filter.combinator,
       attribute: filter.attribute,
       predicate: filter.predicate,
@@ -107,7 +124,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
 
   def render_header_cell(cell, **attrs)
     cell = cell.call if cell.respond_to?(:call)
-    cell = @model_class.human_attribute_name(cell) if cell.is_a?(Symbol)
+    cell = @data[:class].human_attribute_name(cell) if cell.is_a?(Symbol)
     cell = cell.render_in(self) if cell.respond_to?(:render_in)
 
     content_tag(:th, cell, class: %{
@@ -135,14 +152,10 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   def current_scope_name
-    @current_scope_name ||= params.dig(@search_param, :scope).presence || @scopes.find(&:default)&.name&.to_s
-  end
-
-  def scope_param_name
-    @scope_param_name ||= "#{@search_param}[scope]"
+    @search.current_scope.name
   end
 
   def initial_mode
-    @initial_mode ||= params.dig(@search_param, @search_key) ? "search" : "scopes"
+    @initial_mode ||= @search.value[@search.searchbar_key] ? "search" : "scopes"
   end
 end

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -4,7 +4,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   BatchAction = Struct.new(:display_name, :icon, :action, :method, keyword_init: true) # rubocop:disable Lint/StructNewOverride
   Column = Struct.new(:header, :data, :col, :wrap, keyword_init: true)
   Filter = Struct.new(:presentation, :combinator, :attribute, :predicate, :options, keyword_init: true)
-  private_constant :BatchAction, :Column, :Filter
+  Scope = Struct.new(:name, :label, :default, keyword_init: true)
+  private_constant :BatchAction, :Column, :Filter, :Scope
 
   Data = Struct.new(:rows, :class, :url, :prev, :next, :columns, :fade, :batch_actions, keyword_init: true) # rubocop:disable Lint/StructNewOverride
   Search = Struct.new(:name, :value, :url, :searchbar_key, :filters, :scopes, keyword_init: true)
@@ -27,6 +28,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
 
     # Search
     @filters = @search.filters.map { Filter.new(**_1) }
+    @scopes = @search.scopes.map { Scope.new(**_1) }
     @search_param = @search.name
     @search_params = @search.value
     @search_key = @search.searchbar_key
@@ -132,6 +134,13 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     ")
   end
 
+  def current_scope_name
+    @current_scope_name ||= params.dig(@search_param, :scope).presence || @scopes.find(&:default)&.name&.to_s
+  end
+
+  def scope_param_name
+    @scope_param_name ||= "#{@search_param}[scope]"
+  end
 
   def initial_mode
     @initial_mode ||= params.dig(@search_param, @search_key) ? "search" : "scopes"

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -126,7 +126,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     cell = cell.call(data) if cell.respond_to?(:call)
     cell = data.public_send(cell) if cell.is_a?(Symbol)
     cell = cell.render_in(self) if cell.respond_to?(:render_in)
-    cell = tag.div(cell, class: "flex items-center gap-1.5 justify-start overflow-hidden") if column.wrap
+    cell = tag.div(cell, class: "flex items-center gap-1.5 justify-start overflow-x-hidden") if column.wrap
 
     tag.td(cell, class: "
       py-2 px-4 h-10 vertical-align-middle leading-none

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -84,10 +84,6 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     @batch_actions_form_id ||= "#{stimulus_id}--batch-actions-#{@id}"
   end
 
-  def table_frame_id
-    @table_frame_id ||= "#{stimulus_id}--table-frame-#{@id}"
-  end
-
   def search_form_id
     @search_form_id ||= "#{stimulus_id}--search-form-#{@id}"
   end

--- a/admin/app/components/solidus_admin/ui/table/ransack_filter/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/ransack_filter/component.html.erb
@@ -52,7 +52,7 @@
                      checked: selection.checked,
                      size: :s,
                      form: @form,
-                     "data-action": "#{stimulus_id}#search #{stimulus_id}#sortCheckboxes",
+                     "data-action": "#{stimulus_id}#search #{stimulus_id}#sortCheckboxes #{stimulus_id}#updateHiddenInputs",
                      "data-#{stimulus_id}-target": "checkbox"
                    ) %>
 

--- a/admin/app/components/solidus_admin/ui/table/ransack_filter/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/ransack_filter/component.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= stimulus_id %>" data-controller="<%= stimulus_id %>">
+<fieldset class="<%= stimulus_id %>" data-controller="<%= stimulus_id %>">
   <input type="hidden" form="<%= @form %>"
          name="<%= @combinator.name %>"
          value="<%= @combinator.value %>">
@@ -68,4 +68,4 @@
       </div>
     </div>
   </details>
-</div>
+</fieldset>

--- a/admin/app/components/solidus_admin/ui/table/ransack_filter/component.js
+++ b/admin/app/components/solidus_admin/ui/table/ransack_filter/component.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     useDebounce(this, { wait: 50 })
     useClickOutside(this)
     this.init()
+    this.updateHiddenInputs()
   }
 
   clickOutside(event) {
@@ -42,6 +43,15 @@ export default class extends Controller {
   search() {
     this.dispatch("search")
     this.highlightFilter()
+  }
+
+  updateHiddenInputs() {
+    this.checkboxTargets.forEach((checkbox) => {
+      const hiddenElements = checkbox.parentElement.querySelectorAll("input[type='hidden']")
+      checkbox.checked
+        ? hiddenElements.forEach(e => e.removeAttribute("disabled"))
+        : hiddenElements.forEach(e => e.setAttribute("disabled", true))
+    })
   }
 
   sortCheckboxes() {

--- a/admin/app/controllers/solidus_admin/controller_helpers/search.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/search.rb
@@ -3,9 +3,24 @@
 module SolidusAdmin::ControllerHelpers::Search
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def search_scope(name, default: false, &block)
+      search_scopes << SearchScope.new(
+        name: name.to_s,
+        block: block,
+        default: default,
+      )
+    end
+
+    def search_scopes
+      @search_scopes ||= []
+    end
+  end
+
   private
 
   def apply_search_to(relation, param:)
+    relation = apply_scopes_to(relation, param: param)
     apply_ransack_search_to(relation, param: param)
   end
 
@@ -14,4 +29,20 @@ module SolidusAdmin::ControllerHelpers::Search
       .ransack(params[param]&.except(:scope))
       .result(distinct: true)
   end
+
+  def apply_scopes_to(relation, param:)
+    current_scope_name = params.dig(param, :scope)
+
+    search_block = (
+      self.class.search_scopes.find { _1.name == current_scope_name } ||
+      self.class.search_scopes.find { _1.default }
+    )&.block
+
+    # Run the search if a block is present, fall back to the relation even if the
+    # block is present but returns nil.
+    (search_block && instance_exec(relation, &search_block)) || relation
+  end
+
+  SearchScope = Struct.new(:name, :block, :default, keyword_init: true)
+  private_constant :SearchScope
 end

--- a/admin/app/controllers/solidus_admin/controller_helpers/search.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/search.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusAdmin::ControllerHelpers::Search
+  extend ActiveSupport::Concern
+
+  private
+
+  def apply_search_to(relation, param:)
+    apply_ransack_search_to(relation, param: param)
+  end
+
+  def apply_ransack_search_to(relation, param:)
+    relation
+      .ransack(params[param]&.except(:scope))
+      .result(distinct: true)
+  end
+end

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -3,12 +3,13 @@
 module SolidusAdmin
   class OrdersController < SolidusAdmin::BaseController
     include Spree::Core::ControllerHelpers::StrongParameters
+    include SolidusAdmin::ControllerHelpers::Search
 
     def index
-      orders = Spree::Order
-        .order(created_at: :desc, id: :desc)
-        .ransack(params[:q])
-        .result(distinct: true)
+      orders = apply_search_to(
+        Spree::Order.order(created_at: :desc, id: :desc),
+        param: :q,
+      )
 
       set_page_and_extract_portion_from(
         orders,

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -5,6 +5,12 @@ module SolidusAdmin
     include Spree::Core::ControllerHelpers::StrongParameters
     include SolidusAdmin::ControllerHelpers::Search
 
+    search_scope(:completed, default: true) { _1.complete }
+    search_scope(:canceled) { _1.canceled }
+    search_scope(:returned) { _1.with_state(:returned) }
+    search_scope(:in_progress) { _1.with_state([:cart] + _1.checkout_step_names) }
+    search_scope(:all) { _1 }
+
     def index
       orders = apply_search_to(
         Spree::Order.order(created_at: :desc, id: :desc),

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -2,6 +2,24 @@
 
 module SolidusAdmin
   class ProductsController < SolidusAdmin::BaseController
+    include SolidusAdmin::ControllerHelpers::Search
+
+    def index
+      products = apply_search_to(
+        Spree::Product.order(created_at: :desc, id: :desc),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(
+        products,
+        per_page: SolidusAdmin::Config[:products_per_page]
+      )
+
+      respond_to do |format|
+        format.html { render component('products/index').new(page: @page) }
+      end
+    end
+
     def edit
       redirect_to action: :show
     end
@@ -30,22 +48,6 @@ module SolidusAdmin
         respond_to do |format|
           format.html { render component('products/show').new(product: @product), status: :unprocessable_entity }
         end
-      end
-    end
-
-    def index
-      products = Spree::Product
-        .order(created_at: :desc, id: :desc)
-        .ransack(params[:q])
-        .result(distinct: true)
-
-      set_page_and_extract_portion_from(
-        products,
-        per_page: SolidusAdmin::Config[:products_per_page]
-      )
-
-      respond_to do |format|
-        format.html { render component('products/index').new(page: @page) }
       end
     end
 

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -4,6 +4,9 @@ module SolidusAdmin
   class ProductsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
+    search_scope(:all, default: true)
+    search_scope(:deleted) { _1.with_discarded.discarded }
+
     def index
       products = apply_search_to(
         Spree::Product.order(created_at: :desc, id: :desc),

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -2,6 +2,7 @@
 
 SolidusAdmin::Engine.routes.draw do
   resource :account, only: :show
+
   resources(
     :products,
     only: [:index, :show, :edit, :update],

--- a/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/table/component_preview.rb
@@ -14,21 +14,25 @@ class SolidusAdmin::UI::Table::ComponentPreview < ViewComponent::Preview
   def simple
     render current_component.new(
       id: 'simple-list',
-      model_class: Spree::Product,
-      rows: Array.new(10) { |n|
-        Spree::Product.new(id: n, name: "Product #{n}", price: n * 10.0, available_on: n.days.ago)
+      data: {
+        class: Spree::Product,
+        rows: Array.new(10) { |n|
+          Spree::Product.new(id: n, name: "Product #{n}", price: n * 10.0, available_on: n.days.ago)
+        },
+        columns: [
+          { header: :id, data: -> { _1.id.to_s } },
+          { header: :name, data: :name },
+          { header: -> { "Availability at #{Time.current}" }, data: -> { "#{time_ago_in_words _1.available_on} ago" } },
+          { header: -> { component("ui/badge").new(name: "$$$") }, data: -> { component("ui/badge").new(name: _1.display_price, color: :green) } },
+          { header: "Generated at", data: Time.current.to_s },
+        ],
+        prev: nil,
+        next: '#2',
       },
-      search_key: :no_key,
-      search_url: '#',
-      columns: [
-        { header: :id, data: -> { _1.id.to_s } },
-        { header: :name, data: :name },
-        { header: -> { "Availability at #{Time.current}" }, data: -> { "#{time_ago_in_words _1.available_on} ago" } },
-        { header: -> { component("ui/badge").new(name: "$$$") }, data: -> { component("ui/badge").new(name: _1.display_price, color: :green) } },
-        { header: "Generated at", data: Time.current.to_s },
-      ],
-      prev_page_link: nil,
-      next_page_link: '#2',
+      search: {
+        name: :no_key,
+        url: '#',
+      },
     )
   end
 end

--- a/admin/spec/features/orders_spec.rb
+++ b/admin/spec/features/orders_spec.rb
@@ -9,6 +9,7 @@ describe "Orders", type: :feature do
     create(:order, number: "R123456789", total: 19.99)
 
     visit "/admin/orders"
+    click_on "In Progress"
 
     expect(page).to have_content("R123456789")
     expect(page).to have_content("$19.99")


### PR DESCRIPTION
## Summary

<img width="1570" alt="image" src="https://github.com/solidusio/solidus/assets/1051/367abc68-6392-4220-8b5a-810e6267855f">

This is a big-ish refactoring of the `ui/table` component, including:

- added support for scopes
- added search helpers for controllers
- grouped keyword arguments
- removed the internal turbo frame
- fixed resetting filters when exiting a search

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
