### PR TITLE
[Admin] Add `stock_items/edit` modal component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
       - setup
       - test
 
-  test_with_coverage:
+  test_solidus_with_coverage:
     parameters:
       database:
         type: string
@@ -350,7 +350,7 @@ workflows:
       - solidus_installer
 
       # Only test with coverage support with the default versions
-      - test_with_coverage:
+      - test_solidus_with_coverage:
           post-steps:
             - codecov/upload:
                 file: $COVERAGE_FILE

--- a/admin/app/components/solidus_admin/orders/cart/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/component.html.erb
@@ -30,20 +30,11 @@
             <% @order.line_items.each do |line_item| %>
               <tr class="border-gray-100 border-t">
                 <td class="px-6 py-4">
-                  <div class="flex gap-2 grow">
-                    <% variant = line_item.variant %>
-                    <%= render component("ui/thumbnail").new(
-                      src: (variant.images.first || variant.product.gallery.images.first)&.url(:small),
-                      alt: variant.name
-                    ) %>
-                    <div class="flex-col">
-                      <div class="leading-5 text-black body-small-bold"><%= variant.name %></div>
-                      <div class="leading-5 text-gray-500 body-small">
-                        SKU: <%= variant.sku %>
-                        <%= variant.options_text.presence&.prepend("- ") %>
-                      </div>
-                    </div>
-                  </div>
+                  <%= render component("ui/resource_item").new(
+                    thumbnail: (line_item.variant.images.first || line_item.variant.product.gallery.images.first)&.url(:small),
+                    title: line_item.variant.name,
+                    subtitle: "#{line_item.variant.sku}#{line_item.variant.options_text.presence&.prepend("- ")}",
+                  ) %>
                 </td>
                 <td class="px-6 py-4">
                   <%= form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), html: {

--- a/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
@@ -1,0 +1,81 @@
+<div
+  data-controller="<%= stimulus_id %>"
+  data-<%= stimulus_id %>-initial-count-on-hand-value="<%= @stock_item.count_on_hand_was || @stock_item.count_on_hand %>"
+  data-action="input-><%= stimulus_id %>#updateCountOnHand"
+>
+  <%= render component("ui/modal").new(title: t(".title"), close_path: solidus_admin.stock_items_path(page: params[:page], q: permitted_query_params)) do |modal| %>
+    <%= form_for @stock_item, url: solidus_admin.stock_item_path(@stock_item), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <div class="flex gap-4">
+          <%= link_to spree.edit_admin_product_variant_path(
+            @stock_item.variant.product,
+            @stock_item.variant,
+          ), class: 'hover:bg-gray-25 rounded p-1 w-1/2 border border-gray-100' do %>
+            <%= render component("ui/resource_item").new(
+              thumbnail:
+                (
+                  @stock_item.variant.images.first ||
+                    @stock_item.variant.product.gallery.images.first
+                )&.url(:small),
+              title: @stock_item.variant.name,
+              subtitle:
+                "#{@stock_item.variant.sku}#{@stock_item.variant.options_text.presence&.prepend(" - ")}",
+            ) %>
+          <% end %>
+          <%= link_to spree.edit_admin_stock_location_path(@stock_item.stock_location), class: 'hover:bg-gray-25 rounded p-1 w-1/2 border border-gray-100' do %>
+            <%= render component("ui/resource_item").new(
+              title: @stock_item.stock_location.name,
+              subtitle: "#{Spree::StockLocation.model_name.human} #{@stock_item.stock_location.code}",
+            ) %>
+          <% end %>
+        </div>
+
+        <%= render component("ui/forms/field").text_field(
+          f,
+          :count_on_hand,
+          disabled: true,
+          value: @stock_item.count_on_hand_was || @stock_item.count_on_hand,
+          "data-#{stimulus_id}-target": 'countOnHand',
+        ) %>
+        <%= render component("ui/forms/field").new(
+          label: t(".quantity_adjustment"),
+          hint: t(".quantity_adjustment_hint_html"),
+        ) do %>
+          <%= render component("ui/forms/input").new(
+            value: params[:quantity_adjustment] || 0,
+            name: :quantity_adjustment,
+            type: :number,
+            step: 1,
+            "data-#{stimulus_id}-target": 'quantityAdjustment',
+          ) %>
+        <% end %>
+
+        <%= render component("ui/forms/switch_field").new(
+          name: "#{f.object_name}[backorderable]",
+          label: Spree::StockItem.human_attribute_name(:backorderable),
+          error: f.object.errors[:backorderable],
+          hint: t(".backorderable_hint_html"),
+          checked: f.object.backorderable?,
+          include_hidden: true,
+        ) %>
+      </div>
+    <% end %>
+
+    <% modal.with_actions do %>
+      <%= render component("ui/button").new(
+        tag: :a,
+        scheme: :secondary,
+        text: t(".cancel"),
+        href: solidus_admin.stock_items_path(page: params[:page], q: params[:q]),
+      ) %>
+
+      <%= render component("ui/button").new(
+        tag: :button,
+        text: t(".submit"),
+        form: form_id,
+      ) %>
+    <% end %>
+  <% end %>
+
+  <%= render component("stock_items/index").new(page: @page) %>
+</div>

--- a/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
@@ -58,6 +58,14 @@
           checked: f.object.backorderable?,
           include_hidden: true,
         ) %>
