### PR TITLE
Use Null Promotion Configuration in core

### DIFF
--- a/api/spec/lib/spree/api_configuration_spec.rb
+++ b/api/spec/lib/spree/api_configuration_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Spree::ApiConfiguration do
     end
 
     it "can delete attributes" do
+      config.promotion_attributes << :name # name is not included by default with the NullPromotionConfiguration
       expect(promotion_attributes).to include(:name)
       config.promotion_attributes.delete(:name)
       expect(promotion_attributes).not_to include(:name)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -592,11 +592,9 @@ module Spree
     # @!attribute [rw] promotions
     # @return [Spree::Core::NullPromotionConfiguration] an object that conforms to the API of
     #   the example promotion configuration class Spree::Core::NullPromotionConfiguration.
-    # Currently, this defaults to the legacy promotion configuration, until that system is fully extracted
-    # to the `solidus_legacy_promotions` gem.
     attr_writer :promotions
     def promotions
-      @promotions ||= SolidusLegacyPromotions::Configuration.new
+      @promotions ||= Spree::Core::NullPromotionConfiguration.new
     end
 
     class << self

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Spree::AppConfiguration do
   end
 
   it "uses core's promotion configuration class by default" do
-    expect(prefs.promotions).to be_a SolidusLegacyPromotions::Configuration
+    expect(prefs.promotions).to be_a Spree::Core::NullPromotionConfiguration
   end
 
   context "deprecated preferences" do
@@ -52,23 +52,23 @@ RSpec.describe Spree::AppConfiguration do
     end
 
     it "uses order adjustments recalculator class by default" do
-      expect(prefs.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
+      expect(prefs.promotion_adjuster_class).to eq Spree::NullPromotionAdjuster
     end
 
     it "uses promotion handler coupon class by default" do
-      expect(prefs.coupon_code_handler_class).to eq Spree::PromotionHandler::Coupon
+      expect(prefs.coupon_code_handler_class).to eq Spree::NullPromotionHandler
     end
 
     it "uses promotion handler shipping class by default" do
-      expect(prefs.shipping_promotion_handler_class).to eq Spree::PromotionHandler::Shipping
+      expect(prefs.shipping_promotion_handler_class).to eq Spree::NullPromotionHandler
     end
 
     it "uses promotion code batch mailer class by default" do
-      expect(prefs.promotion_code_batch_mailer_class).to eq Spree::PromotionCodeBatchMailer
+      expect(prefs.promotion_code_batch_mailer_class).to eq Spree::DeprecatedConfigurableClass
     end
 
     it "uses promotion chooser class by default" do
-      expect(prefs.promotion_chooser_class).to eq Spree::PromotionChooser
+      expect(prefs.promotion_chooser_class).to eq Spree::DeprecatedConfigurableClass
     end
   end
 
@@ -113,7 +113,7 @@ RSpec.describe Spree::AppConfiguration do
 
   describe '#promotions' do
     subject { prefs.promotions }
-    it { is_expected.to be_a SolidusLegacyPromotions::Configuration }
+    it { is_expected.to be_a Spree::Core::NullPromotionConfiguration }
   end
 
   describe '@default_country_iso_code' do

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -54,6 +54,7 @@ module SolidusLegacyPromotions
 
     initializer "solidus_legacy_promotions", after: "spree.load_config_initializers" do
       Spree::Config.order_contents_class = "Spree::OrderContents"
+      Spree::Config.promotions = SolidusLegacyPromotions::Configuration.new
     end
   end
 end


### PR DESCRIPTION
## Summary

We want to use the legacy `Spree::LegacyPromotions::Configuration` only in the solidus_legacy_promotions test suite. In the core test suite, we use the `Spree::Core::NullPromotionConfiguration`. This will finally allow us to move all the classes and specs to the `solidus_legacy_promotions` gem in a future PR.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

