### PR TITLE
Format date with #to_fs

### DIFF
--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -81,7 +81,7 @@
         <td><%= tax_rate.amount %></td>
         <td><%= tax_rate.included_in_price? ? t('spree.say_yes') : t('spree.say_no') %></td>
         <td><%= tax_rate.show_rate_in_label? ? t('spree.say_yes') : t('spree.say_no') %></td>
-        <td><%= tax_rate.expires_at.to_date.to_s(:short_date) if tax_rate.expires_at %></td>
+        <td><%= tax_rate.expires_at.to_date.to_fs(:short_date) if tax_rate.expires_at %></td>
         <td><%= tax_rate.calculator && tax_rate.calculator.class.model_name.human %></td>
         <td class="actions">
           <% if can?(:update, tax_rate) %>

--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -25,6 +25,7 @@ describe "Tax Rates", type: :feature do
     click_link "Tax Rates"
     click_link "New Tax Rate"
     fill_in "Rate", with: "0.05"
+    fill_in "Expiration Date", with: "2050-01-01"
     click_button "Create"
     expect(page).to have_content("Tax Rate has been successfully created!")
   end


### PR DESCRIPTION
## Summary

Hello!!!

The `#to_s(format)` method [was deprecated and removed from Rails 7.0](https://github.com/rails/rails/blob/de7c495209811f8f918fa9f915e64df61a6080c1/guides/source/7_0_release_notes.md#deprecations-8), the correct method is now `#to_fs`. 
This is causing `ActionView::Template::Error wrong number of arguments (given 1, expected 0)`
when a tax rate with an expiration date is displayed.

The test was passing just because an expiration date was not set.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
