### PR TITLE
Fix flaky spec with synchronize

### DIFF
--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -65,6 +65,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
 end
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
+Capybara.enable_aria_label = true
 
 # DATABASE CLEANER
 require 'database_cleaner'

--- a/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
@@ -12,10 +12,16 @@ RSpec.describe "Orders", type: :feature, solidus_admin: true do
   it "lists products", :js do
     visit "/admin/orders"
 
-    click_button "Filter"
+    # Keep on clicking until the Promotions menu appears
+    page.document.synchronize do
+      click_button "Filter"
+
+      within("div[role=search]") do
+        expect(page).to have_content("Promotions")
+      end
+    end
 
     within("div[role=search]") do
-      expect(page).to have_content("Promotions")
       find(:xpath, "//summary[normalize-space(text())='Promotions']").click
     end
     check "10OFF"

--- a/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe "Orders", type: :feature, solidus_admin: true do
 
   it "lists products", :js do
     visit "/admin/orders"
-    find("button[aria-label=Filter]").click
+
+    click_button "Filter"
+
     within("div[role=search]") do
       expect(page).to have_content("Promotions")
       find(:xpath, "//summary[normalize-space(text())='Promotions']").click

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -75,6 +75,7 @@ require 'axe-rspec'
 require 'axe-capybara'
 
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
+Capybara.enable_aria_label = true
 
 RSpec.configure do |config|
   config.fixture_path = File.join(__dir__, "fixtures")


### PR DESCRIPTION
## Summary

This will keep clicking the Filter button until the promotions menu
appears. The problem this fixes is that a few milliseconds after
navigation, the JS controller that switches the filter bar out might not
have loaded.

Alternative fixes here:
https://github.com/solidusio/solidus/pull/5782
https://github.com/solidusio/solidus/pull/5783