### PR TITLE
Create custom orders index component for solidus_legacy_promotions

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -77,14 +77,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
             option
           ]
         end
-      },
-      {
-        label: t('.filters.promotions'),
-        combinator: 'or',
-        attribute: "promotions_id",
-        predicate: "in",
-        options: Spree::Promotion.all.pluck(:name, :id),
-      },
+      }
     ]
   end
 

--- a/legacy_promotions/lib/components/admin/solidus_legacy_promotions/orders/index/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_legacy_promotions/orders/index/component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SolidusLegacyPromotions::Orders::Index::Component < SolidusAdmin::Orders::Index::Component
+  def filters
+    super + [
+      {
+        label: t('.filters.promotions'),
+        combinator: 'or',
+        attribute: "promotions_id",
+        predicate: "in",
+        options: Spree::Promotion.all.pluck(:name, :id),
+      }
+    ]
+  end
+end

--- a/legacy_promotions/lib/components/admin/solidus_legacy_promotions/orders/index/component.yml
+++ b/legacy_promotions/lib/components/admin/solidus_legacy_promotions/orders/index/component.yml
@@ -1,0 +1,3 @@
+en:
+  filters:
+    promotions: Promotions

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -29,6 +29,14 @@ module SolidusLegacyPromotions
       end
     end
 
+    initializer "solidus_legacy_promotions.add_admin_order_index_component" do
+      if SolidusSupport.admin_available?
+        config.to_prepare do
+          SolidusAdmin::Config.components["orders/index"] = SolidusLegacyPromotions::Orders::Index::Component
+        end
+      end
+    end
+
     initializer "solidus_legacy_promotions.add_solidus_admin_menu_items" do
       if SolidusSupport.admin_available?
         SolidusAdmin::Config.configure do |config|

--- a/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Orders", type: :feature, solidus_admin: true do
+  let(:promotion) { create(:promotion, name: "10OFF") }
+  let!(:order_with_promotion) { create(:completed_order_with_promotion, number: "R123456789", promotion: promotion) }
+  let!(:order_without_promotion) { create(:completed_order_with_totals, number: "R987654321") }
+
+  before { sign_in create(:admin_user, email: "admin@example.com") }
+
+  it "lists products", :js do
+    visit "/admin/orders"
+    find("button[aria-label=Filter]").click
+    within("div[role=search]") do
+      expect(page).to have_content("Promotions")
+      find(:xpath, "//summary[normalize-space(text())='Promotions']").click
+    end
+    check "10OFF"
+    expect(page).to have_content("R123456789")
+    expect(page).not_to have_content("R987654321")
+    expect(page).to be_axe_clean
+  end
+end


### PR DESCRIPTION
The new admin allows orders to be filtered by promotion name. However, with the legacy promotion system extracted into an extension, we can't rely on `Spree::Promotion` to exist in `solidus_admin`. In order to get around this issue, we create a new index component for the admin orders page that includes the filter, and register it in an initializer.

This also adds a spec for filtering by promotion name.
