### PR TITLE
[v4.2] Use Order#email to show the order's email in new admin

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -74,7 +74,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::BaseComponent
       class_name: "w-[400px]",
       header: :customer,
       data: ->(order) do
-        customer_email = order.user&.email
+        customer_email = order.email
         content_tag :div, String(customer_email)
       end
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.2`:
 - [Merge pull request #5596 from softr8/backend_order_email](https://github.com/solidusio/solidus/pull/5596)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)