### PR TITLE
Keep backorders when splitting part of variant to new shipment with same SL

### DIFF
--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -43,9 +43,24 @@ module Spree
         total_on_hand >= required || backorderable?
       end
 
+      def positive_stock
+        return unless stock_location
+
+        on_hand = stock_location.count_on_hand(variant)
+        on_hand.positive? ? on_hand : 0
+      end
+
       private
 
       attr_reader :variant, :stock_location_or_id
+
+      def stock_location
+        @stock_location ||= if stock_location_or_id.is_a?(Spree::StockLocation)
+          stock_location_or_id
+        else
+          Spree::StockLocation.find_by(id: stock_location_or_id)
+        end
+      end
 
       def variant_stock_items
         variant.stock_items.select do |stock_item|

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -11,14 +11,8 @@ module Spree
       #        If unspecified it will check inventory in all available StockLocations
       def initialize(variant, stock_location_or_id = nil)
         @variant = variant
-        @stock_items = variant.stock_items.select do |stock_item|
-          if stock_location_or_id
-            stock_item.stock_location == stock_location_or_id ||
-              stock_item.stock_location_id == stock_location_or_id
-          else
-            stock_item.stock_location.active?
-          end
-        end
+        @stock_location_or_id = stock_location_or_id
+        @stock_items = variant_stock_items
       end
 
       # Returns the total number of inventory units on hand for the variant.
@@ -26,7 +20,7 @@ module Spree
       # @return [Fixnum] number of inventory units on hand, or infinity if
       #   inventory is not tracked on the variant.
       def total_on_hand
-        if @variant.should_track_inventory?
+        if variant.should_track_inventory?
           stock_items.sum(&:count_on_hand)
         else
           Float::INFINITY
@@ -47,6 +41,21 @@ module Spree
       #   variant is backorderable, otherwise false
       def can_supply?(required)
         total_on_hand >= required || backorderable?
+      end
+
+      private
+
+      attr_reader :variant, :stock_location_or_id
+
+      def variant_stock_items
+        variant.stock_items.select do |stock_item|
+          if stock_location_or_id
+            stock_item.stock_location == stock_location_or_id ||
+              stock_item.stock_location_id == stock_location_or_id
+          else
+            stock_item.stock_location.active?
+          end
+        end
       end
     end
   end

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe Spree::FulfilmentChanger do
   let(:current_shipment) { order.shipments.first }
   let!(:desired_shipment) { order.shipments.create!(stock_location: desired_stock_location) }
   let(:desired_stock_location) { current_shipment.stock_location }
-  let(:current_shipment_inventory_unit_count) { 1 }
-  let(:quantity) { current_shipment_inventory_unit_count }
 
   let(:shipment_splitter) do
     described_class.new(
@@ -41,6 +39,9 @@ RSpec.describe Spree::FulfilmentChanger do
   end
 
   context "when the current shipment stock location is the same of the target shipment" do
+    let(:current_shipment_inventory_unit_count) { 1 }
+    let(:quantity) { current_shipment_inventory_unit_count }
+
     context "when the stock location is empty" do
       before do
         variant.stock_items.first.update_column(:count_on_hand, 0)

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Spree::FulfilmentChanger do
 
   context "when the current shipment is emptied out by the transfer" do
     let(:current_shipment_inventory_unit_count) { 30 }
-    let(:quantity) { 30 }
+    let(:quantity) { current_shipment_inventory_unit_count }
 
     it_behaves_like "moves inventory units between shipments"
 

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -32,6 +32,55 @@ RSpec.describe Spree::FulfilmentChanger do
     )
   end
 
