### PR TITLE
Add before action to handle option type params

### DIFF
--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -11,6 +11,8 @@ module SolidusAdmin
     search_scope(:in_stock) { _1.where(id: Spree::Variant.in_stock.distinct.select(:product_id)) }
     search_scope(:out_of_stock) { _1.where.not(id: Spree::Variant.in_stock.distinct.select(:product_id)) }
 
+    before_action :split_params, only: [:update]
+
     def index
       products = apply_search_to(
         Spree::Product.includes(:master, :variants),
@@ -97,6 +99,15 @@ module SolidusAdmin
 
       flash[:notice] = t('.success')
       redirect_to products_path, status: :see_other
+    end
+
+    def split_params
+      if params[:product][:taxon_ids].present?
+        params[:product][:taxon_ids] = params[:product][:taxon_ids].split(',')
+      end
+      if params[:product][:option_type_ids].present?
+        params[:product][:option_type_ids] = params[:product][:option_type_ids].split(',')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

As reported in #5751, the new admin UI has a bug with the option type selectors: only one option type can be added.

We narrowed this down to an issue handling option type params in the new admin products controller. We noticed legacy controller contains a before action to handle the incoming option type params, but the new one did not. Re-adding the before action solves the bug. This is required because the form input for option types contains comma separated values within a string:

`<input value="1,2" type="hidden">`

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
