### PR TITLE
TMP: Install Generator use allow-skip-specs frontend template

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
+++ b/core/lib/generators/solidus/install/app_templates/frontend/starter.rb
@@ -1,1 +1,1 @@
-apply 'https://github.com/solidusio/solidus_starter_frontend/raw/main/template.rb'
+apply 'https://github.com/solidusio/solidus_starter_frontend/raw/allow-skip-specs/template.rb'


### PR DESCRIPTION
## Summary

We want to be able to skip frontend specs from extension that run system specs against the generated dummy app.

See https://github.com/solidusio/solidus_starter_frontend/pull/400

Need this branch since the install generator is used in extension dummy app generation.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
