### PR TITLE
Fix(v4.1): Collapse admin nav on small windows

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,5 +1,5 @@
 Spree.ready(function() {
-  if (window.screen.width <= 1024 && !document.cookie.includes("admin_nav_hidden")) {
+  if (window.width <= 1024 && !document.cookie.includes("admin_nav_hidden")) {
     // Set default nav to collapse on small screens - but don't override user preference
     document.body.classList.add("admin-nav-hidden");
     document.cookie = "admin_nav_hidden=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";


### PR DESCRIPTION
It is not clear to me why this only fails on some builds, but not others. However, Capybara/Selenium give us a screen size of 800, and a really large browser window of 1920. Let's check for the browser size instead of the screen size, as I've not found a good way of fixing the screen of a Selenium/Capybara session.
