### PR TITLE
Allow PORT to be specified when using `bin/dev`

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -9,5 +9,5 @@ if ! test -d sandbox; then
   bin/sandbox
 fi
 
-export PORT=3000
+export PORT=${PORT:-3000}
 exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## Summary

This PR adds a small quality of life improvement when running the development
server through the `bin/dev` binstub.

Previously running `bin/dev` would force the development server to run on port
3000, but it is useful to be able to override that if you are running multiple
projects and want to also run the Solidus sandbox app.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
