### PR TITLE
Chore/admin semantic table rows

### DIFF
--- a/admin/app/components/solidus_admin/option_types/index/component.rb
+++ b/admin/app/components/solidus_admin/option_types/index/component.rb
@@ -55,7 +55,7 @@ class SolidusAdmin::OptionTypes::Index::Component < SolidusAdmin::UI::Pages::Ind
     {
       header: :name,
       data: ->(option_type) do
-        content_tag :div, option_type.name
+        link_to option_type.name, row_url(option_type), class: "underline cursor-pointer"
       end
     }
   end
@@ -64,7 +64,7 @@ class SolidusAdmin::OptionTypes::Index::Component < SolidusAdmin::UI::Pages::Ind
     {
       header: :presentation,
       data: ->(option_type) do
-        content_tag :div, option_type.presentation
+        link_to option_type.presentation, row_url(option_type), class: "underline cursor-pointer"
       end
     }
   end

--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -106,9 +106,9 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
       header: :order,
       data: ->(order) do
         if !row_fade(order)
-          content_tag :div, order.number, class: 'font-semibold'
+          link_to order.number, row_url(order), class: "font-semibold underline cursor-pointer"
         else
-          content_tag :div, order.number
+          link_to order.number, row_url(order), class: "underline cursor-pointer"
         end
       end
     }

