### PR TITLE
Legacy Promotions: Move ransackable promo associations from core

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -62,7 +62,7 @@ module Spree
       go_to_state :confirm
     end
 
-    self.allowed_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
+    self.allowed_ransackable_associations = %w[shipments user bill_address ship_address line_items]
     self.allowed_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total store_id]
 
     attr_reader :coupon_code

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Spree::Order, type: :model do
   let(:user) { create(:user, email: "solidus@example.com") }
   let(:order) { create(:order, user:, store:) }
 
+  describe ".ransackable_associations" do
+    subject { described_class.ransackable_associations }
+
+    it { is_expected.to contain_exactly("user", "line_items", "shipments", "bill_address", "ship_address") }
+  end
+
   context '#store' do
     it { is_expected.to respond_to(:store) }
 

--- a/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree_order_decorator.rb
+++ b/legacy_promotions/app/decorators/solidus_legacy_promotions/models/spree_order_decorator.rb
@@ -2,6 +2,12 @@
 
 module SolidusLegacyPromotions
   module SpreeOrderDecorator
+    module ClassMethods
+      def allowed_ransackable_associations
+        super + ["promotions", "order_promotions"]
+      end
+    end
+
     def self.prepended(base)
       base.has_many :order_promotions, class_name: 'Spree::OrderPromotion', dependent: :destroy
       base.has_many :promotions, through: :order_promotions
@@ -17,5 +23,6 @@ module SolidusLegacyPromotions
     end
 
     Spree::Order.prepend(self)
+    Spree::Order.singleton_class.prepend self::ClassMethods
   end
 end

--- a/legacy_promotions/spec/models/spree/order_spec.rb
+++ b/legacy_promotions/spec/models/spree/order_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Spree::Order do
   it { is_expected.to respond_to(:order_promotions) }
   it { is_expected.to respond_to(:promotions) }
 
+  describe ".ransackable_associations" do
+    subject { described_class.ransackable_associations }
+
+    it { is_expected.to include("promotions", "order_promotions") }
+  end
+
   context "#apply_shipping_promotions" do
     let(:order) { build(:order) }
 


### PR DESCRIPTION

## Summary

Moves the safelisting of `promotions` and `order_promotions` as ransackable associations out of `solidus_core` into `solidus_legacy_promotions`. 

`Spree::Order#promotions` and `Spree::Order#order_promotions` are now only defined in the `legacy_promotions` gem. Thus they should not be safelisted as ransackable in core.

