### PR TITLE
Promotion configuration

### DIFF
--- a/api/app/controllers/spree/api/coupon_codes_controller.rb
+++ b/api/app/controllers/spree/api/coupon_codes_controller.rb
@@ -10,7 +10,7 @@ module Spree
         authorize! :update, @order, order_token
 
         @order.coupon_code = params[:coupon_code]
-        @handler = Spree::Config.coupon_code_handler_class.new(@order).apply
+        @handler = Spree::Config.promotions.coupon_code_handler_class.new(@order).apply
 
         if @handler.successful?
           render 'spree/api/promotions/handler', status: 200
@@ -24,7 +24,7 @@ module Spree
         authorize! :update, @order, order_token
 
         @order.coupon_code = params[:id]
-        @handler = Spree::Config.coupon_code_handler_class.new(@order).remove
+        @handler = Spree::Config.promotions.coupon_code_handler_class.new(@order).remove
 
         if @handler.successful?
           render 'spree/api/promotions/handler', status: 200

--- a/backend/app/controllers/spree/admin/promotion_actions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_actions_controller.rb
@@ -36,7 +36,7 @@ class Spree::Admin::PromotionActionsController < Spree::Admin::BaseController
 
   def validate_promotion_action_type
     requested_type = params[:action_type]
-    promotion_action_types = Rails.application.config.spree.promotions.actions
+    promotion_action_types = Spree::Config.promotions.actions
     @promotion_action_type = promotion_action_types.detect do |klass|
       klass.name == requested_type
     end

--- a/backend/app/controllers/spree/admin/promotion_rules_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_rules_controller.rb
@@ -41,7 +41,7 @@ class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
 
   def validate_promotion_rule_type
     requested_type = params[:promotion_rule].delete(:type)
-    promotion_rule_types = Rails.application.config.spree.promotions.rules
+    promotion_rule_types = Spree::Config.promotions.rules
     @promotion_rule_type = promotion_rule_types.detect do |klass|
       klass.name == requested_type
     end

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -49,7 +49,7 @@ module Spree
         @collection = @search.result(distinct: true).
           includes(promotion_includes).
           page(params[:page]).
-          per(params[:per_page] || Spree::Config[:promotions_per_page])
+          per(params[:per_page] || Spree::Config.promotions.promotions_per_page)
 
         @collection
       end

--- a/backend/app/helpers/spree/promotion_rules_helper.rb
+++ b/backend/app/helpers/spree/promotion_rules_helper.rb
@@ -4,7 +4,7 @@ module Spree
   module PromotionRulesHelper
     def options_for_promotion_rule_types(promotion)
       existing = promotion.rules.map { |rule| rule.class.name }
-      rules = Rails.application.config.spree.promotions.rules.reject { |rule| existing.include? rule.name }
+      rules = Spree::Config.promotions.rules.reject { |rule| existing.include? rule.name }
       options = rules.map { |rule| [rule.model_name.human, rule.name] }
       options_for_select(options)
     end

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -1,7 +1,7 @@
 <fieldset id="action_fields" class="no-border-top">
 
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), remote: true, id: 'new_promotion_action_form' do %>
-    <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map {|action| [ action.model_name.human, action.name] } ) %>
+    <% options = options_for_select(Spree::Config.promotions.actions.map {|action| [ action.model_name.human, action.name] } ) %>
     <fieldset>
       <legend align="center"><%= t('spree.promotion_actions') %></legend>
       <% if can?(:update, @promotion) %>

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -275,12 +275,12 @@ describe "Promotion Adjustments", type: :feature, js: true do
             "Complex Calculator"
           end
         end
-        @calculators = Rails.application.config.spree.calculators.promotion_actions_create_item_adjustments
-        Rails.application.config.spree.calculators.promotion_actions_create_item_adjustments = [ComplexCalculator]
+        @calculators = Spree::Config.promotions.calculators['Spree::Promotion::Actions::CreateItemAdjustments']
+        Spree::Config.promotions.calculators['Spree::Promotion::Actions::CreateItemAdjustments'] = [ComplexCalculator]
       end
 
       after do
-        Rails.application.config.spree.calculators.promotion_actions_create_item_adjustments = @calculators
+        Spree::Config.promotions.calculators['Spree::Promotion::Actions::CreateItemAdjustments'] = @calculators
       end
 
       it "does not show array and hash form fields" do

