### PR TITLE
Admin adjustable components

### DIFF
--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::Component < SolidusAdmin::BaseComponent
+  attr_reader :adjustment, :adjustable, :model_name
+
+  def initialize(adjustment)
+    @adjustment = adjustment
+    @adjustable = adjustment.adjustable
+    @model_name = adjustable&.model_name&.human
+  end
+
+  def call
+    render component("ui/thumbnail_with_caption").new(caption: caption, detail: detail) do
+      thumbnail
+    end
+  end
+
+  def thumbnail
+    render(component("ui/thumbnail").for(adjustment.adjustable, class: "basis-10"))
+  end
+
+  def caption
+  end
+
+  def detail
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/spree_line_item/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/spree_line_item/component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::SpreeLineItem::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::Component
+  delegate :variant, to: :adjustable
+
+  def caption
+    options_text = variant.options_text.presence
+    options_text || variant.sku
+  end
+
+  def detail
+    link_to(variant.product.name, solidus_admin.product_path(variant.product), class: "body-link")
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/spree_order/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/spree_order/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::SpreeOrder::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::Component
+  def caption
+    "#{Spree::Order.model_name.human} ##{adjustable.number}"
+  end
+
+  def detail
+    adjustable.display_total
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/spree_shipment/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustable/spree_shipment/component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::SpreeShipment::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustable::Component
+  def caption
+    "#{t('spree.shipment')} ##{adjustable.number}"
+  end
+
+  def detail
+    link_to(
+      adjustable.shipping_method.name,
+      spree.edit_admin_shipping_method_path(adjustable.shipping_method),
+      class: "body-link"
+    )
+  end
+end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/component.rb
@@ -9,6 +9,18 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component < So
     @model_name = source&.model_name&.human
   end
 
+  def call
+    render component("ui/thumbnail_with_caption").new(icon: icon, caption: caption, detail: detail)
+  end
+
+  def caption
+    adjustment.label
+  end
+
   def detail
+  end
+
+  def icon
+    "question-line"
   end
 end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_tax_rate/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_tax_rate/component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeTaxRate::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+  def icon
+    "percent-line"
+  end
+
   def detail
     link_to("#{model_name}: #{zone_name}", spree.edit_admin_tax_rate_path(adjustment.source_id), class: "body-link")
   end
@@ -8,6 +12,6 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeTaxRate::
   private
 
   def zone_name
-    source.zone&.name || t('spree.all_zones')
+    source.zone&.name || t("spree.all_zones")
   end
 end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_unit_cancel/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_unit_cancel/component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeUnitCancel::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
-  def icon
-    "close-circle-line"
-  end
-end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_unit_cancel/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/adjustment/spree_unit_cancel/component.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeUnitCancel::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+  def icon
+    "close-circle-line"
+  end
 end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
@@ -73,18 +73,14 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
         header: :adjustable,
         col: { class: 'w-56' },
         data: ->(adjustment) {
-          component_name = adjustment.adjustable&.class&.table_name&.singularize
-          component_key = ["orders/show/adjustments/index/adjustable", component_name].compact.join("/")
-          render component(component_key).new(adjustment)
+          render_thumbnail_with_caption(adjustment, :adjustable)
         }
       },
       {
         header: :source,
         col: { class: "w-56" },
         data: ->(adjustment) {
-          component_name = adjustment.source&.class&.table_name&.singularize
-          component_key = ["orders/show/adjustments/index/source", component_name].compact.join("/")
-          render component(component_key).new(adjustment)
+          render_thumbnail_with_caption(adjustment, :source)
         }
       },
       {
@@ -139,5 +135,13 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
         end
       },
     ]
+  end
+
+  private
+
+  def render_thumbnail_with_caption(adjustment, role)
+    component_name = adjustment.send(role).class.base_class.name.delete("::").underscore if adjustment.send(role)
+    component_key = ["orders/show/adjustments/index/#{role}", component_name].compact.join("/")
+    render component(component_key).new(adjustment)
   end
 end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
