### PR TITLE
[FIX] Remove spacing at top of OrderShipping#ship method

### DIFF
--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -44,7 +44,6 @@ class Spree::OrderShipping
   # @return The carton created.
   def ship(inventory_units:, stock_location:, address:, shipping_method:,
            shipped_at: Time.current, external_number: nil, tracking_number: nil, suppress_mailer: false)
-
     carton = nil
 
     Spree::InventoryUnit.transaction do


### PR DESCRIPTION
## Summary
Newest version of Rubocop wants us to remove extra spacing at the top of method bodies.

## Checklist
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
