### PR TITLE
Backend: Add missing error translation

### DIFF
--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -505,7 +505,7 @@ describe Spree::Admin::UsersController, type: :controller do
 
       it "cannot be destroyed" do
         is_expected.to be_forbidden
-        expect(subject.body).to eq I18n.t("spree.error_user_destroy_with_orders")
+        expect(subject.body).to eq("Cannot delete a user with orders")
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1516,6 +1516,7 @@ en:
     end: End
     ending_in: Ending in
     error: error
+    error_user_destroy_with_orders: Cannot delete a user with orders
     errors:
       messages:
         cannot_delete_finalized_stock_location: Stock Location cannot be destroyed if you have open stock transfers.


### PR DESCRIPTION
We were missing a translation here, but never noticed, because we were not testing for an actual human-understandable string.

This is broken in the v4.0, v4.1, v4.2 and v4.3 branches with a noisier error message, because in those branches, `I18n.t("unavailable")` is different from `t("unavailable")`.
