### PR TITLE
Include solidus_promotions in release tasks

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -24,3 +24,6 @@ changelog:
     - title: Solidus Sample
       labels:
         - "changelog:solidus_sample"
+    - title: Solidus Promotions
+      labels:
+        - "changelog:solidus_promotions"

--- a/tasks/releasing.rake
+++ b/tasks/releasing.rake
@@ -2,7 +2,7 @@
 
 require 'bundler/gem_tasks'
 
-SOLIDUS_GEM_NAMES = %w[core api backend sample]
+SOLIDUS_GEM_NAMES = %w[core api backend sample promotions]
 
 %w[build install].each do |task_name|
   desc "Run rake #{task} for each Solidus gem"

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -17,14 +17,16 @@ def subproject_task(project, task, title: project, task_name: nil)
   end
 end
 
+SOLIDUS_GEM_NAMES = %w[core api backend frontend sample promotions]
+
 %w[spec db:drop db:create db:migrate db:reset].each do |task|
-  %w(api backend core frontend sample).each do |project|
+  SOLIDUS_GEM_NAMES.each do |project|
     desc "Run specs for #{project}" if task == 'spec'
     subproject_task(project, task)
   end
 
   desc "Run rake #{task} for each Solidus engine"
-  task task => %w(api backend core frontend sample).map { |p| "#{task}:#{p}" }
+  task task => SOLIDUS_GEM_NAMES.map { |p| "#{task}:#{p}" }
 end
 
 desc "Run backend JS specs"


### PR DESCRIPTION
We don't want to include `solidus_promotions` as a dependency in `solidus` yet, but we do want to release the gem, so it should appear in the all the lists of Solidus sub-gems.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
