### PR TITLE
Add can apply to promotions

### DIFF
--- a/promotions/app/models/solidus_promotions/order_adjuster.rb
+++ b/promotions/app/models/solidus_promotions/order_adjuster.rb
@@ -13,7 +13,7 @@ module SolidusPromotions
     def call
       order.reset_current_discounts
 
-      return order if (!SolidusPromotions.config.recalculate_complete_orders && order.complete?) || order.shipped?
+      return order unless SolidusPromotions::Promotion.order_activatable?(order)
 
       discounted_order = DiscountOrder.new(order, promotions, dry_run: dry_run).call
 

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -2,6 +2,8 @@
 
 module SolidusPromotions
   class Promotion < Spree::Base
+    UNACTIVATABLE_ORDER_STATES = ["awaiting_return", "returned", "canceled"]
+
     include Spree::SoftDeletable
 
     belongs_to :category, class_name: "SolidusPromotions::PromotionCategory",
@@ -57,6 +59,14 @@ module SolidusPromotions
 
     def self.ordered_lanes
       lanes.sort_by(&:last).to_h
+    end
+
+    def self.order_activatable?(order)
+      return false if UNACTIVATABLE_ORDER_STATES.include?(order.state)
+      return false if order.shipped?
+      return false if order.complete? && !SolidusPromotions.config.recalculate_complete_orders
+
+      true
     end
 
     self.allowed_ransackable_associations = ["codes"]

--- a/promotions/app/models/solidus_promotions/promotion_handler/coupon.rb
+++ b/promotions/app/models/solidus_promotions/promotion_handler/coupon.rb
@@ -26,6 +26,10 @@ module SolidusPromotions
         self
       end
 
+      def can_apply?
+        SolidusPromotions::Promotion.order_activatable?(order)
+      end
+
       def remove
         if promotion.blank?
           set_error_code :coupon_code_not_found

--- a/promotions/spec/models/solidus_promotions/promotion_handler/coupon_spec.rb
+++ b/promotions/spec/models/solidus_promotions/promotion_handler/coupon_spec.rb
@@ -452,4 +452,15 @@ RSpec.describe SolidusPromotions::PromotionHandler::Coupon, type: :model do
       )
     end
   end
+
+  describe "#can_apply?", :pending do
+    let(:order) { double("Order").as_null_object }
+
+    subject { described_class.new(order).can_apply? }
+
+    it "forwards to SolidusPromotions::Promotion.order_activatable?" do
+      expect(SolidusPromotions::Promotion).to receive(:order_activatable?).with(order)
+      subject
+    end
+  end
 end

--- a/promotions/spec/models/solidus_promotions/promotion_handler/coupon_spec.rb
+++ b/promotions/spec/models/solidus_promotions/promotion_handler/coupon_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe SolidusPromotions::PromotionHandler::Coupon, type: :model do
     end
   end
 
-  describe "#can_apply?", :pending do
+  describe "#can_apply?" do
     let(:order) { double("Order").as_null_object }
 
     subject { described_class.new(order).can_apply? }

--- a/promotions/spec/system/solidus_promotions/backend/orders/adjustments_spec.rb
+++ b/promotions/spec/system/solidus_promotions/backend/orders/adjustments_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Adjustments", :pending, type: :feature do
+  stub_authorization!
+
+  let!(:ship_address) { create(:address) }
+  let!(:tax_zone) { create(:global_zone) } # will include the above address
+  let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.20, zone: tax_zone, tax_categories: [tax_category]) }
+
+  let!(:line_item) { order.line_items[0] }
+
+  let(:tax_category) { create(:tax_category) }
+  let(:variant) { create(:variant, tax_category:) }
+
+  before(:each) do
+    order.recalculate
+
+    visit spree.admin_path
+    click_link "Orders"
+    uncheck "Only show complete orders"
+    click_button "Filter Results"
+    within_row(1) { click_icon :edit }
+    click_link "Adjustments"
+  end
+
+  let!(:order) { create(:order, line_items_attributes: [{ price: 10, variant: }]) }
+
+  context "when the order is completed" do
+    let!(:order) do
+      create(
+        :completed_order_with_totals,
+        line_items_attributes: [{ price: 10, variant: }],
+        ship_address:
+      )
+    end
+
+    let!(:adjustment) { order.adjustments.create!(order:, label: "Rebate", amount: 10) }
+
+    it "shows adjustments" do
+      expect(page).to have_content("Adjustments")
+    end
+
+    context "when the promotion system is configured to allow applying promotions to completed orders" do
+      before do
+        expect(SolidusPromotions.config).to receive(:recalculate_complete_orders).and_return(true)
+      end
+
+      it "shows input field for promotion code" do
+        expect(page).to have_content("Adjustments")
+        expect(page).to have_field("coupon_code")
+      end
+    end
+
+    context "when the promotion system is configured to not allow applying promotions to completed orders" do
+      before do
+        expect(SolidusPromotions.config).to receive(:recalculate_complete_orders).and_return(false)
+      end
+
+      it "does not show input field for promotion code" do
+        expect(page).to have_content("Adjustments")
+        expect(page).not_to have_field("coupon_code")
+      end
+    end
+  end
+
+  it "shows the input field for applying a promotion" do
+    expect(page).to have_field("coupon_code")
+  end
+
+  context "creating a manual adjustment" do
+    let!(:adjustment_reason) { create(:adjustment_reason, name: "Friendly customer") }
+    before do
+      click_link "New Adjustment"
+    end
+
+    it "creates a new adjustment" do
+      fill_in "adjustment_amount", with: "5"
+      fill_in "adjustment_label", with: "Test Adjustment"
+      select "Friendly customer", from: "Reason"
+      click_button "Continue"
+      expect(page).to have_content("Adjustment has been successfully created!")
+      expect(page).to have_content("Test Adjustment")
+    end
+  end
+end

