### PR TITLE
[Admin] Introduce RMA reasons creation capability

### DIFF
--- a/admin/app/components/solidus_admin/return_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/return_reasons/index/component.rb
@@ -17,6 +17,16 @@ class SolidusAdmin::ReturnReasons::Index::Component < SolidusAdmin::RefundsAndRe
     spree.edit_admin_return_reason_path(return_reason)
   end
 
+  def page_actions
+    render component("ui/button").new(
+      tag: :a,
+      text: t('.add'),
+      href: solidus_admin.new_return_reason_path,
+      icon: "add-line",
+      class: "align-self-end w-full",
+    )
+  end
+
   def batch_actions
     [
       {

--- a/admin/app/components/solidus_admin/return_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/return_reasons/index/component.rb
@@ -17,11 +17,16 @@ class SolidusAdmin::ReturnReasons::Index::Component < SolidusAdmin::RefundsAndRe
     spree.edit_admin_return_reason_path(return_reason)
   end
 
+  def turbo_frames
+    %w[new_return_reason_modal]
+  end
+
   def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_return_reason_path,
+      data: { turbo_frame: :new_return_reason_modal },
       icon: "add-line",
       class: "align-self-end w-full",
     )

--- a/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
@@ -1,0 +1,26 @@
+<%= turbo_frame_tag :new_return_reason_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @return_reason, url: solidus_admin.return_reasons_path, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <label class="flex gap-2 items-center">
+          <%= render component("ui/forms/checkbox").new(
+              name: "#{f.object_name}[active]",
+              value: "1",
+              checked: f.object.active
+            ) %>
+            <span class="font-semibold text-xs ml-2"><%= Spree::ReturnReason.human_attribute_name :active %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render component("return_reasons/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/return_reasons/new/component.rb
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::ReturnReasons::New::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, return_reason:)
+    @page = page
+    @return_reason = return_reason
+  end
+
+  def form_id
+    dom_id(@return_reason, "#{stimulus_id}_new_return_reason_form")
+  end
+end

--- a/admin/app/components/solidus_admin/return_reasons/new/component.yml
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.yml
@@ -1,0 +1,6 @@
+en:
+  title: "New Return Reason"
+  cancel: "Cancel"
+  submit: "Add Return Reason"
+  hints:
+    active: "When checked, this retun reason will be available for selection when creating a customer return for an order."

--- a/admin/app/controllers/solidus_admin/return_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/return_reasons_controller.rb
@@ -25,6 +25,35 @@ module SolidusAdmin
       end
     end
 
+    def create
+      @return_reason = Spree::ReturnReason.new(return_reason_params)
+
+      if @return_reason.save
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.return_reasons_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('return_reasons/new')
+              .new(page: @page, return_reason: @return_reason)
+
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def destroy
       @return_reason = Spree::ReturnReason.find_by!(id: params[:id])
 
@@ -51,7 +80,7 @@ module SolidusAdmin
     end
 
     def return_reason_params
-      params.require(:return_reason).permit(:return_reason_id, permitted_return_reason_attributes)
+      params.require(:return_reason).permit(:name, :active)
     end
   end
 end

--- a/admin/app/controllers/solidus_admin/return_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/return_reasons_controller.rb
@@ -5,15 +5,23 @@ module SolidusAdmin
     include SolidusAdmin::ControllerHelpers::Search
 
     def index
-      return_reasons = apply_search_to(
-        Spree::ReturnReason.unscoped.order(id: :desc),
-        param: :q,
-      )
-
-      set_page_and_extract_portion_from(return_reasons)
+      set_index_page
 
       respond_to do |format|
         format.html { render component('return_reasons/index').new(page: @page) }
+      end
+    end
+
+    def new
+      @return_reason = Spree::ReturnReason.new
+
+      set_index_page
+
+      respond_to do |format|
+        format.html {
+          render component('return_reasons/new')
+            .new(page: @page, return_reason: @return_reason)
+        }
       end
     end
 
@@ -27,6 +35,15 @@ module SolidusAdmin
     end
 
     private
+
+    def set_index_page
+      return_reasons = apply_search_to(
+        Spree::ReturnReason.unscoped.order(id: :desc),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(return_reasons)
+    end
 
     def load_return_reason
       @return_reason = Spree::ReturnReason.find_by!(id: params[:id])

--- a/admin/config/locales/return_reasons.en.yml
+++ b/admin/config/locales/return_reasons.en.yml
@@ -2,5 +2,7 @@ en:
   solidus_admin:
     return_reasons:
       title: "Return Reasons"
+      create:
+        success: "Return reason has been successfully created!"
       destroy:
         success: "Return Reasons were successfully removed."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -62,7 +62,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :zones, only: [:index, :destroy]
   admin_resources :refund_reasons, only: [:index, :new, :create, :destroy]
   admin_resources :reimbursement_types, only: [:index]
-  admin_resources :return_reasons, only: [:index, :destroy]
+  admin_resources :return_reasons, only: [:index, :new, :destroy]
   admin_resources :adjustment_reasons, only: [:index, :destroy]
   admin_resources :store_credit_reasons, only: [:index, :destroy]
 end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -62,7 +62,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :zones, only: [:index, :destroy]
   admin_resources :refund_reasons, only: [:index, :new, :create, :destroy]
   admin_resources :reimbursement_types, only: [:index]
-  admin_resources :return_reasons, only: [:index, :new, :destroy]
+  admin_resources :return_reasons, only: [:index, :new, :create, :destroy]
   admin_resources :adjustment_reasons, only: [:index, :destroy]
   admin_resources :store_credit_reasons, only: [:index, :destroy]
 end

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -19,4 +19,20 @@ describe "Return Reasons", :js, type: :feature do
     expect(Spree::ReturnReason.count).to eq(0)
     expect(page).to be_axe_clean
   end
+
+  it "allows an admin to create a new RMA reason" do
+    visit "/admin/return_reasons"
+
+    expect(page).to have_content("Add new")
+    click_on "Add new"
+
+    expect(page).to have_content("New Return Reason")
+    fill_in "Name", with: "Size too small"
+
+    expect(page).to have_css("input[type=checkbox][name='return_reason[active]'][checked='checked']")
+
+    click_on "Add Return Reason"
+
+    expect(page).to have_content("Return reason has been successfully created!")
+  end
 end


### PR DESCRIPTION
## Summary

This PR completes the first part of https://github.com/solidusio/solidus/issues/5808, which is to add a new UI component for creating RMA reasons.
In a future PR we will build on this to allow updating RMA reasons through the same UI component.

### How

* Add new UI component for creating RMA (return) reasons
* Added create action for return reasons admin controller

| Create UI |
|--------|
| <img width="2327" alt="Screenshot 2024-07-17 at 10 31 28 AM" src="https://github.com/user-attachments/assets/48cbf819-7589-49b8-950e-a7d3ed53a83c"> | 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
