### PR TITLE
tests: Give even more dialogs more time to open in tests

### DIFF
--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -33,7 +33,7 @@ describe "Adjustment Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 
@@ -76,7 +76,7 @@ describe "Adjustment Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -33,7 +33,7 @@ describe "Refund Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 
@@ -73,7 +73,7 @@ describe "Refund Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -33,7 +33,7 @@ describe "Return Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 
@@ -75,7 +75,7 @@ describe "Return Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -61,7 +61,7 @@ describe "Roles", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 
@@ -130,7 +130,7 @@ describe "Roles", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -33,7 +33,7 @@ describe "Shipping Categories", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 
@@ -73,7 +73,7 @@ describe "Shipping Categories", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -33,7 +33,7 @@ describe "Store Credit Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 
@@ -73,7 +73,7 @@ describe "Store Credit Reasons", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 

--- a/admin/spec/features/tax_categories_spec.rb
+++ b/admin/spec/features/tax_categories_spec.rb
@@ -35,7 +35,7 @@ describe "Tax categories", :js, type: :feature do
 
     it "closing the modal keeps query params" do
       within("dialog") { click_on "Cancel" }
-      expect(page).not_to have_selector("dialog")
+      expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
     end
 


### PR DESCRIPTION
These dialog tests fail often. We should give them more time to open.
