### PR TITLE
Configuration endpoint for promotion adjustments

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -42,8 +42,8 @@ module Spree
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
     scope :credit, -> { where("#{quoted_table_name}.amount < 0") }
     scope :nonzero, -> { where("#{quoted_table_name}.amount != 0") }
-    scope :promotion, -> { where(source_type: 'Spree::PromotionAction') }
-    scope :non_promotion, -> { where.not(source_type: 'Spree::PromotionAction') }
+    scope :promotion, -> { where(source_type: Spree::Config.adjustment_promotion_source_types.map(&:to_s)) }
+    scope :non_promotion, -> { where.not(source_type: Spree::Config.adjustment_promotion_source_types.map(&:to_s)) }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :is_included, -> { where(included: true) }
     scope :additional, -> { where(included: false) }
@@ -77,7 +77,7 @@ module Spree
 
     # @return [Boolean] true when this is a promotion adjustment (Promotion adjustments have a {PromotionAction} source)
     def promotion?
-      source_type == 'Spree::PromotionAction'
+      source_type.to_s.in?(Spree::Config.adjustment_promotion_source_types.map(&:to_s))
     end
 
     # @return [Boolean] true when this is a tax adjustment (Tax adjustments have a {TaxRate} source)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -24,6 +24,7 @@ require 'spree/core/environment'
 
 module Spree
   class AppConfiguration < Preferences::Configuration
+    include Spree::Core::EnvironmentExtension
     # Preferences (alphabetized to more easily lookup particular preferences)
 
     # @!attribute [rw] address_requires_phone
@@ -582,6 +583,9 @@ module Spree
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface
     class_name_attribute :taxon_attachment_module, default: "Spree::Taxon::ActiveStorageAttachment"
+
+    # Set of classes that can be promotion adjustment sources
+    add_class_set :adjustment_promotion_source_types, default: ["Spree::PromotionAction"]
 
     # Configures the absolute path that contains the Solidus engine
     # migrations. This will be checked at app boot to confirm that all Solidus

--- a/core/lib/spree/core/environment_extension.rb
+++ b/core/lib/spree/core/environment_extension.rb
@@ -8,10 +8,10 @@ module Spree
       extend ActiveSupport::Concern
 
       class_methods do
-        def add_class_set(name)
+        def add_class_set(name, default: [])
           define_method(name) do
             set = instance_variable_get("@#{name}")
-            set ||= send("#{name}=", [])
+            set ||= send("#{name}=", default)
             set
           end
 

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -160,6 +160,12 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  describe "#adjustment_promotion_source_types" do
+    subject { described_class.new.adjustment_promotion_source_types }
+
+    it { is_expected.to contain_exactly(Spree::PromotionAction) }
+  end
+
   it 'has a default admin VAT location with nil values by default' do
     expect(prefs.admin_vat_location).to eq(Spree::Tax::TaxLocation.new)
     expect(prefs.admin_vat_location.state_id).to eq(nil)

--- a/core/spec/lib/spree/core/environment_extension_spec.rb
+++ b/core/spec/lib/spree/core/environment_extension_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Spree::Core::EnvironmentExtension do
   subject! { base.include(described_class).new }
 
   describe '.add_class_set' do
+    let(:class_one) { String }
+    let(:class_two) { Array }
+    let(:class_three) { Hash }
+
     context 'with a class set named "foo"' do
       before { base.add_class_set('foo') }
-
-      let(:class_one) { String }
-      let(:class_two) { Array }
-      let(:class_three) { Hash }
 
       describe '#foo' do
         it { respond_to?(:foo) }
@@ -29,6 +29,16 @@ RSpec.describe Spree::Core::EnvironmentExtension do
         it { expect(subject.foo).to include(class_one) }
         it { expect(subject.foo).to include(class_two) }
         it { expect(subject.foo).not_to include(class_three) }
+      end
+    end
+
+    context "with a default value of [class_one]" do
+      before { base.add_class_set('foo', default: [class_one]) }
+
+      describe '#foo' do
+        it { respond_to?(:foo) }
+        it { expect(subject.foo).to include(class_one) }
+        it { expect(subject.foo).to be_kind_of Spree::Core::ClassConstantizer::Set }
       end
     end
   end


### PR DESCRIPTION
## Summary

This adds an endpoint for configuring which classes are promotion adjustments. Really useful for gems that extend or overwrite the promotion system and have other promotion source classes.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
