### PR TITLE
Push spec coverage for Spree::Order to 100%

### DIFF
--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -623,6 +623,20 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
+  context "resuming a canceled order" do
+    let(:order) { create(:completed_order_with_totals) }
+
+    before do
+      order.cancel!
+    end
+
+    it "also resumes the shipments" do
+      expect(order.shipments.map(&:state)).to eq %w(canceled)
+      order.resume!
+      expect(order.shipments.map(&:state)).to eq %w(pending)
+    end
+  end
+
   context "re-define checkout flow" do
     before do
       @old_checkout_flow = Spree::Order.checkout_flow

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -519,6 +519,18 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
+    context "no payment present" do
+      let(:order) { create :order_ready_to_complete }
+      before do
+        order.payments.destroy_all
+      end
+
+      it "does not allow the order to complete" do
+        expect { order.complete! }.to raise_exception(StateMachines::InvalidTransition)
+        expect(order.errors[:base]).to include("No payment found")
+      end
+    end
+
     context "exchange order completion" do
       before do
         order.email = 'solidus@example.org'

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1870,4 +1870,25 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe ".by_customer" do
+    let(:user) { create(:user, email: "customer@example.com") }
+    let!(:order) { create(:order, user: user) }
+    let!(:other_order) { create(:order) }
+    let(:email) { user.email }
+
+    subject { Spree::Order.by_customer(email) }
+
+    it "finds the order" do
+      expect(subject).to eq([order])
+    end
+
+    context "if user has no order" do
+      let(:email) { "not_a_customer@example.com" }
+
+      it "returns an empty list" do
+        expect(subject).to eq([])
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2049,4 +2049,19 @@ RSpec.describe Spree::Order, type: :model do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#can_approve?" do
+    let(:order) { create(:order, approved_at: approved_at) }
+    let(:approved_at) { nil }
+
+    subject { order.can_approve? }
+
+    it { is_expected.to eq(true) }
+
+    context "when the order is already approved" do
+      let(:approved_at) { Time.current }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1931,4 +1931,12 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe "#to_param" do
+    let(:order) { create(:order, number: "MYNUMBER") }
+
+    subject { order.to_param }
+
+    it { is_expected.to eq("MYNUMBER") }
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2064,4 +2064,15 @@ RSpec.describe Spree::Order, type: :model do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#bill_address_attributes=" do
+    let(:order) { create(:order) }
+    let(:address_attributes) { { name: "Mickey Mouse" } }
+
+    subject { order.bill_address_attributes = address_attributes }
+
+    it "creates a new bill address" do
+      expect { subject }.to change { order.bill_address.name }.to("Mickey Mouse")
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1952,4 +1952,28 @@ RSpec.describe Spree::Order, type: :model do
       expect(subject).to eq([shipped_shipment])
     end
   end
+
+  describe "#name" do
+    let(:bill_address) { create(:address, name: "John Doe") }
+    let(:ship_address) { create(:address, name: "Jane Doe") }
+
+    let(:order) { create(:order, bill_address: bill_address, ship_address: ship_address) }
+
+    subject { order.name }
+
+    it { is_expected.to eq("John Doe") }
+
+    context "if bill address is nil" do
+      let(:bill_address) { nil }
+
+      it { is_expected.to eq("Jane Doe") }
+    end
+
+    context "if both bill address and ship address are nil" do
+      let(:bill_address) { nil }
+      let(:ship_address) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2095,4 +2095,34 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe "#can_add_coupon?" do
+    let(:order) { Spree::Order.new(state: state) }
+
+    subject { order.can_add_coupon? }
+
+    context "when the order is in the cart state" do
+      let(:state) { "cart" }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when the order is completed" do
+      let(:state) { "complete" }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when the order is returned" do
+      let(:state) { "returned" }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when the order is awaiting returns" do
+      let(:state) { "returned" }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2075,4 +2075,24 @@ RSpec.describe Spree::Order, type: :model do
       expect { subject }.to change { order.bill_address.name }.to("Mickey Mouse")
     end
   end
