### PR TITLE
[Admin] Store Credit Reasons edit/update & New request specs to appease Codecov

### DIFF
--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
@@ -1,0 +1,26 @@
+<%= turbo_frame_tag :edit_store_credit_reason_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @store_credit_reason, url: solidus_admin.store_credit_reason_path(@store_credit_reason), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <label class="flex gap-2 items-center">
+          <%= hidden_field_tag "#{f.object_name}[active]", "0" %>
+          <%= render component("ui/forms/checkbox").new(
+            name: "#{f.object_name}[active]",
+            value: "1",
+            checked: f.object.active
+          ) %>
+          <span class="font-semibold text-xs ml-2"><%= Spree::StoreCreditReason.human_attribute_name :active %></span>
+          <%= render component("ui/toggletip").new(text: t(".hints.active")) %>
+        </label>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("store_credit_reasons/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.rb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::StoreCreditReasons::Edit::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, store_credit_reason:)
+    @page = page
+    @store_credit_reason = store_credit_reason
+  end
+
+  def form_id
+    dom_id(@store_credit_reason, "#{stimulus_id}_edit_store_credit_reason_form")
+  end
+end

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.yml
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.yml
@@ -1,8 +1,8 @@
 # Add your component translations here.
 # Use the translation in the example in your template with `t(".hello")`.
 en:
-  title: "New Store Credit Reason"
+  title: "Edit Store Credit Reason"
   cancel: "Cancel"
-  submit: "Add Store Credit Reason"
+  submit: "Update Store Credit Reason"
   hints:
     active: "When checked, this store credit reason will be available for selection when adding store credit to orders."

--- a/admin/app/components/solidus_admin/store_credit_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/index/component.rb
@@ -18,11 +18,12 @@ class SolidusAdmin::StoreCreditReasons::Index::Component < SolidusAdmin::Refunds
   def turbo_frames
     %w[
       new_store_credit_reason_modal
+      edit_store_credit_reason_modal
     ]
   end
 
   def row_url(store_credit_reason)
-    spree.edit_admin_store_credit_reason_path(store_credit_reason)
+    spree.edit_admin_store_credit_reason_path(store_credit_reason, _turbo_frame: :edit_store_credit_reason_modal)
   end
 
   def search_url

--- a/admin/app/controllers/solidus_admin/store_credit_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credit_reasons_controller.rb
@@ -4,6 +4,8 @@ module SolidusAdmin
   class StoreCreditReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
+    before_action :find_store_credit_reason, only: %i[edit update]
+
     def index
       set_index_page
 
@@ -49,6 +51,39 @@ module SolidusAdmin
       end
     end
 
+    def edit
+      set_index_page
+
+      respond_to do |format|
+        format.html { render component('store_credit_reasons/edit').new(page: @page, store_credit_reason: @store_credit_reason) }
+      end
+    end
+
+    def update
+      if @store_credit_reason.update(store_credit_reason_params)
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.store_credit_reasons_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('store_credit_reasons/edit').new(page: @page, store_credit_reason: @store_credit_reason)
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def destroy
       @store_credit_reason = Spree::StoreCreditReason.find_by!(id: params[:id])
 
@@ -63,6 +98,10 @@ module SolidusAdmin
     def load_store_credit_reason
       @store_credit_reason = Spree::StoreCreditReason.find_by!(id: params[:id])
       authorize! action_name, @store_credit_reason
+    end
+
+    def find_store_credit_reason
+      @store_credit_reason = Spree::StoreCreditReason.find(params[:id])
     end
 
     def store_credit_reason_params

--- a/admin/config/locales/store_credit_reasons.en.yml
+++ b/admin/config/locales/store_credit_reasons.en.yml
@@ -3,6 +3,8 @@ en:
     store_credit_reasons:
       title: "Store Credit Reasons"
       destroy:
-        success: "Store Credit Reasons were successfully removed."
+        success: "Store credit reasons were successfully removed."
       create:
-        success: "Store Credit Reason was successfully created."
+        success: "Store credit reason was successfully created."
+      update:
+        success: "Store credit reason was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -64,5 +64,5 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, only: [:index, :destroy]
   admin_resources :adjustment_reasons, except: [:show]
-  admin_resources :store_credit_reasons, only: [:index, :new, :create, :destroy]
+  admin_resources :store_credit_reasons, except: [:show]
 end

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe "Store Credit Reasons", :js, type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists Store Credit Reasons and allows deleting them" do
+  it "lists store credit reasons and allows deleting them" do
     create(:store_credit_reason, name: "Default-store-credit-reason")
 
     visit "/admin/store_credit_reasons"
@@ -14,7 +14,7 @@ describe "Store Credit Reasons", :js, type: :feature do
 
     select_row("Default-store-credit-reason")
     click_on "Delete"
-    expect(page).to have_content("Store Credit Reasons were successfully removed.")
+    expect(page).to have_content("Store credit reasons were successfully removed.")
     expect(page).not_to have_content("Default-store-credit-reason")
     expect(Spree::StoreCreditReason.count).to eq(0)
     expect(page).to be_axe_clean
@@ -43,7 +43,7 @@ describe "Store Credit Reasons", :js, type: :feature do
 
         click_on "Add Store Credit Reason"
 
-        expect(page).to have_content("Store Credit Reason was successfully created.")
+        expect(page).to have_content("Store credit reason was successfully created.")
         expect(Spree::StoreCreditReason.find_by(name: "New Reason")).to be_present
         expect(page.current_url).to include(query)
       end
@@ -56,6 +56,36 @@ describe "Store Credit Reasons", :js, type: :feature do
         expect(page).to have_content("can't be blank")
         expect(page.current_url).to include(query)
       end
+    end
+  end
+
+  context "when editing an existing store credit reason" do
+    let(:query) { "?page=1&q%5Bname_cont%5D=customer" }
+
+    before do
+      Spree::StoreCreditReason.create(name: "New Customer Reward")
+      visit "/admin/store_credit_reasons#{query}"
+      find_row("New Customer Reward").click
+      expect(page).to have_content("Edit Store Credit Reason")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    it "successfully updates the existing store credit reason" do
+      fill_in "Name", with: "Customer complaint"
+
+      click_on "Update Store Credit Reason"
+      expect(page).to have_content("Store credit reason was successfully updated.")
+      expect(page).to have_content("Customer complaint")
+      expect(page).not_to have_content("New Customer Reward")
+      expect(Spree::StoreCreditReason.find_by(name: "Customer complaint")).to be_present
+      expect(page.current_url).to include(query)
     end
   end
 end

--- a/admin/spec/requests/solidus_admin/store_credit_reasons_spec.rb
+++ b/admin/spec/requests/solidus_admin/store_credit_reasons_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidusAdmin::StoreCreditReasonsController", type: :request do
+  let(:admin_user) { create(:admin_user) }
+  let(:store_credit_reason) { create(:store_credit_reason) }
+
+  before do
+    allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
+  end
+
+  describe "GET /index" do
+    it "renders the index template with a 200 OK status" do
+      get solidus_admin.store_credit_reasons_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /new" do
+    it "renders the new template with a 200 OK status" do
+      get solidus_admin.new_store_credit_reason_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      let(:valid_attributes) { { name: "Customer Loyalty", active: true } }
+
+      it "creates a new StoreCreditReason" do
+        expect {
+          post solidus_admin.store_credit_reasons_path, params: { store_credit_reason: valid_attributes }
+        }.to change(Spree::StoreCreditReason, :count).by(1)
+      end
+
+      it "redirects to the index page with a 303 See Other status" do
+        post solidus_admin.store_credit_reasons_path, params: { store_credit_reason: valid_attributes }
+        expect(response).to redirect_to(solidus_admin.store_credit_reasons_path)
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "displays a success flash message" do
+        post solidus_admin.store_credit_reasons_path, params: { store_credit_reason: valid_attributes }
+        follow_redirect!
+        expect(response.body).to include("Store credit reason was successfully created.")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { name: "", active: true } }
+
+      it "does not create a new StoreCreditReason" do
+        expect {
+          post solidus_admin.store_credit_reasons_path, params: { store_credit_reason: invalid_attributes }
+        }.not_to change(Spree::StoreCreditReason, :count)
+      end
+
+      it "renders the new template with unprocessable_entity status" do
+        post solidus_admin.store_credit_reasons_path, params: { store_credit_reason: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "GET /edit" do
+    it "renders the edit template with a 200 OK status" do
+      get solidus_admin.edit_store_credit_reason_path(store_credit_reason)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:valid_attributes) { { name: "Updated Reason", active: false } }
+
+      it "updates the store credit reason" do
+        patch solidus_admin.store_credit_reason_path(store_credit_reason), params: { store_credit_reason: valid_attributes }
+        store_credit_reason.reload
+        expect(store_credit_reason.name).to eq("Updated Reason")
+        expect(store_credit_reason.active).to be(false)
+      end
+
+      it "redirects to the index page with a 303 See Other status" do
+        patch solidus_admin.store_credit_reason_path(store_credit_reason), params: { store_credit_reason: valid_attributes }
+        expect(response).to redirect_to(solidus_admin.store_credit_reasons_path)
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "displays a success flash message" do
+        patch solidus_admin.store_credit_reason_path(store_credit_reason), params: { store_credit_reason: valid_attributes }
+        follow_redirect!
+        expect(response.body).to include("Store credit reason was successfully updated.")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { name: "", active: false } }
+
+      it "does not update the store credit reason" do
+        original_name = store_credit_reason.name
+        patch solidus_admin.store_credit_reason_path(store_credit_reason), params: { store_credit_reason: invalid_attributes }
+        store_credit_reason.reload
+        expect(store_credit_reason.name).to eq(original_name)
+      end
+
+      it "renders the edit template with unprocessable_entity status" do
+        patch solidus_admin.store_credit_reason_path(store_credit_reason), params: { store_credit_reason: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "deletes the store credit reason and redirects to the index page with a 303 See Other status" do
+      # This ensures the store_credit_reason exists prior to deletion.
+      store_credit_reason
+
+      expect {
+        delete solidus_admin.store_credit_reason_path(store_credit_reason)
+      }.to change(Spree::StoreCreditReason, :count).by(-1)
+
+      expect(response).to redirect_to(solidus_admin.store_credit_reasons_path)
+      expect(response).to have_http_status(:see_other)
+    end
+
+    it "displays a success flash message after deletion" do
+      delete solidus_admin.store_credit_reason_path(store_credit_reason)
+      follow_redirect!
+      expect(response.body).to include("Store credit reasons were successfully removed.")
+    end
+  end
+end


### PR DESCRIPTION
This PR finishes off [this issue](https://github.com/orgs/solidusio/projects/12/views/1?pane=issue&itemId=52590558) but it doesn't have an issue ID yet as the issue is still in draft and there is (still) a GitHub bug preventing opening the issue.

This PR migrates the editing/updating of existing store credit reasons to the new admin interface, following the existing pattern used for tax categories.

The form is rendered via a modal dialog on the store credit reasons list by leveraging Turbo frames. Successful updating leads to a turbo stream page refresh, which updates the existing list preserving the query params and the scroll position, for a consistent UX.

The second part of this PR is adding new request specs to appease codecov, which was not happy with the coverage provided solely by our feature specs. I will add similar request specs for all the past PRs I have put up if/when this change has proven to increase the coverage percentage.

The attached video shows the functionality visually:


https://github.com/user-attachments/assets/d1d49aa2-82f4-4a27-a911-86b45c1194f5

## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