--- a/core/app/jobs/spree/promotion_code_batch_job.rb
+++ b/core/app/jobs/spree/promotion_code_batch_job.rb
@@ -10,13 +10,13 @@ module Spree
       ).build_promotion_codes
 
       if promotion_code_batch.email?
-        Spree::Config.promotion_code_batch_mailer_class
+        Spree::Config.promotions.promotion_code_batch_mailer_class
           .promotion_code_batch_finished(promotion_code_batch)
           .deliver_now
       end
     rescue StandardError => error
       if promotion_code_batch.email?
-        Spree::Config.promotion_code_batch_mailer_class
+        Spree::Config.promotions.promotion_code_batch_mailer_class
           .promotion_code_batch_errored(promotion_code_batch)
           .deliver_now
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -509,7 +509,7 @@ module Spree
     end
 
     def apply_shipping_promotions
-      Spree::Config.shipping_promotion_handler_class.new(self).activate
+      Spree::Config.promotions.shipping_promotion_handler_class.new(self).activate
       recalculate
     end
 
@@ -799,7 +799,7 @@ module Spree
     end
 
     def ensure_promotions_eligible
-      Spree::Config.promotion_adjuster_class.new(self).call
+      Spree::Config.promotions.promotion_adjuster_class.new(self).call
 
       if promo_total_changed?
         restart_checkout_flow

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -195,7 +195,7 @@ module Spree
     end
 
     def update_promotions
-      Spree::Config.promotion_adjuster_class.new(order).call
+      Spree::Config.promotions.promotion_adjuster_class.new(order).call
     end
 
     def update_taxes

--- a/core/app/models/spree/promotion/order_adjustments_recalculator.rb
+++ b/core/app/models/spree/promotion/order_adjustments_recalculator.rb
@@ -20,7 +20,7 @@ module Spree
           promotion_adjustments = item.adjustments.select(&:promotion?)
 
           promotion_adjustments.each { |adjustment| recalculate(adjustment) }
-          Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
+          Spree::Config.promotions.promotion_chooser_class.new(promotion_adjustments).update
 
           item.promo_total = promotion_adjustments.select(&:eligible?).sum(&:amount)
         end
@@ -30,7 +30,7 @@ module Spree
         # line items and/or shipments.
         order_promotion_adjustments = order.adjustments.select(&:promotion?)
         order_promotion_adjustments.each { |adjustment| recalculate(adjustment) }
-        Spree::Config.promotion_chooser_class.new(order_promotion_adjustments).update
+        Spree::Config.promotions.promotion_chooser_class.new(order_promotion_adjustments).update
 
         order.promo_total = all_items.sum(&:promo_total) +
                             order_promotion_adjustments.

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -14,7 +14,7 @@ module Spree
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions, optional: true
 
     scope :of_type, ->(type) { where(type: Array.wrap(type).map(&:to_s)) }
-    scope :shipping, -> { of_type(Spree::Config.environment.promotions.shipping_actions.to_a) }
+    scope :shipping, -> { of_type(Spree::Config.promotions.shipping_actions.to_a) }
 
     def preload_relations
       []

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -216,10 +216,6 @@ module Spree
     #   @return [Integer] Products to show per-page in the frontend (default: +12+)
     preference :products_per_page, :integer, default: 12
 
-    # @!attribute [rw] promotions_per_page
-    #   @return [Integer] Promotions to show per-page in the admin (default: +15+)
-    preference :promotions_per_page, :integer, default: 15
-
     # @!attribute [rw] require_master_price
     #   @return [Boolean] Require a price on the master variant of a product (default: +true+)
     preference :require_master_price, :boolean, default: true
@@ -324,12 +320,6 @@ module Spree
     #   Spree::Variant::VatPriceGenerator.
     class_name_attribute :variant_vat_prices_generator_class, default: 'Spree::Variant::VatPriceGenerator'
 
-    # promotion_chooser_class allows extensions to provide their own PromotionChooser
-    class_name_attribute :promotion_chooser_class, default: 'Spree::PromotionChooser'
-
-    # promotion_adjuster_class allows extensions to provide their own Promotion Adjuster
-    class_name_attribute :promotion_adjuster_class, default: 'Spree::Promotion::OrderAdjustmentsRecalculator'
-
     class_name_attribute :allocator_class, default: 'Spree::Stock::Allocator::OnHandFirst'
 
     class_name_attribute :shipping_rate_sorter_class, default: 'Spree::Stock::ShippingRateSorter'
