### PR TITLE
Remove promotion from cancellations spec

### DIFF
--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -149,8 +149,6 @@ RSpec.describe Spree::OrderCancellations do
       let(:line_item) { order.line_items.to_a.first }
       let(:inventory_unit_1) { line_item.inventory_units[0] }
       let(:inventory_unit_2) { line_item.inventory_units[1] }
-      let(:promotion) { create(:promotion, :with_line_item_adjustment) }
-      let(:promotion_action) { promotion.actions[0] }
 
       before do
         order.contents.add(line_item.variant)
@@ -160,7 +158,7 @@ RSpec.describe Spree::OrderCancellations do
           order: order,
           amount: 0.01,
           label: 'some promo',
-          source: promotion_action,
+          source: nil,
           finalized: true,
         )
         order.recalculate


### PR DESCRIPTION
## Summary

Removes a call to the promotion factories from the cancellations spec.
This promotion isn't necessary for testing the rounding here. We can just use a manual adjustment.

This is extracted from the extraction work in #5634 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
