### PR TITLE
[FIX] A few small tweaks for the new promotion admin

### DIFF
--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -9,7 +9,7 @@ module SolidusPromotions
     belongs_to :original_promotion, class_name: "Spree::Promotion", optional: true
     has_many :benefits, class_name: "SolidusPromotions::Benefit", dependent: :destroy
     has_many :conditions, through: :benefits
-    has_many :codes, class_name: "SolidusPromotions::PromotionCode", dependent: :destroy
+    has_many :codes, class_name: "SolidusPromotions::PromotionCode", dependent: :destroy, inverse_of: :promotion
     has_many :code_batches, class_name: "SolidusPromotions::PromotionCodeBatch", dependent: :destroy
     has_many :order_promotions, class_name: "SolidusPromotions::OrderPromotion", dependent: :destroy
 

--- a/promotions/lib/controllers/backend/solidus_promotions/admin/promotion_codes_controller.rb
+++ b/promotions/lib/controllers/backend/solidus_promotions/admin/promotion_codes_controller.rb
@@ -48,6 +48,10 @@ module SolidusPromotions
 
       private
 
+      def model_class
+        SolidusPromotions::PromotionCode
+      end
+
       def load_promotion
         @promotion = SolidusPromotions::Promotion
           .accessible_by(current_ability, :show)


### PR DESCRIPTION
## Summary
Makes a couple of small tweaks to fix a few issues with the new promotions admin:
1. Adds the `inverse_of` option to the `SolidusPromotions::Promotion#codes` association.
    - This helps fix an issue preventing new promotions with a single code from being created. It would generate an undefined method on nil error because the new promotion code would not recognize that it was associated to an unpersisted promotion.
2. Sets the `model_class` on the new `Admin::PromotionCodesController`.
    - Due to how our admin resource controllers are setup, we need to explicitly set the value because the default is to assume everything exists within the `Spree` namespace.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
