### PR TITLE
Add extension point: Promotion finder

### DIFF
--- a/api/app/controllers/spree/api/promotions_controller.rb
+++ b/api/app/controllers/spree/api/promotions_controller.rb
@@ -13,7 +13,7 @@ module Spree
       private
 
       def load_promotion
-        @promotion = Spree::Promotion.with_coupon_code(params[:id]) || Spree::Promotion.find(params[:id])
+        @promotion = Spree::Config.promotions.promotion_finder_class.by_code_or_id(params[:id])
       end
     end
   end

--- a/core/app/models/spree/null_promotion_finder.rb
+++ b/core/app/models/spree/null_promotion_finder.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree
+  module NullPromotionFinder
+    def self.by_code_or_id(*)
+      raise ActiveRecord::RecordNotFound, "No promotion system configured."
+    end
+  end
+end

--- a/core/app/models/spree/promotion_finder.rb
+++ b/core/app/models/spree/promotion_finder.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree
+  class PromotionFinder
+    def self.by_code_or_id(coupon_code)
+      Spree::Promotion.with_coupon_code(coupon_code.to_s) || Spree::Promotion.find(coupon_code)
+    end
+  end
+end

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -13,6 +13,14 @@ module Spree
       #   the standard coupon code handler class
       #   Spree::NullPromotionHandler.
       class_name_attribute :coupon_code_handler_class, default: 'Spree::NullPromotionHandler'
+
+      # Allows providing a different promotion finder.
+      # @!attribute [rw] promotion_finder_class
+      # @see Spree::NullPromotionFinder
+      # @return [Class] an object that conforms to the API of
+      #   the standard promotion finder class
+      #   Spree::NullPromotionFinder.
+      class_name_attribute :promotion_finder_class, default: 'Spree::NullPromotionFinder'
     end
   end
 end

--- a/core/lib/spree/core/promotion_configuration.rb
+++ b/core/lib/spree/core/promotion_configuration.rb
@@ -15,6 +15,9 @@ module Spree
       # promotion_adjuster_class allows extensions to provide their own Promotion Adjuster
       class_name_attribute :promotion_adjuster_class, default: 'Spree::Promotion::OrderAdjustmentsRecalculator'
 
+      # promotion_finder_class allows extensions to provide their own Promotion Finder
+      class_name_attribute :promotion_finder_class, default: 'Spree::PromotionFinder'
+
       # Allows providing a different shipping promotion handler.
       # @!attribute [rw] shipping_promotion_handler_class
       # @see Spree::PromotionHandler::Shipping

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
   it "uses the null coupon code handler class by default" do
     expect(config.coupon_code_handler_class).to eq Spree::NullPromotionHandler
   end
+
+  it "uses the null promotion finder class by default" do
+    expect(config.promotion_finder_class).to eq Spree::NullPromotionFinder
+  end
 end

--- a/core/spec/lib/spree/core/promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/promotion_configuration_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Spree::Core::PromotionConfiguration do
     expect(config.shipping_promotion_handler_class).to eq Spree::PromotionHandler::Shipping
   end
 
+  it "uses promotion finder class by default" do
+    expect(config.promotion_finder_class).to eq Spree::PromotionFinder
+  end
+
   describe "#calculators" do
     subject { config.calculators[promotion_action] }
 

--- a/core/spec/models/spree/null_promotion_finder_spec.rb
+++ b/core/spec/models/spree/null_promotion_finder_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::NullPromotionFinder do
+  describe ".by_code_or_id" do
+    it "raises ActiveRecord::RecordNotFound" do
+      expect { described_class.by_code_or_id("promo") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/core/spec/models/spree/promotion_finder_spec.rb
+++ b/core/spec/models/spree/promotion_finder_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::PromotionFinder do
+  describe ".by_code_or_id" do
+    let!(:promotion) { create(:promotion, code: "promo") }
+
+    it "finds a promotion by its code" do
+      expect(described_class.by_code_or_id("promo")).to eq promotion
+    end
+
+    it "finds a promotion by its ID" do
+      expect(described_class.by_code_or_id(promotion.id)).to eq promotion
+    end
+
+    context "when the promotion does not exist" do
+      it "raises an error" do
+        expect { described_class.by_code_or_id("nonexistent") }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The API gem references the promotion system in very few places, namely in the promotions endpoint. This endpoint is only accessible to admins, and our admin doesn't actually check it, so another option would be to remove the endpoint entirely. 

However, it's simple enough to create a class that does what we need here. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
