### PR TITLE
Ensure the customer returns specs leverages time outs

### DIFF
--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -12,8 +12,8 @@ describe 'Customer returns', type: :feature do
     click_button 'Create'
   end
 
-  def order_state_label
-    find('dd.order-state').text
+  def expect_order_state_label_to_eq(text)
+    within('dd.order-state') { expect(page).to have_content(text) }
   end
 
   before do
@@ -29,7 +29,7 @@ describe 'Customer returns', type: :feature do
 
         expect(page).to have_content 'Customer Return has been successfully created'
 
-        expect(order_state_label).to eq('Returned')
+        expect_order_state_label_to_eq('Returned')
       end
     end
 
@@ -54,16 +54,16 @@ describe 'Customer returns', type: :feature do
         end
       end
 
-      it 'marks the order as returned', :js, :flaky do
+      it 'marks the order as returned', :js do
         create_customer_return('in_transit')
         expect(page).to have_content 'Customer Return has been successfully created'
-        expect(order_state_label).to eq('Complete')
+        expect_order_state_label_to_eq('Complete')
 
         within('[data-hook="rejected_return_items"] tbody tr:nth-child(1)') { click_button('Receive') }
-        expect(order_state_label).to eq('Complete')
+        expect_order_state_label_to_eq('Complete')
 
         within('[data-hook="rejected_return_items"] tbody tr:nth-child(2)') { click_button('Receive') }
-        expect(order_state_label).to eq('Returned')
+        expect_order_state_label_to_eq('Returned')
       end
     end
   end
@@ -76,7 +76,7 @@ describe 'Customer returns', type: :feature do
         create_customer_return('receive')
 
         expect(page).to have_content 'Customer Return has been successfully created'
-        expect(order_state_label).to eq('Returned')
+        expect_order_state_label_to_eq('Returned')
       end
     end
 
@@ -84,10 +84,10 @@ describe 'Customer returns', type: :feature do
       it 'marks the order as returned', :js do
         create_customer_return('in_transit')
         expect(page).to have_content 'Customer Return has been successfully created'
-        expect(order_state_label).to eq('Complete')
+        expect_order_state_label_to_eq('Complete')
 
         within('[data-hook="rejected_return_items"] tbody tr:nth-child(1)') { click_button('Receive') }
-        expect(order_state_label).to eq('Returned')
+        expect_order_state_label_to_eq('Returned')
       end
     end
   end


### PR DESCRIPTION
## Summary

This is the most probable cause of previous flakyness, having a check on an element without giving the UI time to update.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
