### PR TITLE
Fix(Promotions): Return 200 on benefits#edit

### DIFF
--- a/promotions/lib/controllers/backend/solidus_promotions/admin/benefits_controller.rb
+++ b/promotions/lib/controllers/backend/solidus_promotions/admin/benefits_controller.rb
@@ -28,7 +28,7 @@ module SolidusPromotions
         if params.dig(:benefit, :calculator_type)
           @benefit.calculator_type = params[:benefit][:calculator_type]
         end
-        render layout: false, status: :unprocessable_entity
+        render layout: false
       end
 
       def update


### PR DESCRIPTION
In #5981, we accidentally set this render to a response code 422. Since this is the initial render of the form, it should stay a 200. 
