### PR TITLE
Remove unused action in controller callbacks

### DIFF
--- a/admin/app/controllers/solidus_admin/promotion_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/promotion_categories_controller.rb
@@ -4,8 +4,6 @@ module SolidusAdmin
   class PromotionCategoriesController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :load_promotion_category, only: [:move]
-
     def index
       promotion_categories = apply_search_to(
         Spree::PromotionCategory.all,
@@ -26,13 +24,6 @@ module SolidusAdmin
 
       flash[:notice] = t('.success')
       redirect_back_or_to promotion_categories_path, status: :see_other
-    end
-
-    private
-
-    def load_promotion_category
-      @promotion_category = Spree::PromotionCategory.find(params[:id])
-      authorize! action_name, @promotion_category
     end
   end
 end

--- a/api/app/controllers/spree/api/customer_returns_controller.rb
+++ b/api/app/controllers/spree/api/customer_returns_controller.rb
@@ -5,7 +5,7 @@ module Spree
     class CustomerReturnsController < Spree::Api::BaseController
       before_action :load_order
       before_action :build_customer_return, only: [:create]
-      around_action :lock_order, only: [:create, :update, :destroy, :cancel]
+      around_action :lock_order, only: [:create, :update]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -4,8 +4,8 @@ module Spree
   module Api
     class PaymentsController < Spree::Api::BaseController
       before_action :find_order
-      around_action :lock_order, only: [:create, :update, :destroy, :authorize, :capture, :purchase, :void, :credit]
-      before_action :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
+      around_action :lock_order, only: [:create, :update, :authorize, :capture, :purchase, :void]
+      before_action :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void]
 
       def index
         @payments = paginate(@order.payments.ransack(params[:q]).result)

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -3,7 +3,7 @@
 module Spree
   module Api
     class StockMovementsController < Spree::Api::BaseController
-      before_action :stock_location, except: [:update, :destroy]
+      before_action :stock_location
 
       def index
         authorize! :index, StockMovement

--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -9,7 +9,7 @@ module Spree
       destroy.after :update_totals
       update.after :update_totals
 
-      skip_before_action :load_resource, only: [:toggle_state, :edit, :update, :destroy]
+      skip_before_action :load_resource, only: [:edit, :update, :destroy]
 
       before_action :find_adjustment, only: [:destroy, :edit, :update]
 

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -45,6 +45,12 @@ module DummyApp
 
   class Application < ::Rails::Application
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
+
+    if Rails.gem_version >= Gem::Version.new('7.1')
+      config.action_controller.raise_on_missing_callback_actions = true
+      config.action_dispatch.show_exceptions = :none
+    end
+
     # Make the test environment more production-like:
     config.action_controller.allow_forgery_protection = false
     config.action_controller.default_protect_from_forgery = false


### PR DESCRIPTION
## Summary

With Rails 7.1, callbacks only work with actions that are defined
on the controller. This check allowed us to notice we had this some
no more used actions.

This commit also enable the new configuration in the dummy app so we
will be able to spot new errors. The configuration needs to be defined
explicitely because it's not part of the load_defaults but it's copied
in the dummy application directly.

Took advantage of the change for adding another 7.1-only configuration
to the dummy app:

    config.action_dispatch.show_exceptions = :none

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
