### PR TITLE
Test app task: Allow passing in user class

### DIFF
--- a/core/lib/spree/testing_support/extension_rake.rb
+++ b/core/lib/spree/testing_support/extension_rake.rb
@@ -4,8 +4,8 @@ require 'spree/testing_support/common_rake'
 
 desc "Generates a dummy app for testing an extension"
 namespace :extension do
-  task :test_app, [:user_class] do |_t, _args|
+  task :test_app, [:user_class] do |_t, args|
     Spree::DummyGeneratorHelper.inject_extension_requirements = true
-    Rake::Task['common:test_app'].invoke
+    Rake::Task['common:test_app'].invoke(args[:user_class])
   end
 end


### PR DESCRIPTION
Without this, every extension's test app always has `Spree::LegacyUser` configured. Mostly, that's fine, but for solidus_auth_devise, it'd be nicer if the generated spree.rb file would have `Spree.user_class = "Spree::User"` rather than `Spree::LegacyUser`.

See this spec failure as an example of what I mean :) https://github.com/solidusio/solidus_auth_devise/commit/74786979b6102b542075a64bcc1f4b7af895fd3d#diff-8d002d054349f039bafc03785a785a1594ef6b4539298f59e84e95217a97abedR21

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
