### PR TITLE
[Admin] adding new shipping category

### DIFF
--- a/admin/app/components/solidus_admin/shipping_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/shipping_categories/index/component.rb
@@ -15,6 +15,20 @@ class SolidusAdmin::ShippingCategories::Index::Component < SolidusAdmin::Shippin
     )
   end
 
+  def page_actions
+    render component("ui/button").new(
+      tag: :a,
+      text: t('.add'),
+      href: solidus_admin.new_shipping_category_path, data: { turbo_frame: :new_shipping_category_modal },
+      icon: "add-line",
+      class: "align-self-end w-full",
+    )
+  end
+
+  def turbo_frames
+    %w[new_shipping_category_modal]
+  end
+
   def row_url(shipping_category)
     spree.edit_admin_shipping_category_path(shipping_category)
   end

--- a/admin/app/components/solidus_admin/shipping_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/shipping_categories/index/component.rb
@@ -34,7 +34,7 @@ class SolidusAdmin::ShippingCategories::Index::Component < SolidusAdmin::Shippin
   end
 
   def search_key
-    :name_or_description_cont
+    :name_cont
   end
 
   def search_url

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag :new_shipping_category_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @shipping_category, url: solidus_admin.shipping_categories_path(page: params[:page], q: params[:q]), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name) %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render component("shipping_categories/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.rb
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::ShippingCategories::New::Component < SolidusAdmin::ShippingCategories::Index::Component
+  def initialize(page:, shipping_category:)
+    @page = page
+    @shipping_category = shipping_category
+  end
+
+  def form_id
+    dom_id(@shipping_category, "#{stimulus_id}_new_shipping_category_form")
+  end
+end

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.yml
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.yml
@@ -1,0 +1,6 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "New Shipping Category"
+  cancel: "Cancel"
+  submit: "Add Shipping Category"

--- a/admin/app/controllers/solidus_admin/shipping_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/shipping_categories_controller.rb
@@ -4,13 +4,47 @@ module SolidusAdmin
   class ShippingCategoriesController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    def index
-      shipping_categories = apply_search_to(
-        Spree::ShippingCategory.order(id: :desc),
-        param: :q,
-      )
+    def new
+      @shipping_category = Spree::ShippingCategory.new
 
-      set_page_and_extract_portion_from(shipping_categories)
+      set_index_page
+
+      respond_to do |format|
+        format.html { render component('shipping_categories/new').new(page: @page, shipping_category: @shipping_category) }
+      end
+    end
+
+    def create
+      @shipping_category = Spree::ShippingCategory.new(shipping_category_params)
+
+      if @shipping_category.save
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.shipping_categories_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            # we need to explicitly write the refresh tag for now.
+            # See https://github.com/hotwired/turbo-rails/issues/579
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('shipping_categories/new').new(page: @page, shipping_category: @shipping_category)
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
+    def index
+      set_index_page
 
       respond_to do |format|
         format.html { render component('shipping_categories/index').new(page: @page) }
@@ -34,7 +68,16 @@ module SolidusAdmin
     end
 
     def shipping_category_params
-      params.require(:shipping_category).permit(:shipping_category_id, permitted_shipping_category_attributes)
+      params.require(:shipping_category).permit(:name)
+    end
+
+    def set_index_page
+      shipping_categories = apply_search_to(
+        Spree::ShippingCategory.order(id: :desc),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(shipping_categories)
     end
   end
 end

--- a/admin/config/locales/shipping_categories.en.yml
+++ b/admin/config/locales/shipping_categories.en.yml
@@ -4,3 +4,5 @@ en:
       title: "Shipping Categories"
       destroy:
         success: "Shipping categories were successfully removed."
+      create:
+        success: "Shipping category was successfully created."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -56,7 +56,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :payment_methods, only: [:index, :destroy], sortable: true
   admin_resources :stock_items, only: [:index, :edit, :update]
   admin_resources :shipping_methods, only: [:index, :destroy]
-  admin_resources :shipping_categories, only: [:index, :destroy]
+  admin_resources :shipping_categories, only: [:new, :index, :create, :destroy]
   admin_resources :stock_locations, only: [:index, :destroy]
   admin_resources :stores, only: [:index, :destroy]
   admin_resources :zones, only: [:index, :destroy]

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -19,4 +19,43 @@ describe "Shipping Categories", :js, type: :feature do
     expect(Spree::ShippingCategory.count).to eq(0)
     expect(page).to be_axe_clean
   end
+
+  context "when creating a new shipping category" do
+    let(:query) { "?page=1&q%5Bname_or_description_cont%5D=What" }
+
+    before do
+      visit "/admin/shipping_categories#{query}"
+      click_on "Add new"
+      expect(page).to have_content("New Shipping Category")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    context "with valid data" do
+      it "successfully creates a new shipping category, keeping page and q params" do
+        fill_in "Name", with: "Whatever"
+
+        click_on "Add Shipping Category"
+
+        expect(page).to have_content("Shipping category was successfully created.")
+        expect(Spree::ShippingCategory.find_by(name: "Whatever")).to be_present
+        expect(page.current_url).to include(query)
+      end
+    end
+
+    context "with invalid data" do
+      it "fails to create a new shipping category, keeping page and q params" do
+        click_on "Add Shipping Category"
+
+        expect(page).to have_content "can't be blank"
+        expect(page.current_url).to include(query)
+      end
+    end
+  end
 end

--- a/core/app/models/spree/shipping_category.rb
+++ b/core/app/models/spree/shipping_category.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class ShippingCategory < Spree::Base
+    self.allowed_ransackable_attributes = %w[name]
+
     validates :name, presence: true
     has_many :products, inverse_of: :shipping_category
     has_many :shipping_method_categories, inverse_of: :shipping_category


### PR DESCRIPTION
## Summary

This PR migrates the creation of new shipping categories to the new admin interface.
It follows the same kind of work done for Tax categories in https://github.com/solidusio/solidus/pull/5674
There is no issue but a project item that I cannot move or comment, probably due to permission issues. https://github.com/orgs/solidusio/projects/12/views/1?filterQuery=xs&pane=issue&itemId=52590587

I also fixed searching shipping categories. This was a feature not present on old admin and by introducing new UI, and capability to search them, it was missing a ransack config to allow searching them by name. 


https://github.com/solidusio/solidus/assets/824936/5b258fb0-fc87-4238-84f4-56d6fc838cbf



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
