### PR TITLE
Fix component translation scopes

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -25,6 +25,10 @@ module SolidusAdmin
       end
     end
 
+    def self.i18n_scope
+      @i18n_scope ||= name.underscore.tr("/", ".")
+    end
+
     def self.stimulus_id
       @stimulus_id ||= name.underscore
         .sub(/^solidus_admin\/(.*)\/component$/, '\1')

--- a/legacy_promotions/lib/components/admin/solidus_legacy_promotions/orders/index/component.yml
+++ b/legacy_promotions/lib/components/admin/solidus_legacy_promotions/orders/index/component.yml
@@ -1,20 +1,5 @@
 en:
-  columns:
-    items:
-      one: 1 Item
-      other: '%{count} Items'
   filters:
-    status: Status
-    shipment_state: Shipment State
-    payment_state: Payment State
     promotions: Promotions
-  date:
-    formats:
-      short: '%d %b %y'
   scopes:
-    all_orders: All
-    canceled: Canceled
-    complete: Complete
-    returned: Returned
-    in_progress: In Progress
     promotions: Promotions

--- a/promotions/lib/components/admin/solidus_promotions/orders/index/component.yml
+++ b/promotions/lib/components/admin/solidus_promotions/orders/index/component.yml
@@ -1,3 +1,5 @@
 en:
   filters:
     promotions: Promotions
+  scopes:
+    promotions: Promotions


### PR DESCRIPTION
In the `view_component` gem, the `i18n_scope` for a component depends on the file name of the component, and removes `app_components` and everything before that in order to construct a scope.

This fails to work with components that live in `lib/components/admin/`, as with our extensions, as there is no `app/components` in the path to these components.

This change uses the class name instead, which should be easier on memory and correctly works with components from solidus extensions.

This also fixes translations in inherited components, allowing to delete some redundant translations in the promotion gem's `order` component.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
