### PR TITLE
[SolidusAdmin] Remove inaccessible details/summary element

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/search/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/search/component.html.erb
@@ -23,8 +23,7 @@
       ) %>
     </div>
 
-    <details class="px-6 relative overflow-visible">
-      <summary class="hidden"></summary>
+    <div class="px-6 relative overflow-visible">
       <div
         class="
           absolute
@@ -47,6 +46,6 @@
         data-<%= stimulus_id %>-target="results"
       >
       </div>
-    </details>
+    </div>
   </div>
 </div>

--- a/admin/app/components/solidus_admin/ui/forms/search/component.js
+++ b/admin/app/components/solidus_admin/ui/forms/search/component.js
@@ -95,7 +95,7 @@ export default class extends Controller {
     }
 
     if (this.openResults && resultsHtml && this.query) {
-      if (!this.resultsTarget.parentNode.open) this.selectedIndex = 0
+      if (this.resultsTarget.parentNode.classList.contains("hidden")) this.selectedIndex = 0
 
       for (const result of this.resultTargets) {
         if (result === this.selectedResult) {
@@ -108,9 +108,9 @@ export default class extends Controller {
           result.removeAttribute("aria-selected")
         }
       }
-      this.resultsTarget.parentNode.open = true
+      this.resultsTarget.parentNode.classList.remove("hidden")
     } else {
-      this.resultsTarget.parentNode.open = false
+      this.resultsTarget.parentNode.classList.add("hidden")
     }
   }
 }


### PR DESCRIPTION
## Summary

The variant search on the order#show page utilized a `details`/`summary` HTML element in order to get open/close functionality. However, Axe flags this as inaccessible, because the `summary` element does not have a label. This removes the `summary` element in favor of a simple div, and changes the controller to rely on a `hidden` class instead.

This should fix our currently failing builds.
