### PR TITLE
[v4.3] test: Wait for modal to open before testing its content

### DIFF
--- a/admin/spec/features/order_spec.rb
+++ b/admin/spec/features/order_spec.rb
@@ -48,7 +48,7 @@ describe "Order", :js, type: :feature do
     expect(page).to have_content("Order R123456789")
     open_customer_menu
     click_on "Edit billing address"
-    expect(page).to have_css("dialog", wait: 30)
+    expect(page).to have_css("dialog", wait: 5)
 
     within("dialog") do
       fill_in "Name", with: "John Doe"
@@ -74,7 +74,7 @@ describe "Order", :js, type: :feature do
 
     open_customer_menu
     click_on "Edit shipping address"
-    expect(page).to have_css("dialog", wait: 30)
+    expect(page).to have_css("dialog", wait: 5)
 
     within("dialog") do
       fill_in "Name", with: "Jane Doe"
@@ -119,18 +119,18 @@ describe "Order", :js, type: :feature do
       expect(Spree::Order.last.line_items.count).to eq(0)
 
       find("[aria-selected]", text: "Just another product").click
-      expect(page).to have_content("Variant added to cart successfully", wait: 30)
+      expect(page).to have_content("Variant added to cart successfully", wait: 5)
 
       expect(Spree::Order.last.line_items.count).to eq(1)
       expect(Spree::Order.last.line_items.last.quantity).to eq(1)
 
       fill_in "line_item[quantity]", with: 4
-      expect(page).to have_content("Quantity updated successfully", wait: 30)
+      expect(page).to have_content("Quantity updated successfully", wait: 5)
 
       expect(Spree::Order.last.line_items.last.quantity).to eq(4)
 
       accept_confirm("Are you sure?") { click_on "Delete" }
-      expect(page).to have_content("Line item removed successfully", wait: 30)
+      expect(page).to have_content("Line item removed successfully", wait: 5)
 
       expect(Spree::Order.last.line_items.count).to eq(0)
       expect(page).to be_axe_clean

--- a/admin/spec/features/promotions_spec.rb
+++ b/admin/spec/features/promotions_spec.rb
@@ -14,13 +14,13 @@ describe "Promotions", :js, type: :feature do
     visit "/admin/promotions"
     expect(page).to have_content("My active Promotion")
     click_on "Draft"
-    expect(page).to have_content("My draft Promotion", wait: 30)
+    expect(page).to have_content("My draft Promotion", wait: 5)
     click_on "Future"
-    expect(page).to have_content("My future Promotion", wait: 30)
+    expect(page).to have_content("My future Promotion", wait: 5)
     click_on "Expired"
-    expect(page).to have_content("My expired Promotion", wait: 30)
+    expect(page).to have_content("My expired Promotion", wait: 5)
     click_on "All"
-    expect(page).to have_content("My active Promotion", wait: 30)
+    expect(page).to have_content("My active Promotion", wait: 5)
     expect(page).to have_content("My draft Promotion")
     expect(page).to have_content("My future Promotion")
     expect(page).to have_content("My expired Promotion")


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.3`:
 - [Merge pull request #5993 from tvdeyen/harden-admin-feature-specs](https://github.com/solidusio/solidus/pull/5993)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)