### PR TITLE
Bumped license years and added font license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,22 @@
-Spree License
-=============
+# Licenses
+
+## Source Code
+
+### Solidus Source Code (FreeBSD License)
+
+Copyright © 2015-2024, solidus.io and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* Neither the name of Spree Commerce Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+_This software is provided by the copyright holders and contributors "as is" and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner of contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage._
+
+
+### Derived from the original Spree Commerce Repository (FreeBSD License)
 
 Copyright © 2007-2014, Spree Commerce Inc. and other contributors.
 All rights reserved.
@@ -11,3 +28,20 @@ Redistribution and use in source and binary forms, with or without modification,
 * Neither the name of Spree Commerce Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 _This software is provided by the copyright holders and contributors "as is" and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner of contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage._
+
+## Other Assets contained in this repository
+
+### Icons
+Copyright 2024 RemixIcon
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 ## Source Code
 
-### Solidus Source Code (FreeBSD License)
+### Solidus Source Code where not otherwise declared below or in separate license files present  (FreeBSD License)
 
 Copyright © 2015-2024, solidus.io and other contributors.
 All rights reserved.


### PR DESCRIPTION
## Summary

The license file was not aligned with the legal requiremenets of the assets contained in the repo. 

## Modifications made
Aligned license.md with reality: 
- added icon license (required by the icon license)
- added solidus own FreeBSD license
- bumped year of the license to 2024

Fixes: #5947 and bumps FreeBSD license to current year
