### PR TITLE
Fix rubocop violations after the latest release

### DIFF
--- a/api/app/views/spree/api/images/_image.json.jbuilder
+++ b/api/app/views/spree/api/images/_image.json.jbuilder
@@ -2,6 +2,7 @@
 
 json.(image, *image_attributes)
 json.(image, :viewable_type, :viewable_id)
-Spree::Image.attachment_definitions[:attachment][:styles].each do |key, _value|
+
+Spree::Image.attachment_definitions[:attachment][:styles].each_key do |key|
   json.set! "#{key}_url", image.url(key)
 end

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -28,7 +28,7 @@ module Spree
         invoke_callbacks(:update, :before)
 
         attributes = payment_method_params
-        attributes.each do |key, _value|
+        attributes.each_key do |key|
           if key.include?("password") && attributes[key].blank?
             attributes.delete(key)
           end

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -68,7 +68,7 @@ module Spree
         if updating_variant_property_rules?
           url_params = {}
           url_params[:ovi] = []
-          params[:product][:variant_property_rules_attributes].each do |_index, param_attrs|
+          params[:product][:variant_property_rules_attributes].each_value do |param_attrs|
             url_params[:ovi] += param_attrs[:option_value_ids]
           end
           spree.admin_product_product_properties_url(@product, url_params)
@@ -133,7 +133,7 @@ module Spree
       def normalize_variant_property_rules
         return unless updating_variant_property_rules?
 
-        params[:product][:variant_property_rules_attributes].each do |_index, param_attrs|
+        params[:product][:variant_property_rules_attributes].each_value do |param_attrs|
           param_attrs[:option_value_ids] = param_attrs[:option_value_ids].split(',')
         end
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -637,7 +637,7 @@ module Spree
       if can_complete? || complete?
         valid_store_credit_payments.to_a.sum(&:amount)
       else
-        [total, (user.try(:available_store_credit_total, currency: currency) || 0.0)].min
+        [total, user.try(:available_store_credit_total, currency: currency) || 0.0].min
       end
     end
 

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -73,7 +73,7 @@ module Spree
 
         unless promotion.eligible?(order, promotion_code: promotion_code)
           set_promotion_eligibility_error_code(promotion)
-          return (error || ineligible_for_this_order)
+          return error || ineligible_for_this_order
         end
 
         # If any of the actions for the promotion return `true`,

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -24,7 +24,7 @@ module Spree
 
         def hash_to_packages(categories)
           packages = []
-          categories.each do |_id, contents|
+          categories.each_value do |contents|
             packages << build_package(contents)
           end
           packages

--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -46,7 +46,11 @@ module Spree
 
               # Persist the state on the order
               after_transition do |order, transition|
-                order.state = order.state
+                # Hard to say if this is really necessary, it was introduced in this commit:
+                # https://github.com/mamhoff/solidus/commit/fa1d66c42e4c04ee7cd1c20d87e4cdb74a226d3d
+                # But it seems to be harmless, so we'll keep it for now.
+                order.state = order.state # rubocop:disable Lint/SelfAssignment
+
                 order.state_changes.create(
                   previous_state: transition.from,
                   next_state:     transition.to,

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -35,7 +35,7 @@ module Spree
       if amount.is_a?(::Money)
         @money = amount
       else
-        currency = (options[:currency] || Spree::Config[:currency])
+        currency = options[:currency] || Spree::Config[:currency]
 
         @money = Monetize.from_string(amount, currency)
       end

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -50,7 +50,8 @@ Spree::ShippingMethod.create!([
   }
 ])
 
-{
+# The just below rubocop:disable directive will be removed once https://github.com/rubocop/rubocop/issues/12441 is resolved.
+{ # rubocop:disable Style/HashEachMethods
   "UPS Ground (USD)" => [5, "USD"],
   "UPS Ground (EU)" => [5, "USD"],
   "UPS One Day (USD)" => [15, "USD"],


### PR DESCRIPTION
## Summary

Rubocop 1.58 introduced a few new rules.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
