### PR TITLE
Fix(promotions): Add model_class method to PromotionCodesController

### DIFF
--- a/promotions/lib/controllers/backend/solidus_promotions/admin/promotion_codes_controller.rb
+++ b/promotions/lib/controllers/backend/solidus_promotions/admin/promotion_codes_controller.rb
@@ -53,6 +53,10 @@ module SolidusPromotions
           .accessible_by(current_ability, :show)
           .find(params[:promotion_id])
       end
+
+      def model_class
+        SolidusPromotions::PromotionCode
+      end
     end
   end
 end


### PR DESCRIPTION
Because the new promotion system lives outside the `spree` namespace, we need to be diligent about adding `model_class` to all the controllers.

I have not added a spec, because this only fails if solidus_legacy_promotions is not loaded, and that is not the case in our test suite.