@@ -73,10 +73,9 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
         header: :adjustable,
         col: { class: 'w-56' },
         data: ->(adjustment) {
-          tag.figure(safe_join([
-            render(component("ui/thumbnail").for(adjustment.adjustable, class: "basis-10")),
-            figcaption_for_adjustable(adjustment),
-          ]), class: "flex items-center gap-2")
+          component_name = adjustment.adjustable&.class&.table_name&.singularize
+          component_key = ["orders/show/adjustments/index/adjustable", component_name].compact.join("/")
+          render component(component_key).new(adjustment)
         }
       },
       {
@@ -140,58 +139,5 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
         end
       },
     ]
-  end
-
-  def icon_thumbnail(name)
-    render component("ui/thumbnail").new(src: svg_data_uri(icon_tag(name)))
-  end
-
-  def svg_data_uri(data)
-    "data:image/svg+xml;base64,#{Base64.strict_encode64(data)}"
-  end
-
-  def figcaption_for_adjustable(adjustment)
-    # ["Spree::LineItem", "Spree::Order", "Spree::Shipment"]
-    record = adjustment.adjustable
-    record_class = adjustment.adjustable_type&.constantize
-
-    case record || record_class
-    when Spree::LineItem
-      variant = record.variant
-      options_text = variant.options_text.presence
-
-      description = options_text || variant.sku
-      detail = link_to(variant.product.name, solidus_admin.product_path(record.variant.product), class: "body-link")
-    when Spree::Order
-      description = "#{Spree::Order.model_name.human} ##{record.number}"
-      detail = record.display_total
-    when Spree::Shipment
-       description = "#{t('spree.shipment')} ##{record.number}"
-       detail = link_to(record.shipping_method.name, spree.edit_admin_shipping_method_path(record.shipping_method), class: "body-link")
-    when nil
-      # noop
-    else
-      name_method = [:display_name, :name, :number].find { record.respond_to? _1 } if record
-      price_method = [:display_amount, :display_total, :display_cost].find { record.respond_to? _1 } if record
-
-      description = record_class.model_name.human
-      description = "#{description} - #{record.public_send(name_method)}" if name_method
-
-      # attempt creating a link
-      url_options = [:admin, record, :edit, { only_path: true }]
-      url = begin; spree.url_for(url_options); rescue NoMethodError => e; logger.error(e.to_s); nil end
-
-      description = link_to(description, url, class: "body-link") if url
-      detail = record.public_send(price_method) if price_method
-    end
-
-    thumbnail_caption(description, detail)
-  end
-
-  def thumbnail_caption(first_line, second_line)
-    tag.figcaption(safe_join([
-      tag.div(first_line || NBSP, class: 'text-black body-small whitespace-nowrap text-ellipsis overflow-hidden'),
-      tag.div(second_line || NBSP, class: 'text-gray-500 body-small whitespace-nowrap text-ellipsis overflow-hidden')
-    ]), class: "flex flex-col gap-0 max-w-[15rem]")
   end
 end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
@@ -84,7 +84,7 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
         col: { class: "w-56" },
         data: ->(adjustment) {
           component_name = adjustment.source&.class&.table_name&.singularize
-          component_key = ["orders/show/adjustments/index/adjustment", component_name].compact.join("/")
+          component_key = ["orders/show/adjustments/index/source", component_name].compact.join("/")
           render component(component_key).new(adjustment)
         }
       },

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/source/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/source/component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component < SolidusAdmin::BaseComponent
+class SolidusAdmin::Orders::Show::Adjustments::Index::Source::Component < SolidusAdmin::BaseComponent
   attr_reader :adjustment, :source, :model_name
 
   def initialize(adjustment)

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/source/spree_tax_rate/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/source/spree_tax_rate/component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreeTaxRate::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+class SolidusAdmin::Orders::Show::Adjustments::Index::Source::SpreeTaxRate::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Source::Component
   def icon
     "percent-line"
   end

--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/source/spree_unit_cancel/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/source/spree_unit_cancel/component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Orders::Show::Adjustments::Index::Source::SpreeUnitCancel::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Source::Component
+  def icon
+    "close-circle-line"
+  end
+end

