### PR TITLE
Fix bin/rails in solidus_legacy_promotions

### DIFF
--- a/legacy_promotions/bin/rails
+++ b/legacy_promotions/bin/rails
@@ -3,7 +3,7 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
-ENGINE_PATH = File.expand_path('../lib/spree/core/engine', __dir__)
+ENGINE_PATH = File.expand_path('../lib/solidus_legacy_promotions/engine', __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'solidus_legacy_promotions'
+
 module SolidusLegacyPromotions
   class Engine < ::Rails::Engine
     include SolidusSupport::EngineExtensions


### PR DESCRIPTION
This had some copy-pasta, and requiring the engine requires requiring the gem first.
