### PR TITLE
Convert existing Admin modals to Turbo frames

### DIFF
--- a/admin/app/components/solidus_admin/orders/show/address/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/address/component.html.erb
@@ -1,67 +1,69 @@
 <div class="<%= stimulus_id %>" data-controller="<%= stimulus_id %>">
-  <%= render component("orders/show").new(order: @order) %>
+  <%= turbo_frame_tag "edit_order_#{params[:type]}_address_modal" do %>
+    <%= render component("ui/modal").new(title: t(".title.#{@type}")) do |modal| %>
+      <%= form_for @order, url: solidus_admin.send("order_#{@type}_address_path", @order), html: { id: form_id } do |form| %>
+        <div class="w-full flex flex-col mb-4">
+          <div class="flex justify-between items-center mb-4 relative">
+            <h2 class="text-sm font-semibold">
+              <%= t(".subtitle.#{@type}") %>
+            </h2>
 
-  <%= render component("ui/modal").new(title: t(".title.#{@type}"), close_path: solidus_admin.order_path(@order)) do |modal| %>
-    <%= form_for @order, url: solidus_admin.send("order_#{@type}_address_path", @order), html: { id: form_id } do |form| %>
-      <div class="w-full flex flex-col mb-4">
-        <div class="flex justify-between items-center mb-4 relative">
-          <h2 class="text-sm font-semibold">
-            <%= t(".subtitle.#{@type}") %>
-          </h2>
-
-          <% if @addresses.present? %>
-            <%= render component('ui/dropdown').new(
-              text: t(".select_address"),
-              "data-#{stimulus_id}-target": "addresses",
-              class: "max-h-[26rem] overflow-y-auto"
-            ) do %>
-              <% @addresses.each do |address| %>
-                <%= tag.a(
-                  format_address(address),
-                  href: solidus_admin.send("order_#{@type}_address_path", @order, address_id: address.id),
-                  'data-turbo-frame': address_frame_id,
-                  'data-action': "#{component('ui/dropdown').stimulus_id}#close",
-                ) %>
+            <% if @addresses.present? %>
+              <%= render component('ui/dropdown').new(
+                text: t(".select_address"),
+                "data-#{stimulus_id}-target": "addresses",
+                class: "max-h-[26rem] overflow-y-auto"
+              ) do %>
+                <% @addresses.each do |address| %>
+                  <%= tag.a(
+                    format_address(address),
+                    href: solidus_admin.send("order_#{@type}_address_path", @order, address_id: address.id),
+                    'data-turbo-frame': address_frame_id,
+                    'data-action': "#{component('ui/dropdown').stimulus_id}#close",
+                  ) %>
+                <% end %>
               <% end %>
             <% end %>
-          <% end %>
+          </div>
+
+          <div class="w-full flex gap-4">
+            <%= turbo_frame_tag address_frame_id do %>
+              <%= render component('ui/forms/address').new(address: @address, name: "order[#{@type}_address_attributes]") %>
+            <% end %>
+          </div>
+
+          <label class="flex gap-2 items-center">
+            <%= form.hidden_field use_attribute, value: '0', id: false %>
+
+            <%= render component("ui/forms/checkbox").new(
+              name: "#{form.object_name}[#{use_attribute}]",
+              checked: @address == (@type == 'ship' ? @order.bill_address : @order.ship_address),
+              value: '1'
+            ) %>
+
+            <span class="font-normal text-xs">
+              <%= t(".use_this_address.#{@type}") %>
+            </span>
+          </label>
         </div>
+      <% end %>
 
