### PR TITLE
Admin installer fixes

### DIFF
--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -38,6 +38,8 @@ module SolidusAdmin
           gem "actioncable"
         end
 
+        execute_command :bundle, :install
+
         route "mount Lookbook::Engine, at: '#{solidus_mount_point}lookbook' if Rails.env.development?"
       end
 


### PR DESCRIPTION
## Run bundle install after adding lookbook

The following mount task will fail with a bundler error if we do not
also install the lookbook gem. Just adding it to the gemgroup
won't run bundle install for us.
