### PR TITLE
[Admin] Add new users admin order history page

### DIFF
--- a/admin/app/components/solidus_admin/users/addresses/component.rb
+++ b/admin/app/components/solidus_admin/users/addresses/component.rb
@@ -27,7 +27,7 @@ class SolidusAdmin::Users::Addresses::Component < SolidusAdmin::BaseComponent
       },
       {
         text: t('.order_history'),
-        href: spree.orders_admin_user_path(@user),
+        href: solidus_admin.orders_user_path(@user),
         current: false,
       },
       {

--- a/admin/app/components/solidus_admin/users/edit/component.rb
+++ b/admin/app/components/solidus_admin/users/edit/component.rb
@@ -25,9 +25,8 @@ class SolidusAdmin::Users::Edit::Component < SolidusAdmin::BaseComponent
       },
       {
         text: t('.order_history'),
-        href: spree.orders_admin_user_path(@user),
-        # @todo: update this "current" logic once folded into new admin
-        current: action_name != "edit",
+        href: solidus_admin.orders_user_path(@user),
+        current: action_name == "orders",
       },
       {
         text: t('.items'),

--- a/admin/app/components/solidus_admin/users/orders/component.html.erb
+++ b/admin/app/components/solidus_admin/users/orders/component.html.erb
@@ -1,0 +1,52 @@
+<%= page do %>
+  <%= page_header do %>
+    <%= page_header_back(solidus_admin.users_path) %>
+    <%= page_header_title(t(".title", email: @user.email)) %>
+
+    <%= page_header_actions do %>
+      <%= render component("ui/button").new(tag: :a, text: t(".create_order_for_user"), href: spree.new_admin_order_path(user_id: @user.id)) %>
+    <% end %>
+  <% end %>
+
+  <%= page_header do %>
+    <% tabs.each do |tab| %>
+      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
+    <% end %>
+  <% end %>
+
+  <%= page_with_sidebar do %>
+    <%= page_with_sidebar_main do %>
+      <%= render component('ui/panel').new(title: t(".order_history")) do %>
+        <% if @orders.present? %>
+          <%= render component('ui/table').new(
+              id: stimulus_id,
+              data: {
+                class: model_class,
+                rows: rows,
+                fade: -> { row_fade(_1) },
+                columns: columns,
+                url: -> { row_url(_1) },
+              },
+          )%>
+        <% else %>
+            <%= t(".no_orders_found") %>
+            <%= render component("ui/button").new(tag: :a, text: t(".create_one"), href: spree.new_admin_order_path(user_id: @user.id)) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= page_with_sidebar_aside do %>
+      <%= render component("ui/panel").new(title: t("spree.lifetime_stats")) do %>
+        <%= render component("ui/details_list").new(
+          items: [
+            { label: t("spree.total_sales"), value: @user.display_lifetime_value.to_html },
+            { label: t("spree.order_count"), value: @user.order_count.to_i },
+            { label: t("spree.average_order_value"), value: @user.display_average_order_value.to_html },
+            { label: t("spree.member_since"), value: @user.created_at.to_date },
+            { label: t(".last_active"), value: last_login(@user) },
+          ]
+        ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/users/orders/component.rb
+++ b/admin/app/components/solidus_admin/users/orders/component.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::Orders::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(user:, orders:)
+    @user = user
+    @orders = orders
+  end
+
+  def form_id
+    @form_id ||= "#{stimulus_id}--form-#{@user.id}"
+  end
+
+  def tabs
+    [
+      {
+        text: t('.account'),
+        href: solidus_admin.user_path(@user),
+        current: false,
+      },
+      {
+        text: t('.addresses'),
+        href: solidus_admin.addresses_user_path(@user),
+        current: false,
+      },
+      {
+        text: t('.order_history'),
+        href: solidus_admin.orders_user_path(@user),
+        current: true,
+      },
+      {
+        text: t('.items'),
+        href: spree.items_admin_user_path(@user),
+        current: false,
+      },
+      {
+        text: t('.store_credit'),
+        href: spree.admin_user_store_credits_path(@user),
+        current: false,
+      },
+    ]
+  end
+
+  def last_login(user)
+    return t('.last_login.never') if user.try(:last_sign_in_at).blank?
+
+    t(
+      '.last_login.login_time_ago',
+      # @note The second `.try` is only here for the specs to work.
+      last_login_time: time_ago_in_words(user.try(:last_sign_in_at))
+    ).capitalize
+  end
+
+  def model_class
+    Spree::Order
+  end
+
+  def row_url(order)
+    spree.edit_admin_order_path(order)
+  end
+
+  def rows
+    @orders
+  end
+
+  def row_fade(_order)
+    false
+  end
+
+  def columns
+    [
+      number_column,
+      state_column,
+      date_column,
+      payment_column,
+      shipment_column,
+      total_column,
+    ]
+  end
+
+  def number_column
+    {
+      header: :order,
+      data: ->(order) do
+        if !row_fade(order)
+          content_tag :div, order.number, class: 'font-semibold'
+        else
+          content_tag :div, order.number
+        end
+      end
+    }
+  end
+
+  def state_column
+    {
+      header: :state,
+      data: ->(order) do
+        color = {
+          'complete' => :green,
+          'returned' => :red,
+          'canceled' => :blue,
+          'cart' => :graphite_light,
+        }[order.state] || :yellow
+        component('ui/badge').new(name: order.state.humanize, color: color)
+      end
+    }
+  end
+
+  def date_column
+    {
+      header: :date,
+      data: ->(order) do
+        content_tag :div, l(order.created_at, format: :short)
+      end
+    }
+  end
+
+  def total_column
+    {
+      header: :total,
+      data: ->(order) do
+        content_tag :div, number_to_currency(order.total)
+      end
+    }
+  end
+
+  def payment_column
+    {
+      header: :payment,
+      data: ->(order) do
+        component('ui/badge').new(name: order.payment_state.humanize, color: order.paid? ? :green : :yellow) if order.payment_state?
+      end
+    }
+  end
+
+  def shipment_column
+    {
+      header: :shipment,
+      data: ->(order) do
+        component('ui/badge').new(name: order.shipment_state.humanize, color: order.shipped? ? :green : :yellow) if order.shipment_state?
+      end
+    }
+  end
+end

--- a/admin/app/components/solidus_admin/users/orders/component.yml
+++ b/admin/app/components/solidus_admin/users/orders/component.yml
@@ -1,0 +1,16 @@
+en:
+  title: "Users / %{email} / Order History"
+  account: Account
+  addresses: Addresses
+  order_history: Order History
+  items: Items
+  store_credit: Store Credit
+  last_active: Last Active
+  last_login:
+    login_time_ago: "%{last_login_time} ago"
+    never: Never
+    invitation_sent: Invitation sent
+  create_order_for_user: Create order for this user
+  no_orders_found: No Orders found.
+  create_one: Create One
+  back: Back

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -49,6 +49,7 @@ SolidusAdmin::Engine.routes.draw do
     member do
       get :addresses
       put :update_addresses
+      get :orders
     end
   end
 

--- a/admin/spec/features/users_spec.rb
+++ b/admin/spec/features/users_spec.rb
@@ -161,4 +161,49 @@ describe "Users", :js, type: :feature do
       expect(page).to have_field("user[ship_address_attributes][name]", with: "Elrond")
     end
   end
+
+  context "when viewing a user's order history" do
+    context "when a user has no orders" do
+      before do
+        create(:user, email: "customer@example.com")
+        visit "/admin/users"
+        find_row("customer@example.com").click
+        click_on "Order History"
+      end
+
+      it "shows the order history page" do
+        expect(page).to have_content("Users / customer@example.com / Order History")
+        expect(page).to have_content("Lifetime Stats")
+        expect(page).to have_content("Order History")
+        expect(page).to be_axe_clean
+      end
+
+      it "shows the appropriate content" do
+        expect(page).to have_content("No Orders found.")
+      end
+    end
+
+    context "when a user has ordered before" do
+      before do
+        create(:user, :with_orders, email: "loyal_customer@example.com")
+        visit "/admin/users"
+        find_row("loyal_customer@example.com").click
+        click_on "Order History"
+      end
+
+      it "shows the order history page" do
+        expect(page).to have_content("Users / loyal_customer@example.com / Order History")
+        expect(page).to have_content("Lifetime Stats")
+        expect(page).to have_content("Order History")
+        expect(page).to be_axe_clean
+      end
+
+      it "shows the order history" do
+        expect(page).to have_content(/R\d+/) # Matches on any order number.
+        expect(page).to have_content("Shipment")
+        expect(page).to have_content("Payment")
+        expect(page).not_to have_content("No Orders found.")
+      end
+    end
+  end
 end

--- a/admin/spec/requests/solidus_admin/users_spec.rb
+++ b/admin/spec/requests/solidus_admin/users_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe "SolidusAdmin::UsersController", type: :request do
     end
   end
 
+  describe "GET /orders" do
+    let!(:order) { create(:order, user: user) }
+
+    it "renders the orders template and displays the user's orders" do
+      get solidus_admin.orders_user_path(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(order.number)
+    end
+  end
+
   describe "DELETE /destroy" do
     it "deletes the user and redirects to the index page with a 303 See Other status" do
       # Ensure the user exists prior to deletion


### PR DESCRIPTION
## Summary
This PR is for issue https://github.com/solidusio/solidus/issues/5824.

~There is an extra commit from this PR: https://github.com/solidusio/solidus/pull/5865 which will go away once that is merged this branch is rebased off main.~ Branch has been merged and rebased :) 

This migrates the `users/:id/orders` page from the legacy `soldius_backend` to the new `solidus_admin`.

## Screenshots

### Legacy admin order history page from solidus_backend:
<img width="1440" alt="Screenshot 2024-10-09 at 4 45 54 PM" src="https://github.com/user-attachments/assets/25d332d4-5d0e-4be5-8043-e2978ed0fae9">
<img width="1440" alt="Screenshot 2024-10-09 at 4 45 59 PM" src="https://github.com/user-attachments/assets/8347afd5-6621-40e5-ad9d-b3dfc8869f5e">

### New admin order history page:
https://github.com/user-attachments/assets/c7643f39-9592-4596-9fbd-41a6a606c28b




## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
