### PR TITLE
[Admin] Add product properties admin UI

### DIFF
--- a/admin/app/components/solidus_admin/properties/index/component.rb
+++ b/admin/app/components/solidus_admin/properties/index/component.rb
@@ -21,11 +21,18 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
     spree.admin_property_path(property)
   end
 
+  def turbo_frames
+    %w[
+      new_property_modal
+    ]
+  end
+
   def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),
-      href: spree.new_admin_property_path,
+      href: solidus_admin.new_property_path,
+      data: { turbo_frame: :new_property_modal },
       icon: "add-line",
     )
   end

--- a/admin/app/components/solidus_admin/properties/index/component.rb
+++ b/admin/app/components/solidus_admin/properties/index/component.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Index::Component
+  def title
+    t('solidus_admin.properties.title')
+  end
+
   def model_class
     Spree::Property
   end

--- a/admin/app/components/solidus_admin/properties/new/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/new/component.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag :new_property_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @property, url: solidus_admin.properties_path, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :presentation, class: "required") %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render component("properties/index").new(page: @page) %>

--- a/admin/app/components/solidus_admin/properties/new/component.rb
+++ b/admin/app/components/solidus_admin/properties/new/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Properties::New::Component < SolidusAdmin::BaseComponent
+  def initialize(page:, property:)
+    @page = page
+    @property = property
+  end
+
+  def form_id
+    dom_id(@property, "#{stimulus_id}_new_property_form")
+  end
+end

--- a/admin/app/components/solidus_admin/properties/new/component.yml
+++ b/admin/app/components/solidus_admin/properties/new/component.yml
@@ -1,0 +1,4 @@
+en:
+  title: "New Property"
+  cancel: "Cancel"
+  submit: "Add Property"

--- a/admin/app/controllers/solidus_admin/properties_controller.rb
+++ b/admin/app/controllers/solidus_admin/properties_controller.rb
@@ -5,17 +5,23 @@ module SolidusAdmin
     include SolidusAdmin::ControllerHelpers::Search
 
     def index
-      properties = apply_search_to(
-        Spree::Property.order(created_at: :desc, id: :desc),
-        param: :q,
-      )
-
-      set_page_and_extract_portion_from(
-        properties,
-      )
+      set_index_page
 
       respond_to do |format|
         format.html { render component('properties/index').new(page: @page) }
+      end
+    end
+
+    def new
+      @property = Spree::Property.new
+
+      set_index_page
+
+      respond_to do |format|
+        format.html {
+          render component('properties/new')
+            .new(page: @page, property: @property)
+        }
       end
     end
 
@@ -28,6 +34,19 @@ module SolidusAdmin
 
       flash[:notice] = t('.success')
       redirect_to properties_path, status: :see_other
+    end
+
+    private
+
+    def set_index_page
+      properties = apply_search_to(
+        Spree::Property.order(created_at: :desc, id: :desc),
+        param: :q,
+      )
+
+      set_page_and_extract_portion_from(
+        properties,
+      )
     end
   end
 end

--- a/admin/app/controllers/solidus_admin/properties_controller.rb
+++ b/admin/app/controllers/solidus_admin/properties_controller.rb
@@ -25,6 +25,33 @@ module SolidusAdmin
       end
     end
 
+    def create
+      @property = Spree::Property.new(property_params)
+
+      if @property.save
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.properties_path, status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        set_index_page
+
+        respond_to do |format|
+          format.html do
+            page_component = component('properties/new').new(page: @page, property: @property)
+            render page_component, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def destroy
       @properties = Spree::Property.where(id: params[:id])
 
@@ -47,6 +74,10 @@ module SolidusAdmin
       set_page_and_extract_portion_from(
         properties,
       )
+    end
+
+    def property_params
+      params.require(:property).permit(:name, :presentation)
     end
   end
 end

--- a/admin/config/locales/properties.en.yml
+++ b/admin/config/locales/properties.en.yml
@@ -2,5 +2,7 @@ en:
   solidus_admin:
     properties:
       title: "Properties"
+      create:
+        success: "Property was successfully created."
       destroy:
         success: "Properties were successfully removed."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -56,7 +56,7 @@ SolidusAdmin::Engine.routes.draw do
   end
 
   admin_resources :promotions, only: [:index, :destroy]
-  admin_resources :properties, only: [:index, :destroy]
+  admin_resources :properties, only: [:index, :destroy, :new, :create]
   admin_resources :option_types, only: [:index, :destroy], sortable: true
   admin_resources :taxonomies, only: [:index, :destroy], sortable: true
   admin_resources :promotion_categories, only: [:index, :destroy]

--- a/admin/spec/features/properties_spec.rb
+++ b/admin/spec/features/properties_spec.rb
@@ -21,4 +21,19 @@ describe "Properties", :js, type: :feature do
     expect(page).not_to have_content("Type prop")
     expect(Spree::Property.count).to eq(1)
   end
+
+  context "when creating a new product property" do
+    before do
+      visit "/admin/properties"
+      click_on "Add new"
+      expect(page).to have_content("New Property")
+      expect(page).to be_axe_clean
+    end
+
+    it "opens and closes new property modal" do
+      expect(page).to have_selector("dialog")
+      within("dialog") { click_on "Cancel" }
+      expect(page).not_to have_selector("dialog")
+    end
+  end
 end

--- a/admin/spec/features/properties_spec.rb
+++ b/admin/spec/features/properties_spec.rb
@@ -35,5 +35,19 @@ describe "Properties", :js, type: :feature do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
     end
+
+    it "enables creation of a new property" do
+      within("dialog") do
+        fill_in "Name", with: "new prop"
+        fill_in "Presentation", with: "New prop"
+
+        click_on "Add Property"
+      end
+
+      expect(page).not_to have_selector("dialog")
+      expect(page).to have_content("Property was successfully created.")
+
+      expect(page).to have_content("New prop")
+    end
   end
 end

--- a/bin/dev
+++ b/bin/dev
@@ -9,5 +9,5 @@ if ! test -d sandbox; then
   bin/sandbox
 fi
 
-export PORT=3000
+export PORT=${PORT:-3000}
 exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## Summary

This change addresses #5857 and introduces a new UI for creating and
editing product properties in the new admin.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
