### PR TITLE
[v4.2] Allow "sqlite3" as ENV["DB"]

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -3,7 +3,7 @@
           'mysql'
         when 'postgres', 'postgresql'
           'postgres'
-        when 'sqlite', '', nil
+        when /sqlite3?/, '', nil
           'sqlite'
         else
           raise "Invalid DB specified: #{ENV['DB']}"


### PR DESCRIPTION


## Summary

Since solidus-orbs-extension v0.10.0, the CI runner will set the ENV var for sqlite to be `sqlite3`, which currently raises an error.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