+  shared_examples_for "moves inventory units between shipments" do
+    it "adds the desired inventory units to the desired shipment" do
+      expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
+    end
+
+    it "removes the desired inventory units from the current shipment" do
+      expect { subject }.to change { current_shipment.inventory_units.length }.by(-quantity)
+    end
+  end
+
+  shared_examples_for "recalculates shipping costs and order totals" do
+    it "recalculates shipping costs for the current shipment" do
+      expect(current_shipment).to receive(:refresh_rates)
+      subject
+    end
+
+    it "recalculates shipping costs for the new shipment" do
+      expect(desired_shipment).to receive(:refresh_rates)
+      subject
+    end
+
+    it 'updates order totals' do
+      original_total = order.total
+      original_shipment_total = order.shipment_total
+
+      expect { subject }.
+        to change { order.total }.from(original_total).to(original_total + original_shipment_total).
+        and change { order.shipment_total }.by(original_shipment_total)
+    end
+  end
+
+  shared_examples_for "completes transfer to another stock location without tracking inventory changes" do
+    context "when transferring to another stock location" do
+      let(:desired_stock_location) { create(:stock_location) }
+
+      it "is marked as a successful transfer" do
+        expect(subject).to be true
+      end
+
+      it "does not stock in the current stock location" do
+        expect { subject }.not_to change { current_shipment.stock_location.count_on_hand(variant) }
+      end
+
+      it "does not unstock the desired stock location" do
+        expect { subject }.not_to change { desired_shipment.stock_location.count_on_hand(variant) }
+      end
+    end
+  end
+
   subject { shipment_splitter.run! }
 
   before do
@@ -76,49 +125,9 @@ RSpec.describe Spree::FulfilmentChanger do
     let(:quantity) { 1 }
     let(:track_inventory) { nil }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
-    end
-
-    it "removes the desired inventory units from the current shipment" do
-      expect { subject }.to change { current_shipment.inventory_units.length }.by(-quantity)
-    end
-
-    it "recalculates shipping costs for the current shipment" do
-      expect(current_shipment).to receive(:refresh_rates)
-      subject
-    end
-
-    it 'updates order totals' do
-      original_total = order.total
-      original_shipment_total = order.shipment_total
-
-      expect { subject }.
-        to change { order.total }.from(original_total).to(original_total + original_shipment_total).
-        and change { order.shipment_total }.by(original_shipment_total)
-    end
-
-    context "when transferring to another stock location" do
-      let(:desired_stock_location) { create(:stock_location) }
-      let!(:stock_item) do
-        variant.stock_items.find_or_create_by!(
-          stock_location: desired_stock_location,
-          variant: variant,
-        )
-      end
-
-      it "is marked as a successful transfer" do
-        expect(subject).to be true
-      end
-
-      it "does not stock in the current stock location" do
-        expect { subject }.not_to change { current_shipment.stock_location.count_on_hand(variant) }
-      end
-
-      it "does not unstock the desired stock location" do
-        expect { subject }.not_to change { desired_shipment.stock_location.count_on_hand(variant) }
-      end
-    end
+    it_behaves_like "moves inventory units between shipments"
+    it_behaves_like "recalculates shipping costs and order totals"
+    it_behaves_like "completes transfer to another stock location without tracking inventory changes"
   end
 
   context "when not tracking inventory" do
@@ -126,81 +135,16 @@ RSpec.describe Spree::FulfilmentChanger do
     let(:quantity) { 1 }
     let(:track_inventory) { false }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
-    end
-
-    it "removes the desired inventory units from the current shipment" do
-      expect { subject }.to change { current_shipment.inventory_units.length }.by(-quantity)
-    end
-
-    it "recalculates shipping costs for the current shipment" do
-      expect(current_shipment).to receive(:refresh_rates)
-      subject
-    end
-
-    it 'updates order totals' do
-      original_total = order.total
-      original_shipment_total = order.shipment_total
-
-      expect { subject }.
-        to change { order.total }.from(original_total).to(original_total + original_shipment_total).
-        and change { order.shipment_total }.by(original_shipment_total)
-    end
-
-    context "when transferring to another stock location" do
-      let(:desired_stock_location) { create(:stock_location) }
-      let!(:stock_item) do
-        variant.stock_items.find_or_create_by!(
-          stock_location: desired_stock_location,
-          variant: variant,
-        )
-      end
-
-      it "is marked as a successful transfer" do
-        expect(subject).to be true
-      end
-
-      it "does not stock in the current stock location" do
-        expect { subject }.not_to change { current_shipment.stock_location.count_on_hand(variant) }
-      end
-
-      it "does not unstock the desired stock location" do
-        expect { subject }.not_to change { desired_shipment.stock_location.count_on_hand(variant) }
-      end
-    end
+    it_behaves_like "moves inventory units between shipments"
+    it_behaves_like "completes transfer to another stock location without tracking inventory changes"
   end
 
   context "when the current shipment has enough inventory units" do
     let(:current_shipment_inventory_unit_count) { 2 }
     let(:quantity) { 1 }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
