### PR TITLE
[Admin][Users] Add new admin store credits create flow

### DIFF
--- a/admin/app/components/solidus_admin/users/store_credits/index/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.html.erb
@@ -4,7 +4,11 @@
     <%= page_header_title(t(".title", email: @user.email)) %>
 
     <%= page_header_actions do %>
-      <%= render component("ui/button").new(tag: :a, text: t(".add_store_credit"), href: spree.new_admin_user_store_credit_url(user_id: @user.id, only_path: true)) %>
+      <%= render component("ui/button").new(
+        "data-action": "click->#{stimulus_id}#actionButtonClicked",
+        "data-#{stimulus_id}-url-param": solidus_admin.new_user_store_credit_path(user_id: @user.id, _turbo_frame: :new_store_credit_modal),
+        text: t(".add_store_credit"),
+      )%>
     <% end %>
   <% end %>
 
@@ -37,7 +41,11 @@
       <% else %>
         <%= render component('ui/panel').new(title: t(".store_credit")) do %>
           <%= t(".no_credits_found") %>
-          <%= render component("ui/button").new(tag: :a, text: t(".create_one"), href: spree.new_admin_user_store_credit_url(user_id: @user.id, only_path: true)) %>
+          <%= render component("ui/button").new(
+            "data-action": "click->#{stimulus_id}#actionButtonClicked",
+            "data-#{stimulus_id}-url-param": solidus_admin.new_user_store_credit_path(user_id: @user.id, _turbo_frame: :new_store_credit_modal),
+            text: t(".create_one"),
+          )%>
         <% end %>
       <% end %>
     <% end %>
@@ -45,5 +53,9 @@
     <%= page_with_sidebar_aside do %>
       <%= render component("users/stats").new(user: @user) %>
     <% end %>
+  <% end %>
+
+  <% turbo_frames.each do |frame| %>
+    <%= turbo_frame_tag frame %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.js
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  actionButtonClicked(event) {
+    const url = new URL(event.params.url, "http://dummy.com")
+    const params = new URLSearchParams(url.search)
+    const frameId = params.get('_turbo_frame')
+    const frame = frameId ? { frame: frameId } : {}
+    // remove the custom _turbo_frame param from url search:
+    params.delete('_turbo_frame')
+    url.search = params.toString()
+
+    window.Turbo.visit(url.pathname + url.search, frame)
+  }
+}

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.rb
@@ -42,6 +42,12 @@ class SolidusAdmin::Users::StoreCredits::Index::Component < SolidusAdmin::BaseCo
     ]
   end
 
+  def turbo_frames
+    %w[
+      new_store_credit_modal
+    ]
+  end
+
   def rows
     @store_credits
   end

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
@@ -1,0 +1,31 @@
+<%= turbo_frame_tag :new_store_credit_modal do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @store_credit, url: solidus_admin.user_store_credits_path(@user), method: :post, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :amount, class: "required") %>
+        <%= render component("ui/forms/field").select(
+          f,
+          :currency,
+          currency_select_options.html_safe,
+          include_blank: t("spree.currency"),
+          html: { required: true }
+        ) %>
+        <%= render component("ui/forms/field").select(
+          f,
+          :category_id,
+          store_credit_categories_select_options.html_safe,
+          include_blank: t("spree.category"),
+          html: { required: true }
+        ) %>
+        <%= render component("ui/forms/field").text_field(f, :memo) %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t(".cancel")) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t(".submit")) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= render component("users/store_credits/index").new(user: @user, store_credits: @store_credits) %>

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::StoreCredits::New::Component < SolidusAdmin::BaseComponent
+  def initialize(user:, store_credit:, categories:)
+    @user = user
+    @store_credit = store_credit
+    @store_credit_categories = categories
+    @store_credits = Spree::StoreCredit.where(user_id: @user.id).order(id: :desc)
+  end
+
+  def form_id
+    dom_id(@store_credit, "#{stimulus_id}_new_form")
+  end
+
+  def currency_select_options
+    options_from_collection_for_select(Spree::Config.available_currencies, :iso_code, :iso_code, Spree::Config.currency)
+  end
+
+  def store_credit_categories_select_options
+    # Placeholder + Store Credit Categories
+    "<option value>#{t('.choose_category')}</option>" + options_from_collection_for_select(@store_credit_categories, :id, :name)
+  end
+end

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.yml
@@ -1,0 +1,5 @@
+en:
+  title: New Store Credit
+  cancel: Cancel
+  submit: Create
+  choose_category: Choose Store Credit Category

--- a/admin/app/controllers/solidus_admin/store_credits_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credits_controller.rb
@@ -5,6 +5,7 @@ module SolidusAdmin
     before_action :set_user
     before_action :set_store_credit, only: [:show, :edit_amount, :update_amount, :edit_memo, :update_memo, :edit_validity, :invalidate]
     before_action :set_store_credit_reasons, only: [:edit_amount, :update_amount, :edit_validity, :invalidate]
