### PR TITLE
[Admin][Users] Add new admin store credits edit_amount flow

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/field/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/field/component.rb
@@ -46,7 +46,7 @@ class SolidusAdmin::UI::Forms::Field::Component < SolidusAdmin::BaseComponent
         tag: :select,
         choices:,
         size:,
-        value: object.public_send(method),
+        value: (object.public_send(method) if object.respond_to?(method)),
         error: (errors.to_sentence.capitalize if errors),
         **attributes,
       }

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag :edit_amount_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @store_credit, url: solidus_admin.update_amount_user_store_credit_path(@user, @store_credit), method: :put, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :amount, class: "required") %>
+        <%= render component("ui/forms/field").select(
+          f,
+          :store_credit_reason_id,
+          store_credit_reasons_select_options.html_safe,
+          include_blank: t('spree.choose_reason'),
+          html: { required: true }
+        ) %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("users/store_credits/show").new(user: @user, store_credit: @store_credit, events: @store_credit_events) %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::StoreCredits::EditAmount::Component < SolidusAdmin::BaseComponent
+  def initialize(user:, store_credit:, events:, reasons:)
+    @user = user
+    @store_credit = store_credit
+    @store_credit_events = events
+    @store_credit_reasons = reasons
+  end
+
+  def form_id
+    dom_id(@store_credit, "#{stimulus_id}_edit_amount_form")
+  end
+
+  def store_credit_reasons_select_options
+    # Placeholder + Store Credit Reasons
+    "<option value>#{t('.choose_reason')}</option>" + options_from_collection_for_select(@store_credit_reasons, :id, :name)
+  end
+end

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.yml
@@ -1,0 +1,5 @@
+en:
+  title: Edit Store Credit
+  cancel: Cancel
+  submit: Update Store Credit
+  choose_reason: Choose Reason For Changing Amount

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.rb
@@ -47,7 +47,7 @@ class SolidusAdmin::Users::StoreCredits::Index::Component < SolidusAdmin::BaseCo
   end
 
   def row_url(store_credit)
-    spree.admin_user_store_credit_path(@user, store_credit)
+    solidus_admin.user_store_credit_path(@user, store_credit)
   end
 
   def columns

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
@@ -2,20 +2,6 @@
   <%= page_header do %>
     <%= page_header_back(solidus_admin.users_path) %>
     <%= page_header_title(t(".title", email: @user.email, amount: @store_credit.display_amount)) %>
-
-    <%= page_header_actions do %>
-        <%# TODO: can? actions in admin %>
-        <%# if @store_credit.editable? && can?(:edit, @store_credit) %>
-        <% if @store_credit.editable? %>
-          <%= render component("ui/button").new(tag: :a, text: t(".change_amount"), href: spree.edit_amount_admin_user_store_credit_path(@user, @store_credit)) %>
-        <% end %>
-        <%# TODO: can? actions in admin %>
-        <%# if @store_credit.invalidateable? && can?(:invalidate, @store_credit) %>
-        <% if @store_credit.invalidateable? %>
-          <%= render component("ui/button").new(scheme: :danger, tag: :a, text: t(".invalidate"), href: spree.edit_validity_admin_user_store_credit_path(@user, @store_credit)) %>
-        <% end %>
-
-    <% end %>
   <% end %>
 
   <%= page_header do %>
@@ -26,17 +12,40 @@
 
   <%= page_with_sidebar do %>
     <%= page_with_sidebar_main do %>
-      <%= render component('ui/panel').new(title: t(".store_credit")) do %>
-        <%= render component('ui/details_list').new(
-          items: [
-            { label: t('.credited'), value: @store_credit.display_amount },
-            { label: t('.created_by'), value: @store_credit.created_by_email },
-            { label: t('.type'), value: @store_credit.category_name },
-            { label: t('.memo'), value: @store_credit.memo }
-          ]
-        ) %>
-      <% end %>
+      <%= render component('ui/panel').new(title: t(".store_credit")) do |panel| %>
+        <% panel.with_section do %>
+          <%= render component('ui/details_list').new(
+            items: [
+              { label: t('.credited'), value: @store_credit.display_amount },
+              { label: t('.created_by'), value: @store_credit.created_by_email },
+              { label: t('.type'), value: @store_credit.category_name },
+              { label: t('.memo'), value: @store_credit.memo }
+            ]
+          ) %>
+        <% end %>
 
