### PR TITLE
[Admin] Add `Option Types` index component

### DIFF
--- a/admin/app/components/solidus_admin/option_types/index/component.html.erb
+++ b/admin/app/components/solidus_admin/option_types/index/component.html.erb
@@ -1,0 +1,28 @@
+<%= page do %>
+  <%= page_header do %>
+    <%= page_header_title title %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").new(
+        tag: :a,
+        text: t('.create_option_type'),
+        href: spree.new_admin_option_type_path,
+        icon: "add-line",
+      ) %>
+    <% end %>
+  <% end %>
+
+  <%= render component('ui/table').new(
+    id: 'option-types-list',
+    data: {
+      class: Spree::OptionType,
+      rows: @option_types,
+      url: ->(option_type) { spree.edit_admin_option_type_path(option_type) },
+      columns: columns,
+      batch_actions: batch_actions,
+    },
+    sortable: {
+      url: ->(option_type) { solidus_admin.move_option_type_path(option_type) },
+      param: 'position',
+    },
+  ) %>
+<% end %>

--- a/admin/app/components/solidus_admin/option_types/index/component.rb
+++ b/admin/app/components/solidus_admin/option_types/index/component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::OptionTypes::Index::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(option_types:)
+    @option_types = option_types
+  end
+
+  def title
+    Spree::OptionType.model_name.human.pluralize
+  end
+
+  def columns
+    [
+      name_column,
+      presentation_column,
+    ]
+  end
+
+  def name_column
+    {
+      header: :name,
+      data: ->(option_type) do
+        content_tag :div, option_type.name
+      end
+    }
+  end
+
+  def presentation_column
+    {
+      header: :presentation,
+      data: ->(option_type) do
+        content_tag :div, option_type.presentation
+      end
+    }
+  end
+
+  def batch_actions
+    [
+      {
+        display_name: t('.batch_actions.delete'),
+        action: solidus_admin.option_types_path,
+        method: :delete,
+        icon: 'delete-bin-7-line',
+      },
+    ]
+  end
+end

--- a/admin/app/components/solidus_admin/option_types/index/component.yml
+++ b/admin/app/components/solidus_admin/option_types/index/component.yml
@@ -1,0 +1,4 @@
+en:
+  batch_actions:
+    delete: 'Delete'
+  create_option_type: Create Option Type

--- a/admin/app/controllers/solidus_admin/option_types_controller.rb
+++ b/admin/app/controllers/solidus_admin/option_types_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class OptionTypesController < SolidusAdmin::BaseController
+    before_action :load_option_type, only: [:move]
+
+    def move
+      @option_type.insert_at(params[:position].to_i)
+
+      respond_to do |format|
+        format.js { head :no_content }
+      end
+    end
+
+    def destroy
+      @option_types = Spree::OptionType.where(id: params[:id])
+
+      Spree::OptionType.transaction { @option_types.destroy_all }
+
+      flash[:notice] = t('.success')
+      redirect_back_or_to option_types_path, status: :see_other
+    end
+
+    private
+
+    def load_option_type
+      @option_type = Spree::OptionType.find(params[:id])
+      authorize! action_name, @option_type
+    end
+  end
+end

--- a/admin/app/controllers/solidus_admin/option_types_controller.rb
+++ b/admin/app/controllers/solidus_admin/option_types_controller.rb
@@ -4,6 +4,14 @@ module SolidusAdmin
   class OptionTypesController < SolidusAdmin::BaseController
     before_action :load_option_type, only: [:move]
 
+    def index
+      @option_types = Spree::OptionType.all
+
+      respond_to do |format|
+        format.html { render component('option_types/index').new(option_types: @option_types) }
+      end
+    end
+
     def move
       @option_type.insert_at(params[:position].to_i)
 

--- a/admin/config/locales/option_types.en.yml
+++ b/admin/config/locales/option_types.en.yml
@@ -1,0 +1,6 @@
+en:
+  solidus_admin:
+    option_types:
+      title: "Option Types"
+      destroy:
+        success: "Option Types were successfully removed."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -49,7 +49,7 @@ SolidusAdmin::Engine.routes.draw do
     end
   end
 
-  resources :option_types do
+  resources :option_types, only: [:index] do
     collection do
       delete :destroy
     end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -48,4 +48,13 @@ SolidusAdmin::Engine.routes.draw do
       delete :destroy
     end
   end
+
+  resources :option_types do
+    collection do
+      delete :destroy
+    end
+    member do
+      patch :move
+    end
+  end
 end

--- a/admin/spec/features/option_types_spec.rb
+++ b/admin/spec/features/option_types_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Option Types", :js, type: :feature do
+  before { sign_in create(:admin_user, email: 'admin@example.com') }
+
+  it "lists option types and allows deleting them" do
+    create(:option_type, name: "color", presentation: "Color")
+    create(:option_type, name: "size", presentation: "Size")
+
+    visit "/admin/option_types"
+    expect(page).to have_content("color")
+    expect(page).to have_content("size")
+
+    expect(page).to be_axe_clean
+
+    select_row("color")
+    click_on "Delete"
+    expect(page).to have_content("Option Types were successfully removed.")
+    expect(page).not_to have_content("color")
+    expect(Spree::OptionType.count).to eq(1)
+  end
+end


### PR DESCRIPTION
## Summary

See #5522 first

![Screenshot 2023-11-29 at 17 14 11](https://github.com/solidusio/solidus/assets/19948291/321fa85a-1cef-4da7-9b64-cd52df7fc5b3)


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
