### PR TITLE
Make API independent of promotion configuration

### DIFF
--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -112,10 +112,7 @@ module Spree
       :variant_id
     ]
 
-    preference :promotion_attributes, :array, default: [
-      :id, :name, :description, :expires_at, :starts_at, :type, :usage_limit,
-      :advertise, :path
-    ]
+    preference :promotion_attributes, :array, default: Spree::Config.promotions.promotion_api_attributes
 
     preference :store_attributes, :array, default: [
       :id, :name, :url, :meta_description, :meta_keywords, :seo_title,

--- a/api/spec/requests/spree/api/coupon_codes_spec.rb
+++ b/api/spec/requests/spree/api/coupon_codes_spec.rb
@@ -12,26 +12,36 @@ module Spree::Api
 
     before do
       stub_authentication!
+      expect(Spree::Config.promotions.coupon_code_handler_class).to receive(:new).and_return(handler)
     end
 
     describe '#create' do
-      let(:promo) { create(:promotion_with_item_adjustment, code: 'night_melody') }
-      let(:promo_code) { promo.codes.first }
-
       before do
         allow_any_instance_of(Spree::Order).to receive_messages user: current_api_user
       end
 
       context 'when successful' do
         let(:order) { create(:order_with_line_items) }
+        let(:successful_application) do
+          double(
+            'handler',
+            successful?: true,
+            success: "The coupon code was successfully applied to your order.",
+            error: nil,
+            status_code: "coupon_code_applied"
+          )
+        end
+
+        let(:handler) do
+          double('handler', apply: successful_application)
+        end
 
         it 'applies the coupon' do
-          post spree.api_order_coupon_codes_path(order), params: { coupon_code: promo_code.value }
+          post spree.api_order_coupon_codes_path(order), params: { coupon_code: "10OFF" }
 
           expect(response.status).to eq(200)
-          expect(order.reload.promotions).to eq([promo])
           expect(json_response).to eq({
-            "success" => I18n.t('spree.coupon_code_applied'),
+            "success" => "The coupon code was successfully applied to your order.",
             "error" => nil,
             "successful" => true,
             "status_code" => "coupon_code_applied"
@@ -41,12 +51,24 @@ module Spree::Api
 
       context 'when unsuccessful' do
         let(:order) { create(:order) }
+        let(:unsuccessful_application) do
+          double(
+            'handler',
+            successful?: false,
+            success: nil,
+            error:  "This coupon code could not be applied to the cart at this time.",
+            status_code: "coupon_code_unknown_error"
+          )
+        end
+
+        let(:handler) do
+          double('handler', apply: unsuccessful_application)
+        end
 
         it 'returns an error' do
-          post spree.api_order_coupon_codes_path(order), params: { coupon_code: promo_code.value }
+          post spree.api_order_coupon_codes_path(order), params: { coupon_code: "10OFF" }
 
           expect(response.status).to eq(422)
-          expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => nil,
             "error" => I18n.t('spree.coupon_code_unknown_error'),
@@ -58,25 +80,30 @@ module Spree::Api
     end
 
     describe '#destroy' do
-      let(:promo) {
-        create(:promotion_with_item_adjustment,
-               code: 'tenoff',
-               per_code_usage_limit: 5,
-               adjustment_rate: 10)
-      }
-
-      let(:promo_code) { promo.codes.first }
       let(:order) { create(:order_with_line_items, user: current_api_user) }
 
-      before do
-        post spree.api_order_coupon_codes_path(order), params: { coupon_code: promo_code.value }
-        delete spree.api_order_coupon_code_path(order, promo_code.value)
+      subject do
+        delete spree.api_order_coupon_code_path(order, "10OFF")
       end
 
       context 'when successful' do
+        let(:successful_removal) do
+          double(
+            'handler',
+            successful?: true,
+            success: "The coupon code was successfully removed from this order.",
+            error: nil,
+            status_code: "coupon_code_removed"
+          )
+        end
+
+        let(:handler) do
+          double('handler', remove: successful_removal)
+        end
+
         it 'removes the coupon' do
+          subject
           expect(response.status).to eq(200)
-          expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_removed'),
             "error" => nil,
@@ -87,8 +114,22 @@ module Spree::Api
       end
 
       context 'when unsuccessful' do
+        let(:unsuccessful_removal) do
+          double(
+            'handler',
+            successful?: false,
+            success: nil,
+            error: "The coupon code you are trying to remove is not present on this order.",
+            status_code: "coupon_code_not_present"
+          )
+        end
+
+        let(:handler) do
+          double('handler', remove: unsuccessful_removal)
+        end
+
         it 'returns an error' do
-          delete spree.api_order_coupon_code_path(order, promo_code.value)
+          subject
 
           expect(response.status).to eq(422)
           expect(order.reload.promotions).to eq([])

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -21,6 +21,10 @@ module Spree
       #   the standard promotion finder class
       #   Spree::NullPromotionFinder.
       class_name_attribute :promotion_finder_class, default: 'Spree::NullPromotionFinder'
+
+      # !@attribute [rw] promotion_api_attributes
+      #   @return [Array<Symbol>] Attributes to be returned by the API for a promotion
+      preference :promotion_api_attributes, :array, default: []
     end
   end
 end

--- a/core/lib/spree/core/promotion_configuration.rb
+++ b/core/lib/spree/core/promotion_configuration.rb
@@ -9,6 +9,20 @@ module Spree
       #   @return [Integer] Promotions to show per-page in the admin (default: +15+)
       preference :promotions_per_page, :integer, default: 15
 
+      # @!attribute [rw] promotion_attributes
+      #   @return [Array<Symbol>] Attributes to be returned by the API for a promotion
+      preference :promotion_api_attributes, :array, default: [
+        :id,
+        :name,
+        :description,
+        :expires_at,
+        :starts_at,
+        :type,
+        :usage_limit,
+        :advertise,
+        :path
+      ]
+
       # promotion_chooser_class allows extensions to provide their own PromotionChooser
       class_name_attribute :promotion_chooser_class, default: 'Spree::PromotionChooser'
 


### PR DESCRIPTION
## Summary

This removes any usage of promotion factories from the API spec, and allows us to change the promotion configuration without any change to Solidus' API. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