@@ -366,31 +356,6 @@ module Spree
     #   the standard order recalculator class
     #   Spree::OrderUpdater.
     class_name_attribute :order_recalculator_class, default: 'Spree::OrderUpdater'
-
-    # Allows providing a different coupon code handler.
-    # @!attribute [rw] coupon_code_handler_class
-    # @see Spree::PromotionHandler::Coupon
-    # @return [Class] an object that conforms to the API of
-    #   the standard coupon code handler class
-    #   Spree::PromotionHandler::Coupon.
-    class_name_attribute :coupon_code_handler_class, default: 'Spree::PromotionHandler::Coupon'
-
-    # Allows providing a different shipping promotion handler.
-    # @!attribute [rw] shipping_promotion_handler_class
-    # @see Spree::PromotionHandler::Shipping
-    # @return [Class] an object that conforms to the API of
-    #   the standard shipping promotion handler class
-    #   Spree::PromotionHandler::Coupon.
-    class_name_attribute :shipping_promotion_handler_class, default: 'Spree::PromotionHandler::Shipping'
-
-    # Allows providing your own Mailer for promotion code batch mailer.
-    #
-    # @!attribute [rw] promotion_code_batch_mailer_class
-    # @return [ActionMailer::Base] an object that responds to "promotion_code_batch_finished",
-    #   and "promotion_code_batch_errored"
-    #   (e.g. an ActionMailer with a "promotion_code_batch_finished" method) with the same
-    #   signature as Spree::PromotionCodeBatchMailer.promotion_code_batch_finished.
-    class_name_attribute :promotion_code_batch_mailer_class, default: 'Spree::PromotionCodeBatchMailer'
 
     # Allows providing your own Mailer for reimbursement mailer.
     #
@@ -622,6 +587,39 @@ module Spree
     def promotions
       @promotion_configuration ||= Spree::Core::PromotionConfiguration.new
     end
+
+    class << self
+      private
+
+      def promotions_deprecation_message(method)
+        "The `Spree::Config.#{method}` preference is deprecated and will be removed in Solidus 5.0. " \
+        "Use `Spree::Config.promotions.#{method}` instead"
+      end
+    end
+
+    delegate :promotion_adjuster_class, :promotion_adjuster_class=, to: :promotions
+    deprecate promotion_adjuster_class: promotions_deprecation_message("promotion_adjuster_class"), deprecator: Spree.deprecator
+    deprecate "promotion_adjuster_class=": promotions_deprecation_message("promotion_adjuster_class="), deprecator: Spree.deprecator
+
+    delegate :promotion_chooser_class, :promotion_chooser_class=, to: :promotions
+    deprecate promotion_chooser_class: promotions_deprecation_message("promotion_chooser_class"), deprecator: Spree.deprecator
+    deprecate "promotion_chooser_class=": promotions_deprecation_message("promotion_chooser_class="), deprecator: Spree.deprecator
+
+    delegate :shipping_promotion_handler_class, :shipping_promotion_handler_class=, to: :promotions
+    deprecate shipping_promotion_handler_class: promotions_deprecation_message("shipping_promotion_handler_class"), deprecator: Spree.deprecator
+    deprecate "shipping_promotion_handler_class=": promotions_deprecation_message("shipping_promotion_handler_class="), deprecator: Spree.deprecator
+
+    delegate :coupon_code_handler_class, :coupon_code_handler_class=, to: :promotions
+    deprecate coupon_code_handler_class: promotions_deprecation_message("coupon_code_handler_class"), deprecator: Spree.deprecator
+    deprecate "coupon_code_handler_class=": promotions_deprecation_message("coupon_code_handler_class"), deprecator: Spree.deprecator
+
+    delegate :promotion_code_batch_mailer_class, :promotion_code_batch_mailer_class=, to: :promotions
+    deprecate promotion_code_batch_mailer_class: promotions_deprecation_message("promotion_code_batch_mailer_class"), deprecator: Spree.deprecator
+    deprecate "promotion_code_batch_mailer_class=": promotions_deprecation_message("promotion_code_batch_mailer_class="), deprecator: Spree.deprecator
+
+    delegate :preferred_promotions_per_page, :preferred_promotions_per_page=, to: :promotions
+    deprecate preferred_promotions_per_page: promotions_deprecation_message("preferred_promotions_per_page"), deprecator: Spree.deprecator
+    deprecate "preferred_promotions_per_page=": promotions_deprecation_message("preferred_promotions_per_page="), deprecator: Spree.deprecator
 
     def roles
       @roles ||= Spree::RoleConfiguration.new.tap do |roles|

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -656,33 +656,6 @@ module Spree
           Spree::PaymentMethod::Check
         ]
 
