### PR TITLE
Allow Psych 5

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mini_magick', '~> 4.10'
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
-  s.add_dependency 'psych', ['>= 4.0.1', '< 5.0']
+  s.add_dependency 'psych', ['>= 4.0.1', '< 6.0']
   s.add_dependency 'ransack', '~> 4.0'
   s.add_dependency 'sprockets-rails', '!= 3.5.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'


### PR DESCRIPTION
Ruby 3.3 has psych 5 as default gem and we get a Bundler error about psych 5 already been activated although solidus does not allow it.