-    end
-
-    it "removes the desired inventory units from the current shipment" do
-      expect { subject }.to change { current_shipment.inventory_units.length }.by(-quantity)
-    end
-
-    it "recalculates shipping costs for the current shipment" do
-      expect(current_shipment).to receive(:refresh_rates)
-      subject
-    end
-
-    it "recalculates shipping costs for the new shipment" do
-      expect(desired_shipment).to receive(:refresh_rates)
-      subject
-    end
-
-    it 'updates order totals' do
-      original_total = order.total
-      original_shipment_total = order.shipment_total
-
-      expect { subject }.
-        to change { order.total }.from(original_total).to(original_total + original_shipment_total).
-        and change { order.shipment_total }.by(original_shipment_total)
-    end
+    it_behaves_like "moves inventory units between shipments"
+    it_behaves_like "recalculates shipping costs and order totals"
 
     context "when transferring to another stock location" do
       let(:desired_stock_location) { create(:stock_location) }

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -350,9 +350,7 @@ RSpec.describe Spree::FulfilmentChanger do
     let(:current_shipment_inventory_unit_count) { 30 }
     let(:quantity) { 30 }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
-    end
+    it_behaves_like "moves inventory units between shipments"
 
     it "removes the current shipment" do
       expect { subject }.to change { Spree::Shipment.count }.by(-1)
@@ -365,9 +363,7 @@ RSpec.describe Spree::FulfilmentChanger do
 
     let(:desired_shipment) { order.shipments.build(stock_location: current_shipment.stock_location) }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { Spree::Shipment.count }.by(1)
-    end
+    it_behaves_like "moves inventory units between shipments"
 
     context "if the desired shipment is invalid" do
       let(:desired_shipment) { order.shipments.build(stock_location_id: 99_999_999) }

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::FulfilmentChanger do
   let(:variant) { create(:variant) }
   let(:track_inventory) { true }
 
-  let(:order) do
+  let!(:order) do
     create(
       :completed_order_with_totals,
       line_items_attributes: [
@@ -19,7 +19,7 @@ RSpec.describe Spree::FulfilmentChanger do
   end
 
   let(:current_shipment) { order.shipments.first }
-  let(:desired_shipment) { order.shipments.create!(stock_location: desired_stock_location) }
+  let!(:desired_shipment) { order.shipments.create!(stock_location: desired_stock_location) }
   let(:desired_stock_location) { current_shipment.stock_location }
   let(:current_shipment_inventory_unit_count) { 1 }
   let(:quantity) { current_shipment_inventory_unit_count }
@@ -37,7 +37,6 @@ RSpec.describe Spree::FulfilmentChanger do
   subject { shipment_splitter.run! }
 
   before do
-    order && desired_shipment
     variant.stock_items.first.update_column(:count_on_hand, 100)
   end
 

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -2,17 +2,16 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples_for 'unlimited supply' do
-  it 'can_supply? any amount' do
-    expect(subject.can_supply?(1)).to eq true
-    expect(subject.can_supply?(101)).to eq true
-    expect(subject.can_supply?(100_001)).to eq true
-  end
-end
-
 module Spree
   module Stock
     RSpec.describe Quantifier, type: :model do
+      shared_examples_for 'unlimited supply' do
+        it 'can_supply? any amount' do
+          expect(subject.can_supply?(1)).to eq true
+          expect(subject.can_supply?(101)).to eq true
+          expect(subject.can_supply?(100_001)).to eq true
+        end
+      end
       let(:target_stock_location) { nil }
       let!(:stock_location) { create :stock_location_with_items }
       let!(:stock_item) { stock_location.stock_items.order(:id).first }


### PR DESCRIPTION
## Summary

Fixes #5669 
 
When splitting a shipment to the same stock location, when not the whole quantity for the variant is moved it may happen, if there are backordered items, that these disappear (they become on hand).

This PR first reworks and adds further coverage to specs for the `Spree::FulfilmentChanger` service to expose the issue, then addresses it in the last commit.


https://github.com/solidusio/solidus/assets/141220/eea2c906-6a8d-44b4-83cd-8b7207b0b78a



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages]
- [x] I have added automated tests to cover my changes.