### PR TITLE
Fix admin promotions controller

### DIFF
--- a/promotions/lib/components/admin/solidus_promotions/promotions/index/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotions/index/component.rb
@@ -14,7 +14,7 @@ class SolidusPromotions::Promotions::Index::Component < SolidusAdmin::UI::Pages:
   end
 
   def row_url(promotion)
-    solidus_promotions.admin_promotion_path(promotion)
+    solidus_promotions.edit_admin_promotion_path(promotion)
   end
 
   def page_actions
@@ -63,14 +63,16 @@ class SolidusPromotions::Promotions::Index::Component < SolidusAdmin::UI::Pages:
       {
         header: :name,
         data: ->(promotion) do
-          content_tag :div, promotion.name
+          link_to promotion.name, row_url(promotion)
         end
       },
       {
         header: :code,
         data: ->(promotion) do
-          count = promotion.codes.count
-          (count == 1) ? promotion.codes.pick(:value) : t("spree.number_of_codes", count: count)
+          link_to solidus_promotions.admin_promotion_promotion_codes_path(promotion), title: t(".codes") do
+            count = promotion.codes.count
+            (count == 1) ? promotion.codes.pick(:value) : t("spree.number_of_codes", count: count)
+          end
         end
       },
       {

--- a/promotions/lib/components/admin/solidus_promotions/promotions/index/component.yml
+++ b/promotions/lib/components/admin/solidus_promotions/promotions/index/component.yml
@@ -8,3 +8,4 @@ en:
   status:
     active: Active
     inactive: Inactive
+  codes: Codes

--- a/promotions/lib/controllers/admin/solidus_promotions/promotion_categories_controller.rb
+++ b/promotions/lib/controllers/admin/solidus_promotions/promotion_categories_controller.rb
@@ -25,5 +25,11 @@ module SolidusPromotions
       flash[:notice] = t(".success")
       redirect_back_or_to solidus_promotions.promotion_categories_path, status: :see_other
     end
+
+    private
+
+    def authorization_subject
+      SolidusPromotions::PromotionCategory
+    end
   end
 end

--- a/promotions/lib/controllers/admin/solidus_promotions/promotions_controller.rb
+++ b/promotions/lib/controllers/admin/solidus_promotions/promotions_controller.rb
@@ -42,5 +42,9 @@ module SolidusPromotions
     def promotion_params
       params.require(:promotion).permit(:user_id, permitted_promotion_attributes)
     end
+
+    def authorization_subject
+      SolidusPromotions::Promotion
+    end
   end
 end

--- a/promotions/spec/system/solidus_promotions/admin/promotions_spec.rb
+++ b/promotions/spec/system/solidus_promotions/admin/promotions_spec.rb
@@ -32,5 +32,9 @@ RSpec.describe "Promotions", :js, type: :feature, solidus_admin: true do
     expect(page).to have_content("Promotions were successfully removed.")
     expect(page).not_to have_content("My active Promotion")
     expect(SolidusPromotions::Promotion.count).to eq(3)
+
+    click_link("My future Promotion")
+    expect(page).to have_content("My future Promotion")
+    expect(page).to have_content("Starts at")
   end
 end


### PR DESCRIPTION
## Summary

Fix admin promotions index controller: visit the correct URL on row click, and authorize against the right model.
