### PR TITLE
Restrict sqlite3 gem to '~> 1.3', like ActiveRecord

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,8 @@ commands:
             cd /tmp/dummy_extension
             bundle init
             bundle add rails -v "< 7.1" --skip-install
-            bundle add sqlite3 <<parameters.extra_gems>> --skip-install
+            bundle add sqlite3 -v "~> 1.3" --skip-install
+            test -n "<<parameters.extra_gems>>" && bundle add <<parameters.extra_gems>> --skip-install
             bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
             export LIB_NAME=set # dummy requireable file
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ dbs = ENV['DB_ALL'] ? 'all' : ENV.fetch('DB', 'sqlite')
 gem 'mysql2', '~> 0.5.0', require: false if dbs.match?(/all|mysql/)
 gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
+gem 'sqlite3', '~> 1.4', require: false if dbs.match?(/all|sqlite/)
 
 gem 'database_cleaner', '~> 2.0', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false


### PR DESCRIPTION
They just released sqlite3 2.0.0, but ActiveRecord's sqlite3 adapter doesn't know about this yet, leading to conflicting sqlite3 gems in specs.

This is probably a temporary fix until ActiveRecord learns the news.

See https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14
and https://github.com/sparklemotion/sqlite3-ruby/blob/main/CHANGELOG.md
