### PR TITLE
[v4.3] Use Order#email to show the order's email in new admin

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -138,7 +138,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::BaseComponent
       col: { class: "w-[400px]" },
       header: :customer,
       data: ->(order) do
-        customer_email = order.user&.email
+        customer_email = order.email
         content_tag :div, String(customer_email)
       end
     }

--- a/admin/spec/features/orders/index_spec.rb
+++ b/admin/spec/features/orders/index_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Orders", type: :feature do
+  before { sign_in create(:admin_user, email: 'admin@example.com') }
+
+  it "lists orders", :js do
+    create(:order, number: "R123456789", total: 19.99)
+
+    visit "/admin/orders"
+    click_on "In Progress"
+
+    expect(page).to have_content("admin@example.com")
+  end
+end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.3`:
 - [Merge pull request #5596 from softr8/backend_order_email](https://github.com/solidusio/solidus/pull/5596)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)