### PR TITLE
[admin] Fix menu styles & add a backend menu items importer

### DIFF
--- a/admin/app/components/solidus_admin/layout/navigation/account/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/account/component.html.erb
@@ -14,7 +14,7 @@
       cursor-pointer
     ">
     <%= icon_tag("user-smile-fill", class: "inline-block align-text-bottom shrink-0 w-6 h-6 rounded-[4.81rem] body-small fill-yellow bg-black") %>
-    <span class="overflow-hidden whitespace-nowrap text-ellipsis">
+    <span class="overflow-hidden whitespace-nowrap text-ellipsis leading-6">
       <%= @user_label %>
     </span>
   </summary>

--- a/admin/app/components/solidus_admin/layout/navigation/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/component.html.erb
@@ -9,14 +9,14 @@
   <% end %>
 
   <%= link_to @store_url, target: :_blank, class: "flex mb-4 px-2 py-1.5 border border-gray-100 rounded-sm shadow-sm" do %>
-    <div class="flex-grow">
+    <div class="flex-grow flex flex-col gap-0.5">
       <p class="body-small-bold text-black"><%= @store.name %></p>
-      <p class="body-tiny text-gray-500"><%= @store_url %></p>
+      <p class="body-tiny text-gray-500"><%= @store.url %></p>
     </div>
     <%= render component("ui/icon").new(name: 'arrow-right-up-line', class: 'w-4 h-4 fill-gray-400') %>
   <% end %>
 
-  <ul>
+  <ul class="flex flex-col gap-0.5">
     <%= render component("layout/navigation/item").with_collection(items, fullpath: request.fullpath) %>
   </ul>
 

--- a/admin/app/components/solidus_admin/layout/navigation/item/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/item/component.html.erb
@@ -4,7 +4,7 @@
     aria-current="<%= @item.current?(@url_helpers, @fullpath) ? "page" : "false" %>"
     class="
       flex gap-3 items-center
-      py-0.5 px-3 mb-0.5 rounded
+      py-1 px-3 rounded
       hover:text-red-500 hover:bg-gray-50
       <%= "text-red-500 bg-gray-50" if active? %>
       <%= @item.top_level ? "body-small-bold text-black" : "body-small text-gray-600" %>
@@ -19,7 +19,7 @@
   </a>
 
   <% if @item.children? %>
-    <ul class="<%= "hidden" unless active? %>">
+    <ul class="flex flex-col gap-0.5 pt-0.5 <%= "hidden" unless active? %>">
       <%= render self.class.with_collection(@item.children, url_helpers: @url_helpers, fullpath: @fullpath) %>
     </ul>
   <% end %>

--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -17,7 +17,7 @@ module SolidusAdmin
       end
 
       def copy_initializer
-        copy_file "config/initializers/solidus_admin.rb"
+        template 'config/initializers/solidus_admin.rb.tt', 'config/initializers/solidus_admin.rb'
       end
 
       def ignore_tailwind_build_files

--- a/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
+++ b/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
@@ -23,6 +23,15 @@ SolidusAdmin::Config.configure do |config|
   # regeneration of the importmap.
   # config.importmap_cache_sweepers << Rails.root.join("app/javascript/my_admin_components")
 
+  # If you want to avoid defining menu_item customizations twice while migrating to SolidusAdmin
+  # you can import menu_items from the backend by uncommenting the following line,
+  # but you will need to
+  <%- if defined? Spree::Backend -%>
+  config.import_menu_items_from_backend!
+  <%- else -%>
+  # config.import_menu_items_from_backend!
+  <%- end -%>
+
   # Add custom paths to importmap files to be loaded.
   # config.importmap_paths << Rails.root.join("config/solidus_admin_importmap.rb")
   #

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation_solidus_admin.scss
@@ -4,7 +4,7 @@ $color-navbar-hover: $color-navbar !default;
 @import "spree/backend/components/switch_solidus_admin";
 
 .solidus-admin--nav {
-  background-color: $color-light;
+  background-color: $solidus-admin-gray-15;
   position: sticky;
   top: 0;
   bottom: 0;
@@ -93,7 +93,7 @@ $color-navbar-hover: $color-navbar !default;
     }
 
     &--name {
-      line-height: 24px;
+      line-height: 20px;
       font-size: 14px;
       font-weight: 600;
       color: $color-dark;
@@ -101,7 +101,7 @@ $color-navbar-hover: $color-navbar !default;
     }
 
     &--url {
-      line-height: 20px;
+      line-height: 16px;
       font-size: 12px;
       font-weight: 400;
       color: $color-dark-light;
@@ -120,6 +120,7 @@ $color-navbar-hover: $color-navbar !default;
     padding: 0;
     list-style: none;
     text-align: left;
+    margin-bottom: 12px;
 
     li {
       padding: 0;
@@ -150,6 +151,10 @@ $color-navbar-hover: $color-navbar !default;
         height: 18px;
         padding: 0;
       }
+    }
+
+    li > label > span {
+      line-height: 20px;
     }
 
     li.selected > a {

--- a/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_solidus_admin.html.erb
@@ -8,7 +8,7 @@
       <%- end %>
 
       <%= link_to "//#{default_store.url}", target: '_blank', class: 'solidus-admin--nav--store-link' do %>
-        <div style="flex-grow: 1">
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 2px;">
           <span class="solidus-admin--nav--store-link--name"><%= default_store.name %></span>
           <span class="solidus-admin--nav--store-link--url"><%= default_store.url %></span>
         </div>


### PR DESCRIPTION
## Summary

Over time the Spree::Backend and SolidusAdmin menu styles slightly diverged, on top of that whenever a store has menu customization is way more convenient to import them from Backend and maintain them in a single place.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
