### PR TITLE
Fix test suite by running Puma's `master` branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
 gem 'sqlite3', '~> 1.4', require: false if dbs.match?(/all|sqlite/)
 
+
 gem 'database_cleaner', '~> 2.0', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false
 gem 'rspec-rails', '~> 6.0.3', require: false
@@ -30,7 +31,12 @@ gem 'simplecov-cobertura', require: false
 gem 'rack', '< 3', require: false
 gem 'rake', require: false, groups: [:lint, :release]
 gem 'rails-controller-testing', require: false
-gem 'puma', '< 7', require: false
+
+# Temporarily use the master branch of puma until the next release
+# The current release, 6.4.3, has bug that causes Capybara to crash.
+# See https://github.com/puma/puma/pull/3532
+gem 'puma', github: 'puma/puma', branch: 'master', require: false
+
 gem 'i18n-tasks', '~> 0.9', require: false
 gem 'rspec_junit_formatter', require: false
 gem 'yard', require: false


### PR DESCRIPTION

## Summary

The current release is incompatible with Capybara when also using Rackup 1.0.1, causing all feature specs to fail. The fix has been merged into puma's `master` branch, so we can temporarily run that in CI.

See https://github.com/puma/puma/pull/3532 for more context.
