### PR TITLE
Update component.rb

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -153,7 +153,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :total,
       data: ->(order) do
-        content_tag :div, number_to_currency(order.total)
+        content_tag :div, order.display_total
       end
     }
   end


### PR DESCRIPTION
Admin order index page doesn't reflect the stores currency.

## Summary

Changed admin orders index page to use display_total rather than number_to_currency(order.total) this displays the correct currency for the order rather than defaulting to USD

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ X] I have written a thorough PR description.
- [X ] I have kept my commits small and atomic.
- [ X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
