### PR TITLE
Rename Spree::Config.promotions.promotion_adjuster_class

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -799,7 +799,7 @@ module Spree
     end
 
     def ensure_promotions_eligible
-      Spree::Config.promotions.promotion_adjuster_class.new(self).call
+      Spree::Config.promotions.order_adjuster_class.new(self).call
 
       if promo_total_changed?
         restart_checkout_flow

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -195,7 +195,7 @@ module Spree
     end
 
     def update_promotions
-      Spree::Config.promotions.promotion_adjuster_class.new(order).call
+      Spree::Config.promotions.order_adjuster_class.new(order).call
     end
 
     def update_taxes

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -600,15 +600,21 @@ module Spree
     class << self
       private
 
-      def promotions_deprecation_message(method)
+      def promotions_deprecation_message(method, new_method_name = nil)
         "The `Spree::Config.#{method}` preference is deprecated and will be removed in Solidus 5.0. " \
-        "Use `Spree::Config.promotions.#{method}` instead"
+        "Use `Spree::Config.promotions.#{new_method_name || method}` instead"
       end
     end
 
-    delegate :promotion_adjuster_class, :promotion_adjuster_class=, to: :promotions
-    deprecate promotion_adjuster_class: promotions_deprecation_message("promotion_adjuster_class"), deprecator: Spree.deprecator
-    deprecate "promotion_adjuster_class=": promotions_deprecation_message("promotion_adjuster_class="), deprecator: Spree.deprecator
+    def promotion_adjuster_class
+      promotions.order_adjuster_class
+    end
+
+    def promotion_adjuster_class=(klass)
+      promotions.order_adjuster_class = klass
+    end
+    deprecate promotion_adjuster_class: promotions_deprecation_message("promotion_adjuster_class", "order_adjuster_class"), deprecator: Spree.deprecator
+    deprecate "promotion_adjuster_class=": promotions_deprecation_message("promotion_adjuster_class=", "order_adjuster_class="), deprecator: Spree.deprecator
 
     delegate :promotion_chooser_class, :promotion_chooser_class=, to: :promotions
     deprecate promotion_chooser_class: promotions_deprecation_message("promotion_chooser_class"), deprecator: Spree.deprecator

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -3,8 +3,8 @@
 module Spree
   module Core
     class NullPromotionConfiguration < Spree::Preferences::Configuration
-      # promotion_adjuster_class allows extensions to provide their own Promotion Adjuster
-      class_name_attribute :promotion_adjuster_class, default: 'Spree::NullPromotionAdjuster'
+      # order_adjuster_class allows extensions to provide their own Order Adjuster
+      class_name_attribute :order_adjuster_class, default: 'Spree::NullPromotionAdjuster'
 
       # Allows providing a different coupon code handler.
       # @!attribute [rw] coupon_code_handler_class

--- a/core/lib/spree/core/promotion_configuration.rb
+++ b/core/lib/spree/core/promotion_configuration.rb
@@ -26,8 +26,8 @@ module Spree
       # promotion_chooser_class allows extensions to provide their own PromotionChooser
       class_name_attribute :promotion_chooser_class, default: 'Spree::PromotionChooser'
 
-      # promotion_adjuster_class allows extensions to provide their own Promotion Adjuster
-      class_name_attribute :promotion_adjuster_class, default: 'Spree::Promotion::OrderAdjustmentsRecalculator'
+      # order_adjuster_class allows extensions to provide their own Order Adjuster
+      class_name_attribute :order_adjuster_class, default: 'Spree::Promotion::OrderAdjustmentsRecalculator'
 
       # promotion_finder_class allows extensions to provide their own Promotion Finder
       class_name_attribute :promotion_finder_class, default: 'Spree::PromotionFinder'

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
   subject(:config) { described_class.new }
 
   it "uses the null promotion adjuster class by default" do
-    expect(config.promotion_adjuster_class).to eq Spree::NullPromotionAdjuster
+    expect(config.order_adjuster_class).to eq Spree::NullPromotionAdjuster
   end
 
   it "uses the null coupon code handler class by default" do

--- a/core/spec/lib/spree/core/promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/promotion_configuration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Spree::Core::PromotionConfiguration do
   end
 
   it "uses order adjustments recalculator class by default" do
-    expect(config.promotion_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
+    expect(config.order_adjuster_class).to eq Spree::Promotion::OrderAdjustmentsRecalculator
   end
 
   it "uses promotion handler coupon class by default" do


### PR DESCRIPTION

## Summary

This extension point has duplication when used, so we're renaming it to `Spree::Config.promotions.order_adjuster_class`. This describes better what it does.

The new promotions configuration class has not been released, so we don't need a deprecation cycle for this change.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
