### PR TITLE
Mark flaky spec as flaky instead of sleep

### DIFF
--- a/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/orders/index_spec.rb
@@ -9,10 +9,8 @@ RSpec.describe "Orders", type: :feature, solidus_admin: true do
 
   before { sign_in create(:admin_user, email: "admin@example.com") }
 
-  it "lists products", :js do
+  it "lists products", :js, :flaky do
     visit "/admin/orders"
-
-    sleep 1
 
     click_button "Filter"
 


### PR DESCRIPTION
This marks the legacy promotions order index spec as flaky so that we get two retries if it fails. Better than just sending the process to sleep for a second.

Closes #5782 