### PR TITLE
Show "Unavailable" status for products with a future `Available On` date

### DIFF
--- a/admin/app/components/solidus_admin/products/show/component.html.erb
+++ b/admin/app/components/solidus_admin/products/show/component.html.erb
@@ -100,9 +100,20 @@
 
       <%= page_with_sidebar_aside do %>
         <%= render component('ui/panel').new(title: "Publishing") do %>
-          <%= render component("ui/forms/field").text_field(f, :available_on, hint: t(".available_on_html"), type: :date) %>
-          <%= render component("ui/forms/field").text_field(f, :discontinue_on, hint: t(".discontinue_on_html"), type: :date) %>
-
+          <%= render component("ui/forms/field").text_field(
+            f,
+            :available_on,
+            hint: t(".available_on_html"),
+            type: :date,
+            value: f.object.available_on&.to_date
+          ) %>
+          <%= render component("ui/forms/field").text_field(
+            f,
+            :discontinue_on,
+            hint: t(".discontinue_on_html"),
+            type: :date,
+            value: f.object.discontinue_on&.to_date
+          ) %>
           <label class="flex gap-2 items-center">
             <%= render component("ui/forms/checkbox").new(
               name: "#{f.object_name}[promotionable]",

--- a/admin/app/components/solidus_admin/products/status/component.rb
+++ b/admin/app/components/solidus_admin/products/status/component.rb
@@ -5,6 +5,7 @@ class SolidusAdmin::Products::Status::Component < SolidusAdmin::BaseComponent
     available: :green,
     discontinued: :yellow,
     deleted: :red,
+    unavailable: :yellow
   }.freeze
 
   def self.from_product(product)
@@ -13,8 +14,10 @@ class SolidusAdmin::Products::Status::Component < SolidusAdmin::BaseComponent
         :deleted
       elsif product.discontinued?
         :discontinued
-      else
+      elsif product.available?
         :available
+      else
+        :unavailable
       end
 
     new(status: status)

--- a/admin/app/components/solidus_admin/products/status/component.yml
+++ b/admin/app/components/solidus_admin/products/status/component.yml
@@ -2,3 +2,4 @@ en:
   available: 'Available'
   discontinued: 'Discontinued'
   deleted: 'Deleted'
+  unavailable: 'Unavailable'

--- a/admin/spec/components/solidus_admin/ui/forms/input/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/input/component_spec.rb
@@ -34,5 +34,11 @@ RSpec.describe SolidusAdmin::UI::Forms::Input::Component, type: :component do
 
       expect(page).to have_css("input[type='number'][name='name'][value='value']")
     end
+
+    it "renders a date input" do
+      render_inline(described_class.new(type: :date, name: "name", value: "2020-01-01"))
+
+      expect(page).to have_css("input[type='date'][name='name'][value='2020-01-01']")
+    end
   end
 end


### PR DESCRIPTION
## Summary

This change addresses two issues in the new Solidus admin
- Products that are not available shouldn't show `Available` status - this is resolved by adding a new status as `Unavailable`, but I am open to suggestions on this. The issue is that currently products with a future `Available On` date still show as `Available` which is misleading.
- Provide formatted date values to `Field` UI  component - This resolves an issue where the values passed to the `Field` component contained the full date and time, which is not valid given we're using an input of type `date`. This change ensures that the date is formatted correctly before being passed to the component.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.

| Issue | Before | After |
|--------|--------|--------|
| Available On / Discontinue On | <img width="1161" alt="Screenshot 2024-04-19 at 3 36 18 PM" src="https://github.com/solidusio/solidus/assets/3153035/deddb36f-f832-444b-a2c9-1a1d6b1ce385"> | <img width="1434" alt="Screenshot 2024-05-01 at 12 44 02 PM" src="https://github.com/solidusio/solidus/assets/3153035/7fb5645d-3899-4930-b152-676d59d3487d"> | 
| Product Status | <img width="940" alt="Screenshot 2024-05-01 at 12 46 51 PM" src="https://github.com/solidusio/solidus/assets/3153035/08362bc2-849f-4dc4-8c5f-d1da1fd7d909"> | <img width="947" alt="Screenshot 2024-05-01 at 12 45 25 PM" src="https://github.com/solidusio/solidus/assets/3153035/9b35c0bb-1fe1-491f-aaa2-95f987a98e70"> |