### PR TITLE
Update Tailwind executable call for v3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 
 group :admin do
   gem 'solidus_admin', path: 'admin', require: false
-  gem 'tailwindcss-rails', '~> 2.0', require: false
+  gem 'tailwindcss-rails', '~> 3.0', require: false
   gem 'axe-core-rspec', '~> 4.8', require: false
   gem 'axe-core-capybara', '~> 4.8', require: false
 end

--- a/admin/lib/solidus_admin/install_tailwindcss.rb
+++ b/admin/lib/solidus_admin/install_tailwindcss.rb
@@ -39,7 +39,7 @@ create_file "lib/tasks/solidus_admin/tailwind.rake", <<~RUBY
   namespace :solidus_admin do
     namespace :tailwindcss do
       root = Rails.root
-      tailwindcss = Tailwindcss::Commands.executable
+      tailwindcss = Tailwindcss::Ruby.executable
 
       tailwindcss_command = [
         tailwindcss,

--- a/admin/lib/solidus_admin/testing_support/dummy_app/rake_tasks.rb
+++ b/admin/lib/solidus_admin/testing_support/dummy_app/rake_tasks.rb
@@ -33,7 +33,7 @@ namespace :solidus_admin do
         DummyApp::Application.root.join("app/assets/stylesheets/solidus_admin/application.tailwind.css")
       )
 
-      tailwindcss = Tailwindcss::Commands.executable
+      tailwindcss = Tailwindcss::Ruby.executable
 
       tailwindcss_command = [
         tailwindcss,


### PR DESCRIPTION
## Summary

As of `tailwindcss-rails` `>= 3.0` the command for the executable was
extracted to a separate `tailwindcss-ruby` gem, which causes an error in
the rake tasks we generate for the `solidus_admin`.

See release changelog here - https://github.com/rails/tailwindcss-rails/releases/tag/v3.0.0
and the documentation for the new gem here - https://github.com/flavorjones/tailwindcss-ruby?tab=readme-ov-file#ruby

The error this fixes is
```
NoMethodError: undefined method `executable' for Tailwindcss::Commands:Module
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