+
+  describe "#payments_attributes=" do
+    let(:order) { create(:order) }
+    let(:payment_attributes) { [{ payment_method_id: payment_method.id }] }
+    let(:payment_method) { create(:payment_method) }
+
+    subject { order.payments_attributes = payment_attributes }
+
+    it "creates a new payment" do
+      expect { subject }.to change { order.payments.length }.from(0).to(1)
+    end
+
+    context "if the payment method is unavailable" do
+      let(:payment_method) { create(:payment_method, available_to_users: false) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1988,4 +1988,24 @@ RSpec.describe Spree::Order, type: :model do
       expect(subject).to eq([valid_payment.source])
     end
   end
+
+  describe "#coupon_code=" do
+    let(:order) { create(:order) }
+    let(:promotion) { create(:promotion, code: "10off") }
+    let(:coupon_code) { "10OFF" }
+
+    subject { order.coupon_code = coupon_code }
+
+    it "stores the downcased coupon code on the order" do
+      expect { subject }.to change { order.coupon_code }.from(nil).to("10off")
+    end
+
+    context "with an non-string object" do
+      let(:coupon_code) { false }
+
+      it "doesn't store the coupon code on the order" do
+        expect { subject }.not_to change { order.coupon_code }.from(nil)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1976,4 +1976,16 @@ RSpec.describe Spree::Order, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#valid_credit_cards" do
+    let(:order) { create(:order, payments: [valid_payment, invalid_payment]) }
+    let(:valid_payment) { create(:payment, state: "checkout") }
+    let(:invalid_payment) { create(:payment, state: "failed") }
+
+    subject { order.valid_credit_cards }
+
+    it "returns the valid credit cards" do
+      expect(subject).to eq([valid_payment.source])
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2018,4 +2018,19 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe "#refresh_shipment_rates" do
+    let(:order) { create(:order, shipments: [shipment_one, shipment_two]) }
+    let(:shipment_one) { create(:shipment) }
+    let(:shipment_two) { create(:shipment) }
+
+    subject { order.refresh_shipment_rates }
+
+    it "calls #refresh_rates on each shipment" do
+      expect(shipment_one).to receive(:refresh_rates)
+      expect(shipment_two).to receive(:refresh_rates)
+
+      subject
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1939,4 +1939,17 @@ RSpec.describe Spree::Order, type: :model do
 
     it { is_expected.to eq("MYNUMBER") }
   end
+
+  describe "#shipped_shipments" do
+    let(:order) { create(:order, shipments: shipments) }
+    let(:shipments) { [shipped_shipment, unshipped_shipment] }
+    let(:shipped_shipment) { create(:shipment, state: "shipped") }
+    let(:unshipped_shipment) { create(:shipment, state: "ready") }
+
+    subject { order.shipped_shipments }
+
+    it "returns the shipped shipments" do
+      expect(subject).to eq([shipped_shipment])
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1832,4 +1832,42 @@ RSpec.describe Spree::Order, type: :model do
       expect { subject }.to change { Spree::OrderPromotion.count }.from(1).to(0)
     end
   end
+
+  describe ".find_by_param" do
+    let(:order) { create(:order) }
+    let(:param) { order.number }
+
+    subject { Spree::Order.find_by_param(param) }
+
+    it "finds the order" do
+      expect(subject).to eq(order)
+    end
+
+    context "with a non-existent order" do
+      let(:param) { "non-existent" }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe ".find_by_param!" do
+    let(:order) { create(:order) }
+    let(:param) { order.number }
+
+    subject { Spree::Order.find_by_param!(param) }
+
+    it "finds the order" do
+      expect(subject).to eq(order)
+    end
+
+    context "with a non-existent order" do
+      let(:param) { "non-existent" }
+
+      it "returns nil" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1179,6 +1179,16 @@ RSpec.describe Spree::Order, type: :model do
 
       expect { shipment.reload }.not_to raise_error
     end
+
+    context "when the order is already completed" do
+      let(:order) { create(:completed_order_with_pending_payment) }
+
+      it "raises an error" do
+        expect {
+          order.create_proposed_shipments
+        }.to raise_error(Spree::Order::CannotRebuildShipments)
+      end
+    end
   end
 
   describe "#all_inventory_units_returned?" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2125,4 +2125,25 @@ RSpec.describe Spree::Order, type: :model do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#shipped?" do
+    let(:order) { Spree::Order.new(shipment_state: shipment_state) }
+    let(:shipment_state) { "ready" }
+
+    subject { order.shipped? }
+
+    it { is_expected.to eq(false) }
+
+    context "when the all shipments are shipped" do
+      let(:shipment_state) { "shipped" }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when some shipments are shipped" do
+      let(:shipment_state) { "partial" }
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2033,4 +2033,20 @@ RSpec.describe Spree::Order, type: :model do
       subject
     end
   end
+
+  describe "#shipping_eq_billing_address?" do
+    let(:order) { create(:order, bill_address: bill_address, ship_address: ship_address) }
+    let(:bill_address) { create(:address) }
+    let(:ship_address) { create(:address) }
+
+    subject { order.shipping_eq_billing_address? }
+
+    it { is_expected.to eq(false) }
+
+    context "when the addresses are the same" do
+      let(:ship_address) { bill_address }
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1891,4 +1891,44 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe ".by_state" do
+    let!(:cart_order) { create(:order, state: :cart) }
+    let!(:address_order) { create(:order, state: :address) }
+    let!(:complete_order) { create(:order, state: :complete) }
+
+    subject { Spree::Order.by_state(desired_state) }
+
+    context "with a desired state of cart" do
+      let(:desired_state) { :cart }
+
+      it "returns the cart order" do
+        expect(subject).to eq([cart_order])
+      end
+    end
+
+    context "with a desired state of address" do
+      let(:desired_state) { :address }
+
+      it "returns the address order" do
+        expect(subject).to eq([address_order])
+      end
+    end
+
+    context "with a desired state of complete" do
+      let(:desired_state) { :complete }
+
+      it "returns the complete order" do
+        expect(subject).to eq([complete_order])
+      end
+    end
+
+    context "with a desired state of payment" do
+      let(:desired_state) { :payment }
+
+      it "returns an empty list" do
+        expect(subject).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This adds specs for the Spree::Order model so the coverage for that file goes up to 100%. It also covers a case where Spree::Promotion is called from within the rest of the system, so adding specs here makes sure this gets picked up in #5634. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