-        env.promotions.rules = %w[
-          Spree::Promotion::Rules::ItemTotal
-          Spree::Promotion::Rules::Product
-          Spree::Promotion::Rules::User
-          Spree::Promotion::Rules::FirstOrder
-          Spree::Promotion::Rules::UserLoggedIn
-          Spree::Promotion::Rules::OneUsePerUser
-          Spree::Promotion::Rules::Taxon
-          Spree::Promotion::Rules::MinimumQuantity
-          Spree::Promotion::Rules::NthOrder
-          Spree::Promotion::Rules::OptionValue
-          Spree::Promotion::Rules::FirstRepeatPurchaseSince
-          Spree::Promotion::Rules::UserRole
-          Spree::Promotion::Rules::Store
-        ]
-
-        env.promotions.actions = %w[
-          Spree::Promotion::Actions::CreateAdjustment
-          Spree::Promotion::Actions::CreateItemAdjustments
-          Spree::Promotion::Actions::CreateQuantityAdjustments
-          Spree::Promotion::Actions::FreeShipping
-        ]
-
-        env.promotions.shipping_actions = %w[
-          Spree::Promotion::Actions::FreeShipping
-        ]
-
         env.stock_splitters = %w[
           Spree::Stock::Splitter::ShippingCategory
           Spree::Stock::Splitter::Backordered

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -11,6 +11,7 @@ require "sprockets/railtie"
 
 require 'active_support/deprecation'
 require 'spree/deprecated_instance_variable_proxy'
+require 'spree/deprecator'
 require 'acts_as_list'
 require 'awesome_nested_set'
 require 'cancan'
@@ -28,10 +29,6 @@ require_relative './ransack_4_1_patch'
 StateMachines::Machine.ignore_method_conflicts = true
 
 module Spree
-  def self.deprecator
-    @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'Solidus')
-  end
-
   autoload :Deprecation, 'spree/deprecation'
 
   mattr_accessor :user_class, default: 'Spree::LegacyUser'

--- a/core/lib/spree/core/environment/promotions.rb
+++ b/core/lib/spree/core/environment/promotions.rb
@@ -4,11 +4,32 @@ module Spree
   module Core
     class Environment
       class Promotions
-        include EnvironmentExtension
+        class << self
+          private
 
-        add_class_set :rules
-        add_class_set :actions
-        add_class_set :shipping_actions
+          def promotions_deprecation_message(method)
+            "The `Rails.application.config.spree.promotions.#{method}` preference is deprecated and will be removed in Solidus 5.0. " \
+            "Use `Spree::Config.promotions.#{method}` instead."
+          end
+        end
+
+        delegate :rules, :rules=, to: :promotion_config
+        deprecate rules: promotions_deprecation_message("rules"), deprecator: Spree.deprecator
+        deprecate "rules=": promotions_deprecation_message("rules="), deprecator: Spree.deprecator
+
+        delegate :actions, :actions=, to: :promotion_config
+        deprecate actions: promotions_deprecation_message("actions"), deprecator: Spree.deprecator
+        deprecate "actions=": promotions_deprecation_message("actions="), deprecator: Spree.deprecator
+
+        delegate :shipping_actions, :shipping_actions=, to: :promotion_config
+        deprecate shipping_actions: promotions_deprecation_message("shipping_actions"), deprecator: Spree.deprecator
+        deprecate "shipping_actions=": promotions_deprecation_message("shipping_actions="), deprecator: Spree.deprecator
+
+        private
+
+        def promotion_config
+          Spree::Config.promotions
+        end
       end
     end
   end

--- a/core/lib/spree/core/promotion_configuration.rb
+++ b/core/lib/spree/core/promotion_configuration.rb
@@ -2,8 +2,43 @@
 
 module Spree
   module Core
-    class PromotionConfiguration
+    class PromotionConfiguration < Spree::Preferences::Configuration
       include Core::EnvironmentExtension