+
+        <% if params[:q] %>
+          <%= f.hidden_field :q, value: params[:q].to_json, id: false %>
+        <% end %>
+
+        <% if params[:page] %>
+          <%= f.hidden_field :page, value: params[:page], id: false %>
+        <% end %>
       </div>
     <% end %>
 

--- a/admin/app/components/solidus_admin/stock_items/edit/component.js
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = {
+    initialCountOnHand: Number,
+  }
+
+  static targets = ['countOnHand', 'quantityAdjustment']
+
+  connect() {
+    this.updateCountOnHand()
+  }
+
+  updateCountOnHand() {
+    this.countOnHandTarget.value = parseInt(this.initialCountOnHandValue) + parseInt(this.quantityAdjustmentTarget.value)
+  }
+}

--- a/admin/app/components/solidus_admin/stock_items/edit/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::StockItems::Edit::Component < SolidusAdmin::BaseComponent
+  def initialize(stock_item:, page:)
+    @stock_item = stock_item
+    @page = page
+  end
+
+  def title
+    [
+      "#{Spree::StockLocation.model_name.human}: #{@stock_item.stock_location.name}",
+    ].join(' / ')
+  end
+
+  def form_id
+    "#{stimulus_id}-#{dom_id(@stock_item)}"
+  end
+
+  def permitted_query_params
+    return params[:q].permit! if params[:q].respond_to?(:permit)
+    {}
+  end
+end

--- a/admin/app/components/solidus_admin/stock_items/edit/component.yml
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.yml
@@ -1,0 +1,10 @@
+en:
+  submit: "Save"
+  cancel: "Cancel"
+  title: "Edit Stock Levels"
+  quantity_adjustment: "Quantity Adjustment"
+  quantity_adjustment_hint_html: |
+    Enter a positive number to increase the stock level, or a negative number to decrease the stock level.
+  backorderable_hint_html: |
+    Enable to allow customers to place orders even when the product is out of stock.<br>
+    When ordering the product customers will know that the product will be delivered at a later date, once it becomes available again.

--- a/admin/app/components/solidus_admin/stock_items/index/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.html.erb
@@ -3,7 +3,8 @@
     <%= page_header_title title %>
   <% end %>
 
