### PR TITLE
[Admin] Refund Reasons edit/update

### DIFF
--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag :edit_refund_reason_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @refund_reason, url: solidus_admin.refund_reason_path(@refund_reason), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <label class="flex gap-2 items-center">
+          <%= hidden_field_tag "#{f.object_name}[active]", "0" %>
+          <%= render component("ui/forms/checkbox").new(
+            name: "#{f.object_name}[active]",
+            value: "1",
+            checked: f.object.active
+          ) %>
+          <span class="font-semibold text-xs ml-2"><%= Spree::RefundReason.human_attribute_name :active %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("refund_reasons/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.rb
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::RefundReasons::Edit::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, refund_reason:)
+    @page = page
+    @refund_reason = refund_reason
+  end
+
+  def form_id
+    dom_id(@refund_reason, "#{stimulus_id}_edit_refund_reason_form")
+  end
+end

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.yml
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.yml
@@ -1,0 +1,8 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "Edit Refund Reason"
+  cancel: "Cancel"
+  submit: "Update Refund Reason"
+  hints:
+    active: "When checked, this adjustment reason will be available for selection when adding adjustments to orders."

--- a/admin/app/components/solidus_admin/refund_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/refund_reasons/index/component.rb
@@ -14,11 +14,14 @@ class SolidusAdmin::RefundReasons::Index::Component < SolidusAdmin::RefundsAndRe
   end
 
   def row_url(refund_reason)
-    spree.edit_admin_refund_reason_path(refund_reason)
+    spree.edit_admin_refund_reason_path(refund_reason, _turbo_frame: :edit_refund_reason_modal)
   end
 
   def turbo_frames
-    %w[new_refund_reason_modal]
+    %w[
+      new_refund_reason_modal
+      edit_refund_reason_modal
+    ]
   end
 
   def page_actions

--- a/admin/app/controllers/solidus_admin/refund_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/refund_reasons_controller.rb
@@ -4,6 +4,8 @@ module SolidusAdmin
   class RefundReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
+    before_action :find_refund_reason, only: %i[edit update]
+
     def index
       set_index_page
 
@@ -49,6 +51,39 @@ module SolidusAdmin
       end
     end
 
+    def edit
+      set_index_page
+
+      respond_to do |format|
+        format.html { render component('refund_reasons/edit').new(page: @page, refund_reason: @refund_reason) }
+      end
+    end
+
+    def update
+      if @refund_reason.update(refund_reason_params)
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.refund_reasons_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('refund_reasons/edit').new(page: @page, refund_reason: @refund_reason)
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def destroy
       @refund_reason = Spree::RefundReason.find_by!(id: params[:id])
 
@@ -63,6 +98,10 @@ module SolidusAdmin
     def load_refund_reason
       @refund_reason = Spree::RefundReason.find_by!(id: params[:id])
       authorize! action_name, @refund_reason
+    end
+
+    def find_refund_reason
+      @refund_reason = Spree::RefundReason.find(params[:id])
     end
 
     def refund_reason_params

--- a/admin/config/locales/refund_reasons.en.yml
+++ b/admin/config/locales/refund_reasons.en.yml
@@ -6,3 +6,5 @@ en:
         success: "Refund Reasons were successfully removed."
       create:
         success: "Refund reason was successfully created."
+      update:
+        success: "Refund reason was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -60,7 +60,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :stock_locations, only: [:index, :destroy]
   admin_resources :stores, only: [:index, :destroy]
   admin_resources :zones, only: [:index, :destroy]
-  admin_resources :refund_reasons, only: [:index, :new, :create, :destroy]
+  admin_resources :refund_reasons, except: [:show]
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, only: [:index, :destroy]
   admin_resources :adjustment_reasons, except: [:show]

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -58,4 +58,34 @@ describe "Refund Reasons", :js, type: :feature do
       end
     end
   end
+
+  context "when editing an existing refund reason" do
+    let(:query) { "?page=1&q%5Bname_or_description_cont%5D=Ret" }
+
+    before do
+      Spree::RefundReason.create(name: "Return process")
+      visit "/admin/refund_reasons#{query}"
+      find_row("Return process").click
+      expect(page).to have_content("Edit Refund Reason")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    it "successfully updates the existing refund reason" do
+      fill_in "Name", with: "Customer complaint"
+
+      click_on "Update Refund Reason"
+      expect(page).to have_content("Refund reason was successfully updated.")
+      expect(page).to have_content("Customer complaint")
+      expect(page).not_to have_content("Return process")
+      expect(Spree::RefundReason.find_by(name: "Customer complaint")).to be_present
+      expect(page.current_url).to include(query)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR finishes off [this issue](https://github.com/orgs/solidusio/projects/12/views/1?pane=issue&itemId=52590537) but it doesn't have an issue ID yet as the issue is still in draft and there is (still) a GitHub bug preventing opening the issue.

This PR migrates the editing/updating of existing refund reasons to the new admin interface, following the existing pattern used for tax categories.

The form is rendered via a modal dialog on the refund reasons list by leveraging Turbo frames. Successful updating leads to a turbo stream page refresh, which updates the existing list preserving the query params and the scroll position, for a consistent UX.

The attached video shows the functionality visually:


https://github.com/user-attachments/assets/ab3584dc-874b-48cb-92b0-3391da81be5e



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
