### PR TITLE
[Admin] Add `Promotion Categories` index component

### DIFF
--- a/admin/app/components/solidus_admin/promotion_categories/index/component.html.erb
+++ b/admin/app/components/solidus_admin/promotion_categories/index/component.html.erb
@@ -1,0 +1,24 @@
+<%= page do %>
+  <%= page_header do %>
+    <%= page_header_title title %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").new(
+        tag: :a,
+        text: t('.create_promotion_category'),
+        href: spree.new_admin_promotion_category_path,
+        icon: "add-line",
+      ) %>
+    <% end %>
+  <% end %>
+
+  <%= render component('ui/table').new(
+    id: 'promotion-categories-list',
+    data: {
+      class: Spree::PromotionCategory,
+      rows: @promotion_categories,
+      url: ->(promotion_category) { spree.edit_admin_promotion_category_path(promotion_category) },
+      columns: columns,
+      batch_actions: batch_actions,
+    },
+  ) %>
+<% end %>

--- a/admin/app/components/solidus_admin/promotion_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/promotion_categories/index/component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(promotion_categories:)
+    @promotion_categories = promotion_categories
+  end
+
+  def title
+    Spree::PromotionCategory.model_name.human.pluralize
+  end
+
+  def columns
+    [
+      name_column,
+      code_column,
+    ]
+  end
+
+  def name_column
+    {
+      header: :name,
+      data: ->(promotion_category) do
+        content_tag :div, promotion_category.name
+      end
+    }
+  end
+
+  def code_column
+    {
+      header: :code,
+      data: ->(promotion_category) do
+        content_tag :div, promotion_category.code
+      end
+    }
+  end
+
+  def batch_actions
+    [
+      {
+        display_name: t('.batch_actions.delete'),
+        action: solidus_admin.promotion_categories_path,
+        method: :delete,
+        icon: 'delete-bin-7-line',
+      },
+    ]
+  end
+end

--- a/admin/app/components/solidus_admin/promotion_categories/index/component.yml
+++ b/admin/app/components/solidus_admin/promotion_categories/index/component.yml
@@ -1,0 +1,4 @@
+en:
+  batch_actions:
+    delete: 'Delete'
+  create_promotion_category: Create Promotion Category

--- a/admin/app/controllers/solidus_admin/promotion_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/promotion_categories_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class PromotionCategoriesController < SolidusAdmin::BaseController
+    before_action :load_promotion_category, only: [:move]
+
+    def index
+      @promotion_categories = Spree::PromotionCategory.all
+
+      respond_to do |format|
+        format.html { render component('promotion_categories/index').new(promotion_categories: @promotion_categories) }
+      end
+    end
+
+    def destroy
+      @promotion_categories = Spree::PromotionCategory.where(id: params[:id])
+
+      Spree::PromotionCategory.transaction { @promotion_categories.destroy_all }
+
+      flash[:notice] = t('.success')
+      redirect_back_or_to promotion_categories_path, status: :see_other
+    end
+
+    private
+
+    def load_promotion_category
+      @promotion_category = Spree::PromotionCategory.find(params[:id])
+      authorize! action_name, @promotion_category
+    end
+  end
+end

--- a/admin/config/locales/promotion_categories.en.yml
+++ b/admin/config/locales/promotion_categories.en.yml
@@ -1,0 +1,6 @@
+en:
+  solidus_admin:
+    promotion_categories:
+      title: "Promotion Categories"
+      destroy:
+        success: "Promotion Categories were successfully removed."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -57,4 +57,10 @@ SolidusAdmin::Engine.routes.draw do
       patch :move
     end
   end
+
+  resources :promotion_categories, only: [:index] do
+    collection do
+      delete :destroy
+    end
+  end
 end

--- a/admin/spec/features/promotion_cateogries_spec.rb
+++ b/admin/spec/features/promotion_cateogries_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Promotion Categories", :js, type: :feature do
+  before { sign_in create(:admin_user, email: 'admin@example.com') }
+
+  it "lists promotion categories and allows deleting them" do
+    create(:promotion_category, name: "test1", code: "code1")
+    create(:promotion_category, name: "test2", code: "code2")
+
+    visit "/admin/promotion_categories"
+    expect(page).to have_content("test1")
+    expect(page).to have_content("test2")
+
+    expect(page).to be_axe_clean
+
+    select_row("test1")
+    click_on "Delete"
+    expect(page).to have_content("Promotion Categories were successfully removed.")
+    expect(page).not_to have_content("test1")
+    expect(Spree::PromotionCategory.count).to eq(1)
+  end
+end


### PR DESCRIPTION
## Summary

![Screenshot 2023-11-29 at 18 45 07](https://github.com/solidusio/solidus/assets/19948291/a37ee855-9148-495b-8794-adb012ad77e6)


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
