### PR TITLE
Promotion advertiser

### DIFF
--- a/core/app/models/spree/null_promotion_advertiser.rb
+++ b/core/app/models/spree/null_promotion_advertiser.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree
+  class NullPromotionAdvertiser
+    def self.for_product(_product)
+      []
+    end
+  end
+end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -278,8 +278,7 @@ module Spree
 
     # @return [Array] all advertised and not-rejected promotions
     def possible_promotions
-      promotion_ids = promotion_rules.map(&:promotion_id).uniq
-      Spree::Promotion.advertised.where(id: promotion_ids).reject(&:inactive?)
+      Spree::Config.promotions.advertiser_class.for_product(self)
     end
 
     # The number of on-hand stock items; Infinity if any variant does not track

--- a/core/app/models/spree/promotion_advertiser.rb
+++ b/core/app/models/spree/promotion_advertiser.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Spree
+  class PromotionAdvertiser
+    def self.for_product(product)
+      promotion_ids = product.promotion_rules.map(&:promotion_id).uniq
+      Spree::Promotion.advertised.where(id: promotion_ids).reject(&:inactive?)
+    end
+  end
+end

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -30,6 +30,14 @@ module Spree
       #   Spree::NullPromotionHandler.
       class_name_attribute :shipping_promotion_handler_class, default: 'Spree::NullPromotionHandler'
 
+      # Allows providing a different promotion advertiser.
+      # @!attribute [rw] advertiser_class
+      # @see Spree::NullPromotionAdvertiser
+      # @return [Class] an object that conforms to the API of
+      #   the standard promotion advertiser class
+      #   Spree::NullPromotionAdvertiser.
+      class_name_attribute :advertiser_class, default: 'Spree::NullPromotionAdvertiser'
+
       # !@attribute [rw] promotion_api_attributes
       #   @return [Array<Symbol>] Attributes to be returned by the API for a promotion
       preference :promotion_api_attributes, :array, default: []

--- a/core/lib/spree/core/promotion_configuration.rb
+++ b/core/lib/spree/core/promotion_configuration.rb
@@ -57,6 +57,14 @@ module Spree
       #   Spree::PromotionHandler::Coupon.
       class_name_attribute :coupon_code_handler_class, default: 'Spree::PromotionHandler::Coupon'
 
+      # Allows providing a different promotion advertiser.
+      # @!attribute [rw] advertiser_class
+      # @see Spree::PromotionAdvertiser
+      # @return [Class] an object that conforms to the API of
+      #   the standard promotion advertiser class
+      #   Spree::PromotionAdvertiser.
+      class_name_attribute :advertiser_class, default: 'Spree::PromotionAdvertiser'
+
       add_class_set :rules, default: %w[
         Spree::Promotion::Rules::ItemTotal
         Spree::Promotion::Rules::Product

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
   it "uses the null promotion handler as the shipping promo handler" do
     expect(config.shipping_promotion_handler_class).to eq Spree::NullPromotionHandler
   end
+
+  it "uses the null promotion advertiser class by default" do
+    expect(config.advertiser_class).to eq Spree::NullPromotionAdvertiser
+  end
 end

--- a/core/spec/lib/spree/core/promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/promotion_configuration_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Spree::Core::PromotionConfiguration do
     expect(config.promotion_finder_class).to eq Spree::PromotionFinder
   end
 
+  it "uses promotion advertiser class by default" do
+    expect(config.advertiser_class).to eq Spree::PromotionAdvertiser
+  end
+
   describe "#calculators" do
     subject { config.calculators[promotion_action] }
 

--- a/core/spec/models/spree/null_promotion_advertiser_spec.rb
+++ b/core/spec/models/spree/null_promotion_advertiser_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::PromotionAdvertiser, type: :model do
+  describe ".for_product" do
+    subject { described_class.for_product(product) }
+    let(:product) { create(:product) }
+
+    it { is_expected.to eq([]) }
+  end
+end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -499,20 +499,16 @@ RSpec.describe Spree::Product, type: :model do
       expect(Spree::Property.where(name: 'foo').first.presentation).to eq("Foo's Presentation Name")
       expect(Spree::Property.where(name: 'bar').first.presentation).to eq("bar")
     end
+  end
 
-    # Regression test for https://github.com/spree/spree/issues/4416
-    context "#possible_promotions" do
-      let!(:promotion) { create(:promotion, :with_action, advertise: true, starts_at: 1.day.ago) }
-      let!(:rule) do
-        Spree::Promotion::Rules::Product.create(
-          promotion: promotion,
-          products: [product]
-        )
-      end
+  context "#possible_promotions" do
+    let(:product) { create(:product) }
 
-      it "lists the promotion as a possible promotion" do
-        expect(product.possible_promotions).to include(promotion)
-      end
+    subject { product.possible_promotions }
+
+    it "calls the configured promotion advertiser class" do
+      expect(Spree::Config.promotions.advertiser_class).to receive(:for_product).with(product)
+      subject
     end
   end
 

--- a/core/spec/models/spree/promotion_advertiser_spec.rb
+++ b/core/spec/models/spree/promotion_advertiser_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::PromotionAdvertiser, type: :model do
+  describe ".for_product" do
+    subject { described_class.for_product(product) }
+
+    let(:product) { create(:product) }
+    let!(:promotion) { create(:promotion, :with_action, advertise: true, starts_at: 1.day.ago) }
+    let!(:rule) do
+      Spree::Promotion::Rules::Product.create(
+        promotion: promotion,
+        products: [product]
+      )
+    end
+
+    it "lists the promotion as a possible promotion" do
+      expect(subject).to include(promotion)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This creates an extension point for advertising promotions, akin to `Spree::Product#possible_promotions` method. 

It implements both the current implementation and a Null advertiser, so that we can move the current implementation to `solidus_legacy_promotions`.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
