### PR TITLE
 [Admin] Add `Properties` index component

### DIFF
--- a/admin/app/components/solidus_admin/properties/index/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/index/component.html.erb
@@ -1,0 +1,32 @@
+<%= page do %>
+  <%= page_header do %>
+    <%= page_header_title title %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").new(
+        tag: :a,
+        text: t('.add_property'),
+        href: spree.new_admin_property_path,
+        icon: "add-line",
+      ) %>
+    <% end %>
+  <% end %>
+
+  <%= render component('ui/table').new(
+    id: 'property-list',
+    data: {
+      class: Spree::Property,
+      rows: @page.records,
+      url: ->(property) { solidus_admin.properties_path(property) },
+      prev: prev_page_path,
+      next: next_page_path,
+      columns: columns,
+      batch_actions: batch_actions,
+    },
+    search: {
+      name: :q,
+      value: params[:q],
+      url: solidus_admin.properties_path,
+      searchbar_key: :name_cont,
+    },
+  ) %>
+<% end %>

--- a/admin/app/components/solidus_admin/properties/index/component.rb
+++ b/admin/app/components/solidus_admin/properties/index/component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Properties::Index::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(page:)
+    @page = page
+  end
+
+  def title
+    Spree::Property.model_name.human.pluralize
+  end
+
+  def prev_page_path
+    solidus_admin.url_for(**request.params, page: @page.number - 1, only_path: true) unless @page.first?
+  end
+
+  def next_page_path
+    solidus_admin.url_for(**request.params, page: @page.next_param, only_path: true) unless @page.last?
+  end
+
+  def batch_actions
+    [
+      {
+        display_name: t('.batch_actions.delete'),
+        action: solidus_admin.properties_path,
+        method: :delete,
+        icon: 'delete-bin-7-line',
+      },
+    ]
+  end
+
+  def columns
+    [
+      name_column,
+      presentation_column,
+    ]
+  end
+
+  def name_column
+    {
+      header: :name,
+      data: ->(property) do
+        content_tag :div, property.name
+      end
+    }
+  end
+
+  def presentation_column
+    {
+      header: :presentation,
+      data: ->(property) do
+        content_tag :div, property.presentation
+      end
+    }
+  end
+end

--- a/admin/app/components/solidus_admin/properties/index/component.yml
+++ b/admin/app/components/solidus_admin/properties/index/component.yml
@@ -1,0 +1,4 @@
+en:
+  add_property: 'Add Property'
+  batch_actions:
+    delete: 'Delete'

--- a/admin/app/controllers/solidus_admin/properties_controller.rb
+++ b/admin/app/controllers/solidus_admin/properties_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class PropertiesController < SolidusAdmin::BaseController
+    include SolidusAdmin::ControllerHelpers::Search
+
+    def index
+      properties = apply_search_to(
+        Spree::Property.order(created_at: :desc, id: :desc),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(
+        properties,
+      )
+
+      respond_to do |format|
+        format.html { render component('properties/index').new(page: @page) }
+      end
+    end
+
+    def destroy
+      @properties = Spree::Property.where(id: params[:id])
+
+      Spree::Property.transaction do
+        @properties.discard_all
+      end
+
+      flash[:notice] = t('.success')
+      redirect_to properties_path, status: :see_other
+    end
+  end
+end

--- a/admin/config/locales/properties.en.yml
+++ b/admin/config/locales/properties.en.yml
@@ -1,0 +1,6 @@
+en:
+  solidus_admin:
+    properties:
+      title: "Properties"
+      destroy:
+        success: "Properties were successfully removed."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -42,4 +42,10 @@ SolidusAdmin::Engine.routes.draw do
       delete :destroy
     end
   end
+
+  resources :properties, only: [:index] do
+    collection do
+      delete :destroy
+    end
+  end
 end

--- a/admin/spec/features/properties.rb
+++ b/admin/spec/features/properties.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Properties", :js, type: :feature do
+  before { sign_in create(:admin_user, email: 'admin@example.com') }
+
+  it "lists properties and allows deleting them" do
+    create(:property, name: "Type", presentation: "Type")
+    create(:property, name: "Size", presentation: "Size")
+
+    visit "/admin/properties"
+    expect(page).to have_content("Type")
+    expect(page).to have_content("Size")
+
+    expect(page).to be_axe_clean
+
+    select_row("Type")
+    click_on "Delete"
+    expect(page).to have_content("Properties were successfully removed.")
+    expect(page).not_to have_content("Type")
+    expect(Spree::Property.count).to eq(1)
+  end
+end


### PR DESCRIPTION
## Summary

![Screenshot 2023-11-29 at 18 12 52](https://github.com/solidusio/solidus/assets/19948291/daa09004-6d78-4a33-b543-db84d38ab6cb)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
