### PR TITLE
Dummy App generator: Use db var instead of ENV var

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -19,7 +19,7 @@
 <% db_username = ENV['DB_USERNAME'] %>
 <% db_password = ENV['DB_PASSWORD'] %>
 
-<% case ENV['DB']
+<% case db
   when 'mysql' %>
 development:
   adapter: mysql2


### PR DESCRIPTION


## Summary

A couple of lines before this change, we already normalize `ENV['db']`. We lose that work by relying on the raw ENV var here.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
