### PR TITLE
Call empty only on incomplete orders

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -46,8 +46,13 @@ module Spree
 
       def empty
         authorize! :update, @order, order_token
-        @order.empty!
-        respond_with(@order, default_template: :show)
+
+        if @order.complete?
+          invalid_resource!(@order)
+        else
+          @order.empty!
+          respond_with(@order, default_template: :show)
+        end
       end
 
       def index

--- a/backend/app/assets/javascripts/spree/backend/views/cart/empty_cart_button.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/empty_cart_button.js
@@ -24,6 +24,6 @@ Spree.Views.Cart.EmptyCartButton = Backbone.View.extend({
 
   render: function() {
     var isNew = function (item) { return item.isNew() };
-    this.$el.prop("disabled", !this.collection.length || this.collection.some(isNew));
+    this.$el.prop("disabled", !this.collection.length || this.collection.some(isNew) || this.model.get("completed_at"));
   }
 });


### PR DESCRIPTION
## Summary

Fixes #4438. This change is based on #5418 from @nirnaeth.

There are two notable changes from #5418:

1. Call order.incomplete? instead of order.shipped? as suggested by @kennyadsl
2. Updated the new feature spec to make it pass.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
