### PR TITLE
Fix the check on select2 translations asset existence

### DIFF
--- a/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
+++ b/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
@@ -33,7 +33,10 @@
 <script data-hook='admin-custom-translations'>
 </script>
 
-<% if I18n.locale != :en && I18n.locale %>
-  <% select2_locale_path = "solidus_admin/select2_locales/select2_locale_#{I18n.locale}" %>
-  <%= javascript_include_tag select2_locale_path, data: {turbolinks_track: 'reload'} if Rails.application.assets.find_asset(select2_locale_path) %>
+<% select2_locale_path = "solidus_admin/select2_locales/select2_locale_#{I18n.locale}.js" %>
+<% if I18n.locale != :en && I18n.locale && (
+    Rails.application.assets&.find_asset(select2_locale_path) || # compiled on the fly
+    Rails.application.assets_manifest.assets[select2_locale_path] # precompiled
+) %>
+  <%= javascript_include_tag select2_locale_path, data: {turbolinks_track: 'reload'} %>
 <% end %>


### PR DESCRIPTION
## Summary

In environment expecting precompiled assets `Rails.application.assets` is `nil` and we should fall back on checking the manifest.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
