### PR TITLE
Fix down migration

### DIFF
--- a/core/db/migrate/20230427095534_drop_deprecated_address_id_from_shipments.rb
+++ b/core/db/migrate/20230427095534_drop_deprecated_address_id_from_shipments.rb
@@ -5,7 +5,7 @@ class DropDeprecatedAddressIdFromShipments < ActiveRecord::Migration[5.2]
   end
 
   def down
-    add_column :spree_shipments, :deprecated_address_id
+    add_column :spree_shipments, :deprecated_address_id, :integer
     add_index :spree_shipments, :deprecated_address_id, name: :index_spree_shipments_on_deprecated_address_id
   end
 end


### PR DESCRIPTION
## Summary

`bin/rails db:rollback`

fails with

```
Caused by:
ArgumentError: wrong number of arguments (given 2, expected 3)
```
This commit is fixing the rollback

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
