### PR TITLE
Fix labeler configuration file for labeler@v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,46 @@
 "changelog:solidus_core":
-  - "core/**/*"
+- any:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "core/**/*"
 "changelog:solidus_backend":
-  - "backend/**/*"
+- any:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "backend/**/*"
 "changelog:solidus_api":
-  - "api/**/*"
+- any:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "api/**/*"
 "changelog:solidus_admin":
-  - "admin/**/*"
+- any:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "admin/**/*"
 "changelog:solidus_sample":
-  - "sample/**/*"
+- any:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "sample/**/*"
 "changelog:solidus":
-  - "lib/**/*"
-  - "README.md"
-  - "solidus.gemspec"
+- any:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "lib/**/*"
+      - "README.md"
+      - "solidus.gemspec"
 "changelog:repository":
-  - any:
-    - "**/*"
-    - "!core/**/*"
-    - "!backend/**/*"
-    - "!api/**/*"
-    - "!admin/**/*"
-    - "!sample/**/*"
-    - "!lib/**/*"
-    - "!README.md"
-    - "!solidus.gemspec"
+- all:
+  - changed_files:
+    - any-glob-to-any-file:
+      - "**/*"
+    - all-globs-to-all-files:
+      - "!core/**/*"
+      - "!backend/**/*"
+      - "!api/**/*"
+      - "!admin/**/*"
+      - "!sample/**/*"
+      - "!lib/**/*"
+      - "!README.md"
+      - "!solidus.gemspec"

--- a/.github/workflows/triage_for_changelog.yml
+++ b/.github/workflows/triage_for_changelog.yml
@@ -1,6 +1,6 @@
 name: "Triage for Changelog"
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   triage:


### PR DESCRIPTION


## Summary

The Github action "labeler" changed the format of the `labeler.yml` configuration file with labeler v5. I've used the format from the `Basic Examples` section, and hope this does what it did previously.

See https://github.com/actions/labeler/blob/v5/README.md
