### PR TITLE
Docker default settings improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       CAPYBARA_DRIVER: selenium_chrome_headless_docker_friendly
       DB_USERNAME: root
       DB_PASSWORD: password
-      RAILS_VERSION: ${RAILS_VERSION:-~> 7.0.2}
+      RAILS_VERSION: ${RAILS_VERSION:-~> 7.1.0}
       DB_ALL: "1"
       DB_MYSQL_HOST: mysql
       DB_POSTGRES_HOST: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - postgres:/var/lib/postgresql/data:cached
 
   app:
-    shm_size: '256mb'
+    shm_size: '512mb'
     build:
       context: .dockerdev
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Just a few small changes to default Docker settings to provide a better experience.
1) The shared memory change is to prevent feature specs from crashing after exceeding the previous limit of 256MB, so we double it to 512MB for now.
2) Rails version < 7.1 has issues with our test suite and the spelling of behaviour vs behavior, so we default to Rails 7.1.0 or greater now.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
