### PR TITLE
Set the bundle group globally during GH actions execution

### DIFF
--- a/.github/workflows/prepare_post_release.yml
+++ b/.github/workflows/prepare_post_release.yml
@@ -11,14 +11,14 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: "release"
     if: |
       github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'release:generate')
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
-        env:
-          BUNDLE_ONLY: "release"
         with:
           ruby-version: "3.2"
           bundler-cache: true

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: "release"
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
-        env:
-          BUNDLE_ONLY: "release"
         with:
           ruby-version: "3.2"
           bundler-cache: true

--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   update:
+    runs-on: ubuntu-latest
     env:
       BUNDLE_ONLY: "release"
-    runs-on: ubuntu-latest
     if: |
       (github.event.pull_request.merged == true) &&
         !contains(github.event.pull_request.labels.*.name, 'changelog:skip')

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -50,8 +50,7 @@ Spree::ShippingMethod.create!([
   }
 ])
 
-# The just below rubocop:disable directive will be removed once https://github.com/rubocop/rubocop/issues/12441 is resolved.
-{ # rubocop:disable Style/HashEachMethods
+{
   "UPS Ground (USD)" => [5, "USD"],
   "UPS Ground (EU)" => [5, "USD"],
   "UPS One Day (USD)" => [15, "USD"],


### PR DESCRIPTION
## Summary

Looks like the setting is not kept on the steps beyond the setup.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
