### PR TITLE
Add filtering by store to orders index component

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -77,6 +77,13 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
             option
           ]
         end
+      },
+      {
+        label: t('.filters.store'),
+        combinator: 'or',
+        attribute: "store_id",
+        predicate: "eq",
+        options: Spree::Store.all.pluck(:name, :id)
       }
     ]
   end

--- a/admin/app/components/solidus_admin/orders/index/component.yml
+++ b/admin/app/components/solidus_admin/orders/index/component.yml
@@ -5,6 +5,7 @@ en:
       other: '%{count} Items'
   filters:
     status: Status
+    store: Store
     shipment_state: Shipment State
     payment_state: Payment State
     promotions: Promotions

--- a/admin/spec/features/orders/index_spec.rb
+++ b/admin/spec/features/orders/index_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe "Orders", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists products", :js do
+  it "lists orders", :js do
     create(:order, number: "R123456789", total: 19.99)
 
     visit "/admin/orders"
@@ -14,5 +14,32 @@ describe "Orders", type: :feature do
     expect(page).to have_content("R123456789")
     expect(page).to have_content("$19.99")
     expect(page).to be_axe_clean
+  end
+
+  context "with multiple stores", :js do
+    let!(:order_in_default_store) { create :order }
+    let(:another_store) { create :store, name: "Another Store" }
+    let!(:order_in_another_store) { create :order, store: another_store }
+
+    it "can filter orders by store" do
+      visit solidus_admin.orders_path
+
+      click_on "In Progress"
+
+      expect(page).to have_content(order_in_default_store.number)
+      expect(page).to have_content(order_in_another_store.number)
+
+      click_on "Filter"
+
+      within("div[role='search']") do
+        find('details', text: "Store").click
+        expect(page).to have_content("Another Store")
+
+        find('label', text: "Another Store").click
+      end
+
+      expect(page).to have_content(order_in_another_store.number)
+      expect(page).to_not have_content(order_in_default_store.number)
+    end
   end
 end


### PR DESCRIPTION
## Summary

In the legacy admin the order search supported a filter by store. This
behaviour is not in the new admin yet, so we're introducing it with this
change.

This PR addresses part of the concerns raised in https://github.com/solidusio/solidus/issues/5614.

| Screenshot |
|--------|
| <img width="533" alt="Screenshot 2024-10-10 at 2 26 22 PM" src="https://github.com/user-attachments/assets/3ca38486-bfc0-4be2-b84d-897ca98417a0"> | 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
