### PR TITLE
Allow to set Rails deprecations behavior during tests

### DIFF
--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -80,7 +80,7 @@ module DummyApp
       config.action_dispatch.show_exceptions = false
     end
     config.consider_all_requests_local = true
-    config.active_support.deprecation = :stderr
+    config.active_support.deprecation = ENV['RAILS_DEPRECATIONS_BEHAVIOR'].presence&.to_sym || :stderr
     config.log_level = :debug
 
     # Improve test suite performance:


### PR DESCRIPTION
Set the desired deprecation behavior via `RAILS_DEPRECATIONS_BEHAVIOR` ENV var. Defaults to `:stderr`. Possible values are

  - `raise` - Raise ActiveSupport::DeprecationException.
  - `stderr` - Log all deprecation warnings to $stderr.
  - `log` - Log all deprecation warnings to Rails.logger.
  - `notify` - Use ActiveSupport::Notifications to notify deprecation.rails.
  - `report` - Use ActiveSupport::ErrorReporter to report deprecations.
  - `silence` - Do nothing

Refs: https://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html
