### PR TITLE
Add missing methods to null promotion configuration

### DIFF
--- a/core/app/models/spree/deprecated_configurable_class.rb
+++ b/core/app/models/spree/deprecated_configurable_class.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Spree
+  class DeprecatedConfigurableClass
+    def initialize(*_args, &_block)
+      issue_deprecation_warning
+    end
+
+    def method_missing(_method_name, *_args, &_block)
+      issue_deprecation_warning
+      self
+    end
+
+    def respond_to_missing?(_method_name, _include_private = false)
+      true
+    end
+
+    private
+
+    def issue_deprecation_warning
+      Spree.deprecator.warn(
+        <<-WARNING
+          It appears you are using Solidus' Legacy promotion system. This system has been extracted into the
+          `solidus_legacy_promotions` gem. Please add the gem to your Gemfile and follow in the instructions in the README.
+        WARNING
+      )
+    end
+  end
+end

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -22,6 +22,11 @@ module Spree
       #   Spree::NullPromotionFinder.
       class_name_attribute :promotion_finder_class, default: 'Spree::NullPromotionFinder'
 
+      # Allows getting and setting `Spree::Config.promotion_code_batch_mailer_class`.
+      # Both will issue a deprecation warning.
+      class_name_attribute :promotion_code_batch_mailer_class, default: 'Spree::DeprecatedConfigurableClass'
+      deprecate :promotion_code_batch_mailer_class, :promotion_code_batch_mailer_class=, deprecator: Spree.deprecator
+
       # Allows providing a different promotion shipping promotion handler.
       # @!attribute [rw] shipping_promotion_handler_class
       # @see Spree::NullPromotionHandler

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -40,6 +40,12 @@ module Spree
       add_class_set :rules
       deprecate :rules, :rules=, deprecator: Spree.deprecator
 
+      # Allows getting and setting actions. Deprecated.
+      # @!attribute [rw] actions
+      # @return [Array] a set of actions
+      add_class_set :actions
+      deprecate :actions, :actions=, deprecator: Spree.deprecator
+
       # Allows providing a different promotion shipping promotion handler.
       # @!attribute [rw] shipping_promotion_handler_class
       # @see Spree::NullPromotionHandler

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -27,6 +27,11 @@ module Spree
       class_name_attribute :promotion_code_batch_mailer_class, default: 'Spree::DeprecatedConfigurableClass'
       deprecate :promotion_code_batch_mailer_class, :promotion_code_batch_mailer_class=, deprecator: Spree.deprecator
 
+      # Allows getting and setting `Spree::Config.promotion_chooser_class`.
+      # Both will issue a deprecation warning.
+      class_name_attribute :promotion_chooser_class, default: 'Spree::DeprecatedConfigurableClass'
+      deprecate :promotion_chooser_class, :promotion_chooser_class=, deprecator: Spree.deprecator
+
       # Allows providing a different promotion shipping promotion handler.
       # @!attribute [rw] shipping_promotion_handler_class
       # @see Spree::NullPromotionHandler

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -46,6 +46,12 @@ module Spree
       add_class_set :actions
       deprecate :actions, :actions=, deprecator: Spree.deprecator
 
+      # Allows getting and setting shipping actions. Deprecated.
+      # @!attribute [rw] shipping_actions
+      # @return [Array] a set of shipping_actions
+      add_class_set :shipping_actions
+      deprecate :shipping_actions, :shipping_actions=, deprecator: Spree.deprecator
+
       # Allows getting an setting calculators for actions. Deprecated.
       # @!attribute [rw] calculators
       # @return [Spree::Core::NestedClassSet] a set of calculators

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -46,6 +46,12 @@ module Spree
       add_class_set :actions
       deprecate :actions, :actions=, deprecator: Spree.deprecator
 
+      # Allows getting an setting calculators for actions. Deprecated.
+      # @!attribute [rw] calculators
+      # @return [Spree::Core::NestedClassSet] a set of calculators
+      add_nested_class_set :calculators
+      deprecate :calculators, :calculators=, deprecator: Spree.deprecator
+
       # Allows providing a different promotion shipping promotion handler.
       # @!attribute [rw] shipping_promotion_handler_class
       # @see Spree::NullPromotionHandler

--- a/core/lib/spree/core/null_promotion_configuration.rb
+++ b/core/lib/spree/core/null_promotion_configuration.rb
@@ -3,6 +3,8 @@
 module Spree
   module Core
     class NullPromotionConfiguration < Spree::Preferences::Configuration
+      include Spree::Core::EnvironmentExtension
+
       # order_adjuster_class allows extensions to provide their own Order Adjuster
       class_name_attribute :order_adjuster_class, default: 'Spree::NullPromotionAdjuster'
 
@@ -31,6 +33,12 @@ module Spree
       # Both will issue a deprecation warning.
       class_name_attribute :promotion_chooser_class, default: 'Spree::DeprecatedConfigurableClass'
       deprecate :promotion_chooser_class, :promotion_chooser_class=, deprecator: Spree.deprecator
