### PR TITLE
Do not use solidus_frontend to test extension test app generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,10 @@ jobs:
       - test_page:
           expected_text: "<title>Sample Store</title>"
       - install_dummy_app
-      - install_dummy_app:
-          extra_gems: "solidus_frontend"
       - run:
-          name: "Ensure solidus_frontend installer is run"
+          name: "Ensure extension test app is created"
           command: |
-            test -f /tmp/dummy_extension/spec/dummy/config/initializers/solidus_frontend.rb
+            test -d /tmp/dummy_extension/spec/dummy
 
   test_solidus:
     parameters:


### PR DESCRIPTION
solidus_frontend is [EOL since 2024-10-21](https://github.com/solidusio/solidus_frontend?tab=readme-ov-file#-warning) using it to test the extension:test_app rake task is not working since it is not compatible with latest Rails, Ruby and Solidus.

Since we already have a test for the extension test app generator we can check for it's dummy app existence instead.

Extracted from #5843 