-        <div class="w-full flex gap-4">
-          <%= turbo_frame_tag address_frame_id do %>
-            <%= render component('ui/forms/address').new(address: @address, name: "order[#{@type}_address_attributes]") %>
-          <% end %>
-        </div>
-
-        <label class="flex gap-2 items-center">
-          <%= form.hidden_field use_attribute, value: '0', id: false %>
-
-          <%= render component("ui/forms/checkbox").new(
-            name: "#{form.object_name}[#{use_attribute}]",
-            checked: @address == (@type == 'ship' ? @order.bill_address : @order.ship_address),
-            value: '1'
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(
+            scheme: :secondary,
+            text: t(".cancel"),
           ) %>
+        </form>
 
-          <span class="font-normal text-xs">
-            <%= t(".use_this_address.#{@type}") %>
-          </span>
-        </label>
-      </div>
-    <% end %>
-
-    <% modal.with_actions do %>
-      <%= render component("ui/button").new(
-        tag: :a,
-        scheme: :secondary,
-        text: t(".cancel"),
-        href: solidus_admin.order_path(@order)
-      ) %>
-
-      <%= render component("ui/button").new(
-        tag: :button,
-        text: t(".save"),
-        form: form_id
-      ) %>
+        <%= render component("ui/button").new(
+          tag: :button,
+          text: t(".save"),
+          form: form_id
+        ) %>
+      <% end %>
     <% end %>
   <% end %>
+
+  <%= render component("orders/show").new(order: @order) %>
 </div>

--- a/admin/app/components/solidus_admin/orders/show/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/component.html.erb
@@ -16,7 +16,7 @@
 
     <%= page_with_sidebar_aside do %>
       <%= render component('ui/panel').new do |panel| %>
-        <% panel.with_menu t(".edit_email"), solidus_admin.order_customer_path(@order) %>
+        <% panel.with_menu t(".edit_email"), solidus_admin.order_customer_path(@order), data: { turbo_frame: :edit_order_email_modal } %>
         <% panel.with_menu t(".edit_shipping"), solidus_admin.edit_order_ship_address_path(@order) %>
         <% panel.with_menu t(".edit_billing"), solidus_admin.edit_order_bill_address_path(@order) %>
         <% panel.with_menu t(".remove_customer"), solidus_admin.order_customer_path(@order), method: :delete, class: "text-red-500" if @order.user %>
@@ -72,5 +72,9 @@
       <% end %>
 
     <% end %>
+  <% end %>
+
+  <% turbo_frames.each do |frame| %>
+    <%= turbo_frame_tag frame %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/orders/show/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/component.html.erb
@@ -17,8 +17,8 @@
     <%= page_with_sidebar_aside do %>
       <%= render component('ui/panel').new do |panel| %>
         <% panel.with_menu t(".edit_email"), solidus_admin.order_customer_path(@order), data: { turbo_frame: :edit_order_email_modal } %>
-        <% panel.with_menu t(".edit_shipping"), solidus_admin.edit_order_ship_address_path(@order) %>
-        <% panel.with_menu t(".edit_billing"), solidus_admin.edit_order_bill_address_path(@order) %>
+        <% panel.with_menu t(".edit_shipping"), solidus_admin.edit_order_ship_address_path(@order), data: { turbo_frame: :edit_order_ship_address_modal } %>
+        <% panel.with_menu t(".edit_billing"), solidus_admin.edit_order_bill_address_path(@order), data: { turbo_frame: :edit_order_bill_address_modal } %>
         <% panel.with_menu t(".remove_customer"), solidus_admin.order_customer_path(@order), method: :delete, class: "text-red-500" if @order.user %>
 
         <% panel.with_section(class: 'flex flex-col gap-6') do %>

--- a/admin/app/components/solidus_admin/orders/show/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/component.rb
@@ -29,6 +29,10 @@ class SolidusAdmin::Orders::Show::Component < SolidusAdmin::BaseComponent
     ], " ")
   end
 
