### PR TITLE
fix(admin stock items spec): Wait for tab to be active

### DIFF
--- a/admin/spec/features/stock_items_spec.rb
+++ b/admin/spec/features/stock_items_spec.rb
@@ -36,24 +36,28 @@ describe "Stock Items", :js, type: :feature do
     expect(find('tr', text: 'MY-SKU-1234567890')).to have_content('1 stock movement')
 
     click_on 'Back Orderable'
+    expect(page).to have_css('[aria-current="true"]', text: 'Back Orderable')
     expect(page).to_not have_content(non_backorderable.variant.sku)
     expect(page).to have_content(backorderable.variant.sku)
     expect(page).to_not have_content(out_of_stock.variant.sku)
     expect(page).to_not have_content(low_stock.variant.sku)
 
     click_on 'Out Of Stock'
+    expect(page).to have_css('[aria-current="true"]', text: 'Out Of Stock')
     expect(page).to_not have_content(non_backorderable.variant.sku)
     expect(page).to_not have_content(backorderable.variant.sku)
     expect(page).to have_content(out_of_stock.variant.sku)
     expect(page).to_not have_content(low_stock.variant.sku)
 
     click_on 'Low Stock'
+    expect(page).to have_css('[aria-current="true"]', text: 'Low Stock')
     expect(page).to_not have_content(non_backorderable.variant.sku)
     expect(page).to_not have_content(backorderable.variant.sku)
     expect(page).to_not have_content(out_of_stock.variant.sku)
     expect(page).to have_content(low_stock.variant.sku)
 
     click_on 'In Stock'
+    expect(page).to have_css('[aria-current="true"]', text: 'In Stock')
     expect(page).to have_content(non_backorderable.variant.sku)
     expect(page).to have_content(backorderable.variant.sku)
     expect(page).to_not have_content(out_of_stock.variant.sku)


### PR DESCRIPTION
## Summary

We need to wait until the tab is active in order to test its contents

