### PR TITLE
Disable admin preview for extensions test apps

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -31,6 +31,7 @@ class CommonRakeTasks
           'solidus:install',
           Dir.pwd, # use the current dir as Rails.root
           "--auto-accept",
+          "--admin-preview=#{ENV.fetch('ADMIN_PREVIEW', 'false')}",
           "--authentication=none",
           "--payment-method=none",
           "--migrate=false",


### PR DESCRIPTION
## Summary

The new admin is far from complete and existing
extensions will fail if we test them with the
new default admin that we generate apps with.

It can be enabled by setting `ADMIN_PREVIEW=true`
in your test env.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
