### PR TITLE
[Admin] Add Update Tax Category feature

### DIFF
--- a/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag :edit_tax_category_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @tax_category, url: solidus_admin.tax_category_path(@tax_category), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name) %>
+        <%= render component("ui/forms/field").text_field(f, :tax_code) %>
+        <%= render component("ui/forms/field").text_field(f, :description) %>
+        <label class="flex gap-2 items-center">
+          <%= render component("ui/forms/checkbox").new(
+              name: "#{f.object_name}[is_default]",
+              value: "1",
+              checked: f.object.is_default
+            ) %>
+            <span class="font-semibold text-xs ml-2"><%= Spree::TaxCategory.human_attribute_name :is_default %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.is_default")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render component("tax_categories/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.rb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::TaxCategories::Edit::Component < SolidusAdmin::TaxCategories::Index::Component
+  def initialize(page:, tax_category:)
+    @page = page
+    @tax_category = tax_category
+  end
+
+  def form_id
+    dom_id(@tax_category, "#{stimulus_id}_edit_tax_category_form")
+  end
+end

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.yml
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.yml
@@ -1,0 +1,8 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "Edit Tax Category"
+  cancel: "Cancel"
+  submit: "Update Tax Category"
+  hints:
+    is_default: "When checked, this tax category will be selected by default when creating new products or variants."

--- a/admin/app/components/solidus_admin/tax_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/tax_categories/index/component.rb
@@ -2,7 +2,7 @@
 
 class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Component
   def row_url(tax_category)
-    spree.edit_admin_tax_category_path(tax_category)
+    spree.edit_admin_tax_category_path(tax_category, _turbo_frame: :edit_tax_category_modal)
   end
 
   def model_class
@@ -24,7 +24,10 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
   end
 
   def turbo_frames
-    %w[new_tax_category_modal]
+    %w[
+      new_tax_category_modal
+      edit_tax_category_modal
+    ]
   end
 
   def search_key

--- a/admin/config/locales/tax_categories.en.yml
+++ b/admin/config/locales/tax_categories.en.yml
@@ -6,3 +6,5 @@ en:
         success: "Tax categories were successfully removed."
       create:
         success: "Tax category was successfully created."
+      update:
+        success: "Tax category was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -51,7 +51,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :option_types, only: [:index, :destroy], sortable: true
   admin_resources :taxonomies, only: [:index, :destroy], sortable: true
   admin_resources :promotion_categories, only: [:index, :destroy]
-  admin_resources :tax_categories, only: [:new, :index, :create, :destroy]
+  admin_resources :tax_categories, except: [:show]
   admin_resources :tax_rates, only: [:index, :destroy]
   admin_resources :payment_methods, only: [:index, :destroy], sortable: true
   admin_resources :stock_items, only: [:index, :edit, :update]


### PR DESCRIPTION
## Summary

Recently, it was introduced in the new admin the ability to create a new tax category via a modal dialog. It's now time to allow editing an existing one. 

The new feature works similarly to the one for creating a new tax category, i.e. it opens a modal dialog with the edit form. When submitting the form, if the tax category has errors then they're shown to the user, otherwise the record is updated, the modal is removed, and a success message is shown.


https://github.com/solidusio/solidus/assets/141220/17a31df5-6db3-412f-83f9-cfdba4199c12



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- [x] ✅ I have added automated tests to cover my changes.
- [x] 📸 I have attached screenshots to demo visual changes.
The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).

