### PR TITLE
Do not constantize Spree.user_class in UserClassHandle

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -39,6 +39,10 @@ module Spree
     end
   end
 
+  def self.user_class_name
+    @@user_class
+  end
+
   # Load the same version defaults for all available Solidus components
   #
   # @see Spree::Preferences::Configuration#load_defaults

--- a/core/lib/spree/user_class_handle.rb
+++ b/core/lib/spree/user_class_handle.rb
@@ -21,8 +21,8 @@ module Spree
     # @return [String] the name of the user class as a string.
     # @raise [RuntimeError] if Spree.user_class is nil
     def to_s
-      fail "'Spree.user_class' has not been set yet." unless Spree.user_class
-      "::#{Spree.user_class}"
+      fail "'Spree.user_class' has not been set yet." unless Spree.user_class_name
+      "::#{Spree.user_class_name}"
     end
   end
 end

--- a/core/spec/lib/spree/user_class_handle_spec.rb
+++ b/core/spec/lib/spree/user_class_handle_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "spree/core"
+require "spree/user_class_handle"
+
+RSpec.describe Spree::UserClassHandle do
+  describe "#to_s" do
+    around do |example|
+      @prev_user_class = Spree.user_class_name
+      example.run
+      Spree.user_class = @prev_user_class
+    end
+
+    subject { described_class.new.to_s }
+
+    context "when Spree.user_class is nil" do
+      before do
+        Spree.user_class = nil
+      end
+
+      it "is expected to fail" do
+        expect { subject }.to raise_error(RuntimeError, "'Spree.user_class' has not been set yet.")
+      end
+    end
+
+    context "when Spree.user_class is not nil" do
+      before do
+        Spree.user_class = "Spree::User"
+      end
+
+      it "is expected to return the user class as a string" do
+        expect(subject).to eq("::Spree::User")
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Spree.user_class` will constantize the configured user class. If called during Rails start-up, this will autoload the configured user class, which is not necessarily desired. We can do without the autoloading by directly getting the name of the class from a new method `Spree.user_class_name`. 
