### PR TITLE
Fix flaky admin stoc items spec

### DIFF
--- a/admin/spec/features/stock_items_spec.rb
+++ b/admin/spec/features/stock_items_spec.rb
@@ -5,21 +5,20 @@ require 'spec_helper'
 describe "Stock Items", :js, type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists stock items and allows navigating through scopes" do
-    non_backorderable = create(:stock_item, backorderable: false)
-    non_backorderable.variant.update!(sku: 'MY-SKU-1234567890')
-    backorderable = create(:stock_item, backorderable: true)
-    out_of_stock = begin
-      item = create(:stock_item, backorderable: false)
-      item.reduce_count_on_hand_to_zero
-      item
-    end
-    low_stock = begin
-      item = create(:stock_item, backorderable: false)
-      item.set_count_on_hand(SolidusAdmin::Config[:low_stock_value] - 1)
-      item
-    end
+  # We don't want multiple stock items per variant, and stock locations are created implicitly otherwise,
+  # and their default is to create stock items for all variants, which in this spec we do manually.
+  let!(:stock_location) { create(:stock_location, name: 'default', propagate_all_variants: false) }
 
+  let(:backorderable_variant) { create(:variant, sku: 'backorderable', stock_items: []) }
+  let(:non_backorderable_variant) { create(:variant, sku: 'non-backorderable', stock_items: []) }
+  let(:out_of_stock_variant) { create(:variant, sku: 'out-of-stock', stock_items: []) }
+  let(:low_stock_variant) { create(:variant, sku: 'low-stock', stock_items: []) }
+  let!(:backorderable) { create(:stock_item, variant: backorderable_variant, backorderable: true) }
+  let!(:non_backorderable) { create(:stock_item, variant: non_backorderable_variant, backorderable: false) }
+  let!(:out_of_stock) { create(:stock_item, variant: out_of_stock_variant, backorderable: false, on_hand: 0) }
+  let!(:low_stock) { create(:stock_item, variant: low_stock_variant, backorderable: false, on_hand: SolidusAdmin::Config.low_stock_value - 1) }
+
+  it "lists stock items and allows navigating through scopes" do
     visit "/admin/stock_items"
 
     # `All` default scope
@@ -29,11 +28,11 @@ describe "Stock Items", :js, type: :feature do
     expect(page).to have_content(low_stock.variant.sku)
 
     # Edit stock item
-    find('td', text: 'MY-SKU-1234567890').click
+    find('td', text: 'non-backorderable').click
     fill_in :quantity_adjustment, with: 1
     click_on "Save"
-    expect(find('tr', text: 'MY-SKU-1234567890')).to have_content('11')
-    expect(find('tr', text: 'MY-SKU-1234567890')).to have_content('1 stock movement')
+    expect(find('tr', text: 'non-backorderable')).to have_content('11')
+    expect(find('tr', text: 'non-backorderable')).to have_content('1 stock movement')
 
     click_on 'Back Orderable'
     expect(page).to have_css('[aria-current="true"]', text: 'Back Orderable')

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     association :stock_location, factory: :stock_location_without_variant_propagation
     variant
 
-    after(:create) { |object| object.adjust_count_on_hand(10) }
+    transient do
+      on_hand { 10 }
+    end
+
+    after(:create) { |object, evaluator| object.adjust_count_on_hand(evaluator.on_hand) }
   end
 end


### PR DESCRIPTION
## Summary

This spec failed on me a number of times over the past week, so we spent some time hardening it. Super cool extra feature: We can now create a stock item with a desired on-hand quantity from within the stock item factory!

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
