### PR TITLE
Introducing product brand using taxon_brand_selector

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -291,6 +291,10 @@ module Spree
       @gallery ||= Spree::Config.product_gallery_class.new(self)
     end
 
+    def brand
+      Spree::Config.brand_selector_class.new(self).call
+    end
+
     private
 
     def any_variants_not_track_inventory?

--- a/core/app/models/spree/taxon_brand_selector.rb
+++ b/core/app/models/spree/taxon_brand_selector.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Spree
+  class TaxonBrandSelector
+    BRANDS_TAXONOMY_NAME = "Brands"
+
+    def initialize(product)
+      @product = product
+    end
+
+    def call
+      product.taxons
+             .joins(:taxonomy)
+             .where(spree_taxonomies: { name: BRANDS_TAXONOMY_NAME })
+             .first
+    end
+
+    private
+
+    attr_reader :product
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1075,6 +1075,8 @@ en:
     billing: Billing
     billing_address: Billing Address
     both: Both
+    brand: Brand
+    brands: Brands
     calculated_reimbursements: Calculated Reimbursements
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type or preference source, you must save first before you can edit the calculator settings

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -522,6 +522,13 @@ module Spree
     #   Spree::StoreCreditPrioritizer.
     class_name_attribute :store_credit_prioritizer_class, default: 'Spree::StoreCreditPrioritizer'
 
+    # Allows finding brand for product.
+    #
+    # @!attribute [rw] brand_selector_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::TaxonBrandSelector.
+    class_name_attribute :brand_selector_class, default: 'Spree::TaxonBrandSelector'
+
     # @!attribute [rw] taxon_image_style_default
     #
     # Defines which style to default to when style is not provided

--- a/core/spec/models/spree/taxon_brand_selector_spec.rb
+++ b/core/spec/models/spree/taxon_brand_selector_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::TaxonBrandSelector, type: :model do
+  let(:taxonomy) { create(:taxonomy, name: "Brands") }
+  let(:taxon) { create(:taxon, taxonomy: taxonomy, name: "Brand A") }
+  let(:product) { create(:product, taxons: [taxon]) }
+
+  subject { described_class.new(product) }
+
+  describe "#call" do
+    context "when the product has a taxon under the 'Brands' taxonomy" do
+      it "returns the first taxon under 'Brands'" do
+        expect(subject.call).to eq(taxon)
+      end
+    end
+
+    context "when the product has multiple taxons under the 'Brands' taxonomy" do
+      let(:taxon_b) { create(:taxon, taxonomy: taxonomy, name: "Brand B") }
+      before { product.taxons << taxon_b }
+
+      it "returns the first taxon under 'Brands'" do
+        expect(subject.call).to eq(taxon)
+      end
+    end
+
+    context "when the product does not have a taxon under the 'Brands' taxonomy" do
+      let(:other_taxonomy) { create(:taxonomy, name: "Categories") }
+      let(:other_taxon) { create(:taxon, taxonomy: other_taxonomy, name: "Category A") }
+      let(:product) { create(:product, taxons: [other_taxon]) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
+
+    context "when the product has no taxons" do
+      let(:product) { create(:product) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
+  end
+end

--- a/sample/db/samples/taxonomies.rb
+++ b/sample/db/samples/taxonomies.rb
@@ -2,7 +2,7 @@
 
 taxonomies = [
   { name: "Categories" },
-  { name: "Brand" }
+  { name: "Brands" }
 ]
 
 taxonomies.each do |taxonomy_attrs|

--- a/sample/db/samples/taxons.rb
+++ b/sample/db/samples/taxons.rb
@@ -4,6 +4,7 @@ Spree::Sample.load_sample("taxonomies")
 Spree::Sample.load_sample("products")
 
 categories = Spree::Taxonomy.find_by!(name: "Categories")
+brands = Spree::Taxonomy.find_by!(name: "Brands")
 
 products = {
   solidus_bottles: "Solidus Water Bottle",
@@ -28,6 +29,29 @@ taxons = [
   {
     name: "Categories",
     taxonomy: categories,
+  },
+  {
+    name: "Brands",
+    taxonomy: brands
+  },
+  {
+    name: "Solidus",
+    taxonomy: brands,
+    parent: "Brands",
+    products: [
+      products[:solidus_tote],
+      products[:solidus_hoodie],
+      products[:solidus_mug_set],
+      products[:solidus_hat],
+      products[:solidus_sticker],
+      products[:solidus_notebook],
+      products[:solidus_tshirt],
+      products[:solidus_long_sleeve_tee],
+      products[:solidus_dark_tee],
+      products[:solidus_bottles],
+      products[:solidus_canvas_tote],
+      products[:solidus_cap]
+    ]
   },
   {
     name: "Clothing",


### PR DESCRIPTION
## Summary

This implementation introduces a **brand** concept to Spree products by adding a `brand` method to the `Spree::Product` model. This method delegates brand selection to a configurable class, enabling modularity and customization.

The new `Spree::TaxonBrandSelector` class fetches brands based on the **Brands** taxonomy. Developers can customize this functionality through the `brand_selector_class` attribute in `Spree::AppConfiguration`.

---

## Implementation

### Model Method Implementation

A `brand` method has been added to the `Spree::Product` model to retrieve the associated brand.

#### Changes in `Spree::Product`

The new `brand` method is implemented as follows:

```
def brand
  Spree::Config.brand_selector_class.new(self).call
end 
```

**Class Implementation**

The 'Spree::TaxonBrandSelector' class encapsulates the logic for identifying the brand:

```
module Spree
  class TaxonBrandSelector
	BRANDS_TAXONOMY_NAME = "Brands"

	def initialize(product)
  	@product = product
	end

	def call
  	product.taxons
         	.joins(:taxonomy)
         	.where(spree_taxonomies: { name: BRANDS_TAXONOMY_NAME })
         	.first
	end

	private

	attr_reader :product
  end
end
```

This class queries the database for taxons associated with the product and matches the 'Brands' taxonomy.

**Configuration Implementation**
A new configuration attribute was added to 'Spree::AppConfiguration' to specify the class responsible for selecting the brand for a product:

`class_name_attribute :brand_selector_class, default: 'Spree::TaxonBrandSelector'`

This configuration allows developers to override the default behavior by providing a custom class. By default, it uses 'Spree::TaxonBrandSelector'.

**Testing**
Unit tests were added to verify that the selector correctly identifies the first 'Brands' taxon.

**RSpec Example**


```
require 'rails_helper'

RSpec.describe Spree::TaxonBrandSelector, type: :model do
  let(:taxonomy) { create(:taxonomy, name: "Brands") }
  let(:taxon) { create(:taxon, taxonomy: taxonomy, name: "Brand A") }
  let(:product) { create(:product, taxons: [taxon]) }

  subject { described_class.new(product) }

  describe "#call" do
	context "when the product has a taxon under the 'Brands' taxonomy" do
  	it "returns the first taxon under 'Brands'" do
    	expect(subject.call).to eq(taxon)
  	end
	end
  end
end
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