+       <% if @store_credit.editable? || @store_credit.invalidateable? %>
+          <% panel.with_section do %>
+            <div class="w-[100%] text-right">
+              <% if @store_credit.invalidateable? %>
+                <%= render component("ui/button").new(
+                  scheme: :danger,
+                  tag: :a,
+                  text: t(".invalidate"),
+                  href: spree.edit_validity_admin_user_store_credit_path(@user, @store_credit)
+                )%>
+              <% end %>
+              <% if @store_credit.editable? %>
+                <%= render component("ui/button").new(
+                  "data-action": "click->#{stimulus_id}#actionButtonClicked",
+                  "data-#{stimulus_id}-url-param": solidus_admin.edit_amount_user_store_credit_path(@user, @store_credit, _turbo_frame: :edit_amount_modal),
+                  text: t(".edit"),
+                )%>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
 
       <% if @events.present? %>
         <h1 class="font-semibold text-base text-center w-[100%]"><%= t(".store_credit_history") %></h1>
@@ -55,5 +64,9 @@
     <%= page_with_sidebar_aside do %>
       <%= render component("users/stats").new(user: @user) %>
     <% end %>
+  <% end %>
+
+  <% turbo_frames.each do |frame| %>
+    <%= turbo_frame_tag frame %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.js
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  actionButtonClicked(event) {
+    const url = new URL(event.params.url, "http://dummy.com")
+    const params = new URLSearchParams(url.search)
+    const frameId = params.get('_turbo_frame')
+    const frame = frameId ? { frame: frameId } : {}
+    // remove the custom _turbo_frame param from url search:
+    params.delete('_turbo_frame')
+    url.search = params.toString()
+
+    window.Turbo.visit(url.pathname + url.search, frame)
+  }
+}

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.rb
@@ -48,6 +48,12 @@ class SolidusAdmin::Users::StoreCredits::Show::Component < SolidusAdmin::BaseCom
     ]
   end
 
+  def turbo_frames
+    %w[
+      edit_amount_modal
+    ]
+  end
+
   def form_id
     @form_id ||= "#{stimulus_id}--form-#{@store_credit.id}"
   end

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.yml
@@ -7,7 +7,7 @@ en:
   store_credit: Store Credit
   last_active: Last Active
   add_store_credit: Add Store Credit
-  change_amount: Change Amount
+  edit: Edit Amount
   invalidate: Invalidate
   store_credit_history: Store Credit History
   credited: Credited

--- a/admin/app/controllers/solidus_admin/store_credits_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credits_controller.rb
@@ -3,7 +3,8 @@
 module SolidusAdmin
   class StoreCreditsController < SolidusAdmin::BaseController
     before_action :set_user
-    before_action :set_store_credit, only: [:show]
+    before_action :set_store_credit, only: [:show, :edit_amount, :update_amount]
+    before_action :set_store_credit_reasons, only: [:edit_amount, :update_amount]
 
     def index
       @store_credits = Spree::StoreCredit.where(user_id: @user.id).order(id: :desc)
@@ -21,6 +22,42 @@ module SolidusAdmin
       end
     end
 
+    def edit_amount
+      @store_credit_events = @store_credit.store_credit_events.chronological
+
+      respond_to do |format|
+        format.html {
+          render component("users/store_credits/edit_amount").new(
+            user: @user,
+            store_credit: @store_credit,
+            events: @store_credit_events,
+            reasons: @store_credit_reasons
+        )
+        }
+      end
+    end
+
+    def update_amount
+      return unless ensure_amount
+      return unless ensure_store_credit_reason
+
+      if @store_credit.update_amount(permitted_store_credit_params[:amount], @store_credit_reason, spree_current_user)
+        respond_to do |format|
+          flash[:notice] = t('.success')
+
+          format.html do
+            redirect_to solidus_admin.user_store_credit_path(@user, @store_credit), status: :see_other
+          end
+
+          format.turbo_stream do
+            render turbo_stream: '<turbo-stream action="refresh" />'
+          end
+        end
+      else
+        render_edit_page_with_errors and return
+      end
+    end
+
     private
 
     def set_store_credit
@@ -29,6 +66,53 @@ module SolidusAdmin
 
     def set_user
       @user = Spree.user_class.find(params[:user_id])
+    end
+
+    def set_store_credit_reasons
+      @store_credit_reasons = Spree::StoreCreditReason.active.order(:name)
+    end
+
+    def permitted_store_credit_params
+      permitted_params = [:amount, :currency, :category_id, :memo]
+      permitted_params << :store_credit_reason_id if action_name.to_sym == :update_amount
+
+      params.require(:store_credit).permit(permitted_params).merge(created_by: spree_current_user)
+    end
+
+    def render_edit_page_with_errors
+      @store_credit_events = @store_credit.store_credit_events.chronological
+
+      respond_to do |format|
+        format.html do
+          render component("users/store_credits/edit_amount").new(
+            user: @user,
+            store_credit: @store_credit,
+            events: @store_credit_events,
+            reasons: @store_credit_reasons
+          ),
+            status: :unprocessable_entity
+        end
+      end
+    end
+
+    def ensure_amount
+      if permitted_store_credit_params[:amount].blank?
+        @store_credit.errors.add(:amount, :greater_than, count: 0, value: permitted_store_credit_params[:amount])
+        render_edit_page_with_errors
+        return false
+      end
+      true
+    end
+
+    def ensure_store_credit_reason
+      @store_credit_reason = Spree::StoreCreditReason.find_by(id: permitted_store_credit_params[:store_credit_reason_id])
+
+      if @store_credit_reason.blank?
+        @store_credit.errors.add(:store_credit_reason_id, "Store Credit reason must be provided")
+        render_edit_page_with_errors
+        return false
+      end
+      true
     end
   end
 end

