### PR TITLE
Update to Node 20 in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       args:
         RUBY_VERSION: "3.1"
         PG_VERSION: 13
-        NODE_VERSION: 14
+        NODE_VERSION: 20
         MYSQL_VERSION: "8.0"
         BUNDLER_VERSION: 2
     image: solidus-4.4.0.dev


### PR DESCRIPTION
## Summary

Node version 14 is quite out of date, but most notably there is a 60 second penalty imposed by NodeSource as a way of warning users to upgrade.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
