### PR TITLE
Deprecate Spree::Adjustment#recalculate

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -122,6 +122,7 @@ module Spree
       end
       amount
     end
+    deprecate :recalculate, deprecator: Spree.deprecator
 
     # Calculates based on attached promotion (if this is a promotion
     # adjustment) whether this promotion is still eligible.

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
             adjustment.source.tax_categories = []
           end
           adjustment.source.save
-          adjustment.recalculate
+          adjustment.update!(amount: adjustment.source.compute_amount(adjustment.adjustable))
         end
       end
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe Spree::Adjustment, type: :model do
     let(:order) { create(:order_with_line_items, line_items_price: 100) }
     let(:line_item) { order.line_items.to_a.first }
 
+    around do |example|
+      Spree.deprecator.silence do
+        example.run
+      end
+    end
+
     context "when adjustment is finalized" do
       let(:finalized) { true }
 


### PR DESCRIPTION

## Summary

We've already deprecated Spree::Adjustment#calculate_eligibility, and we've removed all the code paths that call
Spree::Adjustment#recalculate. Let's deprecate it.



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
