### PR TITLE
fix(CI): Set ESLINT_USE_FLAT_CONFIG=false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,7 @@ jobs:
       - image: cimg/ruby:3.2-node
         environment:
           BUNDLE_ONLY: "lint"
+          ESLINT_USE_FLAT_CONFIG: false
     steps:
       - checkout
       - run: 'bundle install'


### PR DESCRIPTION
In ESLint v9 the flat config is default, but we can change the default back to the old one.

See: https://github.com/eslint/eslint/issues/18287
