### PR TITLE
Raise on deprecation when `SOLIDUS_RAISE_DEPRECATIONS` set

### DIFF
--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -41,6 +41,12 @@ module DummyApp
     DummyApp::Application.config.root = root
     DummyApp::Application.initialize! unless DummyApp::Application.initialized?
 
+    # Raise on deprecation warnings.
+    # NOTE: This needs to happen after the application is initialized.
+    if ENV['SOLIDUS_RAISE_DEPRECATIONS'].present?
+      Spree.deprecator.behavior = :raise
+    end
+
     if auto_migrate
       DummyApp::Migrations.auto_migrate
     end
@@ -150,9 +156,4 @@ Spree.config do |config|
     config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
     config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
   end
-end
-
-# Raise on deprecation warnings
-if ENV['SOLIDUS_RAISE_DEPRECATIONS'].present?
-  Spree.deprecator.behavior = :raise
 end

--- a/core/spec/lib/spree/deprecator_spec.rb
+++ b/core/spec/lib/spree/deprecator_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "Spree.deprecator" do
 
     it "does not raise an error unless overridden by environment" do
       if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
-        pending "fix for deprecation behaviour override"
         expect { Dummy.new.deprecated_method }.to raise_error(ActiveSupport::DeprecationException)
       else
         expect { Dummy.new.deprecated_method }.not_to raise_error

--- a/core/spec/lib/spree/deprecator_spec.rb
+++ b/core/spec/lib/spree/deprecator_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Spree.deprecator" do
+  Dummy = Class.new do
+    def deprecated_method
+      "foo"
+    end
+    deprecate :deprecated_method, deprecator: Spree.deprecator
+  end
+
+  context "by default" do
+    it "returns a valid deprecator" do
+      expect(Spree.deprecator).to have_attributes(
+        deprecation_horizon: "5.0",
+        gem_name: "Solidus"
+      )
+    end
+
+    it "does not raise an error unless overridden by environment" do
+      if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
+        pending "fix for deprecation behaviour override"
+        expect { Dummy.new.deprecated_method }.to raise_error(ActiveSupport::DeprecationException)
+      else
+        expect { Dummy.new.deprecated_method }.not_to raise_error
+      end
+    end
+  end
+
+  context "when the behavior has been changed to :raise" do
+    around do |example|
+      behavior_name = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS.detect { |_behavior_name, behavior_proc|
+        behavior_proc == Spree.deprecator.behavior.first
+      }.first
+
+      Spree.deprecator.behavior = :raise
+
+      example.run
+
+      Spree.deprecator.behavior = behavior_name
+    end
+
+    it "raises an error when a deprecated method is called" do
+      expect { Dummy.new.deprecated_method }
+        .to raise_error(ActiveSupport::DeprecationException)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #5766

This issue can be reproduced on the first commit by running the specs with the environment variable to override deprecation behaviour, as such

```
SOLIDUS_RAISE_DEPRECATIONS=true bundle exec rspec spec/lib/spree/deprecator_spec.rb
```

which produces the following output

```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Spree.deprecator by default does not raise an error unless overridden by environment
     # fix for deprecation behaviour override
     Failure/Error: expect { Dummy.new.deprecated_method }.to raise_error(ActiveSupport::DeprecationException)
       expected ActiveSupport::DeprecationException but nothing was raised
```

We were able to fix this issue by moving the code that sets the deprecation behaviour after the `DummyApp` is initialized, which seems to reset that.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
