### PR TITLE
Fix migration down method for promotion_orders promotions foreign key

### DIFF
--- a/core/db/migrate/20231031175215_add_promotion_order_promotion_foreign_key.rb
+++ b/core/db/migrate/20231031175215_add_promotion_order_promotion_foreign_key.rb
@@ -5,6 +5,6 @@ class AddPromotionOrderPromotionForeignKey < ActiveRecord::Migration[7.0]
   end
 
   def down
-    remove_foreign_key :spree_orders_promotions, :spree_orders
+    remove_foreign_key :spree_orders_promotions, :spree_promotions
   end
 end


### PR DESCRIPTION
## Summary

The most recent migration `AddPromotionOrderPromotionForeignKey` has an incorrect down method.
The `remove_foreign_key` method has an incorrect "to" table in the second parameter.

This migration creates a foreign key between `spree_orders_promotions` and `spree_promotions`, so the down method should refer to `spree_promotions` instead of `spree_orders`.

If you rollback this migration you will be removing the foreign key between `spree_orders_promotions` and `spree_orders`.
This causes the rollback of the previous migration to fail with a `Table 'spree_orders_promotions' has no foreign key for spree_orders` error, as the previous migration also tries to remove the foreign key between `spree_orders_promotions` and `spree_orders` but the foreign key is no longer there. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
