### PR TITLE
CI: Bump GH Actions versions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,7 +18,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v9.3.0
+        uses: sqren/backport-github-action@v9.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-

--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -12,7 +12,7 @@ jobs:
   ensure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check for the presence of a changelog label"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/prepare_post_release.yml
+++ b/.github/workflows/prepare_post_release.yml
@@ -21,7 +21,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'release:generate')
       )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -15,7 +15,7 @@ jobs:
       BUNDLE_ONLY: "release"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/.github/workflows/triage_for_changelog.yml
+++ b/.github/workflows/triage_for_changelog.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -21,7 +21,7 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'changelog:skip')
       )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"


### PR DESCRIPTION
## Summary

GitHub deprecated actions not using Node 20.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
