### PR TITLE
[Admin] Create new Store Credit Reasons

### DIFF
--- a/admin/app/components/solidus_admin/store_credit_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/index/component.rb
@@ -5,14 +5,20 @@ class SolidusAdmin::StoreCreditReasons::Index::Component < SolidusAdmin::Refunds
     Spree::StoreCreditReason
   end
 
-  def actions
+  def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),
-      href: spree.new_admin_store_credit_reason_path,
+      href: solidus_admin.new_store_credit_reason_path, data: { turbo_frame: :new_store_credit_reason_modal },
       icon: "add-line",
       class: "align-self-end w-full",
     )
+  end
+
+  def turbo_frames
+    %w[
+      new_store_credit_reason_modal
+    ]
   end
 
   def row_url(store_credit_reason)

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag :new_store_credit_reason_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @store_credit_reason, url: solidus_admin.store_credit_reasons_path, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <label class="flex gap-2 items-center">
+          <%= hidden_field_tag "#{f.object_name}[active]", "0" %>
+          <%= render component("ui/forms/checkbox").new(
+            name: "#{f.object_name}[active]",
+            value: "1",
+            checked: f.object.active
+          ) %>
+          <span class="font-semibold text-xs ml-2"><%= Spree::StoreCreditReason.human_attribute_name :active %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render component("store_credit_reasons/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.rb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::StoreCreditReasons::New::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, store_credit_reason:)
+    @page = page
+    @store_credit_reason = store_credit_reason
+  end
+
+  def form_id
+    dom_id(@store_credit_reason, "#{stimulus_id}_new_store_credit_reason_form")
+  end
+end

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.yml
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.yml
@@ -1,0 +1,8 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "New Store Credit Reason"
+  cancel: "Cancel"
+  submit: "Add Store Credit Reason"
+  hints:
+    active: "When checked, this adjustment reason will be available for selection when adding adjustments to orders."

--- a/admin/app/controllers/solidus_admin/store_credit_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credit_reasons_controller.rb
@@ -5,15 +5,47 @@ module SolidusAdmin
     include SolidusAdmin::ControllerHelpers::Search
 
     def index
-      store_credit_reasons = apply_search_to(
-        Spree::StoreCreditReason.unscoped.order(id: :desc),
-        param: :q,
-      )
-
-      set_page_and_extract_portion_from(store_credit_reasons)
+      set_index_page
 
       respond_to do |format|
         format.html { render component('store_credit_reasons/index').new(page: @page) }
+      end
+    end
+
+    def new
+      @store_credit_reason = Spree::StoreCreditReason.new
+
+      set_index_page
+
+      respond_to do |format|
+        format.html { render component('store_credit_reasons/new').new(page: @page, store_credit_reason: @store_credit_reason) }
+      end
+    end
+
+    def create
+      @store_credit_reason = Spree::StoreCreditReason.new(store_credit_reason_params)
+
+      if @store_credit_reason.save
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.store_credit_reasons_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('store_credit_reasons/new').new(page: @page, store_credit_reason: @store_credit_reason)
+            render page_component, status: :unprocessable_entity
+          end
+        end
       end
     end
 
@@ -34,7 +66,16 @@ module SolidusAdmin
     end
 
     def store_credit_reason_params
-      params.require(:store_credit_reason).permit(:store_credit_reason_id, permitted_store_credit_reason_attributes)
+      params.require(:store_credit_reason).permit(:name, :active)
+    end
+
+    def set_index_page
+      store_credit_reasons = apply_search_to(
+        Spree::StoreCreditReason.unscoped.order(id: :desc),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(store_credit_reasons)
     end
   end
 end

--- a/admin/config/locales/store_credit_reasons.en.yml
+++ b/admin/config/locales/store_credit_reasons.en.yml
@@ -4,3 +4,5 @@ en:
       title: "Store Credit Reasons"
       destroy:
         success: "Store Credit Reasons were successfully removed."
+      create:
+        success: "Store Credit Reason was successfully created."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -64,5 +64,5 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, only: [:index, :destroy]
   admin_resources :adjustment_reasons, except: [:show]
-  admin_resources :store_credit_reasons, only: [:index, :destroy]
+  admin_resources :store_credit_reasons, only: [:index, :new, :create, :destroy]
 end

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -19,4 +19,43 @@ describe "Store Credit Reasons", :js, type: :feature do
     expect(Spree::StoreCreditReason.count).to eq(0)
     expect(page).to be_axe_clean
   end
+
+  context "when creating a new store credit reason" do
+    let(:query) { "?page=1&q%5Bname_cont%5D=new" }
+
+    before do
+      visit "/admin/store_credit_reasons#{query}"
+      click_on "Add new"
+      expect(page).to have_content("New Store Credit Reason")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    context "with valid data" do
+      it "successfully creates a new store credit reason, keeping page and q params" do
+        fill_in "Name", with: "New Reason"
+
+        click_on "Add Store Credit Reason"
+
+        expect(page).to have_content("Store Credit Reason was successfully created.")
+        expect(Spree::StoreCreditReason.find_by(name: "New Reason")).to be_present
+        expect(page.current_url).to include(query)
+      end
+    end
+
+    context "with invalid data" do
+      it "fails to create a new store credit reason, keeping page and q params" do
+        click_on "Add Store Credit Reason"
+
+        expect(page).to have_content("can't be blank")
+        expect(page.current_url).to include(query)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR is for [this issue](https://github.com/orgs/solidusio/projects/12/views/1?pane=issue&itemId=52590558) but it doesn't have an issue ID yet as the issue is still in draft. The update functionality will follow in a second PR to keep things small and easy to review.

This PR migrates the creation of new store credit reasons to the new admin interface, following the existing pattern used for tax categories and refund reasons.

The form is rendered via a modal dialog on the store credit reasons list by leveraging Turbo frames. Successful creation leads to a turbo stream page refresh, which updates the existing list preserving the query params and the scroll position, for a consistent UX.

The attached video shows the functionality visually:

https://github.com/user-attachments/assets/473e8093-698e-4755-a475-219250aeb953


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
