### PR TITLE
[v4.0] Restrict sqlite3 gem to '~> 1.3', like ActiveRecord

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,9 @@ commands:
             mkdir -p /tmp/dummy_extension
             cd /tmp/dummy_extension
             bundle init
-            bundle add rails sqlite3 <<parameters.extra_gems>> --skip-install
-            bundle add solidus --git "file://$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
+            bundle add rails -v "< 7.1" --skip-install
+            bundle add sqlite3 -v "~> 1.3" --skip-install
+            test -n "<<parameters.extra_gems>>" && bundle add <<parameters.extra_gems>> --skip-install
             export LIB_NAME=set # dummy requireable file
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ dbs = ENV['DB_ALL'] ? 'all' : ENV.fetch('DB', 'sqlite')
 gem 'mysql2', '~> 0.5.0', require: false if dbs.match?(/all|mysql/)
 gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
+gem 'sqlite3', '~> 1.4', require: false if dbs.match?(/all|sqlite/)
 
 gem 'database_cleaner', '~> 1.3', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.0`:
 - [Merge pull request #5727 from mamhoff/restrict-sqlite-to-1.x](https://github.com/solidusio/solidus/pull/5727)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)