-  <%= render component('ui/table').new(
+  <%=
+  render component('ui/table').new(
     id: stimulus_id,
     data: {
       class: Spree::StockItem,
@@ -12,10 +13,11 @@
       next: next_page_path,
       columns: columns,
       batch_actions: batch_actions,
+      url: -> { solidus_admin.edit_stock_item_path(_1, page: params[:page], q: permitted_query_params) },
     },
     search: {
       name: :q,
-      value: params[:q],
+      value: permitted_query_params,
       url: solidus_admin.stock_items_path,
       searchbar_key: :variant_product_name_or_variant_sku_or_variant_option_values_name_or_variant_option_values_presentation_cont,
       filters: filters,

--- a/admin/app/components/solidus_admin/stock_items/index/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.rb
@@ -78,7 +78,7 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::BaseComponent
   def image_column
     {
       col: { class: "w-[72px]" },
-      header: tag.span('aria-label': t('.image'), role: 'text'),
+      header: tag.span('aria-label': Spree::Image.model_name.human, role: 'text'),
       data: ->(stock_item) do
         image = stock_item.variant.gallery.images.first or return
 

--- a/admin/app/components/solidus_admin/stock_items/index/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.rb
@@ -172,4 +172,9 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::BaseComponent
       end
     }
   end
+
+  def permitted_query_params
+    return params[:q].permit! if params[:q].respond_to?(:permit)
+    {}
+  end
 end

--- a/admin/app/components/solidus_admin/ui/forms/field/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/field/component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Forms::Field::Component < SolidusAdmin::BaseComponent
+  extend SolidusAdmin::ComponentsHelper
+
   def initialize(label:, hint: nil, tip: nil, error: nil, input_attributes: nil, **attributes)
     @label = label
     @hint = hint
@@ -67,6 +69,25 @@ class SolidusAdmin::UI::Forms::Field::Component < SolidusAdmin::BaseComponent
         error: (errors.to_sentence.capitalize if errors),
         **attributes,
       }
+    )
+  end
+
+  def self.toggle(form, method, object: nil, hint: nil, tip: nil, size: :m, **attributes)
+    object_name, object, label, errors = extract_form_details(form, object, method)
+
+    new(
+      label: label,
+      hint: hint,
+      tip: tip,
+      error: errors,
+    ).with_content(
+      component('ui/forms/switch').new(
+        name: "#{object_name}[#{method}]",
+        size: size,
+        checked: object.public_send(method),
+        include_hidden: true,
+        **attributes,
+      )
     )
   end
 

--- a/admin/app/components/solidus_admin/ui/forms/switch/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/switch/component.rb
@@ -6,34 +6,38 @@ class SolidusAdmin::UI::Forms::Switch::Component < SolidusAdmin::BaseComponent
     m: 'w-10 h-6 after:w-5 after:h-5 after:checked:translate-x-4',
   }.freeze
 
-  def initialize(size: :m, **attributes)
+  def initialize(size: :m, include_hidden: false, **attributes)
     @size = size
     @attributes = attributes
+    @include_hidden = include_hidden
+    @attributes[:class] = "
+      #{SIZES.fetch(@size)}
+      rounded-full after:rounded-full
+      appearance-none	inline-block relative p-0.5 cursor-pointer
+
+      outline-none
+      focus:ring focus:ring-gray-300 focus:ring-0.5 focus:ring-offset-1
+      active:ring active:ring-gray-300 active:ring-0.5 active:ring-offset-1
+
+      disabled:cursor-not-allowed
+      after:top-0 after:left-0
+      after:content-[''] after:block
+      after:transition-all after:duration-300 after:ease-in-out
+
+      bg-gray-200 after:bg-white
+      hover:bg-gray-300
+      checked:bg-gray-500 checked:hover:bg-gray-70
+      disabled:opacity-40
+      #{attributes[:class]}
+    "
   end
 
   def call
