### PR TITLE
Remove call to private method `#update_cancellations` from `OrderUpdater#recalculate_adjustments`

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -114,7 +114,6 @@ module Spree
       # http://www.boe.ca.gov/formspubs/pub113/
       update_promotions
       update_taxes
-      update_cancellations
       update_item_totals
     end
 
@@ -217,10 +216,8 @@ module Spree
     end
 
     def update_cancellations
-      line_items.each do |line_item|
-        line_item.adjustments.select(&:cancellation?).each(&:recalculate)
-      end
     end
+    deprecate :update_cancellations, deprecator: Spree.deprecator
 
     def update_item_totals
       [*line_items, *shipments].each do |item|


### PR DESCRIPTION

## Summary

This removes the final occurrence of Spree::Adjustment#recalculate.

Order Cancellation adjustments are always finalized, and recalculating them is always a no-op. No need to carry the code path forward. 

See https://github.com/solidusio/solidus/blob/main/core/app/models/spree/unit_cancel.rb#L27
and https://github.com/solidusio/solidus/blob/main/core/app/models/spree/adjustment.rb#L101

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
