### PR TITLE
Improve solidus_promotions/MIGRATING.md

### DIFF
--- a/legacy_promotions/lib/tasks/solidus_legacy_promotions/delete_ineligible_adjustments.rake
+++ b/legacy_promotions/lib/tasks/solidus_legacy_promotions/delete_ineligible_adjustments.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :solidus_legacy_promotions do
+  desc "Delete ineligible adjustments"
+  task delete_ineligible_adjustments: :environment do
+    Spree::Adjustment.where(eligible: false).delete_all
+  end
+end


### PR DESCRIPTION

## Summary

This commit adds an introductory section telling the reader how the migration process works.

It also adds a last section telling the reader to remove any ineligible adjustments from their database.

Lastly, it corrects the location of Spree configuration from the `solidus_promotions` initializer to the `spree.rb` initializer.
