### PR TITLE
[Admin] Implement `enable_alpha_features?` preference config for selective feature access

### DIFF
--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -9,17 +9,23 @@ SolidusAdmin::Engine.routes.draw do
     get 'states', to: 'countries#states'
   end
 
-  # Needs a constraint to avoid interpreting "new" as a product's slug
-  admin_resources :products, only: [
-    :index, :show, :edit, :update, :destroy
-  ], constraints: ->{ _1.path != "/admin/products/new" } do
+  admin_resources :products, only: [:index, :update, :destroy] do
     collection do
       put :discontinue
       put :activate
     end
   end
 
-  admin_resources :orders, except: [:destroy] do
+  # Needs a constraint to avoid interpreting "new" as a product's slug
+  admin_resources :products, only: [
+    :show, :edit
+  ], constraints: ->{ SolidusAdmin::Config.enable_alpha_features? && _1.path != "/admin/products/new" }
+
+  admin_resources :orders, only: [:index]
+
+  admin_resources :orders, except: [
+    :destroy, :index
+  ], constraints: ->{ SolidusAdmin::Config.enable_alpha_features? } do
     resources :line_items, only: [:destroy, :create, :update]
     resource :customer
     resource :ship_address, only: [:show, :edit, :update], controller: "addresses", type: "ship"

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -71,6 +71,13 @@ module SolidusAdmin
     #                     Default: 10
     preference :low_stock_value, :integer, default: 10
 
+    # @!attribute [rw] enable_alpha_features?
+    #   @return [Boolean] Determines whether alpha features are enabled or disabled in the application.
+    #                     Setting this to `true` enables access to alpha stage features that might still be in testing or development.
+    #                     Use with caution, as these features may not be fully stable or complete.
+    #                     Default: false
+    preference :enable_alpha_features?, :boolean, default: false
+
     preference :storefront_product_path_proc, :proc, default: ->(_version) {
       ->(product) { "/products/#{product.slug}" }
     }

--- a/admin/spec/features/order_spec.rb
+++ b/admin/spec/features/order_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe "Order", :js, type: :feature do
-  before { sign_in create(:admin_user, email: 'admin@example.com') }
+  before do
+    allow(SolidusAdmin::Config).to receive(:enable_alpha_features?) { true }
+    sign_in create(:admin_user, email: 'admin@example.com')
+  end
 
   it "allows detaching a customer from an order" do
     order = create(:order, number: "R123456789", user: create(:user))

--- a/admin/spec/features/product_spec.rb
+++ b/admin/spec/features/product_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe "Product", type: :feature do
-  before { sign_in create(:admin_user, email: 'admin@example.com') }
+  before do
+    allow(SolidusAdmin::Config).to receive(:enable_alpha_features?) { true }
+    sign_in create(:admin_user, email: 'admin@example.com')
+  end
 
   it "lists products", :js do
     create(:product, name: "Just a product", slug: 'just-a-prod', price: 19.99)

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe "Products", type: :feature do
-  before { sign_in create(:admin_user, email: 'admin@example.com') }
+  before do
+    allow(SolidusAdmin::Config).to receive(:enable_alpha_features?) { true }
+    sign_in create(:admin_user, email: 'admin@example.com')
+  end
 
   it "lists products", :js do
     create(:product, name: "Just a product", slug: 'just-a-prod', price: 19.99)


### PR DESCRIPTION
## Summary

Using this config to conditionally disable orders and products routes, restricting them to only index actions unless the config is enabled. This setup was done to manage access to features still in development.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
