### PR TITLE
Solidus Admin: Import legacy items after routes are generated

### DIFF
--- a/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
+++ b/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
@@ -14,9 +14,15 @@ SolidusAdmin::Config.configure do |config|
   # you can import menu_items from the backend by uncommenting the following line,
   # but you will need to
   <%- if defined? Spree::Backend -%>
-  config.import_menu_items_from_backend!
+  Rails.application.config.after_initialize do
+    Rails.application.reload_routes!
+    config.import_menu_items_from_backend!
+  end
   <%- else -%>
-  # config.import_menu_items_from_backend!
+  # Rails.application.config.after_initialize do
+  #  Rails.application.reload_routes!
+  #  config.import_menu_items_from_backend!
+  # end
   <%- end -%>
 
   # Add custom paths to importmap files to be loaded.


### PR DESCRIPTION
## Summary

When importing legacy menu items into the new storefront's API, the `import_menu_items_from_backend` method will try reading the legacy menu item's paths. Those path might be defined in lambdas referencing route helpers, but those route helper are only available after the application's routes have been fully loaded.

I understand this is somewhat kludgy, but on the upside: It works.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