+    before_action :set_store_credit_events, only: [:show, :edit_amount, :edit_memo, :edit_validity]
 
     def index
       @store_credits = Spree::StoreCredit.where(user_id: @user.id).order(id: :desc)
@@ -15,16 +16,12 @@ module SolidusAdmin
     end
 
     def show
-      @store_credit_events = @store_credit.store_credit_events.chronological
-
       respond_to do |format|
         format.html { render component("users/store_credits/show").new(user: @user, store_credit: @store_credit, events: @store_credit_events) }
       end
     end
 
     def edit_amount
-      @store_credit_events = @store_credit.store_credit_events.chronological
-
       respond_to do |format|
         format.html {
           render component("users/store_credits/edit_amount").new(
@@ -59,8 +56,6 @@ module SolidusAdmin
     end
 
     def edit_memo
-      @store_credit_events = @store_credit.store_credit_events.chronological
-
       respond_to do |format|
         format.html {
           render component("users/store_credits/edit_memo").new(
@@ -92,8 +87,6 @@ module SolidusAdmin
     end
 
     def edit_validity
-      @store_credit_events = @store_credit.store_credit_events.chronological
-
       respond_to do |format|
         format.html {
           render component("users/store_credits/edit_validity").new(
@@ -142,6 +135,10 @@ module SolidusAdmin
 
     def set_store_credit_reasons
       @store_credit_reasons = Spree::StoreCreditReason.active.order(:name)
+    end
+
+    def set_store_credit_events
+      @store_credit_events = @store_credit.store_credit_events.chronological
     end
 
     def permitted_store_credit_params

--- a/admin/app/controllers/solidus_admin/store_credits_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credits_controller.rb
@@ -35,8 +35,8 @@ module SolidusAdmin
     end
 
     def update_amount
-      return unless ensure_amount
-      return unless ensure_store_credit_reason
+      return unless ensure_amount { render_edit_with_errors }
+      return unless ensure_store_credit_reason { render_edit_with_errors }
 
       if @store_credit.update_amount(permitted_store_credit_params[:amount], @store_credit_reason, spree_current_user)
         respond_to do |format|
@@ -100,7 +100,7 @@ module SolidusAdmin
     end
 
     def invalidate
-      return unless ensure_store_credit_reason
+      return unless ensure_store_credit_reason { render_edit_with_errors }
 
       if @store_credit.invalidate(@store_credit_reason, spree_current_user)
         flash[:notice] = t('.success')
@@ -171,7 +171,7 @@ module SolidusAdmin
     def ensure_amount
       if permitted_store_credit_params[:amount].blank?
         @store_credit.errors.add(:amount, :greater_than, count: 0, value: permitted_store_credit_params[:amount])
-        render_edit_with_errors
+        yield if block_given? # Block is for error template rendering on a per-action basis so this can be re-used.
         return false
       end
       true
@@ -182,7 +182,7 @@ module SolidusAdmin
 
       if @store_credit_reason.blank?
         @store_credit.errors.add(:store_credit_reason_id, "Store Credit reason must be provided")
-        render_edit_with_errors
+        yield if block_given? # Block is for error template rendering on a per-action basis so this can be re-used.
         return false
       end
       true

--- a/admin/app/controllers/solidus_admin/store_credits_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credits_controller.rb
@@ -51,7 +51,7 @@ module SolidusAdmin
           end
         end
       else
-        render_edit_with_errors and return
+        render_edit_with_errors
       end
     end
 

--- a/admin/app/controllers/solidus_admin/store_credits_controller.rb
+++ b/admin/app/controllers/solidus_admin/store_credits_controller.rb
@@ -111,8 +111,6 @@ module SolidusAdmin
       end
 
       respond_to do |format|
-        flash[:notice] = t('.success')
-
         format.html do
           redirect_to solidus_admin.user_store_credit_path(@user, @store_credit), status: :see_other
         end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -53,7 +53,7 @@ SolidusAdmin::Engine.routes.draw do
       get :items
     end
 
-    resources :store_credits, only: [:index, :show], constraints: { id: /\d+/ }, controller: "store_credits" do
+    resources :store_credits, only: [:index, :show, :new, :create], controller: "store_credits" do
       member do
         get :edit_amount
         put :update_amount


### PR DESCRIPTION
## Summary
This PR is for issue: https://github.com/solidusio/solidus/issues/5824

This is the 🎉 last piece 🎉 of the refactored store credits flow! This completes the extraction, migration, and refactoring of the store credits flow from the legacy `solidus_backend` to the new `solidus_admin`. This also completes the users admin more generally.

## Screenshots


https://github.com/user-attachments/assets/ee11d41e-7033-49ba-a0c2-262e24f2511c



<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
