### PR TITLE
[ADMIN] Fix flash messages coloring

### DIFF
--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -29,7 +29,7 @@
 
     <div class="fixed inset-x-0 bottom-3 flex items-center justify-center flex-col gap-3 pointer-events-none" role="alert">
       <% flash.each do |key, message| %>
-        <%= render component("ui/toast").new(text: message, scheme: key == :error ? :error : :default) %>
+        <%= render component("ui/toast").new(text: message, scheme: key.to_sym == :error ? :error : :default) %>
       <% end %>
     </div>
   </body>


### PR DESCRIPTION
## Summary

Previously, all flash messages were showing with the same (black) background. Internally, the flash object [converts and stores keys as strings](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/middleware/flash.rb#L163).

<img width="473" alt="Screenshot 2024-03-05 at 13 48 37" src="https://github.com/solidusio/solidus/assets/141220/0bcaa348-4af8-4a98-b711-9d6109a46778">


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages]

