### PR TITLE
Explicitly require URI in app configuration

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -22,6 +22,8 @@ require "spree/core/search/variant"
 require 'spree/preferences/configuration'
 require 'spree/core/environment'
 
+require 'uri'
+
 module Spree
   class AppConfiguration < Preferences::Configuration
     # Preferences (alphabetized to more easily lookup particular preferences)


### PR DESCRIPTION
Without this we get

    uninitialized constant Spree::AppConfiguration::URI

errors.