+  def turbo_frames
+    %w[edit_order_email_modal]
+  end
+
   def customer_name(user)
     (
       user.default_user_bill_address ||

--- a/admin/app/components/solidus_admin/orders/show/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/component.rb
@@ -30,7 +30,11 @@ class SolidusAdmin::Orders::Show::Component < SolidusAdmin::BaseComponent
   end
 
   def turbo_frames
-    %w[edit_order_email_modal]
+    %w[
+      edit_order_email_modal
+      edit_order_bill_address_modal
+      edit_order_ship_address_modal
+    ]
   end
 
   def customer_name(user)

--- a/admin/app/components/solidus_admin/orders/show/email/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/email/component.html.erb
@@ -1,7 +1,7 @@
 <div class="<%= stimulus_id %>">
   <%= render component("orders/show").new(order: @order) %>
-  <%= render component("ui/modal").new(title: t(".title"), close_path: close_path) do |modal| %>
-    <%= form_for @order, url: close_path, html: { id: form_id} do |f| %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @order, url: solidus_admin.order_path(@order), html: { id: form_id } do |f| %>
       <%= render component("ui/forms/field").text_field(f, :email) %>
       <label class="font-normal text-sm mt-4 block">
         <%= t('.guest_checkout') %>:
@@ -11,7 +11,9 @@
     <% end %>
 
     <% modal.with_actions do %>
-      <%= render component("ui/button").new(tag: :a, scheme: :secondary, href: close_path, type: :submit, text: t('.cancel')) %>
+      <form method="dialog">
+        <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+      </form>
       <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/orders/show/email/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/email/component.html.erb
@@ -1,20 +1,23 @@
 <div class="<%= stimulus_id %>">
-  <%= render component("orders/show").new(order: @order) %>
-  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @order, url: solidus_admin.order_path(@order), html: { id: form_id } do |f| %>
-      <%= render component("ui/forms/field").text_field(f, :email) %>
-      <label class="font-normal text-sm mt-4 block">
-        <%= t('.guest_checkout') %>:
-        <output class="font-semibold text-sm"><%= @order.user ? t('.no') : t('.yes') %></output>
-        <%= render component('ui/toggletip').new(text: t('.guest_checkout_tip'), class: "align-middle") %>
-      </label>
-    <% end %>
+  <%= turbo_frame_tag "edit_order_email_modal" do %>
+    <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+      <%= form_for @order, url: solidus_admin.order_path(@order), html: { id: form_id } do |f| %>
+        <%= render component("ui/forms/field").text_field(f, :email) %>
+        <label class="font-normal text-sm mt-4 block">
+          <%= t('.guest_checkout') %>:
+          <output class="font-semibold text-sm"><%= @order.user ? t('.no') : t('.yes') %></output>
+          <%= render component('ui/toggletip').new(text: t('.guest_checkout_tip'), class: "align-middle") %>
+        </label>
+      <% end %>
 
-    <% modal.with_actions do %>
-      <form method="dialog">
-        <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
-      </form>
-      <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
     <% end %>
   <% end %>
+
+  <%= render component("orders/show").new(order: @order) %>
 </div>

--- a/admin/app/components/solidus_admin/orders/show/email/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/email/component.rb
@@ -8,8 +8,4 @@ class SolidusAdmin::Orders::Show::Email::Component < SolidusAdmin::BaseComponent
   def form_id
     dom_id(@order, "#{stimulus_id}_email_form")
   end
-
-  def close_path
-    @close_path ||= solidus_admin.order_path(@order)
-  end
 end

--- a/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
@@ -3,77 +3,79 @@
   data-<%= stimulus_id %>-initial-count-on-hand-value="<%= @stock_item.count_on_hand_was || @stock_item.count_on_hand %>"
   data-action="input-><%= stimulus_id %>#updateCountOnHand"
 >
-  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @stock_item, url: solidus_admin.stock_item_path(@stock_item), html: { id: form_id } do |f| %>
-      <div class="flex flex-col gap-6 pb-4">
-        <div class="flex gap-4">
-          <%= link_to spree.edit_admin_product_variant_path(
-            @stock_item.variant.product,
-            @stock_item.variant,
-          ), class: 'hover:bg-gray-25 rounded p-1 w-1/2 border border-gray-100' do %>
-            <%= render component("ui/resource_item").new(
-              thumbnail:
-                (
-                  @stock_item.variant.images.first ||
-                    @stock_item.variant.product.gallery.images.first
-                )&.url(:small),
-              title: @stock_item.variant.name,
-              subtitle:
-                "#{@stock_item.variant.sku}#{@stock_item.variant.options_text.presence&.prepend(" - ")}",
-            ) %>
-          <% end %>
-          <%= link_to spree.edit_admin_stock_location_path(@stock_item.stock_location), class: 'hover:bg-gray-25 rounded p-1 w-1/2 border border-gray-100' do %>
-            <%= render component("ui/resource_item").new(
-              title: @stock_item.stock_location.name,
-              subtitle: "#{Spree::StockLocation.model_name.human} #{@stock_item.stock_location.code}",
-            ) %>
-          <% end %>
-        </div>
+  <%= turbo_frame_tag :edit_stock_item_modal do %>
+    <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+      <%= form_for @stock_item, url: solidus_admin.stock_item_path(@stock_item), html: { id: form_id } do |f| %>
+        <div class="flex flex-col gap-6 pb-4">
+          <div class="flex gap-4">
+            <%= link_to spree.edit_admin_product_variant_path(
+              @stock_item.variant.product,
+              @stock_item.variant,
+            ), class: 'hover:bg-gray-25 rounded p-1 w-1/2 border border-gray-100' do %>
+              <%= render component("ui/resource_item").new(
+                thumbnail:
+                  (
+                    @stock_item.variant.images.first ||
+                      @stock_item.variant.product.gallery.images.first
+                  )&.url(:small),
+                title: @stock_item.variant.name,
+                subtitle:
+                  "#{@stock_item.variant.sku}#{@stock_item.variant.options_text.presence&.prepend(" - ")}",
+              ) %>
+            <% end %>
+            <%= link_to spree.edit_admin_stock_location_path(@stock_item.stock_location), class: 'hover:bg-gray-25 rounded p-1 w-1/2 border border-gray-100' do %>
+              <%= render component("ui/resource_item").new(
+                title: @stock_item.stock_location.name,
+                subtitle: "#{Spree::StockLocation.model_name.human} #{@stock_item.stock_location.code}",
+              ) %>
+            <% end %>
+          </div>
 
-        <%= render component("ui/forms/field").text_field(
-          f,
-          :count_on_hand,
-          disabled: true,
-          value: @stock_item.count_on_hand_was || @stock_item.count_on_hand,
-          "data-#{stimulus_id}-target": 'countOnHand',
-        ) %>
-        <%= render component("ui/forms/field").new(
-          label: t(".quantity_adjustment"),
-          hint: t(".quantity_adjustment_hint_html"),
-        ) do %>
-          <%= render component("ui/forms/input").new(
-            value: params[:quantity_adjustment] || 0,
-            name: :quantity_adjustment,
-            type: :number,
-            step: 1,
-            "data-#{stimulus_id}-target": 'quantityAdjustment',
+          <%= render component("ui/forms/field").text_field(
+            f,
+            :count_on_hand,
+            disabled: true,
+            value: @stock_item.count_on_hand_was || @stock_item.count_on_hand,
+            "data-#{stimulus_id}-target": 'countOnHand',
           ) %>
-        <% end %>
+          <%= render component("ui/forms/field").new(
+            label: t(".quantity_adjustment"),
+            hint: t(".quantity_adjustment_hint_html"),
+          ) do %>
+            <%= render component("ui/forms/input").new(
+              value: params[:quantity_adjustment] || 0,
+              name: :quantity_adjustment,
+              type: :number,
+              step: 1,
+              "data-#{stimulus_id}-target": 'quantityAdjustment',
+            ) %>
+          <% end %>
 
-        <%= render component("ui/forms/switch_field").new(
-          name: "#{f.object_name}[backorderable]",
-          label: Spree::StockItem.human_attribute_name(:backorderable),
-          error: f.object.errors[:backorderable],
-          hint: t(".backorderable_hint_html"),
-          checked: f.object.backorderable?,
-          include_hidden: true,
-        ) %>
-      </div>
-    <% end %>
+          <%= render component("ui/forms/switch_field").new(
+            name: "#{f.object_name}[backorderable]",
+            label: Spree::StockItem.human_attribute_name(:backorderable),
+            error: f.object.errors[:backorderable],
+            hint: t(".backorderable_hint_html"),
+            checked: f.object.backorderable?,
+            include_hidden: true,
+          ) %>
+        </div>
+      <% end %>
 
-    <% modal.with_actions do %>
-      <form method="dialog">
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(
+            scheme: :secondary,
+            text: t(".cancel"),
+          ) %>
+        </form>
+
         <%= render component("ui/button").new(
-          scheme: :secondary,
-          text: t(".cancel"),
+          tag: :button,
+          text: t(".submit"),
+          form: form_id,
         ) %>
-      </form>
-
-      <%= render component("ui/button").new(
-        tag: :button,
-        text: t(".submit"),
-        form: form_id,
-      ) %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
@@ -3,7 +3,7 @@
   data-<%= stimulus_id %>-initial-count-on-hand-value="<%= @stock_item.count_on_hand_was || @stock_item.count_on_hand %>"
   data-action="input-><%= stimulus_id %>#updateCountOnHand"
 >
-  <%= render component("ui/modal").new(title: t(".title"), close_path: solidus_admin.stock_items_path(page: params[:page], q: permitted_query_params)) do |modal| %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @stock_item, url: solidus_admin.stock_item_path(@stock_item), html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
         <div class="flex gap-4">
@@ -58,24 +58,16 @@
           checked: f.object.backorderable?,
           include_hidden: true,
         ) %>
-
-        <% if params[:q] %>
-          <%= f.hidden_field :q, value: params[:q].to_json, id: false %>
-        <% end %>
-
-        <% if params[:page] %>
-          <%= f.hidden_field :page, value: params[:page], id: false %>
-        <% end %>
       </div>
     <% end %>
 
     <% modal.with_actions do %>
-      <%= render component("ui/button").new(
-        tag: :a,
-        scheme: :secondary,
-        text: t(".cancel"),
-        href: solidus_admin.stock_items_path(page: params[:page], q: params[:q]),
-      ) %>
+      <form method="dialog">
+        <%= render component("ui/button").new(
+          scheme: :secondary,
+          text: t(".cancel"),
+        ) %>
+      </form>
 
       <%= render component("ui/button").new(
         tag: :button,

--- a/admin/app/components/solidus_admin/stock_items/edit/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.rb
@@ -15,9 +15,4 @@ class SolidusAdmin::StockItems::Edit::Component < SolidusAdmin::BaseComponent
   def form_id
     "#{stimulus_id}-#{dom_id(@stock_item)}"
   end
-
-  def permitted_query_params
-    return params[:q].permit! if params[:q].respond_to?(:permit)
-    {}
-  end
 end

--- a/admin/app/components/solidus_admin/stock_items/index/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.rb
@@ -167,11 +167,6 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
     }
   end
 
-  def permitted_query_params
-    return params[:q].permit! if params[:q].respond_to?(:permit)
-    {}
-  end
-
   def turbo_frames
     %w[edit_stock_item_modal]
   end

--- a/admin/app/components/solidus_admin/stock_items/index/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.rb
@@ -14,7 +14,7 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
   end
 
   def row_url(stock_item)
-    solidus_admin.edit_stock_item_path(stock_item, page: params[:page], q: permitted_query_params)
+    solidus_admin.edit_stock_item_path(stock_item, _turbo_frame: :edit_stock_item_modal)
   end
 
   def scopes
@@ -170,5 +170,9 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
   def permitted_query_params
     return params[:q].permit! if params[:q].respond_to?(:permit)
     {}
+  end
+
+  def turbo_frames
+    %w[edit_stock_item_modal]
   end
 end

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -104,7 +104,15 @@ export default class extends Controller {
     if (this.modeValue === "batch") {
       this.toggleCheckbox(event.currentTarget)
     } else {
-      window.Turbo.visit(event.params.url)
+      const url = new URL(event.params.url, "http://dummy.com")
+      const params = new URLSearchParams(url.search)
+      const frameId = params.get('_turbo_frame')
+      const frame = frameId ? { frame: frameId } : {}
+      // remove the custom _turbo_frame param from url search:
+      params.delete('_turbo_frame')
+      url.search = params.toString()
+
+      window.Turbo.visit(url.pathname + url.search, frame)
     }
   }
 

--- a/admin/app/controllers/solidus_admin/addresses_controller.rb
+++ b/admin/app/controllers/solidus_admin/addresses_controller.rb
@@ -26,7 +26,12 @@ module SolidusAdmin
 
     def update
       if @order.contents.update_cart(order_params)
-        redirect_to order_path(@order), status: :see_other, notice: t('.success')
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html { redirect_to order_path(@order), status: :see_other }
+          format.turbo_stream { render turbo_stream: '<turbo-stream action="refresh" />' }
+        end
       else
         flash.now[:error] = @order.errors[:base].join(", ") if @order.errors[:base].any?
 

--- a/admin/app/controllers/solidus_admin/customers_controller.rb
+++ b/admin/app/controllers/solidus_admin/customers_controller.rb
@@ -4,7 +4,11 @@ class SolidusAdmin::CustomersController < SolidusAdmin::BaseController
   before_action :load_order, only: [:show, :destroy]
 
   def show
-    render component('orders/show/email').new(order: @order)
+    respond_to do |format|
+      format.html do
+        render component('orders/show/email').new(order: @order)
+      end
+    end
   end
 
   def destroy

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -54,7 +54,11 @@ module SolidusAdmin
         flash[:error] = t('.error')
       end
 
-      redirect_to spree.edit_admin_order_path(@order)
+      respond_to do |format|
+        format.html { redirect_to spree.edit_admin_order_path(@order) }
+
+        format.turbo_stream { render turbo_stream: '<turbo-stream action="refresh" />' }
+      end
     end
 
     def edit

--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -30,7 +30,10 @@ module SolidusAdmin
       @stock_item.stock_movements.build(quantity: quantity_adjustment, originator: current_solidus_admin_user)
 
       if @stock_item.save
-        redirect_to solidus_admin.stock_items_path, status: :see_other
+        respond_to do |format|
+          format.html { redirect_to solidus_admin.stock_items_path, status: :see_other }
+          format.turbo_stream { render turbo_stream: '<turbo-stream action="refresh" />' }
+        end
       else
         respond_to do |format|
           format.html { render component('stock_items/edit').new(stock_item: @stock_item, page: @page), status: :unprocessable_entity }

--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -26,14 +26,11 @@ module SolidusAdmin
 
     def update
       quantity_adjustment = params[:quantity_adjustment].to_i
-      @stock_item.assign_attributes(stock_item_params.except(:page, :q))
+      @stock_item.assign_attributes(stock_item_params)
       @stock_item.stock_movements.build(quantity: quantity_adjustment, originator: current_solidus_admin_user)
 
       if @stock_item.save
-        redirect_to solidus_admin.stock_items_path(
-          page: stock_item_params[:page].to_i.presence,
-          q: stock_item_params[:q].presence&.then { |q| JSON.parse(q) }
-        ), status: :see_other
+        redirect_to solidus_admin.stock_items_path, status: :see_other
       else
         respond_to do |format|
           format.html { render component('stock_items/edit').new(stock_item: @stock_item, page: @page), status: :unprocessable_entity }
@@ -61,7 +58,7 @@ module SolidusAdmin
     end
 
     def stock_item_params
-      params.require(:stock_item).permit(:backorderable, :page, :q)
+      params.require(:stock_item).permit(:backorderable)
     end
   end
 end


### PR DESCRIPTION
## Summary

After introducing the first modal form backed by Turbo frames and Turbo refresh with https://github.com/solidusio/solidus/pull/5674, we can convert the other existing ones to the same pattern. 

Some insights can be obtained also by taking a look at the already mentioned PR that introduced the functionality for the first time.  

The stock item edit modal differs slightly from the established pattern, as the URL for the modal is managed via a Stimulus controller and some data attributes, rather than  the usual `A` tag (all the stock item row is clickable, and TRs can only have TH and TD as descendants). In order to keep things simple, this PR adds the ability of the Stimulus controller to parse the URL and, if a `_turbo_frame` attribute is present, it's used for adding Turbo frame navigation capability. The parameter is then removed from the URL, so it cannot produce further side-effects.

The PR could be split for easing reviews, one PR for each modal conversion, but the changes are similar across the modals, so unless splitting is encouraged, I'd rather keep these changes all together.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
