### PR TITLE
[Admin] Shipping Categories edit/update

### DIFF
--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag :edit_shipping_category_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @shipping_category, url: solidus_admin.shipping_category_path(@shipping_category), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name) %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("shipping_categories/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.rb
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::ShippingCategories::Edit::Component < SolidusAdmin::ShippingCategories::Index::Component
+  def initialize(page:, shipping_category:)
+    @page = page
+    @shipping_category = shipping_category
+  end
+
+  def form_id
+    dom_id(@shipping_category, "#{stimulus_id}_edit_shipping_category_form")
+  end
+end

--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.yml
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.yml
@@ -1,0 +1,6 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "Edit Shipping Category"
+  cancel: "Cancel"
+  submit: "Update Shipping Category"

--- a/admin/app/components/solidus_admin/shipping_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/shipping_categories/index/component.rb
@@ -26,11 +26,14 @@ class SolidusAdmin::ShippingCategories::Index::Component < SolidusAdmin::Shippin
   end
 
   def turbo_frames
-    %w[new_shipping_category_modal]
+    %w[
+      new_shipping_category_modal
+      edit_shipping_category_modal
+    ]
   end
 
   def row_url(shipping_category)
-    spree.edit_admin_shipping_category_path(shipping_category)
+    spree.edit_admin_shipping_category_path(shipping_category, _turbo_frame: :edit_shipping_category_modal)
   end
 
   def search_key

--- a/admin/app/controllers/solidus_admin/shipping_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/shipping_categories_controller.rb
@@ -4,6 +4,8 @@ module SolidusAdmin
   class ShippingCategoriesController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
+    before_action :find_shipping_category, only: %i[edit update]
+
     def new
       @shipping_category = Spree::ShippingCategory.new
 
@@ -51,6 +53,39 @@ module SolidusAdmin
       end
     end
 
+    def edit
+      set_index_page
+
+      respond_to do |format|
+        format.html { render component('shipping_categories/edit').new(page: @page, shipping_category: @shipping_category) }
+      end
+    end
+
+    def update
+      if @shipping_category.update(shipping_category_params)
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.shipping_categories_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('shipping_categories/edit').new(page: @page, shipping_category: @shipping_category)
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def destroy
       @shipping_category = Spree::ShippingCategory.find_by!(id: params[:id])
 
@@ -65,6 +100,10 @@ module SolidusAdmin
     def load_shipping_category
       @shipping_category = Spree::ShippingCategory.find_by!(id: params[:id])
       authorize! action_name, @shipping_category
+    end
+
+    def find_shipping_category
+      @shipping_category = Spree::ShippingCategory.find(params[:id])
     end
 
     def shipping_category_params

--- a/admin/config/locales/shipping_categories.en.yml
+++ b/admin/config/locales/shipping_categories.en.yml
@@ -6,3 +6,5 @@ en:
         success: "Shipping categories were successfully removed."
       create:
         success: "Shipping category was successfully created."
+      update:
+        success: "Shipping category was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -56,7 +56,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :payment_methods, only: [:index, :destroy], sortable: true
   admin_resources :stock_items, only: [:index, :edit, :update]
   admin_resources :shipping_methods, only: [:index, :destroy]
-  admin_resources :shipping_categories, only: [:new, :index, :create, :destroy]
+  admin_resources :shipping_categories, except: [:show]
   admin_resources :stock_locations, only: [:index, :destroy]
   admin_resources :stores, only: [:index, :destroy]
   admin_resources :zones, only: [:index, :destroy]

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -58,4 +58,34 @@ describe "Shipping Categories", :js, type: :feature do
       end
     end
   end
+
+  context "when editing an existing shipping category" do
+    let(:query) { "?page=1&q%5Bname_or_description_cont%5D=mail" }
+
+    before do
+      Spree::ShippingCategory.create(name: "Letter Mail")
+      visit "/admin/shipping_categories#{query}"
+      find_row("Letter Mail").click
+      expect(page).to have_content("Edit Shipping Category")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    it "successfully updates the existing shipping category" do
+      fill_in "Name", with: "Air Mail"
+
+      click_on "Update Shipping Category"
+      expect(page).to have_content("Shipping category was successfully updated.")
+      expect(page).to have_content("Air Mail")
+      expect(page).not_to have_content("Letter Mail")
+      expect(Spree::ShippingCategory.find_by(name: "Air Mail")).to be_present
+      expect(page.current_url).to include(query)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR finishes off the excellent work by Loic that was left in draft on https://github.com/solidusio/solidus/pull/5723
and includes an updated spec.

This PR follows the work started on #5718 where Shipping categories creation was implemented. This PR adds the edit/update functionality for shipping categories.
The issue is #5720

The attached video shows the functionality visually:

https://github.com/user-attachments/assets/e56eb5b5-f634-4590-b9ff-b71a75b134ca

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
