### PR TITLE
Decorate Default Return Refund Amount Calculator in LegacyPromotions

### DIFF
--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -14,7 +14,7 @@ module Spree
       private
 
       def weighted_order_adjustment_amount(inventory_unit)
-        inventory_unit.order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
+        inventory_unit.order.adjustments.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
       end
 
       def weighted_line_item_amount(inventory_unit)

--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree_calculator_returns_default_refund_amount_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree_calculator_returns_default_refund_amount_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusLegacyPromotions
+  module SpreeCalculatorReturnsDefaultRefundAmountDecorator
+    private
+
+    def weighted_order_adjustment_amount(inventory_unit)
+      inventory_unit.order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
+    end
+
+    Spree::Calculator::Returns::DefaultRefundAmount.prepend self
+  end
+end


### PR DESCRIPTION
This calculator uses the `eligible` API from `Spree::Adjustment`, which in a system with the new promotions system will not be necessary.

This hasn't been caught before because deprecation warnings did not raise until https://github.com/solidusio/solidus/pull/5813 was merged.

