### PR TITLE
Deprecated Configurable Class: Allow class methods

### DIFF
--- a/core/app/models/spree/deprecated_configurable_class.rb
+++ b/core/app/models/spree/deprecated_configurable_class.rb
@@ -2,28 +2,39 @@
 
 module Spree
   class DeprecatedConfigurableClass
-    def initialize(*_args, &_block)
-      issue_deprecation_warning
+    def self.new(*_args, &_block)
+      @deprecation_proxy ||= DeprecationProxy.new
     end
 
-    def method_missing(_method_name, *_args, &_block)
-      issue_deprecation_warning
-      self
+    def self.method_missing(method_name, *args, &block)
+      @deprecation_proxy ||= DeprecationProxy.new
+      @deprecation_proxy.send(method_name, args, block)
     end
 
-    def respond_to_missing?(_method_name, _include_private = false)
+    def self.respond_to_missing?(_method_name, _include_private = false)
       true
     end
 
-    private
+    class DeprecationProxy
+      def method_missing(_method_name, *_args, &_block)
+        issue_deprecation_warning
+        self
+      end
 
-    def issue_deprecation_warning
-      Spree.deprecator.warn(
-        <<-WARNING
-          It appears you are using Solidus' Legacy promotion system. This system has been extracted into the
-          `solidus_legacy_promotions` gem. Please add the gem to your Gemfile and follow in the instructions in the README.
-        WARNING
-      )
+      def respond_to_missing?(_method_name, _include_private = false)
+        true
+      end
+
+      private
+
+      def issue_deprecation_warning
+        Spree.deprecator.warn(
+          <<-WARNING
+            It appears you are using Solidus' Legacy promotion system. This system has been extracted into the
+            `solidus_legacy_promotions` gem. Please add the gem to your Gemfile and follow in the instructions in the README.
+          WARNING
+        )
+      end
     end
   end
 end

--- a/core/spec/models/spree/deprecated_configurable_class_spec.rb
+++ b/core/spec/models/spree/deprecated_configurable_class_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe Spree::DeprecatedConfigurableClass do
   it "responds to anything" do
     expect(described_class.new).to respond_to(:anything)
   end
+
+  context "when calling a class method" do
+    it "warns when a method is called" do
+      described_class.some_method
+
+      expect(deprecator).to have_received(:warn).with(/It appears you are using Solidus' Legacy promotion system/).at_least(:once)
+    end
+
+    it "can take method chains" do
+      described_class.foo.bar.baz
+
+      expect(deprecator).to have_received(:warn).with(/It appears you are using Solidus' Legacy promotion system/).at_least(:once)
+    end
+  end
 end


### PR DESCRIPTION

## Summary

The previous implementation of `Spree::DeprecatedConfigurableClass` could deal with instance methods, but not with class methods. This creates a thing that issues deprecation warnings on instance methods and class methods.

