### PR TITLE
Fix flaky admin customer return spec

### DIFF
--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -62,7 +62,7 @@ describe 'Customer returns', type: :feature do
         within('[data-hook="rejected_return_items"] tbody tr:nth-child(1)') { click_button('Receive') }
         expect_order_state_label_to_eq('Complete')
 
-        within('[data-hook="rejected_return_items"] tbody tr:nth-child(2)') { click_button('Receive') }
+        within('[data-hook="rejected_return_items"] tbody') { click_button('Receive') }
         expect_order_state_label_to_eq('Returned')
       end
     end


### PR DESCRIPTION


## Summary

This spec tests behavior from the backend gem, and it relies on the ordering of return items to be consistent. However, it appears to not be consistent, so sometimes this spec fails, because the receivable return item is in line 1 of the table, not in line 2.

I expect the new admin to get this functionality at some point in time, so I'm not bothering with fixing the order of return items, just making sure that the remaining item is received.

See https://output.circle-artifacts.com/output/job/886635ab-de5f-4926-8d31-b3a11e631479/artifacts/0/test-artifacts/screenshot_2024-05-17-13-05-16.279.html for an HTML screenshot of the failing spec.
