### PR TITLE
Menu item should not match url if match_path is set

### DIFF
--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -78,18 +78,17 @@ module Spree
       end
 
       def match_path?(request)
-        matches =
-          if match_path.is_a? Regexp
-            request.fullpath =~ match_path
-          elsif match_path.respond_to?(:call)
-            match_path.call(request)
-          elsif match_path
-            request.fullpath.starts_with?("#{spree.admin_path}#{match_path}")
-          end
-        matches ||= request.fullpath.to_s.starts_with?(url.to_s) if url.present?
-        matches ||= @sections.include?(request.controller_class.controller_name.to_sym) if @sections.present?
-
-        matches
+        if match_path.is_a? Regexp
+          request.fullpath =~ match_path
+        elsif match_path.respond_to?(:call)
+          match_path.call(request)
+        elsif match_path
+          request.fullpath.starts_with?("#{spree.admin_path}#{match_path}")
+        elsif url.present?
+          request.fullpath.to_s.starts_with?(url.to_s)
+        elsif @sections.present?
+          @sections.include?(request.controller_class.controller_name.to_sym)
+        end
       end
 
       def url

--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe Spree::BackendConfiguration::MenuItem do
       expect(subject.match_path?(matching_request)).to be true
       expect(subject.match_path?(other_request)).to be false
     end
+
+    it 'should not match the url if a match_path is set' do
+      subject = described_class.new(match_path: %r{/url$/}, url: "/foo/url")
+      request = double(ActionDispatch::Request, fullpath: '/foo/url_which_starts_with_the_same_characters')
+
+      expect(subject.match_path?(request)).to be_falsey
+    end
   end
 
   describe "#url" do


### PR DESCRIPTION

## Summary
The menu item should not match the url if a match_path prevents this behavior. Previously the match_path method went truthy, if the url of the menu item started with the same url as the request regardless of the given match_path - configuration.

**Example**

The regex in the match_path of menu item 1 should highlight only if the url ends with "bar":
``` 
Menu Item 1: {url: '/foo/bar', match_path: %r{/bar$/} } 
Menu Item 2: {url: '/foo/bar_baz'}
Request: /foo/bar_baz
```

In the prevous implementation both menu items got highlighted, because they started with the same url. In the implemation of this Pull Request only the second menu item will be highlighted.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- ✅ I have added automated tests to cover my changes.
