### PR TITLE
Moving solidus_sample to be development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'puma', '< 6', require: false
 gem 'i18n-tasks', '~> 0.9', require: false
 gem 'rspec_junit_formatter', require: false
 gem 'yard', require: false
+gem 'solidus_sample'
 
 # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
 gem 'factory_bot_rails', '>= 4.8', require: false

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ bin/rails db:seed
 bin/rails spree_sample:load
 ```
 
+`solidus_sample` is a development dependency, if you need to run `spree_sample:load`
+in production environments, then you have to add it to your local Gemfile `gem 'solidus_sample'`.
+
 There are also options and rake tasks provided by
 [solidus\_auth\_devise](https://github.com/solidusio/solidus_auth_devise).
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -183,6 +183,11 @@ module Solidus
       generate 'solidus_admin:install'
     end
 
+    def install_solidus_sample
+      say_status :installing, "SolidusSample", :blue
+      bundle_command 'add solidus_sample --group=development'
+    end
+
     def install_subcomponents
       apply_template_for :authentication, @selected_authentication
       apply_template_for :frontend, @selected_frontend

--- a/lib/solidus.rb
+++ b/lib/solidus.rb
@@ -3,4 +3,3 @@
 require 'solidus_core'
 require 'solidus_api'
 require 'solidus_backend'
-require 'solidus_sample'

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version
-  s.add_dependency 'solidus_sample', s.version
+
+  s.add_development_dependency 'solidus_sample', s.version
 end


### PR DESCRIPTION
## Summary
Solidus Sample gem includes seed data to setup local development in an easy way, it includes catalogs for countries, states, products, taxonomies/taxons and images. This gem itself needs about 10mb of disk space and most of the times it is only needed in local development or one time.

### Example

```
~ $ du -a /app/vendor/bundle/ruby/2.7.0/gems/ 2>/dev/null | sort -n -r | head -n 100
363848	/app/vendor/bundle/ruby/2.7.0/gems/
...
9696	/app/vendor/bundle/ruby/2.7.0/gems/solidus_sample-2.11.15
9648	/app/vendor/bundle/ruby/2.7.0/gems/solidus_sample-2.11.15/db
9640	/app/vendor/bundle/ruby/2.7.0/gems/solidus_sample-2.11.15/db/samples
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