-    tag.input(
+    input = tag.input(
       type: 'checkbox',
-      class: "
-        #{SIZES.fetch(@size)}
-        rounded-full after:rounded-full
-        appearance-none	inline-block relative p-0.5 cursor-pointer
-
-        outline-none
-        focus:ring focus:ring-gray-300 focus:ring-0.5 focus:ring-offset-1
-        active:ring active:ring-gray-300 active:ring-0.5 active:ring-offset-1
-
-        disabled:cursor-not-allowed
-        after:top-0 after:left-0
-        after:content-[''] after:block
-        after:transition-all after:duration-300 after:ease-in-out
-
-        bg-gray-200 after:bg-white
-        hover:bg-gray-300
-        checked:bg-gray-500 checked:hover:bg-gray-70
-        disabled:opacity-40
-      ",
       **@attributes,
     )
+
+    @include_hidden ? hidden_field_tag(@attributes.fetch(:name), false) + input : input
   end
 end

--- a/admin/app/components/solidus_admin/ui/forms/switch_field/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/switch_field/component.html.erb
@@ -1,0 +1,20 @@
+<label class="flex flex-wrap items-center gap-2 w-full border border-gray-100 rounded px-4 py-2">
+  <div class="flex gap-1 items-center grow py-2">
+    <span class="text-gray-700 body-tiny-bold body-text-bold"><%= @label %></span>
+
+    <%= render component("ui/toggletip").new(text: @tip) if @tip.present? %>
+  </div>
+
+  <%= render component("ui/forms/switch").new(**@attributes) %>
+
+  <% if @hint.present? || @error.present? %>
+    <div
+      class="
+        w-full body-small [:disabled~&]:text-gray-300 text-gray-500 flex gap-1 flex-col pt-2 pb-4
+      "
+    >
+      <%= tag.span @hint if @hint.present? %>
+      <%= tag.span safe_join(@error, tag.br), class: "text-red-400" if @error.present? %>
+    </div>
+  <% end %>
+</label>

--- a/admin/app/components/solidus_admin/ui/forms/switch_field/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/switch_field/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::Forms::SwitchField::Component < SolidusAdmin::BaseComponent
+  def initialize(label:, error:, hint: nil, tip: nil, **attributes)
+    @label = label
+    @error = error
+    @hint = hint
+    @tip = tip
+    @attributes = attributes
+  end
+end

--- a/admin/app/components/solidus_admin/ui/resource_item/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/resource_item/component.html.erb
@@ -1,0 +1,10 @@
+<div class="flex gap-2 grow">
+  <%= render component("ui/thumbnail").new(
+    src: @thumbnail,
+    alt: @title,
+  ) if @thumbnail %>
+  <div class="flex-col">
+    <div class="leading-5 text-black body-small-bold"><%= @title %></div>
+    <div class="leading-5 text-gray-500 body-small"><%= @subtitle %></div>
+  </div>
+</div>

--- a/admin/app/components/solidus_admin/ui/resource_item/component.rb
+++ b/admin/app/components/solidus_admin/ui/resource_item/component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::ResourceItem::Component < SolidusAdmin::BaseComponent
+  def initialize(title:, subtitle:, thumbnail: nil)
+    @thumbnail = thumbnail
+    @title = title
+    @subtitle = subtitle
+  end
+end

--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -30,7 +30,10 @@ module SolidusAdmin
       @stock_item.stock_movements.build(quantity: quantity_adjustment, originator: current_solidus_admin_user)
 
       if @stock_item.save
-        redirect_to solidus_admin.stock_items_path, status: :see_other
+        redirect_to solidus_admin.stock_items_path(
+          page: stock_item_params[:page].to_i.presence,
+          q: stock_item_params[:q].presence&.then { |q| JSON.parse(q) }
+        ), status: :see_other
       else
         respond_to do |format|
           format.html { render component('stock_items/edit').new(stock_item: @stock_item, page: @page), status: :unprocessable_entity }

--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -19,6 +19,9 @@ module SolidusAdmin
     end
 
     def edit
+      respond_to do |format|
+        format.html { render component('stock_items/edit').new(stock_item: @stock_item, page: @page) }
+      end
     end
 
     def update
@@ -29,6 +32,9 @@ module SolidusAdmin
       if @stock_item.save
         redirect_to solidus_admin.stock_items_path, status: :see_other
       else
+        respond_to do |format|
+          format.html { render component('stock_items/edit').new(stock_item: @stock_item, page: @page), status: :unprocessable_entity }
+        end
       end
     end
 

--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -3,6 +3,8 @@
 module SolidusAdmin
   class StockItemsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
+    before_action :load_stock_items, only: [:index, :edit, :update]
+    before_action :load_stock_item, only: [:edit, :update]
 
     search_scope(:all, default: true) { _1 }
     search_scope(:back_orderable) { _1.where(backorderable: true) }
@@ -11,16 +13,46 @@ module SolidusAdmin
     search_scope(:in_stock) { _1.where('count_on_hand > 0') }
 
     def index
-      stock_items = apply_search_to(
-        Spree::StockItem.order(created_at: :desc, id: :desc),
-        param: :q,
-      )
-
-      set_page_and_extract_portion_from(stock_items)
-
       respond_to do |format|
         format.html { render component('stock_items/index').new(page: @page) }
       end
+    end
+
+    def edit
+    end
+
+    def update
+      quantity_adjustment = params[:quantity_adjustment].to_i
+      @stock_item.assign_attributes(stock_item_params.except(:page, :q))
+      @stock_item.stock_movements.build(quantity: quantity_adjustment, originator: current_solidus_admin_user)
+
+      if @stock_item.save
+        redirect_to solidus_admin.stock_items_path, status: :see_other
+      else
+      end
+    end
+
+    private
+
+    def load_stock_items
+      @stock_items = apply_search_to(
+        Spree::StockItem.reorder(nil),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(@stock_items, ordered_by: {
+        variant_id: :desc,
+        stock_location_id: :desc,
+        id: :desc,
+      })
+    end
+
+    def load_stock_item
+      @stock_item = Spree::StockItem.find(params[:id])
+    end
+
+    def stock_item_params
+      params.require(:stock_item).permit(:backorderable, :page, :q)
     end
   end
 end

--- a/admin/config/initializers/view_component.rb
+++ b/admin/config/initializers/view_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Rails.application.config.view_component.capture_compatibility_patch_enabled = true
+
+if Rails.env.development? || Rails.env.test?
+  Rails.application.config.view_component.instrumentation_enabled = true
+  Rails.application.config.view_component.use_deprecated_instrumentation_name = false
+
+  bold = ActiveSupport::LogSubscriber::BOLD
+  clear = ActiveSupport::LogSubscriber::CLEAR
+
+  ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
+    next unless args.last[:name].starts_with?("SolidusAdmin::")
+
+    event = ActiveSupport::Notifications::Event.new(*args)
+    SolidusAdmin::BaseComponent.logger.debug \
+      "  Rendered #{bold}#{event.payload[:name]}#{clear}" \
+      " (Duration: #{event.duration.round(1)}ms)"
+  end
+end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -40,7 +40,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :tax_categories, only: [:index, :destroy]
   admin_resources :tax_rates, only: [:index, :destroy]
   admin_resources :payment_methods, only: [:index, :destroy], sortable: true
-  admin_resources :stock_items, only: [:index]
+  admin_resources :stock_items, only: [:index, :edit, :update]
   admin_resources :shipping_methods, only: [:index, :destroy]
   admin_resources :shipping_categories, only: [:index, :destroy]
   admin_resources :stock_locations, only: [:index, :destroy]

--- a/admin/spec/components/previews/solidus_admin/ui/forms/switch_field/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/switch_field/component_preview.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# @component "ui/forms/switch_field"
+class SolidusAdmin::UI::Forms::SwitchField::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+
+  # @param label text
+  # @param error text
+  # @param hint text
+  # @param tip text
+  # @param size select { choices: [s, m] }
+  # @param checked toggle
+  # @param disabled toggle
+  def playground(
+    label: "Your Label",
+    error: "Your Error Message",
+    hint: "Your Hint Text",
+    tip: "Your Tip Text",
+    size: :m,
+    checked: false,
+    disabled: false
+  )
+    render current_component.new(
+      label: label,
+      name: nil,
+      error: [error],
+      hint: hint,
+      tip: tip,
+      size: size.to_sym,
+      checked: checked,
+      disabled: disabled,
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/forms/switch_field/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/switch_field/component_preview/overview.html.erb
@@ -1,0 +1,9 @@
+<div class="mb-8 py-10">
+  <%= render current_component.new(
+      label: "Enable Notifications",
+      error: ["Unable to save settings"],
+      hint: "Turn on to receive regular updates",
+      tip: "Notifications can be customized in settings",
+      size: :m
+  ) %>
+</div>

--- a/admin/spec/components/previews/solidus_admin/ui/resource_item/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/resource_item/component_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# @component "ui/resource_item"
+class SolidusAdmin::UI::ResourceItem::ComponentPreview < ViewComponent::Preview
+  include SolidusAdmin::Preview
+
+  def overview
+    render_with_template
+  end
+
+  # @param thumbnail text
+  # @param title text
+  # @param subtitle text
+  def render_resource_item(title: "Your Title", subtitle: "Your Subtitle", thumbnail: "https://picsum.photos/200/300")
+    render current_component.new(
+      title: title,
+      subtitle: subtitle,
+      thumbnail: thumbnail
+    )
+  end
+end

--- a/admin/spec/components/previews/solidus_admin/ui/resource_item/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/resource_item/component_preview/overview.html.erb
@@ -1,0 +1,7 @@
+<div class="mb-8">
+  <%= render current_component.new(
+    title: "Sample Product Name",
+    subtitle: "SKU12345 - Additional details here",
+    thumbnail: "https://picsum.photos/200/300"
+  ) %>
+</div>

--- a/admin/spec/components/solidus_admin/ui/forms/switch_field/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/switch_field/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::Forms::SwitchField::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end

--- a/admin/spec/components/solidus_admin/ui/resource_item/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/resource_item/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::UI::ResourceItem::Component, type: :component do
+  it "renders the overview preview" do
+    render_preview(:overview)
+  end
+end


### PR DESCRIPTION
## Summary

<img width="1016" alt="image" src="https://github.com/solidusio/solidus/assets/1051/a26b0385-77b5-4aa2-a719-4ea91dd147f3">


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
