### PR TITLE
Add template variants scope

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -80,6 +80,11 @@ module Spree
 
     after_destroy :destroy_option_values_variants
 
+    scope :template_variants, -> do
+      left_joins(product: { option_types: :option_values }).where(is_master: true).where.not(spree_option_values: { id: nil }).reorder(nil).distinct
+    end
+    scope :non_template_variants, -> { where.not(id: template_variants) }
+
     # Returns variants that are in stock. When stock locations are provided as
     # a parameter, the scope is limited to variants that are in stock in the
     # provided stock locations.

--- a/core/lib/spree/core/search/variant.rb
+++ b/core/lib/spree/core/search/variant.rb
@@ -22,7 +22,7 @@ module Spree
 
         def initialize(query_string, scope: Spree::Variant.all)
           @query_string = query_string
-          @scope = scope
+          @scope = scope.non_template_variants
         end
 
         # Searches the variants table using the ransack 'search_terms' defined on the class.
@@ -39,7 +39,7 @@ module Spree
             @scope.ransack(search_term_params(word)).result.pluck(:id)
           end
 
-          Spree::Variant.where(id: matches.inject(:&))
+          @scope.where(id: matches.inject(:&))
         end
 
         private

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -27,6 +27,16 @@ module Spree
       it { refute_found("bca", variant) }
     end
 
+    context "with a template variant" do
+      let!(:option_type) { create(:option_type, option_values: [option_value]) }
+      let(:option_value) { build(:option_value) }
+      let(:product) { create(:product, option_types: [option_type], sku: "TEMPLATE") }
+      let(:variant) { create(:variant, product: product, sku: "NOT_TEMPLATE") }
+
+      it { refute_found("TEMPLATE", product.master) }
+      it { assert_found("NOT_TEMPLATE", variant) }
+    end
+
     context "by product" do
       it { assert_found("My Special Product", variant) }
       it { assert_found("My Spec", variant) }

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -7,6 +7,28 @@ RSpec.describe Spree::Variant, type: :model do
 
   let!(:variant) { create(:variant) }
 
+  describe '.non_template_variants' do
+    let(:option_type) { create(:option_type, option_values: [option_value]) }
+    let(:option_value) { build(:option_value) }
+    let(:product) { create(:product, option_types: [option_type]) }
+    let!(:variant) { create(:variant, product: product) }
+
+    subject { described_class.non_template_variants }
+
+    it { is_expected.to contain_exactly(variant) }
+  end
+
+  describe '.template_variants' do
+    let(:option_type) { create(:option_type, option_values: [option_value]) }
+    let(:option_value) { build(:option_value) }
+    let(:product) { create(:product, option_types: [option_type]) }
+    let!(:variant) { create(:variant, product: product) }
+
+    subject { described_class.template_variants }
+
+    it { is_expected.to contain_exactly(product.master) }
+  end
+
   describe 'delegates' do
     let(:product) { build(:product) }
     let(:variant) { build(:variant, product: product) }


### PR DESCRIPTION
## Summary

This introduces logic that removes the ability to add template ("master") variants to admin carts. 

When a product has option types and option values, it can have multiple variants. It will also have a variant with the `is_master` flag set to `true`, but that variant will not be sellable in the frontend. For a t-shirt that has the option types "Size" and "Color", for example, the master variant would not have a color and not have a size - thus it would be impossible to actually buy. 

However, for items that don't have option types - single-variant products - the variant with the `is_master` flag is actually what customers would add to their cart. The logic in this PR respects that.

If your store uses `.where(is_master: false)` to find out whether something is sellable, you can now instead do `.sellable`. 

## Checklist

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
