### PR TITLE
Allow Rails 7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ commands:
             ruby -v >> /tmp/.ruby-versions
             gem --version >> /tmp/.gems-versions
             bundle --version >> /tmp/.gems-versions
-            gem search -eq rails -v "~> 7" -v "< 7.2" >> /tmp/.gems-versions # get the latest rails from rubygems
+            gem search -eq rails -v "~> 7" -v "< 8.0" >> /tmp/.gems-versions # get the latest rails from rubygems
             gem search -eq solidus >> /tmp/.gems-versions # get the latest solidus from rubygems
 
             cat /tmp/.ruby-versions
@@ -173,7 +173,7 @@ commands:
           name: "Prepare the rails application"
           command: |
             cd /tmp
-            test -d my_app || (gem install rails -v "< 7.1" && gem install solidus)
+            test -d my_app || (gem install rails -v "< 8.0" && gem install solidus)
             test -d my_app || rails new my_app --skip-git
       - save_cache:
           key: solidus-installer-v10-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
@@ -224,8 +224,8 @@ commands:
             mkdir -p /tmp/dummy_extension
             cd /tmp/dummy_extension
             bundle init
-            bundle add rails -v "< 7.1" --skip-install
-            bundle add sqlite3 -v "~> 1.3" --skip-install
+            bundle add rails -v "< 8.0" --skip-install
+            bundle add sqlite3 -v "~> 2.0" --skip-install
             test -n "<<parameters.extra_gems>>" && bundle add <<parameters.extra_gems>> --skip-install
             bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
             export LIB_NAME=set # dummy requireable file
@@ -374,7 +374,7 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.0", "7.1"],
+                  rails: ["7.0", "7.1", "7.2"],
                   ruby: ["3.1"],
                   database: ["mysql"],
                   paperclip: [true],
@@ -386,7 +386,7 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.0", "7.1"],
+                  rails: ["7.0", "7.1", "7.2"],
                   ruby: ["3.1"],
                   database: ["postgres"],
                   paperclip: [false],
@@ -398,7 +398,7 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.0"],
+                  rails: ["7.1"],
                   ruby: ["3.2"],
                   database: ["sqlite"],
                   paperclip: [false],
@@ -410,8 +410,8 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.1", "main"],
-                  ruby: ["3.3.2"],
+                  rails: ["7.2", "main"],
+                  ruby: ["3.3.5"],
                   database: ["sqlite"],
                   paperclip: [false],
                 },

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,8 +167,8 @@ commands:
             cat /tmp/.gems-versions
       - restore_cache:
           keys:
-            - solidus-installer-v10-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
-            - solidus-installer-v10-{{ checksum "/tmp/.ruby-versions" }}-
+            - solidus-installer-v11-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+            - solidus-installer-v11-{{ checksum "/tmp/.ruby-versions" }}-
       - run:
           name: "Prepare the rails application"
           command: |
@@ -176,7 +176,7 @@ commands:
             test -d my_app || (gem install rails -v "< 8.0" && gem install solidus)
             test -d my_app || rails new my_app --skip-git
       - save_cache:
-          key: solidus-installer-v10-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
+          key: solidus-installer-v11-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
           paths:
             - /tmp/my_app
             - /home/circleci/.rubygems

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec require: false
 if /(stable|main)/.match? ENV['RAILS_VERSION']
   gem 'rails', github: 'rails', require: false, branch: ENV['RAILS_VERSION']
 else
-  gem 'rails', ENV['RAILS_VERSION'] || '< 7.2', require: false
+  gem 'rails', ENV['RAILS_VERSION'] || ['> 7.0', '< 8.0.0.beta1'], require: false
 end
 # rubocop:enable Bundler/DuplicatedGem
 

--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -50,7 +50,7 @@ describe 'Customer returns', type: :feature do
         within('[data-hook="rejected_return_items"] tbody tr:nth-child(1)') do
           click_button('Receive')
 
-          expect(page).to have_button("Receive", disabled: true)
+          expect(page).to have_button("Receive", disabled: true, wait: 5)
         end
       end
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -11,7 +11,7 @@ module Spree
     include Spree::CalculatedAdjustments
     include Spree::AdjustmentSource
 
-    enum level: {
+    enum :level, {
       item: 0,
       order: 1
     }, _suffix: true

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -14,7 +14,7 @@ module Spree
     enum :level, {
       item: 0,
       order: 1
-    }, _suffix: true
+    }, suffix: true
 
     belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates, optional: true
 

--- a/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
@@ -1,1 +1,1 @@
-apply 'https://github.com/solidusio/solidus_starter_frontend/raw/main/template.rb'
+apply 'https://github.com/solidusio/solidus_starter_frontend/raw/rails-7.2/template.rb'

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -20,6 +20,7 @@ end
 
 # @private
 class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
 end
 
 # @private

--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -4,21 +4,6 @@ module DummyApp
   module Migrations
     extend self
 
-    # Ensure database exists
-    def database_exists?
-      ActiveRecord::Base.connection
-    rescue ActiveRecord::NoDatabaseError
-      false
-    else
-      true
-    end
-
-    def needs_migration?
-      return true if !database_exists?
-
-      ActiveRecord::Base.connection.migration_context.needs_migration?
-    end
-
     def auto_migrate
       if needs_migration?
         puts "Configuration changed. Re-running migrations"
@@ -34,6 +19,14 @@ module DummyApp
     end
 
     private
+
+    def needs_migration?
+      ActiveRecord::Migration.check_all_pending!
+    rescue ActiveRecord::PendingMigrationError, ActiveRecord::NoDatabaseError
+      true
+    else
+      false
+    end
 
     def sh(cmd)
       puts cmd

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,12 +27,12 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 7.0', '< 7.2']
+    s.add_dependency rails_dep, ['>= 7.0', '< 8.0.0.beta1']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'
   s.add_dependency 'acts_as_list', '< 2.0'
-  s.add_dependency 'awesome_nested_set', '~> 3.3'
+  s.add_dependency 'awesome_nested_set', ['~> 3.3', '>= 3.7.0']
   s.add_dependency 'cancancan', ['>= 2.2', '< 4.0']
   s.add_dependency 'carmen', '~> 1.1.0'
   s.add_dependency 'discard', '~> 1.0'

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -37,7 +37,7 @@ module SolidusPromotions
       joins(:benefits).distinct
     end
 
-    enum lane: SolidusPromotions.config.preferred_lanes
+    enum :lane, SolidusPromotions.config.preferred_lanes
 
     def self.with_coupon_code(val)
       joins(:codes).where(


### PR DESCRIPTION
## Summary

Allows to update host apps to Rails 7.2.

The only change is that we need to raise the minimum version of Ruby to 3.1, but since it is EOL anyway
it should not be a big deal for anyone.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
