### PR TITLE
SolidusAdmin: Components per Adjustment Source

### DIFF
--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/component.html.erb
@@ -1,0 +1,12 @@
+<figure class="flex items-center gap-2">
+  <figcaption class="flex flex-col gap-0 max-w-[15rem]">
+    <div class="text-black body-small whitespace-nowrap text-ellipsis overflow-hidden">
+      <%= adjustment.label %>
+    </div>
+    <% if detail %>
+      <div class="text-gray-500 body-small whitespace-nowrap text-ellipsis overflow-hidden">
+        <%= detail %>
+      </div>
+    <% end %>
+  </figcaption>
+</figure>

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component < SolidusAdmin::BaseComponent
+  attr_reader :adjustment, :source, :model_name
+
+  def initialize(adjustment)
+    @adjustment = adjustment
+    @source = adjustment.source
+    @model_name = source&.model_name&.human
+  end
+
+  def detail
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_tax_rate/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_tax_rate/component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeTaxRate::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+  def detail
+    link_to("#{model_name}: #{zone_name}", spree.edit_admin_tax_rate_path(adjustment.source_id), class: "body-link")
+  end
+
+  private
+
+  def zone_name
+    source.zone&.name || t('spree.all_zones')
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_unit_cancel/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_unit_cancel/component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeUnitCancel::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
@@ -83,9 +83,9 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
         header: :source,
         col: { class: "w-56" },
         data: ->(adjustment) {
-          tag.figure(safe_join([
-            figcaption_for_source(adjustment),
-          ]), class: "flex items-center gap-2")
+          component_name = adjustment.source&.class&.table_name&.singularize
+          component_key = ["orders/show/adjustments/index/adjustment", component_name].compact.join("/")
+          render component(component_key).new(adjustment)
         }
       },
       {
@@ -148,26 +148,6 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
 
   def svg_data_uri(data)
     "data:image/svg+xml;base64,#{Base64.strict_encode64(data)}"
-  end
-
-  def figcaption_for_source(adjustment)
-    return thumbnail_caption(adjustment.label, nil) unless adjustment.source_type
-
-    # ["Spree::PromotionAction", nil, "Spree::UnitCancel", "Spree::TaxRate"]
-    record = adjustment.source
-    record_class = adjustment.source_type&.constantize
-    model_name = record_class.model_name.human
-
-    case record || record_class
-    when Spree::TaxRate
-      detail = link_to("#{model_name}: #{record.zone&.name || t('spree.all_zones')}", spree.edit_admin_tax_rate_path(adjustment.source_id), class: "body-link")
-    when Spree::PromotionAction
-      detail = link_to("#{model_name}: #{record.promotion.name}", spree.edit_admin_promotion_path(adjustment.source_id), class: "body-link")
-    else
-      detail = "#{model_name}: #{record.display_amount}" if record.respond_to?(:display_amount)
-    end
-
-    thumbnail_caption(adjustment.label, detail)
   end
 
   def figcaption_for_adjustable(adjustment)

--- a/legacy_promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/adjustment/spree_promotion_action/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/adjustment/spree_promotion_action/component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreePromotionAction::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+  def detail
+    link_to("#{model_name}: #{promotion_name}", spree.edit_admin_promotion_path(adjustment.source_id), class: "body-link")
+  end
+
+  private
+
+  def promotion_name
+    source.promotion.name
+  end
+end

--- a/legacy_promotions/spec/features/solidus_admin/orders/show/adjustments_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/show/adjustments_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Order", :js, type: :feature, solidus_admin: true do
+  let(:admin) { create(:admin_user) }
+  let(:order) { create(:order, number: "R123456789") }
+
+  before do
+    allow(SolidusAdmin::Config).to receive(:enable_alpha_features?) { true }
+    sign_in admin
+  end
+
+  context "with a promotion adjustment" do
+    let(:order) { create(:order_ready_to_ship, number: "R123456789") }
+    let(:promotion) { create(:promotion, :with_adjustable_action) }
+
+    before do
+      Spree::Adjustment.create!(
+        order: order,
+        source: promotion.actions.first,
+        adjustable: order.line_items.first,
+        amount: 2,
+        label: "Promotion Adjustment"
+      )
+    end
+
+    it "can display the adjustment" do
+      visit "/admin/orders/R123456789"
+
+      click_on "Adjustments"
+      expect(page).to have_content("Promotion Adjustment")
+      expect(page).to be_axe_clean
+    end
+  end
+end


### PR DESCRIPTION
This adds a few components that just display adjustment sources. There are no visual changes. The improvement I was looking for is to de-couple the adjustments table from individual source types through dynamic component lookup:

```
component_name = adjustment.source&.class&.table_name&.singularize
component_key = ["orders/show/adjustments/index/adjustment", component_name].compact.join("/")
render component(component_key).new(adjustment)
```

This allows the `solidus_legacy_promotions` gem to ship with a component that knows how to render an adjustment source of type `Spree::PromotionAction` without hardcoding anything in `SolidusAdmin`.
