### PR TITLE
Do not initialize promotions object on startup

### DIFF
--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -112,7 +112,17 @@ module Spree
       :variant_id
     ]
 
-    preference :promotion_attributes, :array, default: Spree::Config.promotions.promotion_api_attributes
+    def promotion_attributes
+      Spree::Config.promotions.promotion_api_attributes
+    end
+    alias_method :preferred_promotion_attributes, :promotion_attributes
+
+    def promotion_attributes=(value)
+      Spree::Config.promotions.promotion_api_attributes = value
+    end
+    alias_method :preferred_promotion_attributes=, :promotion_attributes=
+    promotion_attributes_deprecation_message = "Spree::ApiConfiguration#promotion_attributes= is deprecated. Please use Spree::Config.promotions.promotion_api_attributes= instead."
+    deprecate "promotion_attributes=" => promotion_attributes_deprecation_message, deprecator: Spree.deprecator
 
     preference :store_attributes, :array, default: [
       :id, :name, :url, :meta_description, :meta_keywords, :seo_title,

--- a/api/spec/lib/spree/api_configuration_spec.rb
+++ b/api/spec/lib/spree/api_configuration_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Spree::ApiConfiguration do
+  subject(:config) { Spree::ApiConfiguration.new }
+
+  describe "#promotion_attributes" do
+    subject(:promotion_attributes) { config.promotion_attributes }
+
+    it { is_expected.to eq(Spree::Config.promotions.promotion_api_attributes) }
+
+    it "can be changed" do
+      config.promotion_attributes << :foo
+      expect(promotion_attributes).to include(:foo)
+    end
+
+    it "can delete attributes" do
+      expect(promotion_attributes).to include(:name)
+      config.promotion_attributes.delete(:name)
+      expect(promotion_attributes).not_to include(:name)
+    end
+  end
+
+  describe "#promotion_attributes=" do
+    subject(:promotion_attributes_setter) { config.promotion_attributes = [:name] }
+
+    around do |example|
+      original_attributes = Spree::Config.promotions.promotion_api_attributes
+      Spree.deprecator.silence do
+        example.run
+      end
+      Spree::Config.promotions.promotion_api_attributes = original_attributes
+    end
+
+    it "sets the promotion_attributes" do
+      promotion_attributes_setter
+      expect(config.promotion_attributes).to eq([:name])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Initializing the app with the code prior to this commit would
instantiate the promotions configuration, which is not good because
instantiating it via `Spree::Config.promotions` leads to the object
being instacached and very, very hard to change.
    
Also, we currently have to spots in the app where we can configure the
promotion api attributes, and this reduces it to just one by deprecating
the preference :promotion_attributes on `Spree::ApiConfiguration`.

This includes some commit from #5727 to see the tests through.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
