### PR TITLE
Fix failing API promotions specs

### DIFF
--- a/api/spec/requests/spree/api/promotions_spec.rb
+++ b/api/spec/requests/spree/api/promotions_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'ostruct'
 
 module Spree::Api
   describe 'Promotions', type: :request do
@@ -25,7 +26,7 @@ module Spree::Api
     end
 
     let(:found_promotion) do
-      OpenStruct.new(
+      ::OpenStruct.new(
         id: 1,
         name: 'Test Promotion',
         description: 'Promotion for testing purposes',


### PR DESCRIPTION
## Summary
Three of these examples were failing with the following error:

     NameError:
       uninitialized constant Spree::Api::OpenStruct

             OpenStruct.new(
             ^^^^^^^^^^

Requiring ostruct and ensuring the correct scope is used when referencing OpenStruct fixes the errors.

<img width="978" alt="Screenshot 2024-09-23 at 1 23 53 PM" src="https://github.com/user-attachments/assets/84c5e4fb-7ed9-404d-800e-24daa2bce2ac">

<img width="622" alt="Screenshot 2024-09-23 at 1 24 18 PM" src="https://github.com/user-attachments/assets/4785f855-5933-4c24-a069-8988468c1d62">


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
