### PR TITLE
Components registry safe reload

### DIFF
--- a/admin/docs/customizing_components.md
+++ b/admin/docs/customizing_components.md
@@ -100,14 +100,9 @@ end
 If you need more control, you can explicitly register your component in the
 Solidus Admin container instead of using an implicit path:
 
-> ⓘ  Right now, that will raise an error when the application is reloaded. We
-> need to fix it.
-
 ```ruby
 # config/initalizers/solidus_admin.rb
-Rails.application.config.to_prepare do
-  SolidusAdmin::Config.components['ui/button'] = MyApplication::Button::Component
-end
+SolidusAdmin::Config.components['ui/button'] = "MyApplication::Button::Component"
 ```
 
 ### Tweaking a component

--- a/admin/lib/solidus_admin/component_registry.rb
+++ b/admin/lib/solidus_admin/component_registry.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  class ComponentRegistry
+    ComponentNotFoundError = Class.new(NameError)
+
+    def initialize
+      @names = {}
+    end
+
+    def []=(key, value)
+      @names[key] = value
+    end
+
+    def [](key)
+      if @names[key]
+        @names[key].constantize
+      else
+        infer_constant_from(key)
+      end
+    end
+
+    private
+
+    def infer_constant_from(key)
+      "solidus_admin/#{key}/component".classify.constantize
+    rescue NameError
+      prefix = "#{SolidusAdmin::Configuration::ENGINE_ROOT}/app/components/solidus_admin/"
+      suffix = "/component.rb"
+      dictionary = Dir["#{prefix}**#{suffix}"].map { _1.delete_prefix(prefix).delete_suffix(suffix) }
+      corrections = DidYouMean::SpellChecker.new(dictionary: dictionary).correct(key.to_s)
+
+      raise ComponentNotFoundError.new(
+        "Unknown component #{key}#{DidYouMean.formatter.message_for(corrections)}",
+        key.classify,
+        receiver: ::SolidusAdmin
+      )
+    end
+  end
+end

--- a/admin/spec/solidus_admin/component_registry_spec.rb
+++ b/admin/spec/solidus_admin/component_registry_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusAdmin::ComponentRegistry do
+  let(:registry) { described_class.new }
+  let(:key) { "ui/button" }
+
+  subject { registry[key] }
+
+  context "with a default class" do
+    it { is_expected.to eq(SolidusAdmin::UI::Button::Component) }
+  end
+
+  context "with a spelling mistake" do
+    let(:key) { "ui/buton" }
+
+    it "raises an understandable error" do
+      expect { subject }.to raise_error("Unknown component ui/buton\nDid you mean?  ui/button")
+    end
+  end
+
+  context "with a custom class" do
+    before do
+      # Using an existing class here so I don't have to define a new one.
+      # Extensions that use this should use their own.
+      registry["ui/button"] = "SolidusAdmin::UI::Panel::Component"
+    end
+
+    it { is_expected.to eq(SolidusAdmin::UI::Panel::Component) }
+  end
+
+  context "with a custom class with a spelling mistake" do
+    before do
+      registry["ui/button"] = "DoesNotExistClass"
+    end
+
+    it "raises an NameError" do
+      expect { subject }.to raise_error("uninitialized constant DoesNotExistClass")
+    end
+  end
+end

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -31,9 +31,7 @@ module SolidusLegacyPromotions
 
     initializer "solidus_legacy_promotions.add_admin_order_index_component" do
       if SolidusSupport.admin_available?
-        config.to_prepare do
-          SolidusAdmin::Config.components["orders/index"] = SolidusLegacyPromotions::Orders::Index::Component
-        end
+        SolidusAdmin::Config.components["orders/index"] = "SolidusLegacyPromotions::Orders::Index::Component"
       end
     end
 


### PR DESCRIPTION
## Summary

In a Zeitwerk world, we can't use reloadable constant in initializers.
This moves the constantization of the names of components into a new
`ComponentRegistry` class. 

This PR is build on top of #5779 so that the theory can directly be tested. Really relevant is only the second commit here. 