+
+      # Allows getting and setting rules. Deprecated.
+      # @!attribute [rw] rules
+      # @return [Array] a set of rules
+      add_class_set :rules
+      deprecate :rules, :rules=, deprecator: Spree.deprecator
 
       # Allows providing a different promotion shipping promotion handler.
       # @!attribute [rw] shipping_promotion_handler_class

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -62,4 +62,11 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
       expect(config.actions).to be_empty
     end
   end
+
+  it "has deprecated nested class set for calculcators" do
+    Spree.deprecator.silence do
+      expect { config.calculators["Spree::PromotionAction"] = ["Spree::Calculator"] }.not_to raise_error
+      expect { config.calculators["Spree::PromotionAction"] }.not_to raise_error
+    end
+  end
 end

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
     end
   end
 
+  it "has a setter for a set of shipping actions" do
+    Spree.deprecator.silence do
+      expect { config.shipping_actions = ["Spree::PromotionAction"] }.not_to raise_error
+    end
+  end
+
   it "has a getter for a set of actions" do
     Spree.deprecator.silence do
       expect(config.actions).to be_empty

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -50,4 +50,16 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
       expect(config.rules).to be_empty
     end
   end
+
+  it "has a setter for a set of actions" do
+    Spree.deprecator.silence do
+      expect { config.actions = ["Spree::PromotionAction"] }.not_to raise_error
+    end
+  end
+
+  it "has a getter for a set of actions" do
+    Spree.deprecator.silence do
+      expect(config.actions).to be_empty
+    end
+  end
 end

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
       expect(config.promotion_code_batch_mailer_class).to eq Spree::DeprecatedConfigurableClass
     end
   end
+
+  it "uses the deprecated configurable class for promotion chooser" do
+    Spree.deprecator.silence do
+      expect(config.promotion_chooser_class).to eq Spree::DeprecatedConfigurableClass
+    end
+  end
 end

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -38,4 +38,16 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
       expect(config.promotion_chooser_class).to eq Spree::DeprecatedConfigurableClass
     end
   end
+
+  it "has a setter for a set of rules" do
+    Spree.deprecator.silence do
+      expect { config.rules = ["Spree::PromotionRule"] }.not_to raise_error
+    end
+  end
+
+  it "has a getter for a set of rules" do
+    Spree.deprecator.silence do
+      expect(config.rules).to be_empty
+    end
+  end
 end

--- a/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
+++ b/core/spec/lib/spree/core/null_promotion_configuration_spec.rb
@@ -26,4 +26,10 @@ RSpec.describe Spree::Core::NullPromotionConfiguration do
   it "uses the null promotion advertiser class by default" do
     expect(config.advertiser_class).to eq Spree::NullPromotionAdvertiser
   end
+
+  it "uses the deprecated configurable class for promotion code batch mailer" do
+    Spree.deprecator.silence do
+      expect(config.promotion_code_batch_mailer_class).to eq Spree::DeprecatedConfigurableClass
+    end
+  end
 end

--- a/core/spec/models/spree/deprecated_configurable_class_spec.rb
+++ b/core/spec/models/spree/deprecated_configurable_class_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::DeprecatedConfigurableClass do
+  let(:deprecator) { Spree.deprecator }
+
+  before do
+    allow(deprecator).to receive(:warn)
+  end
+
+  it "warns when a method is called" do
+    described_class.new.some_method
+
+    expect(deprecator).to have_received(:warn).with(/It appears you are using Solidus' Legacy promotion system/).at_least(:once)
+  end
+
+  it "can be instantiated with any arguments" do
+    described_class.new(:foo, :bar).some_method
+
+    expect(deprecator).to have_received(:warn).with(/It appears you are using Solidus' Legacy promotion system/).at_least(:once)
+  end
+
+  it "can take method chains" do
+    described_class.new.foo.bar.baz
+
+    expect(deprecator).to have_received(:warn).with(/It appears you are using Solidus' Legacy promotion system/).at_least(:once)
+  end
+end

--- a/core/spec/models/spree/deprecated_configurable_class_spec.rb
+++ b/core/spec/models/spree/deprecated_configurable_class_spec.rb
@@ -26,4 +26,8 @@ RSpec.describe Spree::DeprecatedConfigurableClass do
 
     expect(deprecator).to have_received(:warn).with(/It appears you are using Solidus' Legacy promotion system/).at_least(:once)
   end
+
+  it "responds to anything" do
+    expect(described_class.new).to respond_to(:anything)
+  end
 end


### PR DESCRIPTION
## Summary

We've delegated a lot of configuration accessors from `Spree::Config.instance` to `Spree::Config.promotions`. When we switch the default configuration to be the `Spree::Core::NullPromotionConfiguration` (which does nothing), we need to have those setters in place, and we need them to issue deprecation warnings. This adds a configurable class that does nothing but issue many deprecation warnings, and adds the needed methods to `Spree::Core::NullPromotionConfiguration`. 

For future readers: All of these deprecation warning will go away by using a non-stubbed promotion system, either the one in `solidus_legacy_promotions` or the one in the upcoming  `solidus_promotions`.  

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
