### PR TITLE
Move line_item_comparison_hooks config to Spree::Config

### DIFF
--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -78,7 +78,7 @@ module Spree
     def find_matching_line_item(other_order_line_item)
       order.line_items.detect do |my_li|
         my_li.variant == other_order_line_item.variant &&
-          order.line_item_comparison_hooks.all? do |hook|
+          Spree::Config.line_item_comparison_hooks.all? do |hook|
             order.send(hook, my_li, other_order_line_item.serializable_hash)
           end
       end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -168,6 +168,13 @@ module Spree
     #   @return [String] template to use for layout on the frontend (default: +"spree/layouts/spree_application"+)
     preference :layout, :string, default: 'spree/layouts/spree_application'
 
+    # !@attribute [rw] line_item_comparison_hooks
+    #   @return [Array<Symbol>] An array of methods to call on {Spree::Order} to determine if a line item is equal to another
+    #   (default: +[]+)
+    #   @example
+    #   config.line_item_comparison_hooks << :my_custom_method
+    preference :line_item_comparison_hooks, :array, default: []
+
     # @!attribute [rw] logo
     #   @return [String] URL of logo used on frontend (default: +'logo/solidus.svg'+)
     preference :logo, :string, default: 'logo/solidus.svg'

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -67,12 +67,7 @@ module Spree
 
     context "merging using extension-specific line_item_comparison_hooks" do
       before do
-        Spree::Order.register_line_item_comparison_hook(:foos_match)
-      end
-
-      after do
-        # reset to avoid test pollution
-        Spree::Order.line_item_comparison_hooks = Set.new
+        stub_spree_preferences(line_item_comparison_hooks: [:foos_match])
       end
 
       context "2 equal line items" do

--- a/promotions/lib/solidus_promotions/engine.rb
+++ b/promotions/lib/solidus_promotions/engine.rb
@@ -40,10 +40,7 @@ module SolidusPromotions
 
     initializer "solidus_promotions.spree_config", after: "spree.load_config_initializers" do
       Spree::Config.adjustment_promotion_source_types << "SolidusPromotions::Benefit"
-
-      Rails.application.config.to_prepare do
-        Spree::Order.line_item_comparison_hooks << :free_from_order_benefit?
-      end
+      Spree::Config.line_item_comparison_hooks << :free_from_order_benefit?
     end
 
     initializer "solidus_promotions.core.pub_sub", after: "spree.core.pub_sub" do |app|


### PR DESCRIPTION
Setting line item comparison hooks in a `config.to_prepare` block will currently autoload the Spree::Order model (and subsequently any model referenced in that class definition), slowing down the boot process in development mode (when we want our app/ directory to be autoloaded.

This moves setting those hooks to Spree::Config, which is already loaded by the time initializers run. This allows us to move code out of `config.to_prepare` hooks, and stop the order class from being inadvertently eager loaded.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
