### PR TITLE
Use at least solidus_support 0.12.0

### DIFF
--- a/admin/spec/features/properties_spec.rb
+++ b/admin/spec/features/properties_spec.rb
@@ -98,7 +98,7 @@ describe "Properties", :js, type: :feature do
     it "shows validation errors" do
       visit "/admin/properties"
       find_row("Color").click
-
+      expect(page).to have_field("Name", with: "Color")
       fill_in "Name", with: ""
       click_on "Update Property"
 

--- a/legacy_promotions/solidus_legacy_promotions.gemspec
+++ b/legacy_promotions/solidus_legacy_promotions.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
-  s.add_dependency 'solidus_support'
+  s.add_dependency 'solidus_support', '>= 0.12.0'
 end

--- a/promotions/solidus_promotions.gemspec
+++ b/promotions/solidus_promotions.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "importmap-rails", "~> 1.2"
   spec.add_dependency "ransack-enum", "~> 1.0"
   spec.add_dependency "solidus_core", [">= 4.0.0", "< 5"]
-  spec.add_dependency "solidus_support", "~> 0.5"
+  spec.add_dependency "solidus_support", ">= 0.12.0"
   spec.add_dependency "stimulus-rails", "~> 1.2"
   spec.add_dependency "turbo-rails", ">= 1.4"
 end


### PR DESCRIPTION
solidus_support 0.11.0 introduced flickwerk for patch
loading. Somehow this messes with the zeitwerk autoloader
and things acting weird (inflections broken, wrong constant
module nesting, etc.)

0.12.0 [reverted flickwerk](https://github.com/solidusio/solidus_support/pull/93).