### PR TITLE
[Admin] Edit/Update roles via new admin UI

### DIFF
--- a/admin/app/components/solidus_admin/roles/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/edit/component.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag :edit_role_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @role, url: solidus_admin.role_path(@role), html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("roles/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/roles/edit/component.rb
+++ b/admin/app/components/solidus_admin/roles/edit/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Roles::Edit::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, role:)
+    @page = page
+    @role = role
+  end
+
+  def form_id
+    dom_id(@role, "#{stimulus_id}_edit_role_form")
+  end
+end

--- a/admin/app/components/solidus_admin/roles/edit/component.yml
+++ b/admin/app/components/solidus_admin/roles/edit/component.yml
@@ -1,0 +1,6 @@
+# Add your component translations here.
+# Use the translation in the example in your template with `t(".hello")`.
+en:
+  title: "Edit Role"
+  cancel: "Cancel"
+  submit: "Update Role"

--- a/admin/app/components/solidus_admin/roles/index/component.rb
+++ b/admin/app/components/solidus_admin/roles/index/component.rb
@@ -14,7 +14,7 @@ class SolidusAdmin::Roles::Index::Component < SolidusAdmin::UsersAndRoles::Compo
   end
 
   def row_url(role)
-    solidus_admin.roles_path(role)
+    solidus_admin.edit_role_path(role, _turbo_frame: :edit_role_modal)
   end
 
   def page_actions
@@ -29,6 +29,7 @@ class SolidusAdmin::Roles::Index::Component < SolidusAdmin::UsersAndRoles::Compo
   def turbo_frames
     %w[
       new_role_modal
+      edit_role_modal
     ]
   end
 

--- a/admin/config/locales/roles.en.yml
+++ b/admin/config/locales/roles.en.yml
@@ -6,3 +6,5 @@ en:
         success: "Roles were successfully removed."
       create:
         success: "Role was successfully created."
+      update:
+        success: "Role was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -63,7 +63,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :refund_reasons, except: [:show]
   admin_resources :reimbursement_types, only: [:index]
   admin_resources :return_reasons, except: [:show]
-  admin_resources :roles, only: [:index, :new, :create, :destroy]
+  admin_resources :roles, except: [:show]
   admin_resources :adjustment_reasons, except: [:show]
   admin_resources :store_credit_reasons, except: [:show]
 end

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -74,4 +74,34 @@ describe "Roles", :js, type: :feature do
       end
     end
   end
+
+  context "when editing an existing role" do
+    let(:query) { "?page=1&q%5Bname_cont%5D=er" }
+
+    before do
+      Spree::Role.create(name: "Reviewer")
+      visit "/admin/roles#{query}"
+      find_row("Reviewer").click
+      expect(page).to have_content("Edit Role")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens a modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+      expect(page.current_url).to include(query)
+    end
+
+    it "successfully updates the existing role" do
+      fill_in "Name", with: "Publisher"
+
+      click_on "Update Role"
+      expect(page).to have_content("Role was successfully updated.")
+      expect(page).to have_content("Publisher")
+      expect(page).not_to have_content("Reviewer")
+      expect(Spree::Role.find_by(name: "Publisher")).to be_present
+      expect(page.current_url).to include(query)
+    end
+  end
 end

--- a/admin/spec/requests/solidus_admin/roles_spec.rb
+++ b/admin/spec/requests/solidus_admin/roles_spec.rb
@@ -64,6 +64,53 @@ RSpec.describe "SolidusAdmin::RolesController", type: :request do
     end
   end
 
+  describe "GET /edit" do
+    it "renders the edit template with a 200 OK status" do
+      get solidus_admin.edit_role_path(role)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:valid_attributes) { { name: "Publisher" } }
+
+      it "updates the role" do
+        patch solidus_admin.role_path(role), params: { role: valid_attributes }
+        role.reload
+        expect(role.name).to eq("Publisher")
+      end
+
+      it "redirects to the index page with a 303 See Other status" do
+        patch solidus_admin.role_path(role), params: { role: valid_attributes }
+        expect(response).to redirect_to(solidus_admin.roles_path)
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "displays a success flash message" do
+        patch solidus_admin.role_path(role), params: { role: valid_attributes }
+        follow_redirect!
+        expect(response.body).to include("Role was successfully updated.")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { name: "admin" } }
+
+      it "does not update the role" do
+        original_name = role.name
+        patch solidus_admin.role_path(role), params: { role: invalid_attributes }
+        role.reload
+        expect(role.name).to eq(original_name)
+      end
+
+      it "renders the edit template with unprocessable_entity status" do
+        patch solidus_admin.role_path(role), params: { role: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe "DELETE /destroy" do
     let!(:role_to_delete) { create(:role) }
 


### PR DESCRIPTION

## Summary

This PR is part 2 of issue https://github.com/solidusio/solidus/issues/5823 That first PR adds the basic Role UI (creation/deletion/index), while this PR adds the modification logic for editing/updating.

The attached video shows the functionality visually:
_(Note that currently `Spree::Role` does not require `name` to be present, but when it is present, it must be unique)_

https://github.com/user-attachments/assets/b66e6e0c-ddf8-4ecd-a270-44298a64efa3

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
