### PR TITLE
Pin view_component to < 3.21.0

### DIFF
--- a/admin/solidus_admin.gemspec
+++ b/admin/solidus_admin.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '> 4.2'
   s.add_dependency 'stimulus-rails', '~> 1.2'
   s.add_dependency 'turbo-rails', '~> 2.0'
-  s.add_dependency 'view_component', '~> 3.9'
+  s.add_dependency 'view_component', ['~> 3.9', '< 3.21.0']
 end


### PR DESCRIPTION
3.21.0 introduced a bug with testing view components.

See https://app.circleci.com/pipelines/github/solidusio/solidus/7230/workflows/0c098ce0-9789-48f0-87de-0c0f4812d5aa/jobs/67717

https://github.com/ViewComponent/view_component/issues/2187