### PR TITLE
[Admin] Use Rails.application.mounted_helpers in base component

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -37,23 +37,5 @@ module SolidusAdmin
     end
 
     delegate :stimulus_id, to: :class
-
-    class << self
-      private
-
-      def engines_with_routes
-        Rails::Engine.subclasses.map(&:instance).reject do |engine|
-          engine.routes.empty?
-        end
-      end
-    end
-
-    # For each engine with routes, define a method that returns the routes proxy.
-    # This allows us to use the routes in the context of a component class.
-    engines_with_routes.each do |engine|
-      define_method(engine.engine_name) do
-        engine.routes.url_helpers
-      end
-    end
   end
 end

--- a/admin/app/components/solidus_admin/ui/pages/index/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/pages/index/component.html.erb
@@ -1,12 +1,12 @@
 <%= page do %>
-  <% if @tabs %>
+  <% if tabs %>
     <%= page_header do %>
       <%= render_title %>
     <% end %>
 
     <%= page_header do %>
       <% rendered_tabs = capture do %>
-        <% @tabs.each do %>
+        <% renderable_tabs.each do %>
           <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: _1.text, 'aria-current': _1.current, href: _1.href)) %>
         <% end %>
       <% end %>

--- a/admin/app/components/solidus_admin/ui/pages/index/component.rb
+++ b/admin/app/components/solidus_admin/ui/pages/index/component.rb
@@ -22,11 +22,16 @@ class SolidusAdmin::UI::Pages::Index::Component < SolidusAdmin::BaseComponent
 
   def initialize(page:)
     @page = page
-    @tabs = tabs&.map { |tab| Tab.new(**tab) }
   end
 
   def row_fade(_record)
     false
+  end
+
+  def renderable_tabs
+    return unless tabs
+
+    tabs.map { |tab| Tab.new(**tab) }
   end
 
   def title

--- a/admin/lib/solidus_admin/engine.rb
+++ b/admin/lib/solidus_admin/engine.rb
@@ -63,5 +63,11 @@ module SolidusAdmin
         SolidusAdmin::Engine.root.join("app/components"),
       ]
     end
+
+    initializer "solidus_admin.routing_proxies" do |app|
+      ActiveSupport.on_load(:after_routes_loaded) do
+        SolidusAdmin::BaseComponent.include app.routes.mounted_helpers
+      end
+    end
   end
 end

--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -20,23 +20,19 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
 
   describe "#spree" do
     it "gives access to spree routing helpers" do
-      without_partial_double_verification do
-        allow(Spree::Core::Engine.routes.url_helpers).to receive(:foo_path).and_return("/foo/bar")
-      end
-      component = described_class.new
-
-      expect(component.spree.foo_path).to eq("/foo/bar")
+      expect(described_class.new).to respond_to(:spree)
     end
   end
 
   describe "#solidus_admin" do
     it "gives access to solidus_admin routing helpers" do
-      without_partial_double_verification do
-        allow(SolidusAdmin::Engine.routes.url_helpers).to receive(:foo_path).and_return("/foo/bar")
-      end
-      component = described_class.new
+      expect(described_class.new).to respond_to(:solidus_admin)
+    end
+  end
 
-      expect(component.solidus_admin.foo_path).to eq("/foo/bar")
+  describe "#main_app" do
+    it "gives access to main_app routing helpers" do
+      expect(described_class.new).to respond_to(:main_app)
     end
   end
 


### PR DESCRIPTION
Rather than implementing routing proxies ourselves, we can use what Rails offers.

Fixes #6038
