### PR TITLE
[Admin] Batch Action confirmation modal (instead of alert)

### DIFF
--- a/admin/app/components/solidus_admin/ui/modal/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/modal/component.html.erb
@@ -1,5 +1,6 @@
 <dialog
   data-controller="<%= stimulus_id %>"
+  data-modal-open="<%= @attributes[:open] %>"
   <%= tag.attributes(
     "aria-label": @title,
     class: "relative z-10",

--- a/admin/app/components/solidus_admin/ui/modal/component.js
+++ b/admin/app/components/solidus_admin/ui/modal/component.js
@@ -2,6 +2,8 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {
-    this.element.showModal();
+    if (this.element.getAttribute('data-modal-open') === "true") {
+      this.element.showModal();
+    }
   }
 }

--- a/admin/app/components/solidus_admin/ui/modal/component.rb
+++ b/admin/app/components/solidus_admin/ui/modal/component.rb
@@ -3,7 +3,7 @@
 class SolidusAdmin::UI::Modal::Component < SolidusAdmin::BaseComponent
   renders_one :actions
 
-  def initialize(title:, close_path: nil, open: false, **attributes)
+  def initialize(title:, close_path: nil, open: true, **attributes)
     @title = title
     @close_path = close_path
     @attributes = attributes

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -94,6 +94,25 @@
     <% end %>
   <% end %>
 
+  <% @data.batch_actions.each do |batch_action| %>
+    <% if batch_action.require_confirmation %>
+      <% title = t(".action_confirmation", action: batch_action.label.downcase) %>
+      <% id = batch_confirm_modal_id(batch_action) %>
+
+      <%= render component("ui/modal").new(title: title, open: false, id: id) do |modal| %>
+        <div class="flex flex-col gap-6 pb-4">
+          <span class="font-semibold text-xs ml-2">ARE YOU SURE?????</span>
+        </div>
+        <% modal.with_actions do %>
+          <form method="dialog">
+            <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+          </form>
+          <%= render component("ui/button").new(type: :submit, text: t('.submit')) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <table class="table-fixed w-full border-collapse">
     <colgroup>
       <% @data.columns.each do |column| %>

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -129,19 +129,48 @@ export default class extends Controller {
     return this.checkboxTargets.filter((checkbox) => checkbox.checked)
   }
 
-  confirmAction(event) {
-    const message = event.params.message
-      .replace(
-        "${count}",
-        this.selectedRows().length
-      ).replace(
-        "${resource}",
-        this.selectedRows().length > 1 ?
-        event.params.resourcePlural :
-        event.params.resourceSingular
-      )
+  async confirmAction(event) {
+    event.preventDefault()
+    // const message = event.params.message
+    //   .replace("${count}", this.selectedRows().length)
+    //   .replace("${resource}", this.selectedRows().length > 1 ?
+    //     event.params.resourcePlural :
+    //     event.params.resourceSingular
+    //   )
 
-    if (!confirm(message)) {
+    const modal = document.getElementById(event.params.modalId)
+    modal.showModal()
+
+    return new Promise((resolve, reject) => {
+      const submitButton = modal.querySelector('button[type="submit"]')
+      const cancelButton = modal.querySelector('button[type="button"]')
+
+      if (submitButton) {
+        submitButton.addEventListener('click', () => {
+          modal.close()
+          resolve()
+        }, { once: true })
+      }
+
+      if (cancelButton) {
+        cancelButton.addEventListener('click', () => {
+          modal.close()
+          reject()
+        }, { once: true })
+      }
+    })
+  }
+
+  async handleConfirmation(event) {
+    event.preventDefault()
+    try {
+      await this.confirmAction(event)
+      // User clicked submit
+      console.log('User confirmed the action')
+      event.currentTarget.submit()
+      debugger
+    } catch {
+      // User clicked cancel
       event.preventDefault()
     }
   }

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -117,16 +117,21 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     }
 
     if batch_action.require_confirmation
-      params["data-action"] = "click->#{stimulus_id}#confirmAction"
+      params["data-action"] = "click->#{stimulus_id}#handleConfirmation"
       params["data-#{stimulus_id}-message-param"] = t(
         ".action_confirmation",
         action: batch_action.label.downcase
       )
       params["data-#{stimulus_id}-resource-singular-param"] = @data.singular_name.downcase
       params["data-#{stimulus_id}-resource-plural-param"] = @data.plural_name.downcase
+      params["data-#{stimulus_id}-modal-id-param"] = batch_confirm_modal_id(batch_action)
     end
 
     render component("ui/button").new(**params)
+  end
+
+  def batch_confirm_modal_id(batch_action)
+    "#{batch_action.label.downcase}_#{@data.plural_name.downcase}_confirmation_modal"
   end
 
   def render_ransack_filter_dropdown(filter, index)


### PR DESCRIPTION
This would up being tougher than I originally thought it would be, and it's not quite there yet. Any insight is appreciated.

wip - confirmation works, but no way to continue the form submission without errors

Not sure if i should abandon the current stimulus triggers in favour of swapping out this:
`params["data-action"] = "click->#{stimulus_id}#handleConfirmation"` for something that renders a turbo_frame modal, which would actually have all the form submission info? maybe the batch action button should only cause the modal to open and the modal submission should contain the form info? 


<img width="1311" alt="Screenshot 2024-08-09 at 8 31 57 PM" src="https://github.com/user-attachments/assets/8ede1f60-db32-40e9-aac9-1f865af86d5e">


## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
