### PR TITLE
[Admin] Adjustment Reasons edit/update

### DIFF
--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag :edit_adjustment_reason_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @adjustment_reason, url: solidus_admin.adjustment_reason_path(@adjustment_reason), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <label class="flex gap-2 items-center">
+          <%= hidden_field_tag "#{f.object_name}[active]", "0" %>
+          <%= render component("ui/forms/checkbox").new(
+            name: "#{f.object_name}[active]",
+            value: "1",
+            checked: f.object.active
+          ) %>
+          <span class="font-semibold text-xs ml-2"><%= Spree::AdjustmentReason.human_attribute_name :active %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("adjustment_reasons/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.rb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::AdjustmentReasons::Edit::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, adjustment_reason:)
+    @page = page
+    @adjustment_reason = adjustment_reason
+  end
+
+  def form_id
+    dom_id(@adjustment_reason, "#{stimulus_id}_edit_adjustment_reason_form")
+  end
+end

--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.yml
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.yml
@@ -1,0 +1,8 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "Edit Adjustment Reason"
+  cancel: "Cancel"
+  submit: "Update Adjustment Reason"
+  hints:
+    active: "When checked, this adjustment reason will be available for selection when adding adjustments to orders."

--- a/admin/app/components/solidus_admin/adjustment_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/index/component.rb
@@ -24,11 +24,14 @@ class SolidusAdmin::AdjustmentReasons::Index::Component < SolidusAdmin::RefundsA
   end
 
   def turbo_frames
-    %w[new_adjustment_reason_modal]
+    %w[
+      new_adjustment_reason_modal
+      edit_adjustment_reason_modal
+    ]
   end
 
   def row_url(adjustment_reason)
-    spree.edit_admin_adjustment_reason_path(adjustment_reason)
+    spree.edit_admin_adjustment_reason_path(adjustment_reason, _turbo_frame: :edit_adjustment_reason_modal)
   end
 
   def batch_actions

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
@@ -11,7 +11,7 @@
             value: "1",
             checked: f.object.active
           ) %>
-          <span class="font-semibold text-xs ml-2"><%= Spree::TaxCategory.human_attribute_name :active %></span>
+          <span class="font-semibold text-xs ml-2"><%= Spree::AdjustmentReason.human_attribute_name :active %></span>
           <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
         </label>
       </div>

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
@@ -5,6 +5,7 @@
         <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
         <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
         <label class="flex gap-2 items-center">
