### PR TITLE
Limit supported rails version to before 7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec require: false
 if /(stable|main)/.match? ENV['RAILS_VERSION']
   gem 'rails', github: 'rails', require: false, branch: ENV['RAILS_VERSION']
 else
-  gem 'rails', ENV['RAILS_VERSION'] || '~> 7.1.0', require: false
+  gem 'rails', ENV['RAILS_VERSION'] || '< 7.2', require: false
 end
 # rubocop:enable Bundler/DuplicatedGem
 


### PR DESCRIPTION
## Summary

This PR aimed to limit rails version to below 7.2 for improving error message during `bundle install`
