### PR TITLE
Move adjustment promotion code id to legacy promotions

### DIFF
--- a/admin/spec/features/orders/adjustments_spec.rb
+++ b/admin/spec/features/orders/adjustments_spec.rb
@@ -22,8 +22,7 @@ describe "Order", :js, type: :feature do
       created_at: Time.current,
       updated_at: Time.current,
       included: false,
-      source: taxrate,
-      promotion_code_id: nil,
+      source: taxrate
     )
     visit "/admin/orders/R123456789"
 
@@ -60,8 +59,7 @@ describe "Order", :js, type: :feature do
       created_at: Time.current,
       updated_at: Time.current,
       included: false,
-      source: nil,
-      promotion_code_id: nil,
+      source: nil
     )
     visit "/admin/orders/R123456789"
 

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -72,7 +72,7 @@ module Spree
 
     preference :adjustment_attributes, :array, default: [
       :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
-      :amount, :label, :promotion_code_id,
+      :amount, :label,
       :finalized, :eligible, :created_at, :updated_at
     ]
 

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -6126,8 +6126,6 @@ components:
           type: integer
         label:
           type: string
-        promotion_code_id:
-          type: integer
         source_id:
           type: integer
         source_type:

--- a/core/db/migrate/20160101010000_solidus_one_four.rb
+++ b/core/db/migrate/20160101010000_solidus_one_four.rb
@@ -90,14 +90,12 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.datetime "updated_at", precision: 6
       t.integer "order_id", null: false
       t.boolean "included", default: false
-      t.integer "promotion_code_id"
       t.integer "adjustment_reason_id"
       t.boolean "finalized", default: false, null: false
       t.index ["adjustable_id", "adjustable_type"], name: "index_spree_adjustments_on_adjustable_id_and_adjustable_type"
       t.index ["adjustable_id"], name: "index_adjustments_on_order_id"
       t.index ["eligible"], name: "index_spree_adjustments_on_eligible"
       t.index ["order_id"], name: "index_spree_adjustments_on_order_id"
-      t.index ["promotion_code_id"], name: "index_spree_adjustments_on_promotion_code_id"
       t.index ["source_id", "source_type"], name: "index_spree_adjustments_on_source_id_and_source_type"
     end
 

--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree_adjustment_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree_adjustment_decorator.rb
@@ -56,8 +56,12 @@ module SolidusLegacyPromotions
 
     private
 
+    def legacy_promotion?
+      source_type == "Spree::PromotionAction"
+    end
+
     def require_promotion_code?
-      promotion? && !source.promotion.apply_automatically && source.promotion.codes.any?
+      legacy_promotion? && !source.promotion.apply_automatically && source.promotion.codes.any?
     end
 
     Spree::Adjustment.prepend self

--- a/legacy_promotions/bin/rails
+++ b/legacy_promotions/bin/rails
@@ -3,7 +3,7 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
-ENGINE_PATH = File.expand_path('../lib/spree/core/engine', __dir__)
+ENGINE_PATH = File.expand_path('../lib/solidus_legacy_promotions/engine', __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)

--- a/legacy_promotions/db/migrate/20240621100123_add_promotion_code_id_to_spree_adjustments.rb
+++ b/legacy_promotions/db/migrate/20240621100123_add_promotion_code_id_to_spree_adjustments.rb
@@ -1,0 +1,10 @@
+class AddPromotionCodeIdToSpreeAdjustments < ActiveRecord::Migration[5.0]
+  def up
+    unless column_exists?(:spree_adjustments, :promotion_code_id)
+      add_column :spree_adjustments, :promotion_code_id, :integer
+    end
+    unless index_exists?(:spree_adjustments, :promotion_code_id)
+      add_index :spree_adjustments, :promotion_code_id, name: "index_spree_adjustments_on_promotion_code_id"
+    end
+  end
+end

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'solidus_legacy_promotions'
+
 module SolidusLegacyPromotions
   class Engine < ::Rails::Engine
     include SolidusSupport::EngineExtensions

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -89,6 +89,8 @@ module SolidusLegacyPromotions
       Spree::Config.order_contents_class = "Spree::OrderContents"
       Spree::Config.promotions = SolidusLegacyPromotions::Configuration.new
       Spree::Config.adjustment_promotion_source_types << "Spree::PromotionAction"
+
+      Spree::Api::Config.adjustment_attributes << :promotion_code_id
     end
   end
 end

--- a/legacy_promotions/spec/lib/spree/api_config_spec.rb
+++ b/legacy_promotions/spec/lib/spree/api_config_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::Api::Config do
+  describe "#adjustment_attributes" do
+    subject { described_class.adjustment_attributes }
+
+    it { is_expected.to include(:promotion_code_id) }
+  end
+end

--- a/legacy_promotions/spec/models/spree/adjustment_spec.rb
+++ b/legacy_promotions/spec/models/spree/adjustment_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Spree::Adjustment, type: :model do
 
   let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', adjustable: order, order: order, amount: 5) }
 
+  it { is_expected.to respond_to(:promotion_code) }
   context '#recalculate' do
     subject { adjustment.recalculate }
     let(:adjustment) do


### PR DESCRIPTION
## Summary

Historically, adjustments did not know about their promotion code ID, and solidus_friendly_promotions joins over the `friendly_order_promotions` join table instead. This column is part of the legacy promotion system. 