--- a/admin/config/locales/store_credits.en.yml
+++ b/admin/config/locales/store_credits.en.yml
@@ -1,0 +1,10 @@
+en:
+  solidus_admin:
+    store_credits:
+      title: "Store Credits"
+      destroy:
+        success: "Store credit was successfully removed."
+      create:
+        success: "Store credit was successfully created."
+      update_amount:
+        success: "Store credit was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -53,7 +53,12 @@ SolidusAdmin::Engine.routes.draw do
       get :items
     end
 
-    resources :store_credits, only: [:index, :show], controller: "store_credits"
+    resources :store_credits, only: [:index, :show], constraints: { id: /\d+/ }, controller: "store_credits" do
+      member do
+        get :edit_amount
+        put :update_amount
+      end
+    end
   end
 
   admin_resources :promotions, only: [:index, :destroy]

--- a/admin/spec/requests/solidus_admin/store_credits_spec.rb
+++ b/admin/spec/requests/solidus_admin/store_credits_spec.rb
@@ -5,14 +5,16 @@ require "spec_helper"
 RSpec.describe SolidusAdmin::StoreCreditsController, type: :request do
   let(:admin_user) { create(:admin_user) }
   let(:user) { create(:user) }
-  let!(:store_credit) { create(:store_credit, user: user) }
-  let!(:store_credit_event) { create(:store_credit_adjustment_event) }
+  let!(:store_credit) { create(:store_credit, user:) }
+  let!(:store_credit_event) { create(:store_credit_adjustment_event, store_credit:, amount_remaining: 50) }
+  let(:valid_params) { { amount: 100, store_credit_reason_id: create(:store_credit_reason).id } }
+  let(:invalid_params) { { amount: nil } }
 
   before do
     allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
   end
 
-  describe "GET /store_credits" do
+  describe "GET /index" do
     it "renders the store credits template with a 200 OK status" do
       get solidus_admin.user_store_credits_path(user)
       expect(response).to have_http_status(:ok)
@@ -25,6 +27,70 @@ RSpec.describe SolidusAdmin::StoreCreditsController, type: :request do
       get solidus_admin.user_store_credit_path(user, store_credit)
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(store_credit.amount.to_s)
+    end
+  end
+
+  describe "GET /edit_amount" do
+    it "renders the edit_amount template with a 200 OK status" do
+      get solidus_admin.edit_amount_user_store_credit_path(user, store_credit)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(store_credit.amount.to_s)
+    end
+  end
+
+  describe "PUT /update_amount" do
+    context "with valid parameters" do
+      it "updates the store credit amount" do
+        expect {
+          put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: valid_params }
+        }.to change { store_credit.reload.amount }.to(100)
+      end
+
+      it "redirects to the store credit show page with a 303 See Other status" do
+        put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: valid_params }
+        expect(response).to redirect_to(solidus_admin.user_store_credit_path(user, store_credit))
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "displays a success flash message" do
+        put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: valid_params }
+        follow_redirect!
+        expect(response.body).to include("Store credit was successfully updated.")
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not update the store credit amount" do
+        expect {
+          put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: invalid_params }
+        }.not_to change { store_credit.reload.amount }
+      end
+
+      it "renders the edit_amount template with unprocessable_entity status" do
+        put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: invalid_params }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "displays error messages in the response" do
+        put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: invalid_params }
+        expect(response.body).to include("must be greater than 0")
+      end
+    end
+  end
+
+  describe "private methods" do
+    describe "#ensure_amount" do
+      it "adds an error when the amount is blank" do
+        put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: invalid_params }
+        expect(response.body).to include("must be greater than 0")
+      end
+    end
+
+    describe "#ensure_store_credit_reason" do
+      it "adds an error when the store credit reason is blank" do
+        put solidus_admin.update_amount_user_store_credit_path(user, store_credit), params: { store_credit: { amount: 100, store_credit_reason_id: nil } }
+        expect(response.body).to include("Store Credit reason must be provided")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
This PR is for issue: https://github.com/solidusio/solidus/issues/5824

The store credits flow is in the process of being significantly refactored so this is only part of the edit flow. It was a bit of a nightmare to get working but it's finally there, with error messages and all the different turbo refreshes working as desired. The path stays the same throughout. Again, no designs, so I did my best.

## Screenshots
https://github.com/user-attachments/assets/67004fd4-288d-4601-863e-546b1004badb
