### PR TITLE
Fix backporting of PRs with backport label first

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ jobs:
       github.event.pull_request.merged == true
       && contains(
            join(github.event.pull_request.labels.*.name, '---'),
-           '---backport'
+           'backport'
          )
       && (
         (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport')) ||


### PR DESCRIPTION
If the backportable PR contains the backport-vxx label as the first label the condition does not match.
