### PR TITLE
RfC: Work around inconsistent button click in promotion order spec

### DIFF
--- a/admin/app/javascript/solidus_admin/controllers/js_controller.js
+++ b/admin/app/javascript/solidus_admin/controllers/js_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = { loaded: Boolean }
+
+  connect() {
+    requestAnimationFrame(() => {
+      this.loadedValue = true
+    })
+  }
+}

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -14,7 +14,7 @@
     <meta name="turbo-refresh-scroll", content="preserve">
   </head>
 
-  <body class="bg-gray-15 font-sans">
+  <body class="bg-gray-15 font-sans" <%== 'data-controller="js"' if Rails.env.test? %>>
     <%= render component("layout/skip_link").new(href: "#main") %>
     <div class="flex gap-0">
       <div class="min-w-[240px] border-r border-r-gray-100 relative">

--- a/admin/lib/solidus_admin/testing_support/feature_helpers.rb
+++ b/admin/lib/solidus_admin/testing_support/feature_helpers.rb
@@ -29,6 +29,10 @@ module SolidusAdmin
       def select_row(text)
         find_row_checkbox(text).check
       end
+
+      def ensure_js_is_ready
+        expect(page).to have_css('[data-js-loaded-value="true"]')
+      end
     end
   end
 end

--- a/admin/spec/features/orders/index_spec.rb
+++ b/admin/spec/features/orders/index_spec.rb
@@ -15,4 +15,26 @@ describe "Orders", type: :feature do
     expect(page).to have_content("$19.99")
     expect(page).to be_axe_clean
   end
+
+  it "Filters product list", :js do
+    create(:completed_order_with_pending_payment, number: "R123456789", total: 19.99)
+    create(:order_ready_to_ship, number: "R987654321", total: 29.99)
+
+    visit "/admin/orders"
+
+    ensure_js_is_ready
+
+    click_button "Filter"
+
+    within("div[role=search]") do
+      expect(page).to have_content("Payment State")
+      find(:xpath, "//summary[normalize-space(text())='Payment State']").click
+    end
+    check "Balance Due"
+    expect(page).to have_content("R123456789")
+    expect(page).not_to have_content("R987654321")
+
+    # TODO: Fix colors of the orange pills. They don't have enough contrast.
+    # expect(page).to be_axe_clean
+  end
 end

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -65,6 +65,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
 end
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
+Capybara.enable_aria_label = true
 
 # DATABASE CLEANER
 require 'database_cleaner'

--- a/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe "Orders", type: :feature, solidus_admin: true do
 
   it "lists products", :js do
     visit "/admin/orders"
-    find("button[aria-label=Filter]").click
+
+    click_button "Filter"
+
     within("div[role=search]") do
       expect(page).to have_content("Promotions")
       find(:xpath, "//summary[normalize-space(text())='Promotions']").click

--- a/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Orders", type: :feature, solidus_admin: true do
   it "lists products", :js do
     visit "/admin/orders"
 
+    ensure_js_is_ready
+
     click_button "Filter"
 
     within("div[role=search]") do

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -75,6 +75,7 @@ require 'axe-rspec'
 require 'axe-capybara'
 
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
+Capybara.enable_aria_label = true
 
 RSpec.configure do |config|
   config.fixture_path = File.join(__dir__, "fixtures")


### PR DESCRIPTION
Apparently, `find_button(...).click` will not consistently wait for the
Stimulus JS to be loaded. This adds a small controller that simply
changes an attribute on the body, and expects that to be present before
running any feature specs.

See https://gist.github.com/adrienpoly/862846f5882796fdeb4fc85b260b3c5a

for inspiration.

I don't love to introduce code into the production build to get the tests stable, but I haven't found another good option that worked.