### PR TITLE
Add missing option types to product sample data

### DIFF
--- a/sample/db/samples/product_option_types.rb
+++ b/sample/db/samples/product_option_types.rb
@@ -5,12 +5,17 @@ Spree::Sample.load_sample("products")
 size = Spree::OptionType.find_by!(presentation: "Size")
 color = Spree::OptionType.find_by!(presentation: "Color")
 
-solidus_cap = Spree::Product.find_by!(name: "Solidus cap")
+products_with_variants = [
+  "Solidus cap",
+  "Solidus hoodie",
+  "Solidus t-shirt",
+  "Solidus mug set",
+  "Solidus tote",
+  "Solidus Water Bottle"
+]
 
-solidus_cap.option_types = [size, color]
-solidus_cap.save!
-
-solidus_hoodie = Spree::Product.find_by!(name: "Solidus hoodie")
-
-solidus_hoodie.option_types = [size, color]
-solidus_hoodie.save!
+products_with_variants.each do |name|
+  product = Spree::Product.find_by!(name: name)
+  product.option_types = [size, color]
+  product.save!
+end


### PR DESCRIPTION
## Summary

Sample products data was reworked with solidusio/solidus/pull/5437. After these changes, some products with variants remained without option types, meaning that their variants remained not visible and selectable on the FE, and in the admin it was not possible to add new ones as the relevant button was hidden.    

Sample products with variants are visible here: https://github.com/solidusio/solidus/blob/main/sample/db/samples/variants.rb


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
