### PR TITLE
Add `better_errors` gem to the sandbox

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -68,6 +68,9 @@ group :test, :development do
   platforms :mri do
     gem 'pry-byebug'
   end
+
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 RUBY
 unbundled bundle install --gemfile Gemfile


### PR DESCRIPTION

## Summary

To enhance the developer-friendliness and interactivity of stack traces, particularly those from components in the new admin.

Please check the [gem readme](https://github.com/BetterErrors/better_errors) for further info.

We'd go from something like this:

<img width="1383" alt="Screenshot 2024-02-05 at 09 44 04" src="https://github.com/solidusio/solidus/assets/141220/3e1bc073-6189-4cf9-90c6-5ab9bd4c18ec">

To this:

<img width="1393" alt="Screenshot 2024-02-05 at 09 43 13" src="https://github.com/solidusio/solidus/assets/141220/5b299f47-509f-4933-8383-f7e9899e8099">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- [x]  📸 I have attached screenshots to demo visual changes.

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.


