### PR TITLE
[Admin] Add the ability to configure batch action confirmation

### DIFF
--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -33,18 +33,21 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::UI::Pages::Index:
         action: solidus_admin.products_path,
         method: :delete,
         icon: 'delete-bin-7-line',
+        require_confirmation: true,
       },
       {
         label: t('.batch_actions.discontinue'),
         action: solidus_admin.discontinue_products_path,
         method: :put,
         icon: 'pause-circle-line',
+        require_confirmation: true,
       },
       {
         label: t('.batch_actions.activate'),
         action: solidus_admin.activate_products_path,
         method: :put,
         icon: 'play-circle-line',
+        require_confirmation: true,
       },
     ]
   end

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -130,10 +130,16 @@ export default class extends Controller {
   }
 
   confirmAction(event) {
-    const message = event.params.message.replace(
-      "${count}",
-      this.selectedRows().length
-    )
+    const message = event.params.message
+      .replace(
+        "${count}",
+        this.selectedRows().length
+      ).replace(
+        "${resource}",
+        this.selectedRows().length > 1 ?
+        event.params.resourcePlural :
+        event.params.resourceSingular
+      )
 
     if (!confirm(message)) {
       event.preventDefault()

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -125,8 +125,23 @@ export default class extends Controller {
     }
   }
 
+  selectedRows() {
+    return this.checkboxTargets.filter((checkbox) => checkbox.checked)
+  }
+
+  confirmAction(event) {
+    const message = event.params.message.replace(
+      "${count}",
+      this.selectedRows().length
+    )
+
+    if (!confirm(message)) {
+      event.preventDefault()
+    }
+  }
+
   render() {
-    const selectedRows = this.checkboxTargets.filter((checkbox) => checkbox.checked)
+    const selectedRows = this.selectedRows()
 
     if (this.hasSearchFieldTarget) {
       this.searchToolbarTarget.toggleAttribute("hidden", this.modeValue !== "search")

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -18,6 +18,10 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       self.batch_actions = batch_actions.to_a.map { |action| BatchAction.new(**action) }
     end
 
+    def singular_name
+      self[:class].model_name.human if self[:class]
+    end
+
     def plural_name
       self[:class].model_name.human.pluralize if self[:class]
     end
@@ -116,9 +120,10 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       params["data-action"] = "click->#{stimulus_id}#confirmAction"
       params["data-#{stimulus_id}-message-param"] = t(
         ".action_confirmation",
-        action: batch_action.label.downcase,
-        resource: @data.plural_name.downcase
+        action: batch_action.label.downcase
       )
+      params["data-#{stimulus_id}-resource-singular-param"] = @data.singular_name.downcase
+      params["data-#{stimulus_id}-resource-plural-param"] = @data.plural_name.downcase
     end
 
     render component("ui/button").new(**params)

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -5,7 +5,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   Sortable = Struct.new(:url, :param, :animation, :handle, keyword_init: true)
   Scope = Struct.new(:label, :name, :default, keyword_init: true)
   Filter = Struct.new(:label, :combinator, :attribute, :predicate, :options, keyword_init: true)
-  BatchAction = Struct.new(:label, :icon, :action, :method, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+  BatchAction = Struct.new(:label, :icon, :action, :require_confirmation, :method, keyword_init: true) # rubocop:disable Lint/StructNewOverride
   private_constant :BatchAction, :Column, :Filter, :Scope, :Sortable
 
   class Data < Struct.new(:rows, :class, :url, :prev, :next, :columns, :fade, :batch_actions, keyword_init: true) # rubocop:disable Lint/StructNewOverride,Style/StructInheritance
@@ -97,7 +97,7 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   def render_batch_action_button(batch_action)
-    render component("ui/button").new(
+    params = {
       name: request_forgery_protection_token,
       value: form_authenticity_token(form_options: {
         action: batch_action.action,
@@ -110,7 +110,18 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
       icon: batch_action.icon,
       text: batch_action.label,
       scheme: :secondary,
-    )
+    }
+
+    if batch_action.require_confirmation
+      params["data-action"] = "click->#{stimulus_id}#confirmAction"
+      params["data-#{stimulus_id}-message-param"] = t(
+        ".action_confirmation",
+        action: batch_action.label.downcase,
+        resource: @data.plural_name.downcase
+      )
+    end
+
+    render component("ui/button").new(**params)
   end
 
   def render_ransack_filter_dropdown(filter, index)

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -5,6 +5,7 @@ en:
   select_row: 'Select row'
   filter: 'Filter'
   search_placeholder: 'Search all %{resources}'
+  action_confirmation: 'Are you sure you want to %{action} ${count} %{resource}?'
   refine_search: 'Refine Search'
   batch_actions: Batch actions
   cancel: Cancel

--- a/admin/app/components/solidus_admin/ui/table/component.yml
+++ b/admin/app/components/solidus_admin/ui/table/component.yml
@@ -5,7 +5,7 @@ en:
   select_row: 'Select row'
   filter: 'Filter'
   search_placeholder: 'Search all %{resources}'
-  action_confirmation: 'Are you sure you want to %{action} ${count} %{resource}?'
+  action_confirmation: 'Are you sure you want to %{action} ${count} ${resource}?'
   refine_search: 'Refine Search'
   batch_actions: Batch actions
   cancel: Cancel

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -30,7 +30,7 @@ describe "Products", type: :feature do
     visit "/admin/products"
     select_row("Just a product")
 
-    accept_confirm("Are you sure you want to delete 1 products?") do
+    accept_confirm("Are you sure you want to delete 1 product?") do
       click_button "Delete"
     end
 
@@ -48,7 +48,7 @@ describe "Products", type: :feature do
     visit "/admin/products"
     find('main tbody tr:nth-child(2)').find('input').check
 
-    accept_confirm("Are you sure you want to discontinue 1 products?") do
+    accept_confirm("Are you sure you want to discontinue 1 product?") do
       click_button "Discontinue"
     end
 
@@ -66,7 +66,7 @@ describe "Products", type: :feature do
 
     find('main tbody tr:nth-child(2)').find('input').check
 
-    accept_confirm("Are you sure you want to activate 1 products?") do
+    accept_confirm("Are you sure you want to activate 1 product?") do
       click_button "Activate"
     end
 

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -29,7 +29,10 @@ describe "Products", type: :feature do
 
     visit "/admin/products"
     select_row("Just a product")
-    click_button "Delete"
+
+    accept_confirm("Are you sure you want to delete 1 products?") do
+      click_button "Delete"
+    end
 
     expect(page).to have_content("Products were successfully removed.", wait: 5)
     expect(page).not_to have_content("Just a product")
@@ -44,7 +47,10 @@ describe "Products", type: :feature do
 
     visit "/admin/products"
     find('main tbody tr:nth-child(2)').find('input').check
-    click_button "Discontinue"
+
+    accept_confirm("Are you sure you want to discontinue 1 products?") do
+      click_button "Discontinue"
+    end
 
     expect(page).to have_content("Products were successfully discontinued.", wait: 5)
     within('main tbody tr:nth-child(2)') {
@@ -59,7 +65,10 @@ describe "Products", type: :feature do
     }
 
     find('main tbody tr:nth-child(2)').find('input').check
-    click_button "Activate"
+
+    accept_confirm("Are you sure you want to activate 1 products?") do
+      click_button "Activate"
+    end
 
     expect(page).to have_content("Products were successfully activated.", wait: 5)
     within('tbody') do


### PR DESCRIPTION
## Summary

This change introduces a new boolean configuration on the `BatchAction` struct that would allow users of the `UI::Table` component to specify if a batch action requires confirmation.

This change enables this new behaviour on the products index batch actions as a proof of concept.

~This is a draft because we haven't added any tests yet, but if this approach looks reasonable we can do that as well.~
**Update:** Specs have been updated and passing now.

Issue https://github.com/orgs/solidusio/projects/12/views/1?pane=issue&itemId=52056191

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.

## Screenshots

| | Bulk Delete | Bulk Discontinue | Bulk Activate |
|--------|--------|--------|--------|
| Single | <img width="1727" alt="Screenshot 2024-04-01 at 9 29 04 PM" src="https://github.com/solidusio/solidus/assets/3153035/d599ea53-6a62-4f1f-8519-13d3fad94448"> | <img width="1727" alt="Screenshot 2024-04-01 at 9 29 21 PM" src="https://github.com/solidusio/solidus/assets/3153035/4cbe1e29-0cbe-4fda-8d8f-2180d03b117e"> | <img width="1726" alt="Screenshot 2024-04-01 at 9 29 38 PM" src="https://github.com/solidusio/solidus/assets/3153035/e1b04cbb-20fa-43fa-83b5-b14f16fec7d7"> |
|Multiple| <img width="671" alt="Screenshot 2024-03-18 at 2 46 53 PM" src="https://github.com/solidusio/solidus/assets/3153035/f23be71f-2ef6-46e7-8148-028826d44aeb"> | <img width="671" alt="Screenshot 2024-03-18 at 2 47 04 PM" src="https://github.com/solidusio/solidus/assets/3153035/78c5d11c-11d0-436b-bb69-9fae3c58f154"> | <img width="1728" alt="Screenshot 2024-04-01 at 9 30 00 PM" src="https://github.com/solidusio/solidus/assets/3153035/02f04395-659d-4ca1-ab8e-27a2f6933250"> |