### PR TITLE
Improve test coverage for Spree::Adjustment to 100%

### DIFF
--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -293,4 +293,27 @@ RSpec.describe Spree::Adjustment, type: :model do
       end
     end
   end
+
+  describe "#unfinalize!" do
+    let(:adjustable) { create(:order) }
+    let(:adjustment) { build(:adjustment, finalized: true, adjustable: adjustable) }
+
+    subject { adjustment.unfinalize! }
+
+    it "sets the adjustment as finalized" do
+      expect { subject }.to change { adjustment.finalized }.from(true).to(false)
+    end
+
+    it "persists the adjustment" do
+      expect { subject }.to change { adjustment.persisted? }.from(false).to(true)
+    end
+
+    context "for an invalid adjustment" do
+      let(:adjustment) { build(:adjustment, finalized: false, amount: nil, adjustable: adjustable) }
+
+      it "raises an error" do
+        expect { subject }.to raise_exception(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -316,4 +316,20 @@ RSpec.describe Spree::Adjustment, type: :model do
       end
     end
   end
+
+  describe "#cancellation?" do
+    subject { adjustment.cancellation? }
+
+    context "when the adjustment is a cancellation" do
+      let(:adjustment) { build(:adjustment, source_type: "Spree::UnitCancel") }
+
+      it { is_expected.to eq true }
+    end
+
+    context "when the adjustment is not a cancellation" do
+      let(:adjustment) { build(:adjustment) }
+
+      it { is_expected.to eq false }
+    end
+  end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -269,4 +269,28 @@ RSpec.describe Spree::Adjustment, type: :model do
       end
     end
   end
+
+  describe "#unfinalize" do
+    let(:adjustable) { create(:order) }
+    let(:adjustment) { build(:adjustment, finalized: true, adjustable: adjustable) }
+
+    subject { adjustment.unfinalize }
+
+    it "sets the adjustment as finalized" do
+      expect { subject }.to change { adjustment.finalized }.from(true).to(false)
+    end
+
+    it "persists the adjustment" do
+      expect { subject }.to change { adjustment.persisted? }.from(false).to(true)
+    end
+
+    context "for an invalid adjustment" do
+      let(:adjustment) { build(:adjustment, finalized: false, amount: nil, adjustable: adjustable) }
+
+      it "raises no error, returns false, does not persist the adjustment" do
+        expect { subject }.not_to change { adjustment.persisted? }.from(false)
+        expect(subject).to eq false
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -245,4 +245,28 @@ RSpec.describe Spree::Adjustment, type: :model do
       it { is_expected.to eq true }
     end
   end
+
+  describe "#finalize" do
+    let(:adjustable) { create(:order) }
+    let(:adjustment) { build(:adjustment, finalized: false, adjustable: adjustable) }
+
+    subject { adjustment.finalize }
+
+    it "sets the adjustment as finalized" do
+      expect { subject }.to change { adjustment.finalized }.from(false).to(true)
+    end
+
+    it "persists the adjustment" do
+      expect { subject }.to change { adjustment.persisted? }.from(false).to(true)
+    end
+
+    context "for an invalid adjustment" do
+      let(:adjustment) { build(:adjustment, finalized: false, amount: nil, adjustable: adjustable) }
+
+      it "raises no error, returns false, does not persist the adjustment" do
+        expect { subject }.not_to change { adjustment.persisted? }.from(false)
+        expect(subject).to eq false
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -229,4 +229,20 @@ RSpec.describe Spree::Adjustment, type: :model do
       end
     end
   end
+
+  describe "#calculate_eligibility" do
+    subject { adjustment.calculate_eligibility }
+
+    around do |example|
+      Spree.deprecator.silence do
+        example.run
+      end
+    end
+
+    context "when the adjustment is not a promotion adjustment" do
+      let(:adjustment) { build(:adjustment, eligible: true, source: nil) }
+
+      it { is_expected.to eq true }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This tests a few previously untested methods on the Spree::Adjustment model. I'm doing this because the work in #5634 removes some lines from the file, leading to a negative change in test coverage because the overall file gets smaller. By increasing coverage to 100%, a smaller file will not be punished with a larger proportion of untested lines.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
