### PR TITLE
fix(StoreCredit): Add display_number method

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -40,6 +40,8 @@ class Spree::StoreCredit < Spree::PaymentSource
   extend Spree::DisplayMoney
   money_methods :amount, :amount_used, :amount_authorized
 
+  alias_method :display_number, :category_name
+
   # Sets this store credit's amount to a new value,
   # parsing it as a localized number if the new value is a string.
   #

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe Spree::StoreCredit do
     end
   end
 
+  describe "#display_number" do
+    it "returns the category name" do
+      expect(store_credit.display_number).to eq("Exchange")
+    end
+  end
+
   describe "#display_amount" do
     it "returns a Spree::Money instance" do
       expect(store_credit.display_amount).to be_instance_of(Spree::Money)


### PR DESCRIPTION
## Summary

`display_number` is used by many partials and templates displaying the payment source identifier to users
or admins.

`StoreCredit` was missing this method, leading to errors if a store credit is used as payment source. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
