### PR TITLE
Use `spree` routing proxy in theme selection partial

### DIFF
--- a/backend/app/views/spree/admin/shared/_theme_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_theme_selection.html.erb
@@ -1,6 +1,6 @@
 <% theme_options_for_select = Spree::Backend::Config.themes.keys.map { |theme| [theme.to_s.humanize, theme] }.sort %>
 
-<%= form_tag(admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
+<%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
   <%= hidden_field_tag :system_theme, :light %>
   <label class="admin-navbar-selection">
     <i class="fa fa-sun-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
@@ -10,7 +10,7 @@
   </label>
 <% end %>
 
-<%= form_tag(admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
+<%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
   <%= hidden_field_tag :system_theme, :dark %>
   <label class="admin-navbar-selection">
     <i class="fa fa-moon-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>


### PR DESCRIPTION


## Summary

When using the navigation from a gem that isolates its namespace in such a way that the default route helper is not `spree`, this partial fails to render with an undefined method error.

This can easily be fixes by prefixing the route helper with Solidus' routing proxy.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
