### PR TITLE
tests: Give dialogs a little more time to open

### DIFF
--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -26,7 +26,7 @@ describe "Adjustment Reasons", :js, type: :feature do
     before do
       visit "/admin/adjustment_reasons#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Adjustment Reason")
       expect(page).to be_axe_clean
     end
@@ -69,7 +69,7 @@ describe "Adjustment Reasons", :js, type: :feature do
       Spree::AdjustmentReason.create(name: "Good Reason", code: 5999)
       visit "/admin/adjustment_reasons#{query}"
       find_row("Good Reason").click
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Adjustment Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -26,7 +26,7 @@ describe "Return Reasons", :js, type: :feature do
     before do
       visit "/admin/return_reasons#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Return Reason")
       expect(page).to be_axe_clean
     end
@@ -68,7 +68,7 @@ describe "Return Reasons", :js, type: :feature do
       Spree::ReturnReason.create(name: "Good Reason")
       visit "/admin/return_reasons#{query}"
       find_row("Good Reason").click
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Return Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -54,7 +54,7 @@ describe "Roles", :js, type: :feature do
     before do
       visit "/admin/roles#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Role")
       expect(page).to be_axe_clean
     end
@@ -121,7 +121,7 @@ describe "Roles", :js, type: :feature do
       Spree::Role.create(name: "Reviewer", permission_sets: [settings_edit_permission])
       visit "/admin/roles#{query}"
       find_row("Reviewer").click
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Role")
       expect(page).to be_axe_clean
       expect(Spree::Role.find_by(name: "Reviewer").permission_set_ids)

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -26,7 +26,7 @@ describe "Store Credit Reasons", :js, type: :feature do
     before do
       visit "/admin/store_credit_reasons#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Store Credit Reason")
       expect(page).to be_axe_clean
     end
@@ -66,7 +66,7 @@ describe "Store Credit Reasons", :js, type: :feature do
       Spree::StoreCreditReason.create(name: "New Customer Reward")
       visit "/admin/store_credit_reasons#{query}"
       find_row("New Customer Reward").click
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Store Credit Reason")
       expect(page).to be_axe_clean
     end

--- a/admin/spec/features/tax_categories_spec.rb
+++ b/admin/spec/features/tax_categories_spec.rb
@@ -28,7 +28,7 @@ describe "Tax categories", :js, type: :feature do
     before do
       visit "/admin/tax_categories#{query}"
       click_on "Add new"
-      expect(page).to have_selector("dialog")
+      expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Tax Category")
       expect(page).to be_axe_clean
     end


### PR DESCRIPTION
The default time of 2 seconds is not enough sometimes. Give it 3 more seconds to wait until Capybara raises an error.
