### PR TITLE
Configurable promotion adjustment sources

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -42,8 +42,8 @@ module Spree
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
     scope :credit, -> { where("#{quoted_table_name}.amount < 0") }
     scope :nonzero, -> { where("#{quoted_table_name}.amount != 0") }
-    scope :promotion, -> { where(source_type: 'Spree::PromotionAction') }
-    scope :non_promotion, -> { where.not(source_type: 'Spree::PromotionAction') }
+    scope :promotion, -> { where(source_type: Spree::Config.adjustment_promotion_source_types.map(&:to_s)) }
+    scope :non_promotion, -> { where.not(source_type: Spree::Config.adjustment_promotion_source_types.map(&:to_s)) }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :is_included, -> { where(included: true) }
     scope :additional, -> { where(included: false) }
@@ -77,7 +77,7 @@ module Spree
 
     # @return [Boolean] true when this is a promotion adjustment (Promotion adjustments have a {PromotionAction} source)
     def promotion?
-      source_type == 'Spree::PromotionAction'
+      source_type.to_s.in?(Spree::Config.adjustment_promotion_source_types.map(&:to_s))
     end
 
     # @return [Boolean] true when this is a tax adjustment (Tax adjustments have a {TaxRate} source)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -26,6 +26,7 @@ require 'uri'
 
 module Spree
   class AppConfiguration < Preferences::Configuration
+    include Spree::Core::EnvironmentExtension
     # Preferences (alphabetized to more easily lookup particular preferences)
 
     # @!attribute [rw] address_requires_phone
@@ -584,6 +585,9 @@ module Spree
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface
     class_name_attribute :taxon_attachment_module, default: "Spree::Taxon::ActiveStorageAttachment"
+
+    # Set of classes that can be promotion adjustment sources
+    add_class_set :adjustment_promotion_source_types, default: ["Spree::PromotionAction"]
 
     # Configures the absolute path that contains the Solidus engine
     # migrations. This will be checked at app boot to confirm that all Solidus

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -180,6 +180,12 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  describe "#adjustment_promotion_source_types" do
+    subject { described_class.new.adjustment_promotion_source_types }
+
+    it { is_expected.to contain_exactly(Spree::PromotionAction) }
+  end
+
   it 'has a default admin VAT location with nil values by default' do
     expect(prefs.admin_vat_location).to eq(Spree::Tax::TaxLocation.new)
     expect(prefs.admin_vat_location.state_id).to eq(nil)


### PR DESCRIPTION
## Summary

This is the last preparation commit enabling us to extract the legacy promotion system into its own gem. It adds a configuration endpoint to allow multiple source types for promotion adjustments. 

Background: Solidus stores everything that somehow changes the value of something as a `Spree::Adjustment`. The source type of the adjustment tells the system what kind of adjustment it is, and how it thus should be applied. For example, promotion adjustments need to be applied before taxation adjustments. It is thus important for promotion adjustments to be correctly identified. 

In `solidus_friendly_promotions`, the prototype for the future `solidus_promotions` gem, promotion adjustments have a source type of `SolidusFriendlyPromotions::PromotionAction`. In Solidus core, promotion adjustments have a source type of `Spree::PromotionAction`. In order to correctly identify adjustments from both systems, we need some extension point, and this PR provides it. 

The default stays - for now - `Spree::PromotionAction`. However, as an array, multiple promotion adjustment sources are now supported. 

Usage: 
If you happen to write a custom promotion system with a custom adjustment source, do the following in an initializer: 

```rb 
Spree::Config.promotion_adjustment_source_types << 'MyPromotionExtension::Promotion`
```


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
