### PR TITLE
Fix search by variant on stock items

### DIFF
--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -56,7 +56,7 @@ module Spree
       def variant_scope
         scope = Spree::Variant
           .accessible_by(current_ability)
-          .distinct.order(:sku)
+          .distinct
           .includes(
             :images,
             stock_items: :stock_location,

--- a/backend/spec/features/admin/stock_items_spec.rb
+++ b/backend/spec/features/admin/stock_items_spec.rb
@@ -6,8 +6,10 @@ describe 'Stock Items Management', js: true do
   stub_authorization!
 
   let(:admin_user)   { create(:admin_user) }
-  let!(:variant_1) { create(:variant) }
-  let!(:variant_2) { create(:variant) }
+  let!(:variant_1) { create(:variant, product: product1) }
+  let!(:variant_2) { create(:variant, product: product2) }
+  let(:product1) { create(:product, name: 'Ruby Shirt') }
+  let(:product2) { create(:product, name: 'Solidus Shirt') }
   let!(:stock_location) { create(:stock_location_without_variant_propagation) }
 
   scenario 'User can add a new stock locations to any variant' do
@@ -18,5 +20,13 @@ describe 'Stock Items Management', js: true do
       click_on('Create')
     end
     expect(page).to have_content("Created successfully")
+  end
+
+  scenario 'searching by variant' do
+    visit spree.admin_stock_items_path
+    fill_in 'SKU or Option Value', with: 'Ruby'
+    click_on 'Filter Results'
+    expect(page).to have_content "Ruby Shirt"
+    expect(page).to_not have_content "Solidus Shirt"
   end
 end


### PR DESCRIPTION
## Summary

This branch fixes the invalid SQL error that occurs when filtering stock locations by variant (#5506). The implementation changes are still a work in progress, so this pull request is in draft, but I wanted to put this up now so other contributors can see/use the feature spec.

## Checklist

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
