### PR TITLE
Use new global variables stylesheet in legacy promotions

### DIFF
--- a/legacy_promotions/app/assets/stylesheets/solidus_legacy_promotions/promotions.scss
+++ b/legacy_promotions/app/assets/stylesheets/solidus_legacy_promotions/promotions.scss
@@ -1,3 +1,3 @@
-@import "spree/backend/themes/classic";
+@import "spree/backend/globals/variables";
 
 @import "solidus_legacy_promotions/promotions/edit";


### PR DESCRIPTION
Prior to this change, the promotion admin would have a blue color scheme, and not the red one that all the other pages have.
