### PR TITLE
Feat(Admin): Dynamic routing proxies

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -38,12 +38,22 @@ module SolidusAdmin
 
     delegate :stimulus_id, to: :class
 
-    def spree
-      @spree ||= Spree::Core::Engine.routes.url_helpers
+    class << self
+      private
+
+      def engines_with_routes
+        Rails::Engine.subclasses.map(&:instance).reject do |engine|
+          engine.routes.empty?
+        end
+      end
     end
 
-    def solidus_admin
-      @solidus_admin ||= SolidusAdmin::Engine.routes.url_helpers
+    # For each engine with routes, define a method that returns the routes proxy.
+    # This allows us to use the routes in the context of a component class.
+    engines_with_routes.each do |engine|
+      define_method(engine.engine_name) do
+        engine.routes.url_helpers
+      end
     end
   end
 end

--- a/admin/app/components/solidus_admin/layout/navigation/item/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/item/component.html.erb
@@ -1,7 +1,7 @@
 <li class="group <%= "active" if active? %>">
   <a
     href="<%= path %>"
-    aria-current="<%= @item.current?(@url_helpers, @fullpath) ? "page" : "false" %>"
+    aria-current="<%= @item.current?(self, @fullpath) ? "page" : "false" %>"
     class="
       flex gap-3 items-center
       py-1 px-3 rounded
@@ -20,7 +20,7 @@
 
   <% if @item.children? %>
     <ul class="flex flex-col gap-0.5 pt-0.5 <%= "hidden" unless active? %>">
-      <%= render self.class.with_collection(@item.children, url_helpers: @url_helpers, fullpath: @fullpath) %>
+      <%= render self.class.with_collection(@item.children, fullpath: @fullpath) %>
     </ul>
   <% end %>
 </li>

--- a/admin/app/components/solidus_admin/layout/navigation/item/component.rb
+++ b/admin/app/components/solidus_admin/layout/navigation/item/component.rb
@@ -6,22 +6,19 @@ class SolidusAdmin::Layout::Navigation::Item::Component < SolidusAdmin::BaseComp
 
   # @param item [SolidusAdmin::MenuItem]
   # @param fullpath [String] the current path
-  # @param url_helpers [#solidus_admin, #spree] context for generating paths
   def initialize(
     item:,
-    fullpath: "#",
-    url_helpers: Struct.new(:spree, :solidus_admin).new(spree, solidus_admin)
+    fullpath: "#"
   )
     @item = item
-    @url_helpers = url_helpers
     @fullpath = fullpath
   end
 
   def path
-    @item.path(@url_helpers)
+    @item.path(self)
   end
 
   def active?
-    @item.active?(@url_helpers, @fullpath)
+    @item.active?(self, @fullpath)
   end
 end

--- a/promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/source/solidus_promotions_benefit/component.rb
+++ b/promotions/lib/components/admin/solidus_admin/orders/show/adjustments/index/source/solidus_promotions_benefit/component.rb
@@ -10,8 +10,4 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Source::SolidusPromotionsB
   def promotion_name
     source.promotion.name
   end
-
-  def solidus_promotions
-    @solidus_promotions ||= SolidusPromotions::Engine.routes.url_helpers
-  end
 end

--- a/promotions/lib/components/admin/solidus_promotions/promotions/index/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotions/index/component.rb
@@ -101,8 +101,4 @@ class SolidusPromotions::Promotions::Index::Component < SolidusAdmin::UI::Pages:
       }
     ]
   end
-
-  def solidus_promotions
-    @solidus_promotions ||= SolidusPromotions::Engine.routes.url_helpers
-  end
 end


### PR DESCRIPTION
This commit allows the menu of the new admin to accomodate routes from other engines than solidus backend and solidus admin. This is needed for `solidus_promotions`, which is built as a separate Rails Engine, but it is also convenient for `solidus_paypal_commerce_platform` or even for integrating gems like AlchemyCMS lateron.



- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
