### PR TITLE
Performance: Remove includes from Spree::Variant#options_text

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -194,7 +194,7 @@ module Spree
     #
     # @return [String] a sentence-ified string of option values.
     def options_text
-      values = option_values.includes(:option_type).sort_by do |option_value|
+      values = option_values.sort_by do |option_value|
         option_value.option_type.position
       end
 


### PR DESCRIPTION
While it seems like a good idea to include the option types in this instance method on Spree::Variant, it's actually not. This method is likely used in a view context, where the controller will have preloaded the option types and option values already - running `option_values.includes(:option_type)` here will then generate a query even though things are preloaded already.



The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
