### PR TITLE
Test against Ruby 3.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,4 +380,4 @@ workflows:
           matrix: { parameters: { rails: ['7.0'], ruby: ['3.2'], database: ['sqlite'], paperclip: [false] } }
       - test_solidus:
           name: *name
-          matrix: { parameters: { rails: ['7.1', 'main'], ruby: ['3.3'], database: ['sqlite'], paperclip: [false] } }
+          matrix: { parameters: { rails: ['7.1', 'main'], ruby: ['3.3.2'], database: ['sqlite'], paperclip: [false] } }


### PR DESCRIPTION
Ruby 3.3.3 just came out, and there seems to be an issue with the now-included `net-pop` gem. Let's test against 3.3.2 for the time being.

See https://stackoverflow.com/questions/78617432/strange-bundle-update-issue-disappearing-net-pop-0-1-2-dependency
