### PR TITLE
[Admin] Display `last_sign_in_at` in users admin, change default scope

### DIFF
--- a/admin/app/components/solidus_admin/users/index/component.rb
+++ b/admin/app/components/solidus_admin/users/index/component.rb
@@ -88,9 +88,24 @@ class SolidusAdmin::Users::Index::Component < SolidusAdmin::UsersAndRoles::Compo
         data: -> { _1.display_lifetime_value.to_html },
       },
       {
-        header: :created_at,
-        data: ->(user) { l(user.created_at.to_date, format: :long) },
+        header: :last_active,
+        data: ->(user) { last_login(user) },
       },
     ]
+  end
+
+  private
+
+  # @todo add logic to display "Invitation sent" when the user has not yet
+  #   accepted the invitation and filled out account details. To be implemented
+  #   in conjunction with the invitation logic.
+  def last_login(user)
+    return t('.last_login.never') if user.try(:last_sign_in_at).blank?
+
+    t(
+      '.last_login.login_time_ago',
+      # @note The second `.try` is only here for the specs to work.
+      last_login_time: time_ago_in_words(user.try(:last_sign_in_at))
+    ).capitalize
   end
 end

--- a/admin/app/components/solidus_admin/users/index/component.rb
+++ b/admin/app/components/solidus_admin/users/index/component.rb
@@ -39,11 +39,11 @@ class SolidusAdmin::Users::Index::Component < SolidusAdmin::UsersAndRoles::Compo
 
   def scopes
     [
-      { name: :customers, label: t('.scopes.customers'), default: true },
+      { name: :all, label: t('.scopes.all'), default: true },
+      { name: :customers, label: t('.scopes.customers') },
       { name: :admin, label: t('.scopes.admin') },
       { name: :with_orders, label: t('.scopes.with_orders') },
       { name: :without_orders, label: t('.scopes.without_orders') },
-      { name: :all, label: t('.scopes.all') },
     ]
   end
 

--- a/admin/app/components/solidus_admin/users/index/component.yml
+++ b/admin/app/components/solidus_admin/users/index/component.yml
@@ -13,3 +13,7 @@ en:
   status:
     active: Active
     inactive: Inactive
+  last_login:
+    login_time_ago: "%{last_login_time} ago"
+    never: Never
+    invitation_sent: Invitation sent

--- a/admin/app/controllers/solidus_admin/users_controller.rb
+++ b/admin/app/controllers/solidus_admin/users_controller.rb
@@ -4,11 +4,11 @@ module SolidusAdmin
   class UsersController < SolidusAdmin::BaseController
     include SolidusAdmin::ControllerHelpers::Search
 
-    search_scope(:customers, default: true) { _1.left_outer_joins(:role_users).where(role_users: { id: nil }) }
+    search_scope(:all, default: true)
+    search_scope(:customers) { _1.left_outer_joins(:role_users).where(role_users: { id: nil }) }
     search_scope(:admin) { _1.joins(:role_users).distinct }
     search_scope(:with_orders) { _1.joins(:orders).distinct }
     search_scope(:without_orders) { _1.left_outer_joins(:orders).where(orders: { id: nil }) }
-    search_scope(:all)
 
     def index
       users = apply_search_to(

--- a/admin/spec/features/users_spec.rb
+++ b/admin/spec/features/users_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 describe "Users", :js, type: :feature do
-  before { sign_in create(:admin_user, email: 'admin@example.com') }
+  before { sign_in create(:admin_user, email: "admin@example.com") }
 
   it "lists users and allows deleting them" do
     create(:user, email: "customer@example.com")
@@ -11,6 +11,9 @@ describe "Users", :js, type: :feature do
     create(:user, :with_orders, email: "customer-with-order@example.com")
 
     visit "/admin/users"
+    expect(page).to have_content("Last active")
+    expect(page).to have_content("Never")
+
     expect(page).to have_content("customer@example.com")
     expect(page).to have_content("admin-2@example.com")
     expect(page).to have_content("customer-with-order@example.com")
@@ -32,5 +35,21 @@ describe "Users", :js, type: :feature do
     expect(page).to have_content("Users were successfully removed.")
     expect(page).not_to have_content("customer@example.com")
     expect(Spree.user_class.count).to eq(3)
+  end
+
+  context "when a user has recently signed in" do
+    let(:sign_in_date) { DateTime.now }
+
+    before do
+      allow_any_instance_of(Spree.user_class).to receive(:try).with(:email).and_call_original
+      allow_any_instance_of(Spree.user_class).to receive(:try).with(:last_sign_in_at).and_return(sign_in_date)
+    end
+
+    it "lists the last time they were active" do
+      visit "/admin/users"
+      expect(page).to have_content("Last active")
+      expect(page).to have_content("Less than a minute ago")
+      expect(page).not_to have_content("Never")
+    end
   end
 end

--- a/admin/spec/features/users_spec.rb
+++ b/admin/spec/features/users_spec.rb
@@ -11,6 +11,10 @@ describe "Users", :js, type: :feature do
     create(:user, :with_orders, email: "customer-with-order@example.com")
 
     visit "/admin/users"
+    expect(page).to have_content("customer@example.com")
+    expect(page).to have_content("admin-2@example.com")
+    expect(page).to have_content("customer-with-order@example.com")
+    click_on "Customers"
     expect(page).to have_content("Users and Roles")
     expect(page).to have_content("customer@example.com")
     expect(page).not_to have_content("admin-2@example.com")
@@ -19,13 +23,10 @@ describe "Users", :js, type: :feature do
     expect(page).not_to have_content("customer@example.com")
     click_on "With Orders"
     expect(page).to have_content("customer-with-order@example.com")
-    click_on "All"
-    expect(page).to have_content("customer@example.com")
-    expect(page).to have_content("admin-2@example.com")
-    expect(page).to have_content("customer-with-order@example.com")
 
     expect(page).to be_axe_clean
 
+    click_on "All"
     select_row("customer@example.com")
     click_on "Delete"
     expect(page).to have_content("Users were successfully removed.")

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -410,6 +410,7 @@ en:
         analytics_id: Analytics ID
       spree/user:
         email: Email
+        last_active: Last active
         lifetime_value: Total spent
         password: Password
         password_confirmation: Password Confirmation


### PR DESCRIPTION
## Summary
These are a few smaller pieces which can be broken off of the larger work against issue: https://github.com/solidusio/solidus/issues/5824

If there is a reason for why the default scope was "Customers" instead of "All" then I am happy to remove that change, but if not I think it's a good one.

## Screenshots

This shows the updated "All" default scope and the new "Last active" column.

<img width="1440" alt="Screenshot 2024-09-09 at 5 09 30 PM" src="https://github.com/user-attachments/assets/0c26da40-71e7-4ee7-8904-b8694ff8e547">

<img width="1440" alt="Screenshot 2024-09-09 at 5 06 50 PM" src="https://github.com/user-attachments/assets/4c7ea6f8-5a75-49bd-8bfe-c7a612dde6ef">

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
