### PR TITLE
Show the page action for creating a new shipping method

### DIFF
--- a/admin/app/components/solidus_admin/shipping_methods/index/component.rb
+++ b/admin/app/components/solidus_admin/shipping_methods/index/component.rb
@@ -17,7 +17,7 @@ class SolidusAdmin::ShippingMethods::Index::Component < SolidusAdmin::Shipping::
     :name_or_description_cont
   end
 
-  def actions
+  def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),

--- a/admin/spec/features/shipping_methods_spec.rb
+++ b/admin/spec/features/shipping_methods_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe "Shipping Methods", :js, type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists tax categories and allows deleting them" do
+  it "lists shipping methods and allows deleting them" do
     create(:shipping_method, name: "FAAAST")
 
     visit "/admin/shipping_methods"
@@ -14,9 +14,17 @@ describe "Shipping Methods", :js, type: :feature do
 
     select_row("FAAAST")
     click_on "Delete"
+
     expect(page).to have_content("Shipping methods were successfully removed.")
     expect(page).not_to have_content("FAAAST")
     expect(Spree::ShippingMethod.count).to eq(0)
     expect(page).to be_axe_clean
+  end
+
+  it "shows the link for creating a new shipping method" do
+    visit "/admin/shipping_methods"
+
+    expect(page).to have_content("Add new")
+    expect(page).to have_selector(:css, 'a[href="/admin/shipping_methods/new"]')
   end
 end


### PR DESCRIPTION
## Summary

It would be helpful to be able to add shipping methods in the new admin, even though the `new` action views are not migrated yet. This change renames the actions method to page_actions to get that.

| Screenshot |
|--------|
| <img width="2318" alt="Screenshot 2024-04-11 at 3 34 12 PM" src="https://github.com/solidusio/solidus/assets/3153035/1bf6316a-f11b-44a2-8c3a-5fb39389d4a0"> | 


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