--- a/admin/app/components/solidus_admin/ui/thumbnail_with_caption/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/thumbnail_with_caption/component.html.erb
@@ -1,7 +1,8 @@
 <figure class="flex items-center gap-2">
+  <%= icon_thumbnail %>
   <figcaption class="flex flex-col gap-0 max-w-[15rem]">
     <div class="text-black body-small whitespace-nowrap text-ellipsis overflow-hidden">
-      <%= adjustment.label %>
+      <%= caption %>
     </div>
     <% if detail %>
       <div class="text-gray-500 body-small whitespace-nowrap text-ellipsis overflow-hidden">

--- a/admin/app/components/solidus_admin/ui/thumbnail_with_caption/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/thumbnail_with_caption/component.html.erb
@@ -1,5 +1,9 @@
 <figure class="flex items-center gap-2">
-  <%= icon_thumbnail %>
+  <% if content? %>
+    <%= content %>
+  <% else %>
+    <%= icon_thumbnail %>
+  <% end %>
   <figcaption class="flex flex-col gap-0 max-w-[15rem]">
     <div class="text-black body-small whitespace-nowrap text-ellipsis overflow-hidden">
       <%= caption %>

--- a/admin/app/components/solidus_admin/ui/thumbnail_with_caption/component.rb
+++ b/admin/app/components/solidus_admin/ui/thumbnail_with_caption/component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::UI::ThumbnailWithCaption::Component < SolidusAdmin::BaseComponent
+  attr_reader :icon, :caption, :detail
+
+  def initialize(icon: "question-line", caption: "", detail: nil)
+    @icon = icon
+    @caption = caption
+    @detail = detail
+  end
+
+  def icon_thumbnail
+    render component("ui/thumbnail").new(icon: icon)
+  end
+end

--- a/admin/spec/features/orders/adjustments_spec.rb
+++ b/admin/spec/features/orders/adjustments_spec.rb
@@ -85,4 +85,25 @@ describe "Order", :js, type: :feature do
       expect(page).to be_axe_clean
     end
   end
+
+  context "with a shipment being adjusted" do
+    let(:order) { create(:order_with_line_items, number: "R123456789") }
+
+    before do
+      order.shipments.first.adjustments.create!(
+        order: order,
+        label: "Manual shipping discount",
+        amount: -2,
+        source: nil
+      )
+    end
+
+    it "can display a shipment adjustment" do
+      visit "/admin/orders/R123456789"
+
+      click_on "Adjustments"
+      expect(page).to have_content("Manual shipping discount")
+      expect(page).to be_axe_clean
+    end
+  end
 end

--- a/legacy_promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/adjustment/spree_promotion_action/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/adjustment/spree_promotion_action/component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreePromotionAction::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+  def icon
+    "megaphone-line"
+  end
+
   def detail
     link_to("#{model_name}: #{promotion_name}", spree.edit_admin_promotion_path(adjustment.source_id), class: "body-link")
   end

--- a/legacy_promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/source/spree_promotion_action/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/source/spree_promotion_action/component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::SpreePromotionAction::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Adjustment::Component
+class SolidusAdmin::Orders::Show::Adjustments::Index::Source::SpreePromotionAction::Component < SolidusAdmin::Orders::Show::Adjustments::Index::Source::Component
   def icon
     "megaphone-line"
   end


### PR DESCRIPTION
## Summary

This applies the same pattern to adjustment adjustables (line items, order, an shipments) as we have already done to adjustment sources. In order to distinguish the two namespaces, it changes the `adjustment` namespace to `source`, and adds an `adjustable` namespace. 

The HTML needed for the pattern is moved to the `UI` namespace, with a new component, `ThumbnailWithCaption`. 

With this commit, adjustment sources also get icons. I feel this was intended from the get-go but somehow missed. Here's the difference:
 
Before: 
![grafik](https://github.com/solidusio/solidus/assets/703401/6956ddc7-af0e-4ac1-a335-9281297bca8c)

After: 
![grafik](https://github.com/solidusio/solidus/assets/703401/4fbfdea8-1fa8-4323-9d8c-c311bdb0c439)
