### PR TITLE
Fix flaky legacy promotion codes controller spec

### DIFF
--- a/legacy_promotions/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
+++ b/legacy_promotions/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Spree::Admin::PromotionCodesController do
     get :index, params: { promotion_id: promotion.id, format: 'csv' }
     expect(response).to be_successful
     parsed = CSV.parse(response.body, headers: true)
-    expect(parsed.entries.map(&:to_h)).to eq([{ "Code" => code1.value }, { "Code" => code2.value }, { "Code" => code3.value }])
+    expect(parsed.entries.map(&:to_h)).to contain_exactly({ "Code" => code1.value }, { "Code" => code2.value }, { "Code" => code3.value })
   end
 
   it "can create a new code" do


### PR DESCRIPTION


## Summary

This spec wants to test that all promotion codes are in the CSV, but it prescribes order, which is not guaranteed.
See https://app.circleci.com/pipelines/github/solidusio/solidus/6328/workflows/68b0cb09-70e4-41ae-91ad-2f5ee53b7d1b/jobs/58362 for a test run where this failed.

