### PR TITLE
Render variant shipping category

### DIFF
--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -103,7 +103,7 @@
                                   @shipping_categories,
                                   :id,
                                   :name,
-                                  { include_blank: t('.use_product_shipping_category') },
+                                  { include_blank: t('.use_product_shipping_category'), selected: @variant[:shipping_category_id] },
                                   { class: 'custom-select fullwidth' } %>
         </div>
       </div>


### PR DESCRIPTION
## Summary

If a variant does not have a shipping category defined, the form will render with the shipping category from the associated product. If you submit the form, the variant will now have the same shipping category as associated the product.

We fix this by always rendering the form with the shipping category associated with the variant.

Fixes #5675.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
