### PR TITLE
Revert "Temporarily use labeler configuration from PR, not from PR ta…

### DIFF
--- a/.github/workflows/triage_for_changelog.yml
+++ b/.github/workflows/triage_for_changelog.yml
@@ -1,6 +1,6 @@
 name: "Triage for Changelog"
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
…rget"

This reverts commit 3149c0a8492174ccc28771efcc4ff1fc77097e58.

## Summary

In order to be able to test the new labeler configuration, I put a temporary commit in their so the label gets the configuration from the pull request rather than from the PR target. Maybe reverting that commit finally fixes the labeling situation.