### PR TITLE
Stop pinning Chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,7 @@ commands:
   setup:
     steps:
       - checkout
-      - browser-tools/install-chrome:
-          chrome-version: "118.0.5993.70"
-          replace-existing: true
+      - browser-tools/install-chrome
       - run:
           name: Check chrome version
           command: |


### PR DESCRIPTION
We initially did this because of some Bug in Chrome, but now the download of the very specific version here doesn't work any longer.

Let's see what happens if we don't pin.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