--- a/promotions/spec/system/solidus_promotions/backend/orders/adjustments_spec.rb
+++ b/promotions/spec/system/solidus_promotions/backend/orders/adjustments_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Adjustments", :pending, type: :feature do
+RSpec.describe "Adjustments", type: :feature do
   stub_authorization!
 
   let!(:ship_address) { create(:address) }
@@ -13,8 +13,10 @@ RSpec.describe "Adjustments", :pending, type: :feature do
 
   let(:tax_category) { create(:tax_category) }
   let(:variant) { create(:variant, tax_category:) }
+  let(:preferences) { {} }
 
   before(:each) do
+    stub_spree_preferences(SolidusPromotions.configuration, preferences)
     order.recalculate
 
     visit spree.admin_path
@@ -43,10 +45,6 @@ RSpec.describe "Adjustments", :pending, type: :feature do
     end
 
     context "when the promotion system is configured to allow applying promotions to completed orders" do
-      before do
-        expect(SolidusPromotions.config).to receive(:recalculate_complete_orders).and_return(true)
-      end
-
       it "shows input field for promotion code" do
         expect(page).to have_content("Adjustments")
         expect(page).to have_field("coupon_code")
@@ -54,9 +52,7 @@ RSpec.describe "Adjustments", :pending, type: :feature do
     end
 
     context "when the promotion system is configured to not allow applying promotions to completed orders" do
-      before do
-        expect(SolidusPromotions.config).to receive(:recalculate_complete_orders).and_return(false)
-      end
+      let(:preferences) { { recalculate_complete_orders: false } }
 
       it "does not show input field for promotion code" do
         expect(page).to have_content("Adjustments")


### PR DESCRIPTION
## Summary

This fixes the orders/adjustment pages when using the new promotion system. 

Bug report from @boomer196 on Slack:

> Using Solidus v4.4.1 and I have the “new” promotions installed (no legacy).  When I click on the Adjustments tab of an order and it blows up.
> The app/views/spree/admin/adjustments/index.html.erb in solidus_backend has a check to see if it should display the  coupon code section:
> ```
> <% if @order.can_add_coupon? && can?(:update, @order) %>
>   <div data-hook="adjustments_new_coupon_code">
>     <%= text_field_tag "coupon_code", "", placeholder: t('spree.coupon_code') %>
>     <%= button_tag t('spree.add_coupon_code'), id: "add_coupon_code", class: 'btn btn-primary' %>
>   </div>
> <% end %>
> ```
> `app/models/spree/order.rb` has a method called `can_add_coupon?` and it tries to call `can_apply?` on the `Spree::Config.promotions.coupon_code_handler_class`
> 
> ```
> def can_add_coupon?
>   Spree::Config.promotions.coupon_code_handler_class.new(self).can_apply?
> end
> ```
> ```
> ActionView::Template::Error (undefined method `can_apply?' for an instance of SolidusPromotions::PromotionHandler::Coupon):
> 
> Causes:
> NoMethodError (undefined method `can_apply?' for an instance of SolidusPromotions::PromotionHandler::Coupon)
> ```
> 
> 

