### PR TITLE
Deprecate `Spree::NamedType`

### DIFF
--- a/core/app/models/concerns/spree/named_type.rb
+++ b/core/app/models/concerns/spree/named_type.rb
@@ -5,6 +5,8 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
+      Spree.deprecator.warn "Spree::NamedType is deprecated. Please set scopes and validations locally instead.", caller
+
       scope :active, -> { where(active: true) }
       default_scope -> { order(arel_table[:name].lower) }
 

--- a/core/app/models/spree/refund_reason.rb
+++ b/core/app/models/spree/refund_reason.rb
@@ -2,7 +2,10 @@
 
 module Spree
   class RefundReason < Spree::Base
-    include Spree::NamedType
+    scope :active, -> { where(active: true) }
+    default_scope -> { order(arel_table[:name].lower) }
+
+    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
     RETURN_PROCESSING_REASON = 'Return processing'
 

--- a/core/app/models/spree/reimbursement_type.rb
+++ b/core/app/models/spree/reimbursement_type.rb
@@ -2,7 +2,10 @@
 
 module Spree
   class ReimbursementType < Spree::Base
-    include Spree::NamedType
+    scope :active, -> { where(active: true) }
+    default_scope -> { order(arel_table[:name].lower) }
+
+    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
     ORIGINAL = 'original'
 

--- a/core/app/models/spree/return_reason.rb
+++ b/core/app/models/spree/return_reason.rb
@@ -2,7 +2,10 @@
 
 module Spree
   class ReturnReason < Spree::Base
-    include Spree::NamedType
+    scope :active, -> { where(active: true) }
+    default_scope -> { order(arel_table[:name].lower) }
+
+    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
     has_many :return_authorizations
 

--- a/core/app/models/spree/store_credit_reason.rb
+++ b/core/app/models/spree/store_credit_reason.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Spree::StoreCreditReason < Spree::Base
-  include Spree::NamedType
+  scope :active, -> { where(active: true) }
+  default_scope -> { order(arel_table[:name].lower) }
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
   has_many :store_credit_events, inverse_of: :store_credit_reason
 end


### PR DESCRIPTION
## Summary

This module was a pretend shared behavior while the inlcuding classes were not related.

Eventually we'll replace some of the default scopes with regular sorting scopes since default scopes often cause issues.

Ref: https://github.com/solidusio/solidus/pull/5539/commits/b2d4a7cdc73c7aae2bf5da0ee357cdf4944b031b

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
