### PR TITLE
Spree::Variant.in_stock: Only show distinct variants

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -94,7 +94,7 @@ module Spree
       if stock_locations.present?
         in_stock_variants = in_stock_variants.where(spree_stock_items: { stock_location_id: stock_locations.map(&:id) })
       end
-      in_stock_variants
+      in_stock_variants.distinct
     end
 
     # Returns a scope of Variants which are suppliable. This includes:

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -885,6 +885,18 @@ RSpec.describe Spree::Variant, type: :model do
       it "returns all in stock variants" do
         expect(subject).to eq [in_stock_variant]
       end
+
+      context "with stock in several locations" do
+        let!(:other_stock_location) { create(:stock_location, propagate_all_variants: true) }
+
+        before do
+          Spree::StockItem.where(variant: in_stock_variant).update_all(count_on_hand: 10)
+        end
+
+        it "returns just one variant" do
+          expect(subject).to eq([in_stock_variant])
+        end
+      end
     end
 
     context "inventory levels globally not tracked" do


### PR DESCRIPTION

## Summary

Without the `.distinct` added to this scope, it returns the same variant multiple times if there is stock in multiple stock locations.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
