### PR TITLE
Introducing Solidus Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![codecov](https://codecov.io/gh/solidusio/solidus/branch/main/graph/badge.svg)](https://codecov.io/gh/solidusio/solidus/branch/main)
 [![Gem](https://img.shields.io/gem/v/solidus.svg)](https://rubygems.org/gems/solidus)
 [![License](http://img.shields.io/badge/license-BSD-blue.svg)](LICENSE.md)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Solidus%20Guru-006BFF)](https://gurubase.io/g/solidus)
 
 [![Supporters on Open Collective](https://opencollective.com/solidus/tiers/supporter/badge.svg?label=Supporters&color=brightgree)](https://opencollective.com/solidus)
 [![Bronze Partners on Open Collective](https://opencollective.com/solidus/tiers/bronze/badge.svg?label=Bronze&nbsp;Partners&color=brightgree)](https://opencollective.com/solidus)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Solidus Guru](https://gurubase.io/g/solidus) to Gurubase. Solidus Guru uses the data from this repo and data from the [docs](https://guides.solidus.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Solidus Guru", which highlights that Solidus now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Solidus Guru in Gurubase, just let me know that's totally fine.
