### PR TITLE
Support Tailwind CSS in core dummy app

### DIFF
--- a/admin/Rakefile
+++ b/admin/Rakefile
@@ -5,6 +5,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/dummy_app/rake_tasks'
+require 'solidus_admin/testing_support/dummy_app/rake_tasks'
 require 'bundler/gem_tasks'
 
 namespace :tailwindcss do

--- a/admin/lib/solidus_admin/testing_support/admin_assets.rb
+++ b/admin/lib/solidus_admin/testing_support/admin_assets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.when_first_matching_example_defined(solidus_admin: true) do
+    config.before(:suite) do
+      system('bin/rails solidus_admin:tailwindcss:build') or abort 'Failed to build Tailwind CSS'
+      Rails.application.precompiled_assets
+    end
+  end
+end

--- a/admin/lib/solidus_admin/testing_support/dummy_app/rake_tasks.rb
+++ b/admin/lib/solidus_admin/testing_support/dummy_app/rake_tasks.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+namespace :solidus_admin do
+  namespace :tailwindcss do
+    desc "Build Tailwind CSS"
+    task build: :dummy_environment do
+      require "solidus_admin"
+      require "tailwindcss/commands"
+
+      config_file = <<~JS
+        const adminRoot = "#{SolidusAdmin::Engine.root}"
+        const solidusAdmin = require(`${adminRoot}/config/tailwind.config.js`)
+
+        module.exports = {
+          // Read how to use TailwindCSS presets: https://tailwindcss.com/docs/presets.
+          presets: [solidusAdmin],
+
+          content: [
+            // Include paths coming from SolidusAdmin.
+            ...solidusAdmin.content,
+
+            // Include paths to your own components.
+            `${__dirname}/../../../../app/components/admin/**/*`,
+            `${__dirname}/../../../../lib/components/admin/**/*`,
+          ],
+        }
+      JS
+      FileUtils.mkdir_p(DummyApp::Application.root.join("config"))
+      File.write(DummyApp::Application.root.join("config/tailwind.config.js"), config_file)
+      FileUtils.mkdir_p(DummyApp::Application.root.join("app/assets/stylesheets/solidus_admin"))
+      FileUtils.cp(
+        SolidusAdmin::Engine.root.join("app/assets/stylesheets/solidus_admin/application.tailwind.css"),
+        DummyApp::Application.root.join("app/assets/stylesheets/solidus_admin/application.tailwind.css")
+      )
+
+      tailwindcss = Tailwindcss::Commands.executable
+
+      tailwindcss_command = [
+        tailwindcss,
+        "--config", DummyApp::Application.root.join("config/tailwind.config.js"),
+        "--input", DummyApp::Application.root.join("app/assets/stylesheets/solidus_admin/application.tailwind.css"),
+        "--output", DummyApp::Application.root.join("assets/builds/solidus_admin/tailwind.css")
+      ]
+
+      sh tailwindcss_command.shelljoin
+    end
+  end
+end
+
+# Attach Tailwind CSS build to other tasks.
+%w[
+  assets:precompile
+  test:prepare
+  spec:prepare
+  db:test:prepare
+].each do |task_name|
+  next unless Rake::Task.task_defined?(task_name)
+
+  Rake::Task[task_name].enhance(["solidus_admin:tailwindcss:build"])
+end

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -29,11 +29,7 @@ DummyApp::Application.routes.draw do
   mount Spree::Core::Engine, at: '/'
 end
 
-unless SolidusAdmin::Engine.root.join('app/assets/builds/solidus_admin/tailwind.css').exist?
-  Dir.chdir(SolidusAdmin::Engine.root) do
-    system 'bundle exec rake tailwindcss:build' or abort 'Failed to build Tailwind CSS'
-  end
-end
+require "solidus_admin/testing_support/admin_assets"
 
 # RAILS
 require "rspec/rails"
@@ -110,6 +106,9 @@ RSpec.configure do |config|
 
   config.before do
     Rails.cache.clear
+  end
+  config.define_derived_metadata(file_path: %r{spec/features}) do |metadata|
+    metadata[:solidus_admin] = true
   end
 
   config.include FactoryBot::Syntax::Methods

--- a/legacy_promotions/Rakefile
+++ b/legacy_promotions/Rakefile
@@ -5,6 +5,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/dummy_app/rake_tasks'
+require 'solidus_admin/testing_support/dummy_app/rake_tasks'
 require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -21,12 +21,7 @@ DummyApp::Application.routes.draw do
   }
   mount Spree::Core::Engine, at: "/"
 end
-
-unless SolidusAdmin::Engine.root.join('app/assets/builds/solidus_admin/tailwind.css').exist?
-  Dir.chdir(SolidusAdmin::Engine.root) do
-    system 'bundle exec rake tailwindcss:build' or abort 'Failed to build Tailwind CSS'
-  end
-end
+require "solidus_admin/testing_support/admin_assets"
 
 require 'rails-controller-testing'
 require 'rspec/rails'


### PR DESCRIPTION
This allows running the core dummy app with the Tailwind required for setting sails towards the new frontend.

