### PR TITLE
Add routes proxy to locale selection path helper

### DIFF
--- a/backend/app/views/spree/admin/shared/_locale_selection_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection_solidus_admin.html.erb
@@ -4,7 +4,7 @@
 
 <% if available_locale_options_for_select.size > 1 %>
   <li>
-    <%= form_tag(admin_set_locale_path(format: :html), method: :put, style: "width: 100%;") do %>
+    <%= form_tag(spree.admin_set_locale_path(format: :html), method: :put, style: "width: 100%;") do %>
       <label>
         <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-global-line"></use></svg>
         <select name="switch_to_locale" onchange="this.form.requestSubmit()">


### PR DESCRIPTION


## Summary

We need to always add routing proxies so our partials work in the context of other engines.