--- a/admin/app/components/solidus_admin/payment_methods/index/component.rb
+++ b/admin/app/components/solidus_admin/payment_methods/index/component.rb
@@ -59,13 +59,13 @@ class SolidusAdmin::PaymentMethods::Index::Component < SolidusAdmin::UI::Pages::
       {
         header: :name,
         data: ->(payment_method) do
-          content_tag :div, payment_method.name
+          link_to payment_method.name, row_url(payment_method), class: "underline cursor-pointer"
         end
       },
       {
         header: :type,
         data: ->(payment_method) do
-          content_tag :div, payment_method.model_name.human
+          link_to payment_method.model_name.human, row_url(payment_method), class: "underline cursor-pointer"
         end
       },
       {

--- a/admin/app/components/solidus_admin/products/index/component.rb
+++ b/admin/app/components/solidus_admin/products/index/component.rb
@@ -106,7 +106,7 @@ class SolidusAdmin::Products::Index::Component < SolidusAdmin::UI::Pages::Index:
     {
       header: :name,
       data: ->(product) do
-        content_tag :div, product.name
+        link_to product.name, row_url(product), class: "underline cursor-pointer"
       end
     }
   end

--- a/admin/app/components/solidus_admin/properties/index/component.rb
+++ b/admin/app/components/solidus_admin/properties/index/component.rb
@@ -48,7 +48,7 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
     {
       header: :name,
       data: ->(property) do
-        content_tag :div, property.name
+        link_to property.name, row_url(property), class: "underline cursor-pointer"
       end
     }
   end
@@ -57,7 +57,7 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
     {
       header: :presentation,
       data: ->(property) do
-        content_tag :div, property.presentation
+        link_to property.presentation, row_url(property), class: "underline cursor-pointer"
       end
     }
   end

--- a/admin/app/components/solidus_admin/reimbursement_types/index/component.rb
+++ b/admin/app/components/solidus_admin/reimbursement_types/index/component.rb
@@ -15,7 +15,12 @@ class SolidusAdmin::ReimbursementTypes::Index::Component < SolidusAdmin::Refunds
 
   def columns
     [
-      :name,
+      {
+        header: :name,
+        data: ->(reimbursement_type) do
+          reimbursement_type.name
+        end
+      },
       {
         header: :active,
         data: ->(reimbursement_type) do

--- a/admin/app/components/solidus_admin/stock_items/index/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.rb
@@ -90,7 +90,7 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
     {
       header: :name,
       data: ->(stock_item) do
-        content_tag :div, stock_item.variant.name
+        link_to stock_item.variant.name, row_url(stock_item), class: "underline cursor-pointer"
       end
     }
   end
@@ -99,7 +99,7 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
     {
       header: :sku,
       data: ->(stock_item) do
-        content_tag :div, stock_item.variant.sku
+        link_to stock_item.variant.sku, row_url(stock_item), class: "underline cursor-pointer"
       end
     }
   end
@@ -122,7 +122,9 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
   def stock_location_column
     {
       header: :stock_location,
-      data: ->(stock_item) { stock_item.stock_location.name },
+      data: ->(stock_item) do
+        content_tag :div, stock_item.stock_location.name
+      end
     }
   end
 

--- a/admin/app/components/solidus_admin/stores/index/component.rb
+++ b/admin/app/components/solidus_admin/stores/index/component.rb
@@ -44,7 +44,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
       {
         header: :slug,
         data: ->(store) do
-          content_tag :div, store.code
+          link_to store.code, row_url(store), class: "underline cursor-pointer"
         end
       },
       {

--- a/admin/app/components/solidus_admin/taxonomies/index/component.rb
+++ b/admin/app/components/solidus_admin/taxonomies/index/component.rb
@@ -46,7 +46,7 @@ class SolidusAdmin::Taxonomies::Index::Component < SolidusAdmin::UI::Pages::Inde
     {
       header: :name,
       data: ->(taxonomy) do
-        content_tag :div, taxonomy.name
+        link_to taxonomy.name, row_url(taxonomy), class: "underline cursor-pointer"
       end
     }
   end

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -138,15 +138,11 @@
     >
       <% @data.rows.each do |row| %>
         <tr
-          class="border-b border-gray-100 last:border-0 hover:bg-gray-50 cursor-pointer <%= 'bg-gray-15 text-gray-700' if @data.fade&.call(row) %>"
-          <% if @data.url %>
-            data-action="click-><%= stimulus_id %>#rowClicked"
-            data-<%= stimulus_id %>-url-param="<%= @data.url.call(row) %>"
-            <%= "data-sortable-url=#{@sortable.url.call(row)}" if @sortable&.url %>
-          <% end %>
+          class="border-b border-gray-100 last:border-0 hover:bg-gray-50 <%= 'bg-gray-15 text-gray-700' if @data.fade&.call(row) %>"
+          <%= "data-sortable-url=#{@sortable.url.call(row)}" if @sortable&.url %>
         >
           <% @data.columns.each do |column| %>
-            <%= render_data_cell(column, row) %>
+            <%= render_data_cell(column, row, @data.url&.call(row)) %>
           <% end %>
         </tr>
       <% end %>

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -98,21 +98,11 @@ export default class extends Controller {
   }
 
   rowClicked(event) {
-    // If the user clicked on a link, button, input or summary, skip the row url visit
+    // Skip if the user clicked on a link, button, input or summary
     if (event.target.closest("td").contains(event.target.closest("a,select,textarea,button,input,summary"))) return
 
     if (this.modeValue === "batch") {
       this.toggleCheckbox(event.currentTarget)
-    } else {
-      const url = new URL(event.params.url, "http://dummy.com")
-      const params = new URLSearchParams(url.search)
-      const frameId = params.get('_turbo_frame')
-      const frame = frameId ? { frame: frameId } : {}
-      // remove the custom _turbo_frame param from url search:
-      params.delete('_turbo_frame')
-      url.search = params.toString()
-
-      window.Turbo.visit(url.pathname + url.search, frame)
     }
   }
 

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -158,10 +158,10 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
     }, **attrs)
   end
 
-  def render_data_cell(column, data)
+  def render_data_cell(column, data, url = nil)
     cell = column.data
     cell = cell.call(data) if cell.respond_to?(:call)
-    cell = data.public_send(cell) if cell.is_a?(Symbol)
+    cell = link_to data.public_send(cell), url, class: "underline cursor-pointer" if cell.is_a?(Symbol)
     cell = cell.render_in(self) if cell.respond_to?(:render_in)
     cell = tag.div(cell, class: "flex items-center gap-1.5 justify-start overflow-x-hidden") if column.wrap
 

--- a/admin/app/components/solidus_admin/users/index/component.rb
+++ b/admin/app/components/solidus_admin/users/index/component.rb
@@ -83,15 +83,21 @@ class SolidusAdmin::Users::Index::Component < SolidusAdmin::UsersAndRoles::Compo
       },
       {
         header: :order_count,
-        data: ->(user) { user.order_count },
+        data: ->(user) do
+          content_tag :div, user.order_count
+        end
       },
       {
         header: :lifetime_value,
-        data: -> { _1.display_lifetime_value.to_html },
+        data: ->(user) do
+          content_tag :div, user.display_lifetime_value.to_html
+        end
       },
       {
         header: :last_active,
-        data: ->(user) { last_login(user) },
+        data: ->(user) do
+          content_tag :div, last_login(user)
+        end
       },
     ]
   end

