### PR TITLE
[Admin] Create new Refund Reasons

### DIFF
--- a/admin/app/components/solidus_admin/refund_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/refund_reasons/index/component.rb
@@ -17,11 +17,15 @@ class SolidusAdmin::RefundReasons::Index::Component < SolidusAdmin::RefundsAndRe
     spree.edit_admin_refund_reason_path(refund_reason)
   end
 
-  def actions
+  def turbo_frames
+    %w[new_refund_reason_modal]
+  end
+
+  def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),
-      href: spree.new_admin_refund_reason_path,
+      href: solidus_admin.new_refund_reason_path, data: { turbo_frame: :new_refund_reason_modal },
       icon: "add-line",
       class: "align-self-end w-full",
     )

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag :new_refund_reason_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @refund_reason, url: solidus_admin.refund_reasons_path, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <label class="flex gap-2 items-center">
+          <%= render component("ui/forms/checkbox").new(
+              name: "#{f.object_name}[active]",
+              value: "1",
+              checked: f.object.active
+            ) %>
+            <span class="font-semibold text-xs ml-2"><%= Spree::TaxCategory.human_attribute_name :active %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render component("refund_reasons/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.rb
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::RefundReasons::New::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, refund_reason:)
+    @page = page
+    @refund_reason = refund_reason
+  end
+
+  def form_id
+    dom_id(@refund_reason, "#{stimulus_id}_new_refund_reason_form")
+  end
+end

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.yml
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.yml
@@ -1,0 +1,7 @@
+en:
+  title: "New Refund Reason"
+  cancel: "Cancel"
+  submit: "Add Refund Reason"
+  hints:
+    active: "When checked, this refund reason will be available for selection when refunding orders."
+    mutable: "aslkdjlaksj dlkajs"

--- a/admin/config/locales/refund_reasons.en.yml
+++ b/admin/config/locales/refund_reasons.en.yml
@@ -4,3 +4,5 @@ en:
       title: "Refund Reasons"
       destroy:
         success: "Refund Reasons were successfully removed."
+      create:
+        success: "Refund reason was successfully created."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -60,7 +60,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :stock_locations, only: [:index, :destroy]
   admin_resources :stores, only: [:index, :destroy]
   admin_resources :zones, only: [:index, :destroy]
-  admin_resources :refund_reasons, only: [:index, :new, :destroy]
+  admin_resources :refund_reasons, only: [:index, :new, :create, :destroy]
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, only: [:index, :destroy]
   admin_resources :adjustment_reasons, only: [:index, :destroy]

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -60,7 +60,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :stock_locations, only: [:index, :destroy]
   admin_resources :stores, only: [:index, :destroy]
   admin_resources :zones, only: [:index, :destroy]
-  admin_resources :refund_reasons, only: [:index, :destroy]
+  admin_resources :refund_reasons, only: [:index, :new, :destroy]
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, only: [:index, :destroy]
   admin_resources :adjustment_reasons, only: [:index, :destroy]

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -19,4 +19,43 @@ describe "Refund Reasons", :js, type: :feature do
     expect(Spree::RefundReason.count).to eq(0)
     expect(page).to be_axe_clean
   end
+
+  context "when creating a new refund reason" do
+    let(:query) { "?page=1&q%5Bname_or_description_cont%5D=Ret" }
+
+    before do
+      visit "/admin/refund_reasons/#{query}"
+      click_on "Add new"
+      expect(page).to have_content("New Refund Reason")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    context "with valid data" do
+      it "successfully creates a new refund reason, keeping page and q params" do
+        fill_in "Name", with: "Return process"
+
+        click_on "Add Refund Reason"
+
+        expect(page).to have_content("Refund reason was successfully created.")
+        expect(Spree::RefundReason.find_by(name: "Return process")).to be_present
+        expect(page.current_url).to include(query)
+      end
+    end
+
+    context "with invalid data" do
+      it "fails to create a new refund reason, keeping page and q params" do
+        click_on "Add Refund Reason"
+
+        expect(page).to have_content "can't be blank"
+        expect(page.current_url).to include(query)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR migrates the creation of new refund reasons to the new admin interface, following the existing pattern used for tax categories.

The form is rendered via a modal dialog on the refund reasons list by leveraging Turbo frames.  Successful creation leads to a turbo stream page refresh, which updates the existing list preserving the query params and the scroll position, for a consistent UX. 

The attached video shows the functionality visually.


https://github.com/solidusio/solidus/assets/141220/76771204-5dcd-4442-8937-6b2e2eb4b5a7



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- [x] ✅ I have added automated tests to cover my changes.
- [x] 📸 I have attached screenshots to demo visual changes.