### PR TITLE
[v4.3]  Add support for Sprockets v4 to the DummyApp (backports #3379)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'rspec-rails', '~> 6.0.3', require: false
 gem 'rspec-retry', '~> 0.6.2', require: false
 gem 'simplecov', require: false
 gem 'simplecov-cobertura', require: false
+gem 'rack', '< 3', require: false
 gem 'rails-controller-testing', require: false
 gem 'puma', '< 6', require: false
 gem 'i18n-tasks', '~> 0.9', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,6 @@ else
 end
 # rubocop:enable Bundler/DuplicatedGem
 
-# Temporarily locking sprockets to v3.x
-# see https://github.com/solidusio/solidus/issues/3374
-# and https://github.com/rails/sprockets-rails/issues/369
-gem 'sprockets', '~> 3'
-
 gem 'pry'
 gem 'launchy', require: false
 

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -34,8 +34,11 @@ end
 module DummyApp
   def self.setup(gem_root:, lib_name:, auto_migrate: true)
     ENV["LIB_NAME"] = lib_name
-    DummyApp::Application.config.root = File.join(gem_root, 'spec', 'dummy')
+    root = Pathname(gem_root).join('spec/dummy')
+    root.join("app/assets/config").mkpath
+    root.join("app/assets/config/manifest.js").write("// Intentionally empty\n")
 
+    DummyApp::Application.config.root = root
     DummyApp::Application.initialize! unless DummyApp::Application.initialized?
 
     if auto_migrate


### PR DESCRIPTION
This is needed from Sprockets, since v4. It contains all dependencies that needs to be compiled.
