### PR TITLE
[Admin] Add new users admin addresses page

### DIFF
--- a/admin/app/components/solidus_admin/users/addresses/component.html.erb
+++ b/admin/app/components/solidus_admin/users/addresses/component.html.erb
@@ -1,0 +1,56 @@
+<%= page do %>
+  <%= page_header do %>
+    <%= page_header_back(solidus_admin.users_path) %>
+    <%= page_header_title(t(".title", email: @user.email)) %>
+
+    <%= page_header_actions do %>
+      <%= render component("ui/button").new(tag: :a, text: t(".create_order_for_user"), href: spree.new_admin_order_path(user_id: @user.id)) %>
+    <% end %>
+  <% end %>
+
+  <%= page_header do %>
+    <% tabs.each do |tab| %>
+      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
+    <% end %>
+  <% end %>
+
+  <%= page_with_sidebar do %>
+    <%= page_with_sidebar_main do %>
+      <%= render component('ui/panel').new(title: t(".billing_address")) do %>
+        <%= form_for @user, url: solidus_admin.update_addresses_user_path(@user), method: :put, html: { id: "#{form_id}_billing", autocomplete: "off", class: "bill_address" } do |f| %>
+
+          <%= render component('ui/forms/address').new(address: @bill_address, name: "user[bill_address_attributes]") %>
+          <div class="py-1.5 text-center">
+            <%= render component("ui/button").new(tag: :button, text: t(".update"), form: "#{form_id}_billing") %>
+            <%= render component("ui/button").new(tag: :a, text: t(".cancel"), href: solidus_admin.addresses_user_path(@user), scheme: :secondary) %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= render component('ui/panel').new(title: t(".shipping_address")) do %>
+        <%= form_for @user, url: solidus_admin.update_addresses_user_path(@user), method: :put, html: { id: "#{form_id}_shipping", autocomplete: "off", class: "ship_address"  } do |f| %>
+
+          <%= render component('ui/forms/address').new(address: @ship_address, name: "user[ship_address_attributes]") %>
+          <div class="py-1.5 text-center">
+            <%= render component("ui/button").new(tag: :button, text: t(".update"), form: "#{form_id}_shipping") %>
+            <%= render component("ui/button").new(tag: :a, text: t(".cancel"), href: solidus_admin.addresses_user_path(@user), scheme: :secondary) %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= page_with_sidebar_aside do %>
+      <%= render component("ui/panel").new(title: t("spree.lifetime_stats")) do %>
+        <%= render component("ui/details_list").new(
+          items: [
+            { label: t("spree.total_sales"), value: @user.display_lifetime_value.to_html },
+            { label: t("spree.order_count"), value: @user.order_count.to_i },
+            { label: t("spree.average_order_value"), value: @user.display_average_order_value.to_html },
+            { label: t("spree.member_since"), value: @user.created_at.to_date },
+            { label: t(".last_active"), value: last_login(@user) },
+          ]
+        ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/users/addresses/component.yml
+++ b/admin/app/components/solidus_admin/users/addresses/component.yml
@@ -1,0 +1,18 @@
+en:
+  title: "Users / %{email} / Addresses"
+  account: Account
+  addresses: Addresses
+  order_history: Order History
+  items: Items
+  store_credit: Store Credit
+  last_active: Last Active
+  last_login:
+    login_time_ago: "%{last_login_time} ago"
+    never: Never
+    invitation_sent: Invitation sent
+  create_order_for_user: Create order for this user
+  update: Update
+  cancel: Cancel
+  back: Back
+  billing_address: Billing Address
+  shipping_address: Shipping Address

--- a/admin/config/locales/users.en.yml
+++ b/admin/config/locales/users.en.yml
@@ -4,3 +4,9 @@ en:
       title: "Users"
       destroy:
         success: "Users were successfully removed."
+      update_addresses:
+        bill:
+          success: "Billing Address has been successfully updated."
+        ship:
+          success: "Shipping Address has been successfully updated."
+        error: "Address could not be updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -45,7 +45,13 @@ SolidusAdmin::Engine.routes.draw do
     end
   end
 
-  admin_resources :users, only: [:index, :edit, :destroy]
+  admin_resources :users, only: [:index, :edit, :destroy] do
+    member do
+      get :addresses
+      put :update_addresses
+    end
+  end
+
   admin_resources :promotions, only: [:index, :destroy]
   admin_resources :properties, only: [:index, :destroy]
   admin_resources :option_types, only: [:index, :destroy], sortable: true


### PR DESCRIPTION
## Summary
This PR is for issue https://github.com/solidusio/solidus/issues/5824.

This migrates the `users/:id/addresses` page to the new admin. Instead of squashing everything into one controller action with an `if request.put?` wrapper (like the legacy backend controller did), I chose to break this new admin into two actions separated by their methods and responsibilities.

The old admin page did not have anything in the way of validations or error messages, it would simply fail to update the address and leave it as is if the user provided invalid values. (While also showing a message saying that the update was successful?)

This page improves upon that flow, adding validations to the address forms when their values are invalid and preventing the update, but since we are submitting an update against the user and not the address directly, we still need to do some extra work to run the validations and generate errors for the form (rather than silently failing to update like the legacy back-end controller used to do).

## Screenshots:
### Here is an example of the old admin's lack of validation:
https://github.com/user-attachments/assets/04302036-4943-46fc-86db-5c7097c38179
### Here is the new admin with new validation:
https://github.com/user-attachments/assets/a69820f0-0034-4efb-af5f-372600a50c84
### Here is a video to show off the new page more generally:
https://github.com/user-attachments/assets/0eb70472-f6fd-4a43-8aea-9ce013c5fb64

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
