### PR TITLE
[Admin][Users] Add new admin store credits invalidate flow 

### DIFF
--- a/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
@@ -1,0 +1,22 @@
+<%= turbo_frame_tag :edit_validity_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @store_credit, url: solidus_admin.invalidate_user_store_credit_path(@user, @store_credit), method: :put, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").select(
+          f,
+          :store_credit_reason_id,
+          store_credit_reasons_select_options.html_safe,
+          include_blank: t('spree.choose_reason'),
+          html: { required: true }
+        ) %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, scheme: :danger, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("users/store_credits/show").new(user: @user, store_credit: @store_credit, events: @store_credit_events) %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::StoreCredits::EditValidity::Component < SolidusAdmin::BaseComponent
+  def initialize(user:, store_credit:, events:, reasons:)
+    @user = user
+    @store_credit = store_credit
+    @store_credit_events = events
+    @store_credit_reasons = reasons
+  end
+
+  def form_id
+    dom_id(@store_credit, "#{stimulus_id}_edit_validity_form")
+  end
+
+  def store_credit_reasons_select_options
+    # Placeholder + Store Credit Reasons
+    "<option value>#{t('.choose_reason')}</option>" + options_from_collection_for_select(@store_credit_reasons, :id, :name)
+  end
+end

--- a/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.yml
@@ -1,0 +1,5 @@
+en:
+  title: Invalidate Store Credit
+  cancel: Cancel
+  submit: Invalidate
+  choose_reason: Choose Reason For Invalidating

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
@@ -29,16 +29,18 @@
             <% if @store_credit.invalidateable? %>
               <%= render component("ui/button").new(
                 scheme: :danger,
-                tag: :a,
+                "data-action": "click->#{stimulus_id}#actionButtonClicked",
+                "data-#{stimulus_id}-url-param": solidus_admin.edit_validity_user_store_credit_path(@user, @store_credit, _turbo_frame: :edit_validity_modal),
                 text: t(".invalidate"),
-                href: spree.edit_validity_admin_user_store_credit_path(@user, @store_credit)
               )%>
             <% end %>
+
             <%= render component("ui/button").new(
               "data-action": "click->#{stimulus_id}#actionButtonClicked",
               "data-#{stimulus_id}-url-param": solidus_admin.edit_memo_user_store_credit_path(@user, @store_credit, _turbo_frame: :edit_memo_modal),
               text: t(".edit_memo"),
             )%>
+
             <% if @store_credit.editable? %>
               <%= render component("ui/button").new(
                 "data-action": "click->#{stimulus_id}#actionButtonClicked",

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.rb
@@ -52,6 +52,7 @@ class SolidusAdmin::Users::StoreCredits::Show::Component < SolidusAdmin::BaseCom
     %w[
       edit_amount_modal
       edit_memo_modal
+      edit_validity_modal
     ]
   end
 

--- a/admin/config/locales/store_credits.en.yml
+++ b/admin/config/locales/store_credits.en.yml
@@ -11,3 +11,6 @@ en:
       update_memo:
         success: "Store credit was successfully updated."
         failure: "Something went wrong. Store credit could not be updated."
+      invalidate:
+        success: "Store credit was successfully invalidated."
+        failure: "Something went wrong. Store credit could not be invalidated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -59,6 +59,8 @@ SolidusAdmin::Engine.routes.draw do
         put :update_amount
         get :edit_memo
         put :update_memo
+        get :edit_validity
+        put :invalidate
       end
     end
   end

--- a/admin/spec/features/store_credits_spec.rb
+++ b/admin/spec/features/store_credits_spec.rb
@@ -75,18 +75,6 @@ describe "StoreCredits", :js, type: :feature do
         expect(page).to have_content("Added")
       end
 
-      it "allows invalidating of the store credit" do
-        click_on "Invalidate"
-        select "credit given in error", from: "store_credit_reason_id"
-        click_on "Invalidate"
-        expect(page).to have_content("Store Credit History")
-        expect(page).to have_content("Action")
-        expect(page).to have_content("Added")
-        expect(page).to have_content("Invalidated")
-        expect(page).to have_content("Reason for updating")
-        expect(page).to have_content("credit given in error")
-      end
-
       context "when editing the store credit amount" do
         context "with invalid amount" do
           it "shows the appropriate error message" do
@@ -133,6 +121,40 @@ describe "StoreCredits", :js, type: :feature do
             expect(page).to have_content("Users / customer@example.com / Store Credit / $666.00")
             expect(page).to have_content("Adjustment")
             expect(page).to have_content("credit given in error")
+          end
+        end
+      end
+
+      context "when invalidating" do
+        context "without a valid reason" do
+          it "shows the appropriate error message" do
+            click_on "Invalidate"
+            expect(page).to have_selector("dialog", wait: 5)
+            expect(page).to have_content("Invalidate Store Credit")
+
+            within("dialog") do
+              click_on "Invalidate"
+              expect(page).to have_content("Store Credit reason must be provided")
+              click_on "Cancel"
+            end
+          end
+        end
+
+        context "with a valid reason" do
+          it "invalidates the store credit" do
+            click_on "Invalidate"
+            expect(page).to have_selector("dialog", wait: 5)
+            expect(page).to have_content("Invalidate Store Credit")
+
+            within("dialog") do
+              select "credit given in error", from: "store_credit[store_credit_reason_id]"
+              click_on "Invalidate"
+            end
+
+            expect(page).to have_content("Store credit was successfully invalidated.")
+            expect(page).to have_content("Invalidated")
+            expect(page).to have_content("credit given in error")
+            expect(page).not_to have_content("Edit Amount")
           end
         end
       end


### PR DESCRIPTION
## Summary

This PR is for issue: https://github.com/solidusio/solidus/issues/5824

This is the second to last piece of the refactored store credits flow. Just missing the flow to create new store credits in the new admin. Again, no designs so I did my best.

## Screenshots


https://github.com/user-attachments/assets/511ed4ea-7039-4dac-b85c-deaa02885a80



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