--- a/admin/app/components/solidus_admin/users/items/component.rb
+++ b/admin/app/components/solidus_admin/users/items/component.rb
@@ -149,7 +149,7 @@ class SolidusAdmin::Users::Items::Component < SolidusAdmin::BaseComponent
       col: { class: "w-[18%]" },
       header: t(".number_column_header"),
       data: ->(item) do
-        content_tag :div, item.order.number, class: "font-semibold text-sm"
+        link_to item.order.number, row_url(item.order), class: "underline cursor-pointer font-semibold text-sm"
       end
     }
   end
@@ -164,7 +164,7 @@ class SolidusAdmin::Users::Items::Component < SolidusAdmin::BaseComponent
 
     # The `.html_safe` is required for the description to display as desired.
     # rubocop:disable Rails/OutputSafety
-    safe_join([content_tag(:div, content.join("<br>").html_safe, class: "text-sm")])
+    safe_join([link_to(content.join("<br>").html_safe, row_url(item.order), class: "underline cursor-pointer text-sm")])
     # rubocop:enable Rails/OutputSafety
   end
 end

--- a/admin/app/components/solidus_admin/users/orders/component.rb
+++ b/admin/app/components/solidus_admin/users/orders/component.rb
@@ -70,9 +70,9 @@ class SolidusAdmin::Users::Orders::Component < SolidusAdmin::BaseComponent
       header: :order,
       data: ->(order) do
         if !row_fade(order)
-          content_tag :div, order.number, class: 'font-semibold'
+          link_to order.number, row_url(order), class: "font-semibold underline cursor-pointer"
         else
-          content_tag :div, order.number
+          link_to order.number, row_url(order), class: "underline cursor-pointer"
         end
       end
     }

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.rb
@@ -56,21 +56,21 @@ class SolidusAdmin::Users::StoreCredits::Index::Component < SolidusAdmin::BaseCo
         header: :credited,
         col: { class: "w-[12%]" },
         data: ->(store_credit) do
