### PR TITLE
test: Wait for modal to open before testing its content

### DIFF
--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -26,12 +26,12 @@ describe "Adjustment Reasons", :js, type: :feature do
     before do
       visit "/admin/adjustment_reasons#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Adjustment Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -69,12 +69,12 @@ describe "Adjustment Reasons", :js, type: :feature do
       Spree::AdjustmentReason.create(name: "Good Reason", code: 5999)
       visit "/admin/adjustment_reasons#{query}"
       find_row("Good Reason").click
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Adjustment Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/orders/show_spec.rb
+++ b/admin/spec/features/orders/show_spec.rb
@@ -48,7 +48,7 @@ describe "Order", :js, type: :feature do
     expect(page).to have_content("Order R123456789")
     open_customer_menu
     click_on "Edit billing address"
-    expect(page).to have_css("dialog", wait: 30)
+    expect(page).to have_css("dialog", wait: 5)
 
     within("dialog") do
       fill_in "Name", with: "John Doe"
@@ -74,7 +74,7 @@ describe "Order", :js, type: :feature do
 
     open_customer_menu
     click_on "Edit shipping address"
-    expect(page).to have_css("dialog", wait: 30)
+    expect(page).to have_css("dialog", wait: 5)
 
     within("dialog") do
       fill_in "Name", with: "Jane Doe"
@@ -119,18 +119,18 @@ describe "Order", :js, type: :feature do
       expect(Spree::Order.last.line_items.count).to eq(0)
 
       find("[aria-selected]", text: "Just another product").click
-      expect(page).to have_content("Variant added to cart successfully", wait: 30)
+      expect(page).to have_content("Variant added to cart successfully", wait: 5)
 
       expect(Spree::Order.last.line_items.count).to eq(1)
       expect(Spree::Order.last.line_items.last.quantity).to eq(1)
 
       fill_in "line_item[quantity]", with: 4
-      expect(page).to have_content("Quantity updated successfully", wait: 30)
+      expect(page).to have_content("Quantity updated successfully", wait: 5)
 
       expect(Spree::Order.last.line_items.last.quantity).to eq(4)
 
       accept_confirm("Are you sure?") { click_on "Delete" }
-      expect(page).to have_content("Line item removed successfully", wait: 30)
+      expect(page).to have_content("Line item removed successfully", wait: 5)
 
       expect(Spree::Order.last.line_items.count).to eq(0)
       expect(page).to be_axe_clean

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -26,12 +26,12 @@ describe "Refund Reasons", :js, type: :feature do
     before do
       visit "/admin/refund_reasons/#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Refund Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -66,12 +66,12 @@ describe "Refund Reasons", :js, type: :feature do
       Spree::RefundReason.create(name: "Return process")
       visit "/admin/refund_reasons#{query}"
       find_row("Return process").click
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Refund Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -26,12 +26,12 @@ describe "Return Reasons", :js, type: :feature do
     before do
       visit "/admin/return_reasons#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Return Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -68,12 +68,12 @@ describe "Return Reasons", :js, type: :feature do
       Spree::ReturnReason.create(name: "Good Reason")
       visit "/admin/return_reasons#{query}"
       find_row("Good Reason").click
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Return Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -54,12 +54,12 @@ describe "Roles", :js, type: :feature do
     before do
       visit "/admin/roles#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Role")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -121,14 +121,14 @@ describe "Roles", :js, type: :feature do
       Spree::Role.create(name: "Reviewer", permission_sets: [settings_edit_permission])
       visit "/admin/roles#{query}"
       find_row("Reviewer").click
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Role")
       expect(page).to be_axe_clean
       expect(Spree::Role.find_by(name: "Reviewer").permission_set_ids)
         .to contain_exactly(settings_edit_permission.id)
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -26,12 +26,12 @@ describe "Shipping Categories", :js, type: :feature do
     before do
       visit "/admin/shipping_categories#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Shipping Category")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -66,12 +66,12 @@ describe "Shipping Categories", :js, type: :feature do
       Spree::ShippingCategory.create(name: "Letter Mail")
       visit "/admin/shipping_categories#{query}"
       find_row("Letter Mail").click
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Shipping Category")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -26,12 +26,12 @@ describe "Store Credit Reasons", :js, type: :feature do
     before do
       visit "/admin/store_credit_reasons#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Store Credit Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -66,12 +66,12 @@ describe "Store Credit Reasons", :js, type: :feature do
       Spree::StoreCreditReason.create(name: "New Customer Reward")
       visit "/admin/store_credit_reasons#{query}"
       find_row("New Customer Reward").click
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Store Credit Reason")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/tax_categories_spec.rb
+++ b/admin/spec/features/tax_categories_spec.rb
@@ -28,12 +28,12 @@ describe "Tax categories", :js, type: :feature do
     before do
       visit "/admin/tax_categories#{query}"
       click_on "Add new"
+      expect(page).to have_selector("dialog")
       expect(page).to have_content("New Tax Category")
       expect(page).to be_axe_clean
     end
 
-    it "opens a modal" do
-      expect(page).to have_selector("dialog")
+    it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/legacy_promotions/spec/features/solidus_admin/promotions_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/promotions_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe "Promotions", :js, type: :feature, solidus_admin: true do
     visit "/admin/promotions"
     expect(page).to have_content("My active Promotion")
     click_on "Draft"
-    expect(page).to have_content("My draft Promotion", wait: 30)
+    expect(page).to have_content("My draft Promotion", wait: 5)
     click_on "Future"
-    expect(page).to have_content("My future Promotion", wait: 30)
+    expect(page).to have_content("My future Promotion", wait: 5)
     click_on "Expired"
-    expect(page).to have_content("My expired Promotion", wait: 30)
+    expect(page).to have_content("My expired Promotion", wait: 5)
     click_on "All"
-    expect(page).to have_content("My active Promotion", wait: 30)
+    expect(page).to have_content("My active Promotion", wait: 5)
     expect(page).to have_content("My draft Promotion")
     expect(page).to have_content("My future Promotion")
     expect(page).to have_content("My expired Promotion")

--- a/promotions/spec/system/solidus_promotions/admin/promotions_spec.rb
+++ b/promotions/spec/system/solidus_promotions/admin/promotions_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe "Promotions", :js, type: :feature, solidus_admin: true do
     visit "/admin/solidus/promotions"
     expect(page).to have_content("My active Promotion")
     click_on "Draft"
-    expect(page).to have_content("My draft Promotion", wait: 30)
+    expect(page).to have_content("My draft Promotion", wait: 5)
     click_on "Future"
-    expect(page).to have_content("My future Promotion", wait: 30)
+    expect(page).to have_content("My future Promotion", wait: 5)
     click_on "Expired"
-    expect(page).to have_content("My expired Promotion", wait: 30)
+    expect(page).to have_content("My expired Promotion", wait: 5)
     click_on "All"
-    expect(page).to have_content("My active Promotion", wait: 30)
+    expect(page).to have_content("My active Promotion", wait: 5)
     expect(page).to have_content("My draft Promotion")
     expect(page).to have_content("My future Promotion")
     expect(page).to have_content("My expired Promotion")


### PR DESCRIPTION
Capybara needs to be told to expect that the modal is open before we can check for content present in it.

Fixes a lot of extremely flaky specs.
