### PR TITLE
Destroy wallet payment source on source destroy

### DIFF
--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -7,7 +7,10 @@ module Spree
     belongs_to :payment_method, optional: true
 
     has_many :payments, as: :source
-    has_many :wallet_payment_sources, class_name: 'Spree::WalletPaymentSource', as: :payment_source, inverse_of: :payment_source
+    has_many :wallet_payment_sources,
+      class_name: 'Spree::WalletPaymentSource',
+      as: :payment_source,
+      inverse_of: :payment_source
 
     attr_accessor :imported
 

--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -10,7 +10,8 @@ module Spree
     has_many :wallet_payment_sources,
       class_name: 'Spree::WalletPaymentSource',
       as: :payment_source,
-      inverse_of: :payment_source
+      inverse_of: :payment_source,
+      dependent: :destroy
 
     attr_accessor :imported
 

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -13,6 +13,24 @@ RSpec.shared_examples "a payment source" do
     it { is_expected.to respond_to(:user) }
   end
 
+  describe "#wallet_payment_sources" do
+    let(:user) { create(:user) }
+
+    let!(:wallet_payment_source) do
+      # There are nasty validations that do not matter for this test
+      payment_source.save(validate: false)
+      Spree::WalletPaymentSource.new(user: user, payment_source: payment_source).tap do |wps|
+        wps.save(validate: false)
+      end
+    end
+
+    context "when the payment source gets destroyed" do
+      it "destroys the wallet payment source" do
+        expect { payment_source.destroy }.to change { Spree::WalletPaymentSource.count }.by(-1)
+      end
+    end
+  end
+
   describe "#can_capture?" do
     it "should be true if payment is pending" do
       payment = mock_model(Spree::Payment, pending?: true, created_at: Time.current)


### PR DESCRIPTION
## Summary

A wallet payment source without an actual payment source does not make any sense.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
