### PR TITLE
[Admin] Add new migrations and validations in `core` to support new `admin` `Spree::Role` interface 

### DIFF
--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -5,7 +5,7 @@ module Spree
     has_many :role_users, class_name: "Spree::RoleUser", dependent: :destroy
     has_many :users, through: :role_users
 
-    validates_uniqueness_of :name, case_sensitive: true
+    validates :name, presence: true, uniqueness: { case_sensitive: true, allow_blank: true }
 
     def admin?
       name == "admin"

--- a/core/db/migrate/20240821173254_create_spree_permission_sets_in_core.rb
+++ b/core/db/migrate/20240821173254_create_spree_permission_sets_in_core.rb
@@ -1,0 +1,9 @@
+class CreateSpreePermissionSetsInCore < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spree_permission_sets, if_not_exists: true do |t|
+      t.string :name
+      t.string :set
+      t.timestamps null: false
+    end
+  end
+end

--- a/core/db/migrate/20240821173341_create_spree_roles_permissions_in_core.rb
+++ b/core/db/migrate/20240821173341_create_spree_roles_permissions_in_core.rb
@@ -1,0 +1,9 @@
+class CreateSpreeRolesPermissionsInCore < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spree_role_permissions, if_not_exists: true do |t|
+      t.references :role
+      t.references :permission_set
+      t.timestamps null: false
+    end
+  end
+end

--- a/core/db/migrate/20240821173641_add_description_to_spree_roles.rb
+++ b/core/db/migrate/20240821173641_add_description_to_spree_roles.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToSpreeRoles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_roles, :description, :text
+  end
+end


### PR DESCRIPTION
## Summary

This PR is part of issue: https://github.com/solidusio/solidus/issues/5823

- Make Spree::Role names required
- Add solidus_user_roles migrations to core
- Add description to spree_roles table

These new migrations and validations are being added to support the example designs for the new roles admin interface:

<img width="684" alt="Screenshot 2024-08-14 at 7 43 40 PM" src="https://github.com/user-attachments/assets/16bf5730-670c-4487-9a34-65ffbaa7cff8">



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
