### PR TITLE
Fix case statement in database config template

### DIFF
--- a/core/lib/spree/testing_support/dummy_app/database.yml
+++ b/core/lib/spree/testing_support/dummy_app/database.yml
@@ -9,8 +9,8 @@
 
   db_host =
     case adapter
-    when 'mysql' then ENV['DB_MYSQL_HOST'] || ENV['DB_HOST']
-    when 'postgres' then ENV['DB_POSTGRES_HOST'] || ENV['DB_HOST']
+    when 'mysql2' then ENV['DB_MYSQL_HOST'] || ENV['DB_HOST']
+    when 'postgresql' then ENV['DB_POSTGRES_HOST'] || ENV['DB_HOST']
     else ENV['DB_HOST']
     end
 


### PR DESCRIPTION
## Summary

When trying to use the `DB_POSTGRES_HOST` environment variable in some unrelated work, we observed it wasn't changing anything. This fixes a case statement creating this issue.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
