### PR TITLE
Move shipping promotion handling to legacy promotions

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -508,11 +508,6 @@ module Spree
       end
     end
 
-    def apply_shipping_promotions
-      Spree::Config.promotions.shipping_promotion_handler_class.new(self).activate
-      recalculate
-    end
-
     # Clean shipments and make order back to address state (or to whatever state
     # is set by restart_checkout_flow in case of state machine modifications)
     def check_shipments_and_restart_checkout

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -29,6 +29,8 @@ module Spree
       #   the standard promotion finder class
       #   Spree::NullPromotionHandler.
       class_name_attribute :shipping_promotion_handler_class, default: 'Spree::NullPromotionHandler'
+      deprecate :shipping_promotion_handler_class, deprecator: Spree.deprecator
+      deprecate :shipping_promotion_handler_class=, deprecator: Spree.deprecator
 
       # Allows providing a different promotion advertiser.
       # @!attribute [rw] advertiser_class

--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -106,7 +106,6 @@ module Spree
                 before_transition to: :delivery, do: :ensure_shipping_address
                 before_transition to: :delivery, do: :create_proposed_shipments
                 before_transition to: :delivery, do: :ensure_available_shipping_rates
-                before_transition from: :delivery, do: :apply_shipping_promotions
               end
 
               before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
   end
 
   it "uses the null promotion handler as the shipping promo handler" do
-    expect(config.shipping_promotion_handler_class).to eq Spree::NullPromotionHandler
+    Spree.deprecator.silence do
+      expect(config.shipping_promotion_handler_class).to eq Spree::NullPromotionHandler
+    end
   end
 
   it "uses the null promotion advertiser class by default" do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -284,13 +284,7 @@ RSpec.describe Spree::Order, type: :model do
 
       before do
         order.state = 'delivery'
-        allow(order).to receive(:apply_shipping_promotions)
         allow(order).to receive(:ensure_available_shipping_rates) { true }
-      end
-
-      it "attempts to apply free shipping promotions" do
-        expect(order).to receive(:apply_shipping_promotions)
-        order.next!
       end
 
       context "with payment required" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -719,18 +719,6 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
-  context "#apply_shipping_promotions" do
-    it "calls out to the Shipping promotion handler" do
-      expect_any_instance_of(Spree::PromotionHandler::Shipping).to(
-        receive(:activate)
-      ).and_call_original
-
-      expect(order.recalculator).to receive(:recalculate).and_call_original
-
-      order.apply_shipping_promotions
-    end
-  end
-
   context "#products" do
     before :each do
       @variant1 = mock_model(Spree::Variant, product: "product1")

--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree/order_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree/order_decorator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidusLegacyPromotions
+  module OrderDecorator
+    def self.prepended(base)
+      base.state_machine do
+        if states[:delivery]
+          before_transition from: :delivery, do: :apply_shipping_promotions
+        end
+      end
+    end
+
+    def apply_shipping_promotions
+      ::Spree::Config.promotions.shipping_promotion_handler_class.new(self).activate
+      recalculate
+    end
+
+    ::Spree::Order.prepend(self)
+  end
+end

--- a/legacy_promotions/spec/models/spree/order/checkout_spec.rb
+++ b/legacy_promotions/spec/models/spree/order/checkout_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Order, type: :model do
+  let!(:store) { create(:store) }
+  let(:order) { create(:order, store: store) }
+
+  context "from delivery", partial_double_verification: false do
+    before do
+      order.state = 'delivery'
+      allow(order).to receive(:apply_shipping_promotions)
+      allow(order).to receive(:ensure_available_shipping_rates) { true }
+    end
+
+    it "attempts to apply free shipping promotions" do
+      expect(order).to receive(:apply_shipping_promotions)
+      order.next!
+    end
+  end
+end

--- a/legacy_promotions/spec/models/spree/order_spec.rb
+++ b/legacy_promotions/spec/models/spree/order_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::Order do
+  let(:order) { create(:order) }
+
+  context "#apply_shipping_promotions" do
+    it "calls out to the Shipping promotion handler" do
+      expect_any_instance_of(Spree::PromotionHandler::Shipping).to(
+        receive(:activate)
+      ).and_call_original
+
+      expect(order.recalculator).to receive(:recalculate).and_call_original
+
+      order.apply_shipping_promotions
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We should only provide configuration points that are actually necessary for a promotion system. The shipping promotion handler is not necessary for a promotion system that works, thus we can move this stuff to the `legacy_promotions` extension.

Extracted from #5634 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
