### PR TITLE
[specs] Wait for modal before testing its content

### DIFF
--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -26,7 +26,7 @@ describe "Refund Reasons", :js, type: :feature do
     before do
       visit "/admin/refund_reasons/#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("New Refund Reason")
       expect(page).to be_axe_clean
     end
@@ -66,7 +66,7 @@ describe "Refund Reasons", :js, type: :feature do
       Spree::RefundReason.create(name: "Return process")
       visit "/admin/refund_reasons#{query}"
       find_row("Return process").click
-      expect(page).to have_selector("dialog")
+      expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("Edit Refund Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -26,7 +26,7 @@ describe "Shipping Categories", :js, type: :feature do
     before do
       visit "/admin/shipping_categories#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("New Shipping Category")
       expect(page).to be_axe_clean
     end
@@ -66,7 +66,7 @@ describe "Shipping Categories", :js, type: :feature do
       Spree::ShippingCategory.create(name: "Letter Mail")
       visit "/admin/shipping_categories#{query}"
       find_row("Letter Mail").click
-      expect(page).to have_selector("dialog")
+      expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("Edit Shipping Category")
       expect(page).to be_axe_clean
     end


### PR DESCRIPTION
Building off of https://github.com/solidusio/solidus/pull/5993, a few more specs required a short wait time to give the modal a chance to load. They were flaky (failing somewhat regularly in CI, but always passing locally) and this should help remedy that.

<img width="1052" alt="Screenshot 2024-12-04 at 9 42 56 AM" src="https://github.com/user-attachments/assets/d776b010-9328-4315-b5fe-96982c4da1e2">
