### PR TITLE
Re-add translation for `match_choices`

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1734,6 +1734,9 @@ en:
     master_price: Master Price
     master_sku: Master SKU
     master_variant: Master Variant
+    match_choices:
+      all: All
+      none: None
     max_items: Max Items
     member_since: Member Since
     memo: Memo


### PR DESCRIPTION

## Summary

When moving the legacy promotion system translations, I also moved the translation for `spree.match_choices`. These are also used on the backend products edit page, and need to stay in core.
