### PR TITLE
chore(admin): restyle legacy UI flash to not overlap buttons

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
@@ -25,35 +25,28 @@
 }
 
 .flash-wrapper {
+  bottom: 20px;
+  max-width: 320px;
   position: fixed;
-  bottom: 0;
-  left: $width-sidebar;
-  right: 0;
+  right: 20px;
   z-index: 1000;
-
-  .admin-nav-hidden & {
-    left: $width-sidebar-collapsed;
-  }
 }
 
 .flash {
-  border-top: 3px solid;
   padding: 16px;
+  border-radius: 4px;
   text-align: center;
   font-size: 120%;
   color: $body-color;
 
   &.notice {
     background-color: rgba(theme-color-level(warning, -8), .95);
-    border-top-color: theme-color(warning);
   }
   &.success {
     background-color: rgba(theme-color-level(success, -10), .95);
-    border-top-color: theme-color(success);
   }
   &.error {
     background-color: rgba(theme-color-level(danger, -8), .95);
-    border-top-color: theme-color(danger);
   }
 }
 


### PR DESCRIPTION
## Summary

the common form pattern in the solidus admin is to have the buttons be centered at the bottom. when the flash message would display, it would cover up those buttons before it fades, leading to a bit of a slow admin process waiting for the flash to go away due to it covering key buttons

this revises the styles so the flash message shows in the lower right like a little toaster, out of the way of most buttons on a desktop monitor

this change comes by way of using the solidus admin daily and wishing the flash didn't overlap the buttons

this only applies to the legacy UI, as the new UI no longer has this problem from my testing locally. absolutely no worries if this isn't worth merging since it is only for the legacy UI!

also, this is just a proposal! no worries if the style isn't quite right

## screenies

here's what it looks like:

![Screenshot from 2023-12-05 16-36-21](https://github.com/solidusio/solidus/assets/928367/7e299dfd-ee9f-405d-b3db-88ce70b04422)

### close up

![image](https://github.com/solidusio/solidus/assets/928367/7c272d6e-be18-4288-936f-c29a6a0675ab)

### before

here's what it used to be like before these changes, where it's covering some key form buttons

![image](https://github.com/solidusio/solidus/assets/928367/3c90c30b-518b-41b3-adfd-bf490b516eee)


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
