### PR TITLE
Docker development environment improvements

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUBY_VERSION
-FROM ruby:$RUBY_VERSION-slim-buster
+FROM ruby:$RUBY_VERSION-slim-bookworm
 
 ARG PG_VERSION
 ARG MYSQL_VERSION
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
     git \
     imagemagick \
     libvips \
+    libffi-dev \
     libmariadb-dev \
     sqlite3 \
     libsqlite3-dev \
@@ -22,10 +23,10 @@ RUN apt-get update -qq \
   && rm -rf /var/cache/apt/lists/*
 
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' $PG_VERSION > /etc/apt/sources.list.d/pgdg.list
+  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' $PG_VERSION > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467b942d3a79bd29 \
- && echo "deb http://repo.mysql.com/apt/debian/ buster mysql-"$MYSQL_VERSION > /etc/apt/sources.list.d/mysql.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C \
+ && echo "deb http://repo.mysql.com/apt/debian/ bookworm mysql-"$MYSQL_VERSION > /etc/apt/sources.list.d/mysql.list
 
 RUN curl -sSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :backend do
   gem 'capybara', '~> 3.13', require: false
   gem 'capybara-screenshot', '>= 1.0.18', require: false
   gem 'selenium-webdriver', require: false
-  gem 'webdrivers', require: false
 
   # JavaScript testing
   gem 'teaspoon', require: false

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -44,7 +44,6 @@ Rails.application.config.i18n.raise_on_missing_translations = true
 require "capybara/rspec"
 require 'capybara-screenshot/rspec'
 require "selenium/webdriver"
-require 'webdrivers'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 Capybara.disable_animation = true

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -52,7 +52,6 @@ Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 
 require "selenium/webdriver"
-require 'webdrivers'
 
 Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -13,7 +13,6 @@ end
 ENV['RAILS_ENV'] = 'test'
 
 require 'teaspoon/driver/selenium'
-require 'webdrivers'
 
 # Similar to setup described in
 # https://github.com/jejacks0n/teaspoon/wiki/Micro-Applications

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - postgres:/var/lib/postgresql/data:cached
 
   app:
+    shm_size: '256mb'
     build:
       context: .dockerdev
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

This is a collection of fixes and quality of life improvements related to running the specs in Docker (specifically on an ARM based Mac). This includes some fixes from @kennyadsl in #5523. Special thanks to @stewart and @forkata  for helping me work on this issue.

To test this PR, run these commands:
`docker-compose build --build-arg RUBY_VERSION=3.1 app`
`docker-compose up -d`
`docker-compose exec app env DB=postgres bin/rspec`

I would also like to draw some attention to the removal of the `webdrivers` gem here. I believe this is the right thing to do because the project is deprecated and we're on a version of selenium that supports managing it's own drivers with selenium-manager, but I do worry some developers could be unintentionally impacted here, so I'm curious what others think.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
