### PR TITLE
Add solidus legacy promotions to promotions gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,27 +56,22 @@ group :backend do
 end
 
 group :admin do
-  gem 'solidus_admin', path: 'admin', require: false
   gem 'tailwindcss-rails', '~> 3.0', require: false
+end
+
+group :admin, :legacy_promotions, :promotions do
+  gem 'solidus_admin', path: 'admin', require: false
   gem 'axe-core-rspec', '~> 4.8', require: false
   gem 'axe-core-capybara', '~> 4.8', require: false
 end
 
-group :legacy_promotions do
+group :legacy_promotions, :promotions do
   gem 'solidus_legacy_promotions', path: 'legacy_promotions', require: false
-  gem 'solidus_admin', path: 'admin', require: false
   gem 'solidus_backend', path: 'backend', require: false
-  gem 'axe-core-rspec', '~> 4.8', require: false
-  gem 'axe-core-capybara', '~> 4.8', require: false
 end
 
 group :promotions do
   gem 'solidus_promotions', path: 'promotions', require: false
-  gem 'solidus_legacy_promotions', path: 'legacy_promotions', require: false
-  gem 'solidus_admin', path: 'admin', require: false
-  gem 'solidus_backend', path: 'backend', require: false
-  gem 'axe-core-rspec', '~> 4.8', require: false
-  gem 'axe-core-capybara', '~> 4.8', require: false
   gem 'shoulda-matchers', '~> 5.0', require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ end
 
 group :promotions do
   gem 'solidus_promotions', path: 'promotions', require: false
+  gem 'solidus_legacy_promotions', path: 'legacy_promotions', require: false
   gem 'solidus_admin', path: 'admin', require: false
   gem 'solidus_backend', path: 'backend', require: false
   gem 'axe-core-rspec', '~> 4.8', require: false


### PR DESCRIPTION
## Summary

This adds `solidus_legacy_promotions` to the `:promotions` group in the main `Gemfile`, so that rake tasks in `solidus_legacy_promotions` run in development mode. 

It also removes some duplication in the main `Gemfile`, removing these warnings: 

``` 
Your Gemfile lists the gem solidus_admin (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem axe-core-rspec (~> 4.8) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem axe-core-capybara (~> 4.8) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem solidus_legacy_promotions (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem solidus_backend (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```
