### PR TITLE
Separate subframeworks CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,23 @@ commands:
   test:
     steps:
       - run:
-          name: Run Tests
-          command: ./bin/build-ci
+          name: "Run Admin Tests"
+          command: ./bin/build-ci admin
+      - run:
+          name: "Run Api Tests"
+          command: ./bin/build-ci api
+      - run:
+          name: "Run Backend Tests"
+          command: ./bin/build-ci backend
+      - run:
+          name: "Run Backend JS Tests"
+          command: ./bin/build-ci "backend JS"
+      - run:
+          name: "Run Core Tests"
+          command: ./bin/build-ci core
+      - run:
+          name: "Run Sample Tests"
+          command: ./bin/build-ci sample
 
       - store_artifacts:
           path: /tmp/test-artifacts

--- a/bin/build-ci
+++ b/bin/build-ci
@@ -113,15 +113,22 @@ class Project
   end
 end
 
-if ARGV.first # Run a single project
-  projects = Project.all.select { _1.name == ARGV.first }
-elsif ENV['CIRCLE_NODE_INDEX'] # Run projects on a CI node
+
+if ENV['CIRCLE_NODE_INDEX'] # Run projects on a CI node
   projects = Project.weighted_projects(
     node_total: Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1)),
     node_index: Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0)),
   )
-else # Run all projects
+else
   projects = Project.all
+end
+
+# Run a single project if requested
+projects.select! { _1.title == ARGV.first } if ARGV.first
+
+if projects.empty?
+  warn("No projects to run")
+  exit 0
 end
 
 exit Project.run(projects)


### PR DESCRIPTION
## Summary

Make it easier to see the error in the RSpec report when running multiple subframeworks in the same job. Previously it required scrolling inside a long output.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
