### PR TITLE
Exclude 'remixicon.symbol.svg' from asset pipeline

### DIFF
--- a/admin/app/components/solidus_admin/ui/icon/component.rb
+++ b/admin/app/components/solidus_admin/ui/icon/component.rb
@@ -23,7 +23,9 @@ class SolidusAdmin::UI::Icon::Component < SolidusAdmin::BaseComponent
   end
 
   def call
-    href = "#{image_path('solidus_admin/remixicon.symbol.svg')}#ri-#{@name}"
+    # bypass the asset_host configuration to avoid CORS issues with CDNs:
+    # https://github.com/solidusio/solidus/issues/5657
+    href = asset_path("solidus_admin/remixicon.symbol.svg#ri-#{@name}", host: "")
     tag.svg(tag.use("xlink:href": href), **@attrs)
   end
 end


### PR DESCRIPTION
Addresses #5657 - when a Solidus store has `config.action_controller.asset_host` configured to point to a different hostname than the Rails application (i.e. an assets CDN, in production), the admin menu icons do not render as expected.

This is because for security reasons, referencing SVG icons from an external file (using `<use xlink:href="">`) is not possible when the asset is served from a different domain to the one requesting it.

Providing an empty `host` option allows us to skip Rails' built-in [asset-path helper methods](https://github.com/rails/rails/blob/6e284f339bb123575a61852e25dff278a764d9b3/actionview/lib/action_view/helpers/asset_url_helper.rb#L272-L309) that are falling back to the global `asset_host` config, and correct the issue.

**Note:** this change does result in the generated asset path being a protocol-prefixed relative URL (i.e. `"http:/assets/solidus_admin/remixicon.symbol-[SHA].svg"`), but this seems to work OK from my testing.