### PR TITLE
Fix specs failing after Money 6.18.0 release

### DIFF
--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -148,13 +148,13 @@ RSpec.describe Spree::Money do
     it "formats as HTML if asked (nicely) to" do
       money = Spree::Money.new(10, format: '%n %u')
       # The HTML'ified version of "10.00 €"
-      expect(money.to_html).to eq("<span class=\"money-whole\">10</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">00</span> <span class=\"money-currency-symbol\">&#x20AC;</span>")
+      expect(money.to_html).to eq("<span class=\"money-whole\">10</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">00</span> <span class=\"money-currency-symbol\">€</span>")
     end
 
     it "formats as HTML with currency" do
       money = Spree::Money.new(10, format: '%n %u', with_currency: true)
       # The HTML'ified version of "10.00 €"
-      expect(money.to_html).to eq("<span class=\"money-whole\">10</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">00</span> <span class=\"money-currency-symbol\">&#x20AC;</span> <span class=\"money-currency\">EUR</span>")
+      expect(money.to_html).to eq("<span class=\"money-whole\">10</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">00</span> <span class=\"money-currency-symbol\">€</span> <span class=\"money-currency\">EUR</span>")
     end
   end
 


### PR DESCRIPTION
## Summary

Money 6.18.0 includes https://github.com/RubyMoney/money/pull/1026 which replaces the html entity for EURO with its symbol.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages.
