### PR TITLE
Use Order#email to show the order's email in new admin

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -143,7 +143,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
       col: { class: "w-[400px]" },
       header: :customer,
       data: ->(order) do
-        customer_email = order.user&.email
+        customer_email = order.email
         content_tag :div, String(customer_email)
       end
     }

--- a/admin/spec/features/orders/index_spec.rb
+++ b/admin/spec/features/orders/index_spec.rb
@@ -11,6 +11,7 @@ describe "Orders", type: :feature do
     visit "/admin/orders"
     click_on "In Progress"
 
+    expect(page).to have_content("admin@example.com")
     expect(page).to have_content("R123456789")
     expect(page).to have_content("$19.99")
     expect(page).to be_axe_clean


### PR DESCRIPTION
## Summary

`spree_orders` table has the column `email` which stores the email of
guest orders or users email for non guest orders. We should use
that in the new admin to display the email so that guest orders work
as well.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