+
+      # @!attribute [rw] promotions_per_page
+      #   @return [Integer] Promotions to show per-page in the admin (default: +15+)
+      preference :promotions_per_page, :integer, default: 15
+
+      # promotion_chooser_class allows extensions to provide their own PromotionChooser
+      class_name_attribute :promotion_chooser_class, default: 'Spree::PromotionChooser'
+
+      # promotion_adjuster_class allows extensions to provide their own Promotion Adjuster
+      class_name_attribute :promotion_adjuster_class, default: 'Spree::Promotion::OrderAdjustmentsRecalculator'
+
+      # Allows providing a different shipping promotion handler.
+      # @!attribute [rw] shipping_promotion_handler_class
+      # @see Spree::PromotionHandler::Shipping
+      # @return [Class] an object that conforms to the API of
+      #   the standard shipping promotion handler class
+      #   Spree::PromotionHandler::Coupon.
+      class_name_attribute :shipping_promotion_handler_class, default: 'Spree::PromotionHandler::Shipping'
+
+      # Allows providing your own Mailer for promotion code batch mailer.
+      #
+      # @!attribute [rw] promotion_code_batch_mailer_class
+      # @return [ActionMailer::Base] an object that responds to "promotion_code_batch_finished",
+      #   and "promotion_code_batch_errored"
+      #   (e.g. an ActionMailer with a "promotion_code_batch_finished" method) with the same
+      #   signature as Spree::PromotionCodeBatchMailer.promotion_code_batch_finished.
+      class_name_attribute :promotion_code_batch_mailer_class, default: 'Spree::PromotionCodeBatchMailer'
+
+      # Allows providing a different coupon code handler.
+      # @!attribute [rw] coupon_code_handler_class
+      # @see Spree::PromotionHandler::Coupon
+      # @return [Class] an object that conforms to the API of
+      #   the standard coupon code handler class
+      #   Spree::PromotionHandler::Coupon.
+      class_name_attribute :coupon_code_handler_class, default: 'Spree::PromotionHandler::Coupon'
 
       add_nested_class_set :calculators, default: {
         "Spree::Promotion::Actions::CreateAdjustment" => %w[

--- a/core/lib/spree/core/promotion_configuration.rb
+++ b/core/lib/spree/core/promotion_configuration.rb
@@ -40,6 +40,33 @@ module Spree
       #   Spree::PromotionHandler::Coupon.
       class_name_attribute :coupon_code_handler_class, default: 'Spree::PromotionHandler::Coupon'
 
+      add_class_set :rules, default: %w[
+        Spree::Promotion::Rules::ItemTotal
+        Spree::Promotion::Rules::Product
+        Spree::Promotion::Rules::User
+        Spree::Promotion::Rules::FirstOrder
+        Spree::Promotion::Rules::UserLoggedIn
+        Spree::Promotion::Rules::OneUsePerUser
+        Spree::Promotion::Rules::Taxon
+        Spree::Promotion::Rules::MinimumQuantity
+        Spree::Promotion::Rules::NthOrder
+        Spree::Promotion::Rules::OptionValue
+        Spree::Promotion::Rules::FirstRepeatPurchaseSince
+        Spree::Promotion::Rules::UserRole
+        Spree::Promotion::Rules::Store
+      ]
+
+      add_class_set :actions, default: %w[
+        Spree::Promotion::Actions::CreateAdjustment
+        Spree::Promotion::Actions::CreateItemAdjustments
+        Spree::Promotion::Actions::CreateQuantityAdjustments
+        Spree::Promotion::Actions::FreeShipping
+      ]
+
+      add_class_set :shipping_actions, default: %w[
+        Spree::Promotion::Actions::FreeShipping
+      ]
+
       add_nested_class_set :calculators, default: {
         "Spree::Promotion::Actions::CreateAdjustment" => %w[
           Spree::Calculator::FlatPercentItemTotal

--- a/core/lib/spree/deprecator.rb
+++ b/core/lib/spree/deprecator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'active_support/deprecation'
+
+module Spree
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'Solidus')
+  end
+end

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -40,16 +40,32 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.variant_price_selector_class).to eq Spree::Variant::PriceSelector
   end
 
-  it "uses order adjustments recalculator class by default" do
-    expect(prefs.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
-  end
+  context "deprecated preferences" do
+    around do |example|
+      Spree.deprecator.silence do
+        example.run
+      end
+    end
 
-  it "uses promotion handler coupon class by default" do
-    expect(prefs.coupon_code_handler_class).to eq Spree::PromotionHandler::Coupon
-  end
+    it "uses order adjustments recalculator class by default" do
+      expect(prefs.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
+    end
 
-  it "uses promotion handler shipping class by default" do
-    expect(prefs.shipping_promotion_handler_class).to eq Spree::PromotionHandler::Shipping
+    it "uses promotion handler coupon class by default" do
+      expect(prefs.coupon_code_handler_class).to eq Spree::PromotionHandler::Coupon
+    end
+
+    it "uses promotion handler shipping class by default" do
+      expect(prefs.shipping_promotion_handler_class).to eq Spree::PromotionHandler::Shipping
+    end
+
+    it "uses promotion code batch mailer class by default" do
+      expect(prefs.promotion_code_batch_mailer_class).to eq Spree::PromotionCodeBatchMailer
+    end
+
+    it "uses promotion chooser class by default" do
+      expect(prefs.promotion_chooser_class).to eq Spree::PromotionChooser
+    end
   end
 
   context "deprecated preferences" do

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -156,7 +156,14 @@ RSpec.describe Spree::AppConfiguration do
     end
 
     context '.promotions' do
+      around do |example|
+        Spree.deprecator.silence do
+          example.run
+        end
+      end
+
       subject(:promotions) { environment.promotions }
+
       it { is_expected.to be_a Spree::Core::Environment::Promotions }
 
       context '.promotions.rules' do

--- a/core/spec/lib/spree/core/promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/promotion_configuration_spec.rb
@@ -3,8 +3,26 @@
 require "rails_helper"
 
 RSpec.describe Spree::Core::PromotionConfiguration do
+  subject(:config) { described_class.new }
+
+  it "uses base searcher class by default" do
+    expect(config.promotion_chooser_class).to eq Spree::PromotionChooser
+  end
+
+  it "uses order adjustments recalculator class by default" do
+    expect(config.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
+  end
+
+  it "uses promotion handler coupon class by default" do
+    expect(config.coupon_code_handler_class).to eq Spree::PromotionHandler::Coupon
+  end
+
+  it "uses promotion handler shipping class by default" do
+    expect(config.shipping_promotion_handler_class).to eq Spree::PromotionHandler::Shipping
+  end
+
   describe "#calculators" do
-    subject { described_class.new.calculators[promotion_action] }
+    subject { config.calculators[promotion_action] }
 
     context "for Spree::Promotion::Actions::CreateAdjustment" do
       let(:promotion_action) { Spree::Promotion::Actions::CreateAdjustment }

--- a/core/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
+++ b/core/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Spree::Promotion::OrderAdjustmentsRecalculator do
             end
           end
 
-          stub_spree_preferences(promotion_chooser_class: Spree::TestPromotionChooser)
+          stub_spree_preferences(Spree::Config.promotions, promotion_chooser_class: Spree::TestPromotionChooser)
         end
 
         it 'uses the defined promotion chooser' do

--- a/core/spec/models/spree/promotion_handler/shipping_spec.rb
+++ b/core/spec/models/spree/promotion_handler/shipping_spec.rb
@@ -76,7 +76,7 @@ module Spree
         before do
           stub_const('CustomShippingAction', custom_klass)
 
-          allow(Spree::Config.environment.promotions).to receive(:shipping_actions) { ['CustomShippingAction'] }
+          allow(Spree::Config.promotions).to receive(:shipping_actions) { ['CustomShippingAction'] }
 
           order.order_promotions.create!(promotion: promotion, promotion_code: promotion.codes.first)
         end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'spree/testing_support/flaky'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/silence_deprecations'
 require 'spree/testing_support/preferences'
+require 'spree/deprecator'
 require 'spree/config'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary

This extracts the remaining promotion-related things from `Spree::AppConfiguration` and `Rails.application.config.spree` and puts them into `Spree::Core::PromotionConfiguration`. 

`Spree::Core::PromotionConfiguration` will become the blueprint for a configuration class for a promotion system. 

#5634 depends on this or comparable work, because we can't reference classes from `Spree::AppConfiguration` that aren't defined inside `solidus_core` or its direct dependencies. 

I'm extracting a few commits that used to be in here into their own PR because they don't move existing endpoints. 

In a nutshell: All promotion configuration is now found under `Spree::Config.promotions`, instead of under either `Spree::Config` or `Rails.application.config.spree.promotions` or `Rails.application.config.spree.calculators`. Yay!

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
