### PR TITLE
Fix property destroy - use destroy instead of discard

### DIFF
--- a/admin/app/controllers/solidus_admin/properties_controller.rb
+++ b/admin/app/controllers/solidus_admin/properties_controller.rb
@@ -23,7 +23,7 @@ module SolidusAdmin
       @properties = Spree::Property.where(id: params[:id])
 
       Spree::Property.transaction do
-        @properties.discard_all
+        @properties.destroy_all
       end
 
       flash[:notice] = t('.success')

--- a/admin/spec/features/properties.rb
+++ b/admin/spec/features/properties.rb
@@ -6,19 +6,19 @@ describe "Properties", :js, type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
   it "lists properties and allows deleting them" do
-    create(:property, name: "Type", presentation: "Type")
+    create(:property, name: "Type prop", presentation: "Type prop")
     create(:property, name: "Size", presentation: "Size")
 
     visit "/admin/properties"
-    expect(page).to have_content("Type")
+    expect(page).to have_content("Type prop")
     expect(page).to have_content("Size")
 
     expect(page).to be_axe_clean
 
-    select_row("Type")
+    select_row("Type prop")
     click_on "Delete"
     expect(page).to have_content("Properties were successfully removed.")
-    expect(page).not_to have_content("Type")
+    expect(page).not_to have_content("Type prop")
     expect(Spree::Property.count).to eq(1)
   end
 end


### PR DESCRIPTION
As the `Spree::Property` object is not discardable, use the default `destroy_all` method

Fixes #5576 
