### PR TITLE
[Admin] New admin user edit page

### DIFF
--- a/admin/app/components/solidus_admin/users/edit/api_access/component.html.erb
+++ b/admin/app/components/solidus_admin/users/edit/api_access/component.html.erb
@@ -1,0 +1,49 @@
+<%= render component('ui/panel').new(title: t('.api_access')) do %>
+  <section>
+    <% if @user.spree_api_key.present? %>
+      <div id="current-api-key">
+        <h2 class="py-1.5 font-semibold"><%= t('.key') %></h2>
+        <% if @user == helpers.current_solidus_admin_user %>
+          <%= @user.spree_api_key %>
+        <% else %>
+          <i>(<%= t('spree.hidden') %>)</i>
+        <% end %>
+      </div>
+
+      <div class="py-1.5 text-center">
+        <%= form_with url: spree.admin_user_api_key_path(@user), method: :delete, local: true, html: { class: 'clear_api_key inline-flex' } do %>
+          <%= render component("ui/button").new(
+            text: t('.clear_key'),
+            scheme: :secondary,
+            type: :submit,
+            "data-action": "click->#{stimulus_id}#confirm",
+            "data-#{stimulus_id}-message-param": t(".confirm_clear_key"),
+          ) %>
+        <% end %>
+
+        <%= form_with url: spree.admin_user_api_key_path(@user), method: :post, local: true, html: { class: 'regen_api_key inline-flex' } do %>
+          <%= render component("ui/button").new(
+            text: t('.regenerate_key'),
+            scheme: :secondary,
+            type: :submit,
+            "data-action": "click->#{stimulus_id}#confirm",
+            "data-#{stimulus_id}-message-param": t(".confirm_regenerate_key"),
+          ) %>
+        <% end %>
+      </div>
+
+    <% else %>
+      <div class="no-objects-found"><%= t('.no_key') %></div>
+      <div class="filter-actions actions">
+        <div class="py-1.5 text-center">
+          <%= form_with url: spree.admin_user_api_key_path(@user), method: :post, local: true, html: { class: 'generate_api_key inline-flex' } do %>
+            <%= render component("ui/button").new(
+              text: t('.generate_key'),
+              type: :submit,
+            ) %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/admin/app/components/solidus_admin/users/edit/api_access/component.js
+++ b/admin/app/components/solidus_admin/users/edit/api_access/component.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  confirm(event) {
+    if (!confirm(event.params.message)) {
+      event.preventDefault()
+    }
+  }
+}

--- a/admin/app/components/solidus_admin/users/edit/api_access/component.rb
+++ b/admin/app/components/solidus_admin/users/edit/api_access/component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::Edit::ApiAccess::Component < SolidusAdmin::BaseComponent
+  def initialize(user:)
+    @user = user
+  end
+end

--- a/admin/app/components/solidus_admin/users/edit/api_access/component.yml
+++ b/admin/app/components/solidus_admin/users/edit/api_access/component.yml
@@ -1,0 +1,10 @@
+en:
+  api_access: API Access
+  no_key: No key
+  key: "Key"
+  generate_key: Generate API key
+  clear_key: Clear key
+  regenerate_key: Regenerate key
+  hidden: Hidden
+  confirm_clear_key: Are you sure you want to clear this user's API key? It will invalidate the existing key.
+  confirm_regenerate_key: Are you sure you want to regenerate this user's API key? It will invalidate the existing key.

