### PR TITLE
Add `shipping_promotion_handler_class` attribute to null promo config

### DIFF
--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -22,6 +22,14 @@ module Spree
       #   Spree::NullPromotionFinder.
       class_name_attribute :promotion_finder_class, default: 'Spree::NullPromotionFinder'
 
+      # Allows providing a different promotion shipping promotion handler.
+      # @!attribute [rw] shipping_promotion_handler_class
+      # @see Spree::NullPromotionHandler
+      # @return [Class] an object that conforms to the API of
+      #   the standard promotion finder class
+      #   Spree::NullPromotionHandler.
+      class_name_attribute :shipping_promotion_handler_class, default: 'Spree::NullPromotionHandler'
+
       # !@attribute [rw] promotion_api_attributes
       #   @return [Array<Symbol>] Attributes to be returned by the API for a promotion
       preference :promotion_api_attributes, :array, default: []

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
   it "uses the null promotion finder class by default" do
     expect(config.promotion_finder_class).to eq Spree::NullPromotionFinder
   end
+
+  it "uses the null promotion handler as the shipping promo handler" do
+    expect(config.shipping_promotion_handler_class).to eq Spree::NullPromotionHandler
+  end
 end


### PR DESCRIPTION

## Summary

We have a shipping_promotion_handler_class in the legacy promotion system, and we have calling code from Solidus itself, so we need to add this configuration option to the null promotion configuration, too.
