### PR TITLE
Fix(v4.1): Fix linting error

### DIFF
--- a/backend/lib/spree/backend_configuration/menu_item.rb
+++ b/backend/lib/spree/backend_configuration/menu_item.rb
@@ -34,7 +34,6 @@ module Spree
         position: nil,
         match_path: nil
       )
-
         @condition = condition || -> { true }
         @sections = sections
         @icon = icon


### PR DESCRIPTION
No empty lines in the beginning of methods.
