### PR TITLE
Bump Solidus installer CI step to Ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
   solidus_installer:
     executor:
       name: sqlite
-      ruby: "3.0"
+      ruby: "3.1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The Solidus installer step of CI is failing because of some Ruby 3.1 syntax so we update from Ruby 3.0 to 3.1.

Note that CI is currently failing related to this issue: https://github.com/puma/puma/pull/3532
This should be resolved upstream relatively soon.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