--- a/admin/app/components/solidus_admin/users/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/users/edit/component.html.erb
@@ -1,0 +1,62 @@
+<%= page do %>
+  <%= page_header do %>
+    <%= page_header_back(solidus_admin.users_path) %>
+    <%= page_header_title(t(".title", email: @user.email)) %>
+
+    <% # @todo: I am not sure how we want to handle Cancan stuff in the new admin. %>
+    <% # if can?(:admin, Spree::Order) && can?(:create, Spree::Order) %>
+      <%= page_header_actions do %>
+        <%= render component("ui/button").new(tag: :a, text: t(".create_order_for_user"), href: spree.new_admin_order_path(user_id: @user.id)) %>
+      <% end %>
+    <% # end %>
+  <% end %>
+
+  <%= page_header do %>
+    <% tabs.each do |tab| %>
+      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
+    <% end %>
+  <% end %>
+
+  <%= page_with_sidebar do %>
+    <%= page_with_sidebar_main do %>
+
+      <%= render component('ui/panel').new(title: Spree.user_class.model_name.human) do %>
+        <%= form_for @user, url: solidus_admin.user_path(@user), html: { id: form_id, autocomplete: "off" } do |f| %>
+          <div class="py-1.5">
+            <%= render component("ui/forms/field").text_field(f, :email) %>
+          </div>
+          <div class="py-1.5">
+            <%= render component("ui/forms/field").text_field(f, :password) %>
+          </div>
+          <div class="py-1.5">
+            <%= render component("ui/forms/field").text_field(f, :password_confirmation) %>
+          </div>
+          <div class="py-1.5">
+            <%= render component("ui/checkbox_row").new(options: role_options, row_title: "Roles", form: f, method: "spree_role_ids", layout: :subsection) %>
+          </div>
+          <div class="py-1.5 text-center">
+            <%= render component("ui/button").new(tag: :button, text: t(".update"), form: form_id) %>
+            <%= render component("ui/button").new(tag: :a, text: t(".cancel"), href: solidus_admin.user_path(@user), scheme: :secondary) %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= render component("users/edit/api_access").new(user: @user) %>
+
+    <% end %>
+
+    <%= page_with_sidebar_aside do %>
+      <%= render component("ui/panel").new(title: t("spree.lifetime_stats")) do %>
+        <%= render component("ui/details_list").new(
+          items: [
+            { label: t("spree.total_sales"), value: @user.display_lifetime_value.to_html },
+            { label: t("spree.order_count"), value: @user.order_count.to_i },
+            { label: t("spree.average_order_value"), value: @user.display_average_order_value.to_html },
+            { label: t("spree.member_since"), value: @user.created_at.to_date },
+            { label: t(".last_active"), value: last_login(@user) },
+          ]
+        ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/users/edit/component.rb
+++ b/admin/app/components/solidus_admin/users/edit/component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::Edit::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def form_id
+    @form_id ||= "#{stimulus_id}--form-#{@user.id}"
+  end
+
+  def tabs
+    [
+      {
+        text: t('.account'),
+        href: solidus_admin.users_path,
+        current: action_name == "show",
+      },
+      {
+        text: t('.addresses'),
+        href: spree.addresses_admin_user_path(@user),
+        # @todo: update this "current" logic once folded into new admin
+        current: action_name != "show",
+      },
+      {
+        text: t('.order_history'),
+        href: spree.orders_admin_user_path(@user),
+        # @todo: update this "current" logic once folded into new admin
+        current: action_name != "show",
+      },
+      {
+        text: t('.items'),
+        href: spree.items_admin_user_path(@user),
+        # @todo: update this "current" logic once folded into new admin
+        current: action_name != "show",
+      },
+      {
+        text: t('.store_credit'),
+        href: spree.admin_user_store_credits_path(@user),
+        # @todo: update this "current" logic once folded into new admin
+        current: action_name != "show",
+      },
+    ]
+  end
+
+  def last_login(user)
+    return t('.last_login.never') if user.try(:last_sign_in_at).blank?
+
+    t(
+      '.last_login.login_time_ago',
+      # @note The second `.try` is only here for the specs to work.
+      last_login_time: time_ago_in_words(user.try(:last_sign_in_at))
+    ).capitalize
+  end
+
+  def role_options
+    Spree::Role.all.map do |role|
+      { label: role.name, id: role.id }
+    end
+  end
+end

--- a/admin/app/components/solidus_admin/users/edit/component.yml
+++ b/admin/app/components/solidus_admin/users/edit/component.yml
@@ -1,0 +1,16 @@
+en:
+  title: "Users / %{email}"
+  account: Account
+  addresses: Addresses
+  order_history: Order History
+  items: Items
+  store_credit: Store Credit
+  last_active: Last Active
+  last_login:
+    login_time_ago: "%{last_login_time} ago"
+    never: Never
+    invitation_sent: Invitation sent
+  create_order_for_user: Create order for this user
+  update: Update
+  cancel: Cancel
+  back: Back

--- a/admin/app/components/solidus_admin/users/index/component.rb
+++ b/admin/app/components/solidus_admin/users/index/component.rb
@@ -14,7 +14,7 @@ class SolidusAdmin::Users::Index::Component < SolidusAdmin::UsersAndRoles::Compo
   end
 
   def row_url(user)
-    spree.admin_user_path(user)
+    solidus_admin.edit_user_path(user)
   end
 
   def page_actions
@@ -104,7 +104,8 @@ class SolidusAdmin::Users::Index::Component < SolidusAdmin::UsersAndRoles::Compo
 
     t(
       '.last_login.login_time_ago',
-      # @note The second `.try` is only here for the specs to work.
+      # @note The second `.try` is here for the specs and for setups that use a
+      # custom User class which may not have this attribute.
       last_login_time: time_ago_in_words(user.try(:last_sign_in_at))
     ).capitalize
   end

--- a/admin/app/controllers/solidus_admin/users_controller.rb
+++ b/admin/app/controllers/solidus_admin/users_controller.rb
@@ -23,6 +23,14 @@ module SolidusAdmin
       end
     end
 
+    def edit
+      set_user
+
+      respond_to do |format|
+        format.html { render component('users/edit').new(user: @user) }
+      end
+    end
+
     def destroy
       @users = Spree.user_class.where(id: params[:id])
 
@@ -33,6 +41,10 @@ module SolidusAdmin
     end
 
     private
+
+    def set_user
+      @user = Spree.user_class.find(params[:id])
+    end
 
     def user_params
       params.require(:user).permit(:user_id, permitted_user_attributes)

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -45,7 +45,7 @@ SolidusAdmin::Engine.routes.draw do
     end
   end
 
-  admin_resources :users, only: [:index, :destroy]
+  admin_resources :users, only: [:index, :edit, :destroy]
   admin_resources :promotions, only: [:index, :destroy]
   admin_resources :properties, only: [:index, :destroy]
   admin_resources :option_types, only: [:index, :destroy], sortable: true

--- a/admin/spec/requests/solidus_admin/users_spec.rb
+++ b/admin/spec/requests/solidus_admin/users_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidusAdmin::UsersController", type: :request do
+  let(:admin_user) { create(:admin_user) }
+  let(:user) { create(:user) }
+
+  before do
+    allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
+  end
+
+  describe "GET /index" do
+    it "renders the index template with a 200 OK status" do
+      get solidus_admin.users_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /edit" do
+    it "renders the edit template with a 200 OK status" do
+      get solidus_admin.edit_user_path(user)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "deletes the user and redirects to the index page with a 303 See Other status" do
+      # Ensure the user exists prior to deletion
+      user
+
+      expect {
+        delete solidus_admin.user_path(user)
+      }.to change(Spree.user_class, :count).by(-1)
+
+      expect(response).to redirect_to(solidus_admin.users_path)
+      expect(response).to have_http_status(:see_other)
+    end
+
+    it "displays a success flash message after deletion" do
+      delete solidus_admin.user_path(user)
+      follow_redirect!
+      expect(response.body).to include("Users were successfully removed.")
+    end
+  end
+
+  describe "search functionality" do
+    before do
+      create(:user, email: "test@example.com")
+      create(:user, email: "another@example.com")
+    end
+
+    it "filters users based on search parameters" do
+      get solidus_admin.users_path, params: { q: { email_cont: "test" } }
+      expect(response.body).to include("test@example.com")
+      expect(response.body).not_to include("another@example.com")
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1855,6 +1855,7 @@ en:
     order_approved: Order approved
     order_canceled: Order canceled
     order_completed: Order completed
+    order_count: Order Count
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information


### PR DESCRIPTION
## Summary

This PR is for issue: https://github.com/solidusio/solidus/issues/5824

This migrates the `users/:id/edit` page to the new admin. It still relies on the old backend admin controller for the `#update` action as well as the other top level user tabs such as address, order history, and so on.

In the next couple PRs I will migrate the remaining tabs to the new interface, but for now I thought it best to keep the old interface for actions such as creating a new user, which we definitely want to still have working.

**This PR does not handle the issue of permission dependent interface elements.** In the old admin, some buttons would not be visible if the user lacked the permissions to action them. However it looks like that is currently standard for the entirety of the new admin as I don't see any permissions checks or anything like this anywhere in the new admin:
```
      <% if can?(:addresses, @user) %>
        <li class="<%= 'active' if current == :address %>">
          <%= link_to t("spree.admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
        </li>
      <% end %>
```
If we are using a new helper or gem to manage this and I am just missing something definitely let me know which implementation I can reference! Otherwise for now I will put this up as is because handling `if can?` permissions checks across the whole of the admin is a bit out of scope for this PR.

In the next PRs I will migrate the other tabs of the user admin (address, order history etc) and will add the modal for user creation (although I may leave the user creation backend logic as is for now as it looks like the issue specifically states that the user invitation flow should be considered a separate task.

Again there weren't really designs for this so I just went for it and tried to keep to our existing components as much as possible. Hopefully it looks decent!

<img width="1440" alt="Screenshot 2024-09-18 at 10 24 18 PM" src="https://github.com/user-attachments/assets/9aca7556-011c-4710-a9ae-496d7b0760b4">

The attached video shows the functionality visually:

https://github.com/user-attachments/assets/72c40096-5c97-4e40-8688-a6e0cbaefbc9


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
