### PR TITLE
Disallow sprockets-rails 3.5.0

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
   s.add_dependency 'psych', ['>= 4.0.1', '< 5.0']
   s.add_dependency 'ransack', '~> 4.0'
-  s.add_dependency 'sprockets-rails'
+  s.add_dependency 'sprockets-rails', '!= 3.5.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
   s.add_dependency 'omnes', '~> 0.2.2'
 


### PR DESCRIPTION

## Summary

sprockets-rails 3.5.0 breaks our test suite.

See https://github.com/rails/sprockets-rails/issues/524 and https://github.com/rails/sprockets-rails/pull/525

