### PR TITLE
Do not show theme selector if only one theme is configured

### DIFF
--- a/backend/app/views/spree/admin/shared/_theme_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_theme_selection.html.erb
@@ -1,21 +1,23 @@
 <% theme_options_for_select = Spree::Backend::Config.themes.keys.map { |theme| [theme.to_s.humanize, theme] }.sort %>
 
-<%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
-  <%= hidden_field_tag :system_theme, :light %>
-  <label class="admin-navbar-selection">
-    <i class="fa fa-sun-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
-    <select name="switch_to_theme" class="custom-select fullwidth" onchange="this.form.requestSubmit()">
-      <%= options_for_select(theme_options_for_select, session[:admin_light_theme] || Spree::Backend::Config.theme) %>
-    </select>
-  </label>
-<% end %>
+<% if theme_options_for_select.length > 1 %>
+  <%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
+    <%= hidden_field_tag :system_theme, :light %>
+    <label class="admin-navbar-selection">
+      <i class="fa fa-sun-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
+      <select name="switch_to_theme" class="custom-select fullwidth" onchange="this.form.requestSubmit()">
+        <%= options_for_select(theme_options_for_select, session[:admin_light_theme] || Spree::Backend::Config.theme) %>
+      </select>
+    </label>
+  <% end %>
 
-<%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
-  <%= hidden_field_tag :system_theme, :dark %>
-  <label class="admin-navbar-selection">
-    <i class="fa fa-moon-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
-    <select name="switch_to_theme" class="custom-select fullwidth" onchange="this.form.requestSubmit()">
-      <%= options_for_select(theme_options_for_select, session[:admin_dark_theme] || Spree::Backend::Config.dark_theme) %>
-    </select>
-  </label>
+  <%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
+    <%= hidden_field_tag :system_theme, :dark %>
+    <label class="admin-navbar-selection">
+      <i class="fa fa-moon-o fa-fw" title="<%= I18n.t('spree.choose_dashboard_theme') %>"></i>
+      <select name="switch_to_theme" class="custom-select fullwidth" onchange="this.form.requestSubmit()">
+        <%= options_for_select(theme_options_for_select, session[:admin_dark_theme] || Spree::Backend::Config.dark_theme) %>
+      </select>
+    </label>
+  <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_theme_selection_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_theme_selection_solidus_admin.html.erb
@@ -1,25 +1,27 @@
 <% theme_options_for_select = Spree::Backend::Config.themes.keys.map { |theme| [theme.to_s.humanize, theme] }.sort %>
 
-<li>
-  <%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
-    <%= hidden_field_tag :system_theme, :light %>
-    <label>
-      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-sun-line"></use></svg>
-      <select name="switch_to_theme" onchange="this.form.requestSubmit()">
-        <%= options_for_select(theme_options_for_select, session[:admin_light_theme] || Spree::Backend::Config.theme) %>
-      </select>
-      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
-    </label>
-  <% end %>
+<% if theme_options_for_select.length > 1 %>
+  <li>
+    <%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "light-only") do %>
+      <%= hidden_field_tag :system_theme, :light %>
+      <label>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-sun-line"></use></svg>
+        <select name="switch_to_theme" onchange="this.form.requestSubmit()">
+          <%= options_for_select(theme_options_for_select, session[:admin_light_theme] || Spree::Backend::Config.theme) %>
+        </select>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
+      </label>
+    <% end %>
 
-  <%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
-    <%= hidden_field_tag :system_theme, :dark %>
-    <label>
-      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-moon-line"></use></svg>
-      <select name="switch_to_theme" onchange="this.form.requestSubmit()">
-        <%= options_for_select(theme_options_for_select, session[:admin_dark_theme] || Spree::Backend::Config.dark_theme) %>
-      </select>
-      <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
-    </label>
-  <% end %>
-</li>
+    <%= form_tag(spree.admin_set_theme_path(format: :html), method: :put, style: "width: 100%;", class: "dark-only") do %>
+      <%= hidden_field_tag :system_theme, :dark %>
+      <label>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-moon-line"></use></svg>
+        <select name="switch_to_theme" onchange="this.form.requestSubmit()">
+          <%= options_for_select(theme_options_for_select, session[:admin_dark_theme] || Spree::Backend::Config.dark_theme) %>
+        </select>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-expand-up-down-line"></use></svg>
+      </label>
+    <% end %>
+  </li>
+<% end %>


### PR DESCRIPTION
## Summary

There is no usecase for selecting from one theme.

## Checklist

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
