### PR TITLE
Add Admin Tailwind build when generating sandbox 

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,16 @@ data already loaded.
     bin/sandbox
   ```
 
-* Start the server (`bin/rails` will forward any argument to the sandbox)
+* You can start the Rails server and other services from either the Solidus folder or the
+sandbox one by running the command:
 
   ```bash
-  bin/rails server
+  bin/dev
   ```
+
+Please note: if you run `bin/rails server` or similar commands, only the Rails server will
+start. This might cause the error `couldn't find file 'solidus_admin/tailwind.css'` when you
+try to load admin pages.
 
 ### Tests
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -175,6 +175,12 @@ module Solidus
       end
     end
 
+    def install_subcomponents
+      apply_template_for :authentication, @selected_authentication
+      apply_template_for :frontend, @selected_frontend
+      apply_template_for :payment_method, @selected_payment_method
+    end
+
     def install_solidus_admin
       return unless options[:admin_preview]
 
@@ -183,12 +189,6 @@ module Solidus
         bundle_command 'add solidus_admin -v ">= 0.2"'
       end
       generate 'solidus_admin:install'
-    end
-
-    def install_subcomponents
-      apply_template_for :authentication, @selected_authentication
-      apply_template_for :frontend, @selected_frontend
-      apply_template_for :payment_method, @selected_payment_method
     end
 
     def populate_seed_data

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -35,6 +35,7 @@ module Solidus
     class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations and seeds must be run)'
     class_option :active_storage, type: :boolean, default: true, banner: 'Install ActiveStorage as image attachments handler for products and taxons'
     class_option :admin_preview, type: :boolean, default: true, desc: 'Install the admin preview'
+    class_option :build_admin_tailwind, type: :boolean, default: true, desc: 'Build and install Solidus Admin Tailwind CSS file and rake tasks'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string
@@ -188,7 +189,7 @@ module Solidus
       unless File.read(app_path.join('Gemfile')).include?('solidus_admin')
         bundle_command 'add solidus_admin -v ">= 0.2"'
       end
-      generate 'solidus_admin:install'
+      generate "solidus_admin:install #{'--tailwind' if options[:build_admin_tailwind]}"
     end
 
     def populate_seed_data


### PR DESCRIPTION
## Summary

Fixes #5598

This PR attempts to fix the error `couldn't find file 'solidus_admin/tailwind.css'` when loading admin pages from the sandbox application.

The error is caused by the absence of the Admin Tailwind CSS build file, which doesn't exist on (local) copies of the project codebase from GitHub. 

The fix adds the new flag `--build-admin-tailwind` to the `install` process that controls whether to build the CSS file and install the associated rake tasks into the sandbox application. The flag defaults to `true`, so installing Solidus will build Admin Tailwind CSS and add rake tasks. This can be disabled with `rails g solidus:install --no-build-admin-tailwind`, see `rails g solidus:install --help` for more context.

The only effective way to run the server is now via `bin/dev`. 

Also, the main `README` is updated with the new relevant information.



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages]
- [x] 📖 I have updated the README to account for my changes.
(https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
