### PR TITLE
Fix JS locale data for release of Money 6.19

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/format_money.js
+++ b/backend/app/assets/javascripts/spree/backend/format_money.js
@@ -7,5 +7,5 @@ Spree.formatMoney = function(amount, currency) {
   var thousand = Spree.t('currency_delimiter');
   var decimal = Spree.t('currency_separator');
 
-  return accounting.formatMoney(amount, currencyInfo[0], currencyInfo[1], thousand, decimal, currencyInfo[2]);
+  return accounting.formatMoney(amount, currencyInfo[0], currencyInfo[1], thousand, decimal, currencyInfo[2]).trim();
 }

--- a/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
+++ b/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
@@ -17,11 +17,14 @@
     JSON.dump(
       Spree::Config.available_currencies.map { |c|
         format =
-          if c.symbol == "" || c.symbol_first
+          if c.format.present?
+            c.format.gsub("%u", "%s").gsub("%n", "%v")
+          elsif c.symbol == "" || c.symbol_first
             "%s%v"
           else
             "%v %s"
           end
+
         [c.id.to_s.upcase, [
           c.symbol || "¤",
           c.exponent,


### PR DESCRIPTION
## Summary

The money gem in its latest iteration added a space between value and unit of the Swiss Franc. Our heuristic in `_js_locale_data.html.erb` can't deal with that, so we add a third branch to it: If the money gem has a format wish, we'll respect it, but replace its abbreviations with the one the `accounting.js` library prefers.

Cf https://github.com/RubyMoney/money/blob/main/CHANGELOG.md#6190

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