+          <%= hidden_field_tag "#{f.object_name}[active]", "0" %>
           <%= render component("ui/forms/checkbox").new(
             name: "#{f.object_name}[active]",
             value: "1",

--- a/admin/app/controllers/solidus_admin/adjustment_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/adjustment_reasons_controller.rb
@@ -4,6 +4,8 @@ module SolidusAdmin
   class AdjustmentReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
+    before_action :find_adjustment_reason, only: %i[edit update]
+
     def index
       set_index_page
 
@@ -49,6 +51,39 @@ module SolidusAdmin
       end
     end
 
+    def edit
+      set_index_page
+
+      respond_to do |format|
+        format.html { render component('adjustment_reasons/edit').new(page: @page, adjustment_reason: @adjustment_reason) }
+      end
+    end
+
+    def update
+      if @adjustment_reason.update(adjustment_reason_params)
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.adjustment_reasons_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('adjustment_reasons/edit').new(page: @page, adjustment_reason: @adjustment_reason)
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def destroy
       @adjustment_reason = Spree::AdjustmentReason.find_by!(id: params[:id])
 
@@ -63,6 +98,10 @@ module SolidusAdmin
     def load_adjustment_reason
       @adjustment_reason = Spree::AdjustmentReason.find_by!(id: params[:id])
       authorize! action_name, @adjustment_reason
+    end
+
+    def find_adjustment_reason
+      @adjustment_reason = Spree::AdjustmentReason.find(params[:id])
     end
 
     def adjustment_reason_params

--- a/admin/config/locales/adjustment_reasons.en.yml
+++ b/admin/config/locales/adjustment_reasons.en.yml
@@ -6,3 +6,5 @@ en:
         success: "Adjustment Reasons were successfully removed."
       create:
         success: "Adjustment reason was successfully created."
+      update:
+        success: "Adjustment reason was successfully updated."

--- a/admin/config/locales/adjustment_reasons.en.yml
+++ b/admin/config/locales/adjustment_reasons.en.yml
@@ -3,7 +3,7 @@ en:
     adjustment_reasons:
       title: "Adjustment Reasons"
       destroy:
-        success: "Adjustment Reasons were successfully removed."
+        success: "Adjustment reasons were successfully removed."
       create:
         success: "Adjustment reason was successfully created."
       update:

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -63,6 +63,6 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :refund_reasons, only: [:index, :new, :create, :destroy]
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, only: [:index, :destroy]
-  admin_resources :adjustment_reasons, only: [:index, :new, :create, :destroy]
+  admin_resources :adjustment_reasons, except: [:show]
   admin_resources :store_credit_reasons, only: [:index, :destroy]
 end

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -61,4 +61,36 @@ describe "Adjustment Reasons", :js, type: :feature do
       end
     end
   end
+
+  context "when editing an existing adjustment reason" do
+    let(:query) { "?page=1&q%5Bname_or_code_cont%5D=reason" }
+
+    before do
+      Spree::AdjustmentReason.create(name: "Good Reason", code: 5999)
+      visit "/admin/adjustment_reasons#{query}"
+      find_row("Good Reason").click
+      expect(page).to have_content("Edit Adjustment Reason")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    it "successfully updates the existing adjustment reason" do
+      fill_in "Name", with: "Better Reason"
+      page.uncheck "adjustment_reason[active]"
+
+      click_on "Update Adjustment Reason"
+      expect(page).to have_content("Adjustment reason was successfully updated.")
+      expect(page).to have_content("Better Reason")
+      expect(page).not_to have_content("Good Reason")
+      expect(Spree::AdjustmentReason.find_by(name: "Better Reason")).to be_present
+      expect(Spree::AdjustmentReason.find_by(name: "Better Reason").active).to be_falsey
+      expect(page.current_url).to include(query)
+    end
+  end
 end

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -41,11 +41,13 @@ describe "Adjustment Reasons", :js, type: :feature do
       it "successfully creates a new adjustment reason, keeping page and q params" do
         fill_in "Name", with: "New Reason"
         fill_in "Code", with: "1234"
+        page.uncheck "adjustment_reason[active]"
 
         click_on "Add Adjustment Reason"
 
         expect(page).to have_content("Adjustment reason was successfully created.")
         expect(Spree::AdjustmentReason.find_by(name: "New Reason")).to be_present
+        expect(Spree::AdjustmentReason.find_by(name: "New Reason").active).to be_falsey
         expect(page.current_url).to include(query)
       end
     end

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -14,7 +14,7 @@ describe "Adjustment Reasons", :js, type: :feature do
 
     select_row("Default-adjustment-reason")
     click_on "Delete"
-    expect(page).to have_content("Adjustment Reasons were successfully removed.")
+    expect(page).to have_content("Adjustment reasons were successfully removed.")
     expect(page).not_to have_content("Default-adjustment-reason")
     expect(Spree::AdjustmentReason.count).to eq(0)
     expect(page).to be_axe_clean


### PR DESCRIPTION
## Summary
This PR is for [this issue](https://github.com/orgs/solidusio/projects/12/views/1?pane=issue&itemId=52590551) but it doesn't have an issue ID yet as the issue is still in draft and there is a GitHub bug preventing opening the issue.

This PR migrates the editing/updating of existing adjustment reasons to the new admin interface, following the existing pattern used for tax categories.

The form is rendered via a modal dialog on the adjustment reasons list by leveraging Turbo frames. Successful updating leads to a turbo stream page refresh, which updates the existing list preserving the query params and the scroll position, for a consistent UX.

The attached video shows the functionality visually:

https://github.com/user-attachments/assets/ced57f07-81f2-4285-973b-ce4ca0e106b9



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
