### PR TITLE
Use configurable adjustment promotion source types in Thumbnail.for

### DIFF
--- a/admin/app/components/solidus_admin/ui/thumbnail/component.rb
+++ b/admin/app/components/solidus_admin/ui/thumbnail/component.rb
@@ -31,7 +31,7 @@ class SolidusAdmin::UI::Thumbnail::Component < SolidusAdmin::BaseComponent
 
   def self.for(record, **attrs)
     case record
-    when Spree::PromotionAction then new(icon: "megaphone-line", **attrs)
+    when *Spree::Config.adjustment_promotion_source_types then new(icon: "megaphone-line", **attrs)
     when Spree::UnitCancel then new(icon: "close-circle-line", **attrs)
     when Spree::TaxRate then new(icon: "percent-line", **attrs)
     when Spree::LineItem then self.for(record.variant, **attrs)

--- a/admin/spec/components/previews/solidus_admin/ui/thumbnail/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/thumbnail/component_preview/overview.html.erb
@@ -52,7 +52,6 @@
   <% attachment = Object.new.tap { def _1.url(*) "https://placekitten.com/280/200"; end }  %>
   <% image = Spree::Image.new.tap { _1.define_singleton_method(:attachment) { attachment } } %>
   <% [
-    Spree::PromotionAction.new,
     Spree::UnitCancel.new,
     Spree::TaxRate.new,
     image,

--- a/legacy_promotions/spec/components/solidus_admin/ui/thumbnail/component_spec.rb
+++ b/legacy_promotions/spec/components/solidus_admin/ui/thumbnail/component_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SolidusAdmin::UI::Thumbnail::Component, type: :component do
+  describe ".for" do
+    let(:promotion_action) { Spree::PromotionAction.new }
+
+    subject { render_inline described_class.for(promotion_action) }
+
+    it "displays a megaphone" do
+      subject
+      expect(page).to have_xpath("//use[contains(@*, '#ri-megaphone')]")
+    end
+  end
+end

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -76,6 +76,10 @@ require 'axe-capybara'
 
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 
+# VIEW COMPONENTS
+Rails.application.config.view_component.test_controller = "SolidusAdmin::BaseController"
+require "view_component/test_helpers"
+
 RSpec.configure do |config|
   config.fixture_path = File.join(__dir__, "fixtures")
 
@@ -100,6 +104,8 @@ RSpec.configure do |config|
     example.run
     DummyApp.use_solidus_admin = false
   end
+
+  config.include ViewComponent::TestHelpers, type: :component
 
   config.include Spree::TestingSupport::JobHelpers
   config.include SolidusAdmin::TestingSupport::FeatureHelpers, type: :feature


### PR DESCRIPTION
There's a View Component for rendering icons, and it's got a convenience method for rendering adjustables to adjustments.

This uses the `Spree::Config.adjustment_promotion_source_types` configuration option to figure out whether an adjustable needs a megaphone as an icon.

With the legacy promotion system extracted, `Spree::PromotionAction` will not necessarily be available.
