### PR TITLE
[v4.3] Lock solidus_core.gemspec to ransack '< 4.2'

### DIFF
--- a/admin/spec/components/previews/solidus_admin/ui/thumbnail/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/thumbnail/component_preview/overview.html.erb
@@ -50,7 +50,7 @@
 <div class="flex gap-4">
   <% product = Spree::Product.new(name: "A good product") %>
   <% attachment = Object.new.tap { def _1.url(*) "https://placekitten.com/280/200"; end }  %>
-  <% image = Spree::Image.new.tap { _1.define_singleton_method(:attachment) { attachment } } %>
+  <% image = Spree::Image.new.tap { |img| img.define_singleton_method(:attachment) { attachment } } %>
   <% [
     Spree::PromotionAction.new,
     Spree::UnitCancel.new,

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -43,7 +43,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'kt-paperclip', ['>= 6.3', '< 8']
   s.add_dependency 'psych', ['>= 4.0.1', '< 6.0']
-  s.add_dependency 'ransack', '~> 4.0'
+  # @note ransack 4.2 contains a bug which has not yet been addressed.
+  # @see https://github.com/activerecord-hackery/ransack/pull/1468
+  s.add_dependency 'ransack', ['~> 4.0', '< 4.2']
   s.add_dependency 'sprockets-rails'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
   s.add_dependency 'omnes', '~> 0.2.2'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.3`:
 - [Merge pull request #5812 from MadelineCollier/lock-ransack-version](https://github.com/solidusio/solidus/pull/5812)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)