### PR TITLE
Configure promotions via a configuration instance

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -422,12 +422,6 @@ module Spree
       )
     end
 
-    # Allow switching out the promotion configuration class
-    #
-    # @!attribute [rw] promotion_configuration_class
-    # @return [Class] a class instance that fulfils the interface of a promo configuration
-    class_name_attribute :promotion_configuration_class, default: 'Spree::Core::PromotionConfiguration'
-
     # Allows providing your own class for adding payment sources to a user's
     # "wallet" after an order moves to the complete state.
     #
@@ -594,8 +588,13 @@ module Spree
       @stock_configuration ||= Spree::Core::StockConfiguration.new
     end
 
+    # Allows providing your own promotion configuration instance
+    # @!attribute [rw] promotions
+    # @return [Spree::Core::PromotionConfiguration] an object that conforms to the API of
+    #   the standard promotion configuration class Spree::Core::PromotionConfiguration.
+    attr_writer :promotions
     def promotions
-      @promotion_configuration ||= promotion_configuration_class.new
+      @promotions ||= Spree::Core::PromotionConfiguration.new
     end
 
     class << self

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Spree::AppConfiguration do
   end
 
   it "uses core's promotion configuration class by default" do
-    expect(prefs.promotion_configuration_class).to eq Spree::Core::PromotionConfiguration
+    expect(prefs.promotions).to be_a Spree::Core::PromotionConfiguration
   end
 
   context "deprecated preferences" do


### PR DESCRIPTION


## Summary

Prior to this, we would only allow changing the configuration of the promotion system by switching the `promotions_configuration_class`. The `AppConfiguration` would then instantiate that class, and one would be able to do all the necessary customizations via the instance.

This allows customizing a promotion configuration and then setting it as the promotion configuration class. It's a lot easier to understand.

## Checklist

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
