### PR TITLE
Better promotion menus

### DIFF
--- a/legacy_promotions/config/locales/en.yml
+++ b/legacy_promotions/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  solidus_admin:
+    menu_item:
+      legacy_promotions: Promotions
+      legacy_promotion_categories: Promotion Categories
   spree:
     admin:
       promotion_status:
@@ -23,8 +27,8 @@ en:
           general: General
           starts_at_placeholder: Immediately
       tab:
-        promotions: Legacy Promotions
-        promotion_categories: Legacy Promotion Categories
+        legacy_promotions: Promotions
+        legacy_promotion_categories: Promotion Categories
     back_to_promotion_categories_list: Back To Promotions Categories List
     back_to_promotions_list: Back To Promotions List
     base_amount: Base Amount

--- a/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
+++ b/legacy_promotions/lib/solidus_legacy_promotions/engine.rb
@@ -9,7 +9,7 @@ module SolidusLegacyPromotions
     initializer "solidus_legacy_promotions.add_backend_menu_item" do
       if SolidusSupport.backend_available?
         promotions_menu_item = Spree::BackendConfiguration::MenuItem.new(
-          label: :promotions,
+          label: :legacy_promotions,
           icon: Spree::Backend::Config.admin_updated_navbar ? "ri-megaphone-line" : "bullhorn",
           partial: "spree/admin/shared/promotion_sub_menu",
           condition: -> { can?(:admin, Spree::Promotion) },
@@ -17,11 +17,12 @@ module SolidusLegacyPromotions
           data_hook: :admin_promotion_sub_tabs,
           children: [
             Spree::BackendConfiguration::MenuItem.new(
-              label: :promotions,
-              condition: -> { can?(:admin, Spree::Promotion) }
+              label: :legacy_promotions,
+              condition: -> { can?(:admin, Spree::Promotion) },
+              url: :admin_promotions_path
             ),
             Spree::BackendConfiguration::MenuItem.new(
-              label: :promotion_categories,
+              label: :legacy_promotion_categories,
               condition: -> { can?(:admin, Spree::PromotionCategory) },
               url: -> { Spree::Core::Engine.routes.url_helpers.admin_promotion_categories_path },
             )
@@ -42,10 +43,22 @@ module SolidusLegacyPromotions
       if SolidusSupport.admin_available?
         SolidusAdmin::Config.configure do |config|
           config.menu_items << {
-            key: "promotions",
+            key: "legacy_promotions",
             route: -> { spree.admin_promotions_path },
             icon: "megaphone-line",
-            position: 30
+            position: 1.5,
+            children: [
+              {
+                key: "legacy_promotions",
+                route: -> { spree.admin_promotions_path },
+                position: 1
+              },
+              {
+                key: "legacy_promotion_categories",
+                route: -> { spree.admin_promotion_categories_path },
+                position: 2
+              }
+            ]
           }
         end
       end

--- a/promotions/config/locales/en.yml
+++ b/promotions/config/locales/en.yml
@@ -2,11 +2,15 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  solidus_admin:
+    menu_item:
+      promotions: Promotions (new)
+      promotion_categories: Promotion Categories (new)
   spree:
     admin:
       tab:
-        solidus_promotions: Promotions
-        solidus_promotion_categories: Promotion Categories
+        promotions: Promotions (new)
+        promotion_categories: Promotion Categories (new)
     hints:
       solidus_promotions/promotion:
         expires_at: This determines when the promotion expires. <br> If no value is specified, the promotion will never expire.

--- a/promotions/lib/controllers/admin/solidus_promotions/promotion_categories_controller.rb
+++ b/promotions/lib/controllers/admin/solidus_promotions/promotion_categories_controller.rb
@@ -13,7 +13,7 @@ module SolidusPromotions
       set_page_and_extract_portion_from(promotion_categories)
 
       respond_to do |format|
-        format.html { render component("promotion_categories/index").new(page: @page) }
+        format.html { render component("solidus_promotions/categories/index").new(page: @page) }
       end
     end
 

--- a/promotions/lib/controllers/admin/solidus_promotions/promotions_controller.rb
+++ b/promotions/lib/controllers/admin/solidus_promotions/promotions_controller.rb
@@ -19,7 +19,7 @@ module SolidusPromotions
       set_page_and_extract_portion_from(promotions)
 
       respond_to do |format|
-        format.html { render component("promotions/index").new(page: @page) }
+        format.html { render component("solidus_promotions/promotions/index").new(page: @page) }
       end
     end
 

--- a/promotions/lib/solidus_promotions/engine.rb
+++ b/promotions/lib/solidus_promotions/engine.rb
@@ -52,11 +52,14 @@ module SolidusPromotions
       end
     end
 
-    initializer "solidus_promotions.add_admin_order_index_component", after: "solidus_legacy_promotions.add_admin_order_index_component" do
+    initializer "solidus_promotions.add_admin_order_index_component", after: "spree.load_config_initializers" do
       if SolidusSupport.admin_available?
-        SolidusAdmin::Config.components["orders/index"] = "SolidusPromotions::Orders::Index::Component"
-        SolidusAdmin::Config.components["promotions/index"] = "SolidusPromotions::Promotions::Index::Component"
-        SolidusAdmin::Config.components["promotion_categories/index"] = "SolidusPromotions::PromotionCategories::Index::Component"
+        if Spree::Config.promotions.is_a?(SolidusPromotions::Configuration)
+          SolidusAdmin::Config.components["orders/index"] = "SolidusPromotions::Orders::Index::Component"
+        end
+
+        SolidusAdmin::Config.components["solidus_promotions/promotions/index"] = "SolidusPromotions::Promotions::Index::Component"
+        SolidusAdmin::Config.components["solidus_promotions/categories/index"] = "SolidusPromotions::PromotionCategories::Index::Component"
       end
     end
 

--- a/promotions/lib/solidus_promotions/engine.rb
+++ b/promotions/lib/solidus_promotions/engine.rb
@@ -60,30 +60,59 @@ module SolidusPromotions
       end
     end
 
+    initializer "solidus_promotions.add_solidus_admin_menu_items", after: "spree.load_config_initializers" do
+      if SolidusSupport.admin_available?
+        SolidusAdmin::Config.configure do |config|
+          config.menu_items << {
+            key: "promotions",
+            route: -> { solidus_promotions.admin_promotions_path },
+            icon: "megaphone-line",
+            position: 1.6,
+            children: [
+              {
+                key: "promotions",
+                route: -> { solidus_promotions.admin_promotions_path },
+                position: 1
+              },
+              {
+                key: "promotion_categories",
+                route: -> { solidus_promotions.admin_promotion_categories_path },
+                position: 1
+              }
+            ]
+          }
+        end
+      end
+    end
+
     initializer "solidus_promotions.add_backend_menus", after: "spree.backend.environment" do
       if SolidusSupport.backend_available?
         promotions_menu_item = Spree::BackendConfiguration::MenuItem.new(
-          label: :solidus_promotions,
+          label: :promotions,
           icon: Spree::Backend::Config.admin_updated_navbar ? "ri-megaphone-line" : "bullhorn",
           condition: -> { can?(:admin, SolidusPromotions::Promotion) },
           url: -> { SolidusPromotions::Engine.routes.url_helpers.admin_promotions_path },
           data_hook: :admin_solidus_promotion_sub_tabs,
           children: [
             Spree::BackendConfiguration::MenuItem.new(
-              label: :solidus_promotions,
+              label: :promotions,
               url: -> { SolidusPromotions::Engine.routes.url_helpers.admin_promotions_path },
               condition: -> { can?(:admin, SolidusPromotions::Promotion) }
             ),
             Spree::BackendConfiguration::MenuItem.new(
-              label: :solidus_promotion_categories,
+              label: :promotion_categories,
               url: -> { SolidusPromotions::Engine.routes.url_helpers.admin_promotion_categories_path },
               condition: -> { can?(:admin, SolidusPromotions::PromotionCategory) }
             )
           ]
         )
 
+        # We want to appear after the legacy promotions menu item if it exists, otherwise after the products menu item
         product_menu_item_index = Spree::Backend::Config.menu_items.find_index { |item| item.label == :products }
-        Spree::Backend::Config.menu_items.insert(product_menu_item_index + 1, promotions_menu_item)
+        legacy_promotions_menu_item = Spree::Backend::Config.menu_items.find_index { |item| item.label == :legacy_promotions }
+        promotions_menu_index = [product_menu_item_index, legacy_promotions_menu_item].compact.max + 1
+
+        Spree::Backend::Config.menu_items.insert(promotions_menu_index, promotions_menu_item)
       end
     end
   end

--- a/promotions/spec/system/solidus_promotions/admin/orders/index_spec.rb
+++ b/promotions/spec/system/solidus_promotions/admin/orders/index_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe "Orders", type: :feature, solidus_admin: true do
 
   before { sign_in create(:admin_user, email: "admin@example.com") }
 
+  around do |example|
+    SolidusAdmin::Config.components["orders/index"] = "SolidusPromotions::Orders::Index::Component"
+    example.run
+    SolidusAdmin::Config.components["orders/index"] = "SolidusAdmin::Orders::Index::Component"
+  end
+
   it "lists products", :js, :flaky do
     visit "/admin/orders"
 

--- a/promotions/spec/system/solidus_promotions/backend/main_menu_spec.rb
+++ b/promotions/spec/system/solidus_promotions/backend/main_menu_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe "Main Menu", type: :feature do
       end
 
       it "should have a link to promotions" do
-        expect(page).to have_link("Promotions", href: solidus_promotions.admin_promotions_path, count: 2)
+        expect(page).to have_link("Promotions (new)", href: solidus_promotions.admin_promotions_path, count: 2)
       end
       it "should have a link to legacy promotions" do
-        expect(page).to have_link("Legacy Promotions", href: spree.admin_promotions_path, count: 2)
+        expect(page).to have_link("Promotions", href: spree.admin_promotions_path, count: 2)
       end
     end
 
@@ -25,11 +25,11 @@ RSpec.describe "Main Menu", type: :feature do
       end
 
       it "should have a link to promotions" do
-        within(".selected .admin-subnav") { expect(page).to have_link("Promotions", href: solidus_promotions.admin_promotions_path) }
+        within(".selected .admin-subnav") { expect(page).to have_link("Promotions (new)", href: solidus_promotions.admin_promotions_path) }
       end
 
       it "should have a link to promotion categories" do
-        within(".selected .admin-subnav") { expect(page).to have_link("Promotion Categories", href: solidus_promotions.admin_promotion_categories_path) }
+        within(".selected .admin-subnav") { expect(page).to have_link("Promotion Categories (new)", href: solidus_promotions.admin_promotion_categories_path) }
       end
     end
 
@@ -39,11 +39,11 @@ RSpec.describe "Main Menu", type: :feature do
       end
 
       it "should have a link to promotions" do
-        within(".selected .admin-subnav") { expect(page).to have_link("Legacy Promotions", href: spree.admin_promotions_path) }
+        within(".selected .admin-subnav") { expect(page).to have_link("Promotions", href: spree.admin_promotions_path) }
       end
 
       it "should have a link to promotion categories" do
-        within(".selected .admin-subnav") { expect(page).to have_link("Legacy Promotion Categories", href: spree.admin_promotion_categories_path) }
+        within(".selected .admin-subnav") { expect(page).to have_link("Promotion Categories", href: spree.admin_promotion_categories_path) }
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR, built on top of #5933 , allows viewing the configuration of both the legacy promotion system and the new promotion system side-by-side in the new admin, with pleasing menu items. 

Instead of "Legacy Promotions", which looks a bit bad (why does the system come with "legacy" by default?), we call those just "Promotions", and the new Promotion system is termed "Promotions (new). 

There's also fixes in here for always showing the promotions menu items in the same sequence below the products menu item. 
