### PR TITLE
Backend Menu: Fix "Promotions" items

### DIFF
--- a/legacy_promotions/config/locales/en.yml
+++ b/legacy_promotions/config/locales/en.yml
@@ -23,8 +23,8 @@ en:
           general: General
           starts_at_placeholder: Immediately
       tab:
-        promotion_categories: Promotion Categories
-        promotions: Promotions
+        promotions: Legacy Promotions
+        promotion_categories: Legacy Promotion Categories
     back_to_promotion_categories_list: Back To Promotions Categories List
     back_to_promotions_list: Back To Promotions List
     base_amount: Base Amount

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -22,7 +22,8 @@ module SolidusLegacyPromotions
             ),
             Spree::BackendConfiguration::MenuItem.new(
               label: :promotion_categories,
-              condition: -> { can?(:admin, Spree::PromotionCategory) }
+              condition: -> { can?(:admin, Spree::PromotionCategory) },
+              url: -> { Spree::Core::Engine.routes.url_helpers.admin_promotion_categories_path },
             )
           ]
         )

--- a/promotions/config/locales/en.yml
+++ b/promotions/config/locales/en.yml
@@ -5,10 +5,8 @@ en:
   spree:
     admin:
       tab:
-        promotions: Promotions
-        promotion_categories: Promotion Categories
-        legacy_promotions: Legacy Promotions
-        legacy_promotion_categories: Legacy Promotion Categories
+        solidus_promotions: Promotions
+        solidus_promotion_categories: Promotion Categories
     hints:
       solidus_promotions/promotion:
         expires_at: This determines when the promotion expires. <br> If no value is specified, the promotion will never expire.


### PR DESCRIPTION
Prior to this commit, legacy promotions would be called "Promotions", but if `solidus_promotions` is installed, they would be called "Legacy Promotions" in the menu. It's much easier if each of the two promotion engines just inserts its own menu item into the menu, and the legacy promotion system is called "Legacy Promotions" from the get-go.
