### PR TITLE
Fix deprecation warning from Ransack

### DIFF
--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -71,8 +71,8 @@
       <tr data-hook="admin_products_index_headers">
         <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
         <th></th>
-        <th><%= sort_link @search,:name, Spree::Product.human_attribute_name(:name), { default_order: "desc" }, {title: 'admin_products_listing_name_title'} %></th>
-        <th class="align-right"><%= sort_link @search,:master_default_price_amount, Spree::Product.human_attribute_name(:price), {}, {title: 'admin_products_listing_price_title'} %></th>
+        <th><%= sort_link @search,:name, Spree::Product.human_attribute_name(:name), { default_order: "desc", title: 'admin_products_listing_name_title'} %></th>
+        <th class="align-right"><%= sort_link @search,:master_default_price_amount, Spree::Product.human_attribute_name(:price), {title: 'admin_products_listing_price_title'} %></th>
         <th data-hook="admin_products_index_header_actions" class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -69,7 +69,7 @@
   </colgroup>
   <thead>
     <tr data-hook="admin_users_index_headers">
-      <th><%= sort_link @search, :email, Spree.user_class.human_attribute_name(:email), {}, {title: 'users_email_title'} %></th>
+      <th><%= sort_link @search, :email, Spree.user_class.human_attribute_name(:email), {title: 'users_email_title'} %></th>
       <th><%= Spree.user_class.human_attribute_name(:spree_roles) %></th>
       <th class="align-center"><%= t('spree.num_orders') %></th>
       <th class="align-center"><%= Spree.user_class.human_attribute_name(:lifetime_value) %></th>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -25,13 +25,13 @@
       </colgroup>
 
       <thead>
-        <th><%= sort_link @search, :completed_at, Spree::Order.human_attribute_name(:completed_at), {}, {title: 'orders_completed_at_title'} %></th>
+        <th><%= sort_link @search, :completed_at, Spree::Order.human_attribute_name(:completed_at), {title: 'orders_completed_at_title'} %></th>
         <th colspan=2><%= Spree::LineItem.human_attribute_name(:description) %></th>
         <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
         <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
         <th><%= Spree::Order.human_attribute_name(:total) %></th>
-        <th><%= sort_link @search, :state, Spree::Order.human_attribute_name(:state), {}, {title: 'orders_state_title'} %></th>
-        <th><%= sort_link @search, :number, t('spree.admin.user.order_num'), {}, {title: 'orders_number_title'} %></th>
+        <th><%= sort_link @search, :state, Spree::Order.human_attribute_name(:state), {title: 'orders_state_title'} %></th>
+        <th><%= sort_link @search, :number, t('spree.admin.user.order_num'), {title: 'orders_number_title'} %></th>
       </thead>
 
       <tbody>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -22,14 +22,14 @@
       </colgroup>
       <thead>
         <tr data-hook="admin_orders_index_headers">
-          <th><%= sort_link @search, :completed_at,   Spree::Order.human_attribute_name(:completed_at), {}, {title: 'orders_completed_at_title'} %></th>
-          <th><%= sort_link @search, :number,         Spree::Order.human_attribute_name(:number), {}, {title: 'orders_number_title'} %></th>
+          <th><%= sort_link @search, :completed_at,   Spree::Order.human_attribute_name(:completed_at), {title: 'orders_completed_at_title'} %></th>
+          <th><%= sort_link @search, :number,         Spree::Order.human_attribute_name(:number), {title: 'orders_number_title'} %></th>
           <th><%= sort_link @search, :state %></th>
           <th><%= sort_link @search, :payment_state %></th>
           <% if Spree::Order.checkout_step_names.include?(:delivery) %>
             <th><%= sort_link @search, :shipment_state %></th>
           <% end %>
-          <th><%= sort_link @search, :total,          Spree::Order.human_attribute_name(:total), {}, {title: 'orders_total_title'} %></th>
+          <th><%= sort_link @search, :total,          Spree::Order.human_attribute_name(:total), {title: 'orders_total_title'} %></th>
         </tr>
       </thead>
       <tbody>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -23,7 +23,7 @@
       <tr data-hook="zones_header">
         <th><%= sort_link @search,:name, Spree::Zone.human_attribute_name(:name), title: 'zones_order_by_name_title' %></th>
         <th>
-          <%= sort_link @search,:description, Spree::Zone.human_attribute_name(:description), {}, {title: 'zones_order_by_description_title'} %>
+          <%= sort_link @search,:description, Spree::Zone.human_attribute_name(:description), {title: 'zones_order_by_description_title'} %>
         </th>
         <th class="actions"></th>
       </tr>


### PR DESCRIPTION
## Summary

The `sort_link` helper only takes a single options hash since Ransack 3.0: 

https://github.com/activerecord-hackery/ransack/pull/1289

We depend on Ransack `~> 4.0`.
