### PR TITLE
fix: bin/sandbox command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,9 @@ commands:
             cd <<parameters.app_root>>
             unset RAILS_ENV # avoid doing everything on the test environment
             bin/rails server -p 3000 &
-            wget --output-document - --tries=30 --retry-connrefused "http://localhost:3000<<parameters.path>>" | grep "<<parameters.expected_text>>"
+            wget --no-verbose --output-document output.html --tries=30 --retry-connrefused "http://localhost:3000<<parameters.path>>"
+            cat output.html
+            grep "<<parameters.expected_text>>" output.html
             echo "Exited with $?"
             kill $(cat "tmp/pids/server.pid")
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ commands:
             cd <<parameters.app_root>>
             unset RAILS_ENV # avoid doing everything on the test environment
             bin/rails server -p 3000 &
-            wget --quiet --output-document - --tries=30 --retry-connrefused "http://localhost:3000<<parameters.path>>" | grep "<<parameters.expected_text>>"
+            wget --output-document - --tries=30 --retry-connrefused "http://localhost:3000<<parameters.path>>" | grep "<<parameters.expected_text>>"
             echo "Exited with $?"
             kill $(cat "tmp/pids/server.pid")
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -42,7 +42,7 @@ rm -rf ./sandbox
 
 echo "~~~> Creating a pristine Rails app"
 rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new sandbox \
+bundle exec rails _${rails_version}_ new sandbox \
   --database="$RAILSDB" \
   --skip-git \
   --skip-keeps \


### PR DESCRIPTION
Use `bundle exec` to invoke the rails installer,
otherwise it will fail with

```
/Users/<user>/.rubies/ruby-3.3.5/lib/ruby/3.3.0/rubygems.rb:259:in `find_spec_for_exe': can't find gem rails (= 7.2.1.1) with executable rails (Gem::GemNotFoundException)
	from /Users/<user>/.rubies/ruby-3.3.5/lib/ruby/3.3.0/rubygems.rb:278:in `activate_bin_path'
	from /Users/<user>/.gem/ruby/3.3.5/bin/rails:25:in `<main>'
```

although it is installed.

