### PR TITLE
Bundle solidus_admin >= 0.2 in Solidus installer

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -179,7 +179,7 @@ module Solidus
       return unless options[:admin_preview]
 
       say_status :installing, "SolidusAdmin", :blue
-      bundle_command 'add solidus_admin'
+      bundle_command 'add solidus_admin -v ">= 0.2"'
       generate 'solidus_admin:install'
     end
 


### PR DESCRIPTION
## Summary

Currently, running `rails g solidus:install` on a new rails app bundles `solidus_admin` with the version `0.0.0`, which is empty.

This leads to inconsistencies, the first one being the dedicated `solidus_admin` generator is not found and consequently cannot be run. Confirmed to be the source of the issue found at https://github.com/solidusio/solidus/discussions/5606.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