-          content_tag :div, store_credit.display_amount.to_html, class: "text-sm"
+          link_to store_credit.display_amount.to_html, row_url(store_credit), class: "text-sm underline cursor-pointer"
         end
       },
       {
         header: :authorized,
         col: { class: "w-[13%]" },
         data: ->(store_credit) do
-          content_tag :div, store_credit.display_amount_authorized.to_html, class: "text-sm"
+          link_to store_credit.display_amount_authorized.to_html, row_url(store_credit), class: "text-sm underline cursor-pointer"
         end
       },
       {
         header: :used,
         col: { class: "w-[9%]" },
         data: ->(store_credit) do
-          content_tag :div, store_credit.display_amount_used.to_html, class: "text-sm"
+          link_to store_credit.display_amount_used.to_html, row_url(store_credit), class: "text-sm underline cursor-pointer"
         end
       },
       {
@@ -90,9 +90,7 @@ class SolidusAdmin::Users::StoreCredits::Index::Component < SolidusAdmin::BaseCo
       {
         header: :issued_on,
         col: { class: "w-[16%]" },
-        data: ->(store_credit) do
-          I18n.l(store_credit.created_at.to_date)
-        end
+        data: ->(store_credit) { I18n.l(store_credit.created_at.to_date) }
       },
       {
         header: :invalidated,

--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -30,11 +30,13 @@ module SolidusAdmin
       @stock_item.stock_movements.build(quantity: quantity_adjustment, originator: current_solidus_admin_user)
 
       if @stock_item.save
+        binding.pry
         respond_to do |format|
           format.html { redirect_to solidus_admin.stock_items_path, status: :see_other }
           format.turbo_stream { render turbo_stream: '<turbo-stream action="refresh" />' }
         end
       else
+        binding.pry
         respond_to do |format|
           format.html { render component('stock_items/edit').new(stock_item: @stock_item, page: @page), status: :unprocessable_entity }
         end

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -68,7 +68,7 @@ describe "Adjustment Reasons", :js, type: :feature do
     before do
       Spree::AdjustmentReason.create(name: "Good Reason", code: 5999)
       visit "/admin/adjustment_reasons#{query}"
-      find_row("Good Reason").click
+      within("table tbody") { click_on "Good Reason" }
       expect(page).to have_content("Edit Adjustment Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -65,7 +65,7 @@ describe "Refund Reasons", :js, type: :feature do
     before do
       Spree::RefundReason.create(name: "Return process")
       visit "/admin/refund_reasons#{query}"
-      find_row("Return process").click
+      within("table tbody") { click_on "Return process" }
       expect(page).to have_content("Edit Refund Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -67,7 +67,7 @@ describe "Return Reasons", :js, type: :feature do
     before do
       Spree::ReturnReason.create(name: "Good Reason")
       visit "/admin/return_reasons#{query}"
-      find_row("Good Reason").click
+      within("table tbody") { click_on "Good Reason" }
       expect(page).to have_content("Edit Return Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -120,7 +120,7 @@ describe "Roles", :js, type: :feature do
     before do
       Spree::Role.create(name: "Reviewer", permission_sets: [settings_edit_permission])
       visit "/admin/roles#{query}"
-      find_row("Reviewer").click
+      within("table tbody") { click_on "Reviewer" }
       expect(page).to have_content("Edit Role")
       expect(page).to be_axe_clean
       expect(Spree::Role.find_by(name: "Reviewer").permission_set_ids)

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -65,7 +65,7 @@ describe "Shipping Categories", :js, type: :feature do
     before do
       Spree::ShippingCategory.create(name: "Letter Mail")
       visit "/admin/shipping_categories#{query}"
-      find_row("Letter Mail").click
+      within("table tbody") { click_on "Letter Mail" }
       expect(page).to have_content("Edit Shipping Category")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/stock_items_spec.rb
+++ b/admin/spec/features/stock_items_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pry'
 
 describe "Stock Items", :js, type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -65,7 +65,8 @@ describe "Store Credit Reasons", :js, type: :feature do
     before do
       Spree::StoreCreditReason.create(name: "New Customer Reward")
       visit "/admin/store_credit_reasons#{query}"
-      find_row("New Customer Reward").click
+      within("table tbody") { click_on "New Customer Reward" }
+
       expect(page).to have_content("Edit Store Credit Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/users_spec.rb
+++ b/admin/spec/features/users_spec.rb
@@ -65,7 +65,7 @@ describe "Users", :js, type: :feature do
 
       create(:user, email: "customer@example.com")
       visit "/admin/users"
-      find_row("customer@example.com").click
+      within("table tbody") { click_on "customer@example.com" }
     end
 
     it "shows the edit page" do
@@ -114,7 +114,7 @@ describe "Users", :js, type: :feature do
     before do
       create(:user_with_addresses, email: "customer@example.com")
       visit "/admin/users"
-      find_row("customer@example.com").click
+      within("table tbody") { click_on "customer@example.com" }
       click_on "Addresses"
     end
 
@@ -167,7 +167,7 @@ describe "Users", :js, type: :feature do
       before do
         create(:user, email: "customer@example.com")
         visit "/admin/users"
-        find_row("customer@example.com").click
+        within("table tbody") { click_on "customer@example.com" }
         click_on "Order History"
       end
 
@@ -187,7 +187,7 @@ describe "Users", :js, type: :feature do
       before do
         create(:user, :with_orders, email: "loyal_customer@example.com")
         visit "/admin/users"
-        find_row("loyal_customer@example.com").click
+        within("table tbody") { click_on "loyal_customer@example.com" }
         click_on "Order History"
       end
 
@@ -212,7 +212,7 @@ describe "Users", :js, type: :feature do
       before do
         create(:user, email: "customer@example.com")
         visit "/admin/users"
-        find_row("customer@example.com").click
+        within("table tbody") { click_on "customer@example.com" }
         click_on "Items"
       end
 
@@ -232,7 +232,7 @@ describe "Users", :js, type: :feature do
       before do
         create(:order_with_line_items, user: create(:user, email: "loyal_customer@example.com"))
         visit "/admin/users"
-        find_row("loyal_customer@example.com").click
+        within("table tbody") { click_on "loyal_customer@example.com" }
         click_on "Items"
       end
 
@@ -258,7 +258,7 @@ describe "Users", :js, type: :feature do
       before do
         create(:user, email: "customer@example.com")
         visit "/admin/users"
-        find_row("customer@example.com").click
+        within("table tbody") { click_on "customer@example.com" }
         click_on "Store Credit"
       end
 
@@ -281,7 +281,8 @@ describe "Users", :js, type: :feature do
         store_credit.user.update(email: "customer@example.com")
 
         visit "/admin/users"
-        find_row("customer@example.com").click
+        within("table tbody") { click_on "customer@example.com" }
+
         click_on "Store Credit"
       end
 

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -45,14 +45,14 @@ Capybara.exact = true
 Capybara.disable_animation = true
 Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
+  # browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   browser_options.args << '--window-size=1920,1080'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
+  # browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   # Sandbox cannot be used inside unprivileged Docker container
   browser_options.args << '--no-sandbox'

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotions/index/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotions/index/component.rb
@@ -63,7 +63,7 @@ class SolidusAdmin::Promotions::Index::Component < SolidusAdmin::UI::Pages::Inde
       {
         header: :name,
         data: ->(promotion) do
-          content_tag :div, promotion.name
+          link_to promotion.name, row_url(promotion), class: "underline cursor-pointer"
         end
       },
       {

--- a/promotions/lib/components/admin/solidus_promotions/promotions/index/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotions/index/component.rb
@@ -63,7 +63,7 @@ class SolidusPromotions::Promotions::Index::Component < SolidusAdmin::UI::Pages:
       {
         header: :name,
         data: ->(promotion) do
-          link_to promotion.name, row_url(promotion)
+          link_to promotion.name, row_url(promotion), class: "underline cursor-pointer"
         end
       },
       {


### PR DESCRIPTION
## Summary

This PR is for issue: [[Admin] Table component rows do not contain links](https://github.com/solidusio/solidus/issues/5944)

This addresses the major concerns of that issue, but does not remove the click handler as it's still required in one case. That is the case of the `<tr>` clicks. I tried inserting an `<a>` to wrap the whole row, but that didn't work. The browser refused to render it as it seemingly violates the HTML standard for tables. You can have a link, a td, but not both on the same level within the tr. You can only have both if the link is nested inside the td. We might want to look into inserting it inside of each of the `<tr>`'s `<td>`s, but this seems quite messy since some `<td>`s currently have their own behaviour  which would be overruled by that link (row checkbox inputs for one example).

So to recap, this PR addresses our over reliance on the `rowClicked` stimulus handler for all cases except for the `<tr>` itself. Now instead of rendering text or divs, we render semantic UI elements (links) with proper hrefs. Hopefully this makes sense @tvdeyen let me know what you think.


## Before:


https://github.com/user-attachments/assets/3d676a32-a8d2-4f5b-96f2-4bc4c70c9439




## After:

https://github.com/user-attachments/assets/004a9975-4597-4dbe-bf31-3d590fdf20a1



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
