### PR TITLE
Let promotion handler decide whether it can add a coupon to an order

### DIFF
--- a/core/app/models/spree/null_promotion_handler.rb
+++ b/core/app/models/spree/null_promotion_handler.rb
@@ -12,6 +12,7 @@ module Spree
     def activate
       @order
     end
+    alias_method :apply, :activate
 
     def can_apply?
       true

--- a/core/app/models/spree/null_promotion_handler.rb
+++ b/core/app/models/spree/null_promotion_handler.rb
@@ -13,6 +13,10 @@ module Spree
       @order
     end
 
+    def can_apply?
+      true
+    end
+
     def error
       nil
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -464,7 +464,7 @@ module Spree
     end
 
     def can_add_coupon?
-      Spree::Promotion.order_activatable?(self)
+      Spree::Config.promotions.coupon_code_handler_class.new(self).can_apply?
     end
 
     def shipped?

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -11,6 +11,10 @@ module Spree
         @coupon_code = order.coupon_code && order.coupon_code.downcase
       end
 
+      def can_apply?
+        Spree::Promotion.order_activatable?(order)
+      end
+
       def apply
         if coupon_code.present?
           if promotion.present? && promotion.active? && promotion.actions.exists?

--- a/core/spec/models/spree/null_promotion_handler_spec.rb
+++ b/core/spec/models/spree/null_promotion_handler_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Spree::NullPromotionHandler do
     end
   end
 
+  describe "#can_apply?" do
+    subject { handler.can_apply? }
+    let(:order) { double(Spree::Order, coupon_code: nil) }
+
+    it { is_expected.to be true }
+  end
+
   describe "#status" do
     subject { handler.status }
 

--- a/core/spec/models/spree/null_promotion_handler_spec.rb
+++ b/core/spec/models/spree/null_promotion_handler_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Spree::NullPromotionHandler do
     end
   end
 
+  describe "#apply" do
+    subject(:activate) { handler.apply }
+
+    it "returns the unchanged order" do
+      expect(activate).to eq(order)
+    end
+  end
+
   describe "#can_apply?" do
     subject { handler.can_apply? }
     let(:order) { double(Spree::Order, coupon_code: nil) }

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -23,6 +23,36 @@ module Spree
         expect(subject.apply).to be_a Coupon
       end
 
+      describe "#can_apply?" do
+        let(:order) { Spree::Order.new(state: state) }
+
+        subject { described_class.new(order).can_apply? }
+
+        context "when the order is in the cart state" do
+          let(:state) { "cart" }
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "when the order is completed" do
+          let(:state) { "complete" }
+
+          it { is_expected.to eq(false) }
+        end
+
+        context "when the order is returned" do
+          let(:state) { "returned" }
+
+          it { is_expected.to eq(false) }
+        end
+
+        context "when the order is awaiting returns" do
+          let(:state) { "awaiting_return" }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+
       context 'status messages' do
         let(:coupon) { Coupon.new(order) }
 


### PR DESCRIPTION
## Summary

We have the method `Spree::Order#can_add_coupon?` that tells us whether an order can even accept a promotion code. Unfortunately, it directly references the `Spree::Promotion` class that is slated to be moved to `solidus_legacy_promotions`. Rather than adding a new class, I add another method to the coupon promotion handler class that does this. 

I'm also adding the same method to the `NullPromotionHandler` for API parity.

Lastly, I realized that not all promotion handlers in core share the same API, so I alias `activate` to `apply` so that the `NullPromotionHandler` can be a stand-in for all promotion handlers.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
