### PR TITLE
Legacy Promotions: Fix shipping promo application after state machine reload

### DIFF
--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/lib/spree_order_state_machine_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/lib/spree_order_state_machine_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_dependency "spree/core/state_machines/order"
+
+module SolidusLegacyPromotions
+  module SpreeOrderStateMachineDecorator
+    def define_state_machine!
+      super
+      state_machine do
+        if states[:delivery]
+          before_transition from: :delivery, do: :apply_shipping_promotions
+        end
+      end
+    end
+
+    Spree::Core::StateMachines::Order::ClassMethods.prepend self
+  end
+end

--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree/order_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree/order_decorator.rb
@@ -10,7 +10,7 @@ module SolidusLegacyPromotions
       end
     end
 
-    def apply_shipping_promotions
+    def apply_shipping_promotions(_event = nil)
       ::Spree::Config.promotions.shipping_promotion_handler_class.new(self).activate
       recalculate
     end

--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree/order_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree/order_decorator.rb
@@ -2,14 +2,6 @@
 
 module SolidusLegacyPromotions
   module OrderDecorator
-    def self.prepended(base)
-      base.state_machine do
-        if states[:delivery]
-          before_transition from: :delivery, do: :apply_shipping_promotions
-        end
-      end
-    end
-
     def apply_shipping_promotions(_event = nil)
       ::Spree::Config.promotions.shipping_promotion_handler_class.new(self).activate
       recalculate

--- a/legacy_promotions/spec/models/spree/order_spec.rb
+++ b/legacy_promotions/spec/models/spree/order_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe Spree::Order do
 
       order.apply_shipping_promotions
     end
+
+    context "after the order state machine is reloaded", :pending do
+      let(:order) { create(:order_with_line_items, state: :delivery) }
+
+      before do
+        @old_checkout_flow = Spree::Order.checkout_flow
+        Spree::Order.checkout_flow(&@old_checkout_flow)
+      end
+
+      it "calls apply_shipping_promotions " do
+        expect(order).to receive(:apply_shipping_promotions)
+        order.next!
+      end
+    end
   end
 
   context "empty!" do

--- a/legacy_promotions/spec/models/spree/order_spec.rb
+++ b/legacy_promotions/spec/models/spree/order_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Spree::Order do
       order.apply_shipping_promotions
     end
 
-    context "after the order state machine is reloaded", :pending do
+    context "after the order state machine is reloaded" do
       let(:order) { create(:order_with_line_items, state: :delivery) }
 
       before do


### PR DESCRIPTION
## Summary

This fixes a flaky spec in `solidus_starter_frontend`. Let me explain: `solidus_legacy_promotions` adds a 

```rb
before_transition to: :delivery, :apply_shipping_promotions
```

The specs for `solidus_starter_frontend` include one that tests correctly applied shipping promotions.

But another spec in `solidus_starter_frontend` [reloads the state machine](https://github.com/solidusio/solidus_starter_frontend/blob/main/templates/spec/requests/checkouts_spec.rb#L448-L457) using the following mechanism:
 
```rb
@old_checkout_flow = Spree::Order.checkout_flow
# modification to state machine here
Spree::Order.checkout_flow(&@old_checkout_flow)
```

What this PR does is add the `apply_shipping_promotion` before-transition hook directly to the default state machine, rather than evaling it into the order class, where it does not survice reloads of the checkout flow. 