### PR TITLE
Add Legacy promotions gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,9 @@ commands:
       - run:
           name: "Run Sample Tests"
           command: ./bin/build-ci sample
+      - run:
+          name: "Run Legacy Promotion Tests"
+          command: ./bin/build-ci legacy_promotions
 
       - store_artifacts:
           path: /tmp/test-artifacts

--- a/bin/build-ci
+++ b/bin/build-ci
@@ -21,12 +21,13 @@ class Project
 
   def self.all
     [
-      new('admin', weight: 215),
-      new('api', weight: 50),
-      new('backend', weight: 215),
-      new('backend', test_type: :teaspoon, title: "backend JS", weight: 15),
-      new('core', weight: 220),
-      new('sample', weight: 22)
+      new('admin', weight: 102),
+      new('api', weight: 69),
+      new('backend', weight: 282),
+      new('backend', test_type: :teaspoon, title: "backend JS", weight: 18),
+      new('core', weight: 266),
+      new('sample', weight: 28),
+      new('legacy_promotions', weight: 63)
     ]
   end
 

--- a/bin/rspec
+++ b/bin/rspec
@@ -8,6 +8,7 @@ LIBS = %w[
   backend
   core
   sample
+  legacy_promotions
 ]
 
 # Ignore line info, e.g. foo/bar.rb:123 would become foo/bar.rb

--- a/legacy_promotions/Rakefile
+++ b/legacy_promotions/Rakefile
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rake'
+require 'rake/testtask'
+require 'rspec/core/rake_task'
+require 'spree/testing_support/dummy_app/rake_tasks'
+require 'bundler/gem_tasks'
+
+RSpec::Core::RakeTask.new
+task default: :spec
+
+DummyApp::RakeTasks.new(
+  gem_root: File.dirname(__FILE__),
+  lib_name: 'solidus_legacy_promotions'
+)
+
+require 'yard/rake/yardoc_task'
+YARD::Rake::YardocTask.new(:yard)
+# The following workaround can be removed
+# once https://github.com/lsegal/yard/pull/1457 is merged.
+task('yard:require') { require 'yard' }
+task yard: 'yard:require'
+
+namespace :spec do
+  task :isolated do
+    spec_files = Dir['spec/**/*_spec.rb']
+    failed_specs =
+      spec_files.reject do |file|
+        puts "rspec #{file}"
+        system('rspec', file)
+      end
+
+    if !failed_specs.empty?
+      puts "Failed specs:"
+      puts failed_specs
+      exit 1
+    end
+  end
+end
+
+task test_app: 'db:reset'

--- a/legacy_promotions/bin/rails
+++ b/legacy_promotions/bin/rails
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/core/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"

--- a/legacy_promotions/lib/solidus_legacy_promotions.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "solidus_core"
+require "solidus_support"
+
+module SolidusLegacyPromotions
+  VERSION = Spree.solidus_version
+end
+
+require "solidus_legacy_promotions/engine"

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SolidusLegacyPromotions
+  class Engine < ::Rails::Engine
+    include SolidusSupport::EngineExtensions
+  end
+end

--- a/legacy_promotions/solidus_legacy_promotions.gemspec
+++ b/legacy_promotions/solidus_legacy_promotions.gemspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../core/lib/spree/core/version'
+
+Gem::Specification.new do |s|
+  s.platform    = Gem::Platform::RUBY
+  s.name        = 'solidus_legacy_promotions'
+  s.version     = Spree.solidus_version
+  s.summary     = 'Legacy Solidus promotion system'
+  s.description = s.summary
+
+  s.author      = 'Solidus Team'
+  s.email       = 'contact@solidus.io'
+  s.homepage    = 'http://solidus.io'
+  s.license     = 'BSD-3-Clause'
+
+  s.metadata['rubygems_mfa_required'] = 'true'
+
+  s.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|script)/})
+  end
+
+  s.required_ruby_version = '>= 3.0.0'
+  s.required_rubygems_version = '>= 1.8.23'
+
+  s.add_dependency 'solidus_core', s.version
+  s.add_dependency 'solidus_support'
+end

--- a/legacy_promotions/spec/lib/solidus_legacy_promotions_spec.rb
+++ b/legacy_promotions/spec/lib/solidus_legacy_promotions_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusLegacyPromotions do
+  it "has a version number" do
+    expect(SolidusLegacyPromotions::VERSION).not_to be nil
+  end
+end

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ENV["RAILS_ENV"] ||= 'test'
+
+require 'spree/testing_support/dummy_app'
+DummyApp.setup(
+  gem_root: File.expand_path('..', __dir__),
+  lib_name: 'solidus_legacy_promotions'
+)
+
+require 'rspec/rails'
+require 'rspec-activemodel-mocks'
+require 'database_cleaner'
+
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
+require 'spree/testing_support/factory_bot'
+require 'spree/testing_support/preferences'
+require 'spree/testing_support/rake'
+require 'spree/testing_support/job_helpers'
+require 'cancan/matchers'
+
+ActiveJob::Base.queue_adapter = :test
+
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
+
+RSpec.configure do |config|
+  config.fixture_path = File.join(__dir__, "fixtures")
+
+  config.infer_spec_type_from_file_location!
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, comment the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = true
+
+  config.before :suite do
+    FileUtils.rm_rf(Rails.configuration.active_storage.service_configurations[:test][:root]) unless ENV['DISABLE_ACTIVE_STORAGE'] == 'true'
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  config.before :each do
+    Rails.cache.clear
+  end
+
+  config.include Spree::TestingSupport::JobHelpers
+
+  config.include FactoryBot::Syntax::Methods
+end

--- a/legacy_promotions/spec/spec_helper.rb
+++ b/legacy_promotions/spec/spec_helper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+if ENV["COVERAGE"]
+  require 'simplecov'
+  if ENV["COVERAGE_DIR"]
+    SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  end
+  SimpleCov.command_name('solidus:core')
+  SimpleCov.merge_timeout(3600)
+  SimpleCov.start('rails')
+end
+
+require 'rspec/core'
+
+require 'spree/testing_support/flaky'
+require 'spree/testing_support/partial_double_verification'
+require 'spree/testing_support/silence_deprecations'
+require 'spree/testing_support/preferences'
+require 'spree/deprecator'
+require 'spree/config'
+
+require "solidus_legacy_promotions"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.color = true
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.include Spree::TestingSupport::Preferences
+
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
+end

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_backend', s.version
   s.add_dependency 'solidus_core', s.version
   s.add_dependency 'solidus_sample', s.version
+  s.add_dependency 'solidus_legacy_promotions', s.version
 end


### PR DESCRIPTION
## Summary

This adds a new gem to the suite, `solidus_legacy_promotions`. It's indended to be filled with things from core later (see #5634 ) for what it'll look like). 

I would like this scaffold to be around so I can slowly chip away at the commits in #5634 without creating unreviewable PRs for the maintainers. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

