### PR TITLE
Standardize admin controller setup methods

### DIFF
--- a/admin/app/controllers/solidus_admin/adjustment_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/adjustment_reasons_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class AdjustmentReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_adjustment_reason, only: %i[edit update]
+    before_action :set_adjustment_reason, only: %i[edit update]
 
     def index
       set_index_page
@@ -95,7 +95,7 @@ module SolidusAdmin
 
     private
 
-    def find_adjustment_reason
+    def set_adjustment_reason
       @adjustment_reason = Spree::AdjustmentReason.find(params[:id])
     end
 

--- a/admin/app/controllers/solidus_admin/refund_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/refund_reasons_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class RefundReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_refund_reason, only: %i[edit update]
+    before_action :set_refund_reason, only: %i[edit update]
 
     def index
       set_index_page
@@ -95,7 +95,7 @@ module SolidusAdmin
 
     private
 
-    def find_refund_reason
+    def set_refund_reason
       @refund_reason = Spree::RefundReason.find(params[:id])
     end
 

--- a/admin/app/controllers/solidus_admin/return_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/return_reasons_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class ReturnReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_return_reason, only: %i[edit update]
+    before_action :set_return_reason, only: %i[edit update]
 
     def index
       set_index_page
@@ -95,7 +95,7 @@ module SolidusAdmin
 
     private
 
-    def find_return_reason
+    def set_return_reason
       @return_reason = Spree::ReturnReason.find(params[:id])
     end
 

--- a/admin/app/controllers/solidus_admin/roles_controller.rb
+++ b/admin/app/controllers/solidus_admin/roles_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class RolesController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_role, only: %i[edit update]
+    before_action :set_role, only: %i[edit update]
 
     search_scope(:all)
     search_scope(:admin) { _1.where(name: "admin") }
@@ -98,7 +98,7 @@ module SolidusAdmin
 
     private
 
-    def find_role
+    def set_role
       @role = Spree::Role.find(params[:id])
     end
 

--- a/admin/app/controllers/solidus_admin/shipping_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/shipping_categories_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class ShippingCategoriesController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_shipping_category, only: %i[edit update]
+    before_action :set_shipping_category, only: %i[edit update]
 
     def new
       @shipping_category = Spree::ShippingCategory.new
@@ -97,7 +97,7 @@ module SolidusAdmin
 
     private
 
-    def find_shipping_category
+    def set_shipping_category
       @shipping_category = Spree::ShippingCategory.find(params[:id])
     end
 

--- a/admin/app/controllers/solidus_admin/store_credit_reasons_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credit_reasons_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class StoreCreditReasonsController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_store_credit_reason, only: %i[edit update]
+    before_action :set_store_credit_reason, only: %i[edit update]
 
     def index
       set_index_page
@@ -95,7 +95,7 @@ module SolidusAdmin
 
     private
 
-    def find_store_credit_reason
+    def set_store_credit_reason
       @store_credit_reason = Spree::StoreCreditReason.find(params[:id])
     end
 

--- a/admin/app/controllers/solidus_admin/tax_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/tax_categories_controller.rb
@@ -4,7 +4,7 @@ module SolidusAdmin
   class TaxCategoriesController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    before_action :find_tax_category, only: %i[edit update]
+    before_action :set_tax_category, only: %i[edit update]
 
     def new
       @tax_category = Spree::TaxCategory.new
@@ -99,7 +99,7 @@ module SolidusAdmin
 
     private
 
-    def find_tax_category
+    def set_tax_category
       @tax_category = Spree::TaxCategory.find(params[:id])
     end
 


### PR DESCRIPTION
## Summary
Since `rails g scaffold` outputs the following boilerplate:

    def set_post
      @post = Post.find(params[:id])
    end

We should adhere to the Rails conventions and stick to `set_<resource_name>` instead of `find_<resource_name>` in our admin controllers.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
