### PR TITLE
Lock solidus_core.gemspec to ransack '< 4.2'

### DIFF
--- a/admin/spec/components/previews/solidus_admin/ui/thumbnail/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/thumbnail/component_preview/overview.html.erb
@@ -50,7 +50,7 @@
 <div class="flex gap-4">
   <% product = Spree::Product.new(name: "A good product") %>
   <% attachment = Object.new.tap { def _1.url(*) "https://placekitten.com/280/200"; end }  %>
-  <% image = Spree::Image.new.tap { _1.define_singleton_method(:attachment) { attachment } } %>
+  <% image = Spree::Image.new.tap { |img| img.define_singleton_method(:attachment) { attachment } } %>
   <% [
     Spree::UnitCancel.new,
     Spree::TaxRate.new,

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -43,7 +43,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
   s.add_dependency 'psych', ['>= 4.0.1', '< 6.0']
-  s.add_dependency 'ransack', '~> 4.0'
+  # @note ransack 4.2 contains a bug which has not yet been addressed.
+  # @see https://github.com/activerecord-hackery/ransack/pull/1468
+  s.add_dependency 'ransack', ['~> 4.0', '< 4.2']
   s.add_dependency 'sprockets-rails', '!= 3.5.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
   s.add_dependency 'omnes', '~> 0.2.2'


### PR DESCRIPTION
Solidus core's gemspec already required that ransack be '~> 4.0', but the latest version of ransack, v4.2.0, released July 10 2024, introduces a bug. The previous implementation was taking for granted that every predicate would respond to #value, which doesn't seem to be the case when the predicate is an instance of a Arel::SelectManager.

This has already been flagged by @spaghetticode in his PR against ransack: https://github.com/activerecord-hackery/ransack/pull/1468

Since there has been little movement on this PR since January, we should lock to a version that works for us since currently many of our product specs are failing. (eg. spec/models/spree/product_spec.rb:659)

We can remove this lock once the PR is merged and once the above test (and the others that are failing) are able to pass in ransack v4.2.0 or subsequent versions.

## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
