### PR TITLE
Remove spree_orders_promotions from core migration

### DIFF
--- a/core/db/migrate/20160101010000_solidus_one_four.rb
+++ b/core/db/migrate/20160101010000_solidus_one_four.rb
@@ -326,16 +326,6 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.index ["user_id"], name: "index_spree_orders_on_user_id"
     end
 
-    create_table "spree_orders_promotions", force: :cascade do |t|
-      t.integer "order_id"
-      t.integer "promotion_id"
-      t.integer "promotion_code_id"
-      t.datetime "created_at", precision: 6
-      t.datetime "updated_at", precision: 6
-      t.index ["order_id", "promotion_id"], name: "index_spree_orders_promotions_on_order_id_and_promotion_id"
-      t.index ["promotion_code_id"], name: "index_spree_orders_promotions_on_promotion_code_id"
-    end
-
     create_table "spree_payment_capture_events", force: :cascade do |t|
       t.decimal "amount", precision: 10, scale: 2, default: "0.0"
       t.integer "payment_id"


### PR DESCRIPTION
This table is created in
legacy_promotions/db/migrate/20160101010001_solidus_one_four_promotions.rb, and that this is still in core is an oversight.
