### PR TITLE
Unauthorized redirect handling config

### DIFF
--- a/admin/app/controllers/solidus_admin/authentication_adapters/backend.rb
+++ b/admin/app/controllers/solidus_admin/authentication_adapters/backend.rb
@@ -13,7 +13,7 @@ module SolidusAdmin::AuthenticationAdapters::Backend
   def authenticate_solidus_backend_user!
     return if spree_current_user
 
-    instance_exec(&Spree::Admin::BaseController.unauthorized_redirect)
+    Spree::Backend::Config.unauthorized_redirect_handler_class.new(self).call
   end
 
   def store_location

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -68,6 +68,14 @@ module Spree
         redirect_to redirect_url
         nil
       end
+
+      def handle_unauthorized_access
+        if unauthorized_redirect
+          instance_exec(&unauthorized_redirect)
+        else
+          Spree::Backend::Config.unauthorized_redirect_handler_class.new(self).call
+        end
+      end
     end
   end
 end

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -140,6 +140,13 @@ module Spree
     autoload :STOCK_TABS, 'spree/backend_configuration/deprecated_tab_constants'
     autoload :USER_TABS, 'spree/backend_configuration/deprecated_tab_constants'
 
+    # By default, this is set to +Spree::UnauthorizedRedirectHandler+. If you need your admin to behave
+    # differently when a user is unauthorized, you can create your own class that respects the same interface.
+    #
+    # @!attribute [rw] unauthorized_redirect_handler_class
+    #   @return [Class] The class that will handle unauthorized access errors.
+    class_name_attribute :unauthorized_redirect_handler_class, default: "Spree::UnauthorizedRedirectHandler"
+
     # Items can be added to the menu by using code like the following:
     #
     # Spree::Backend::Config.configure do |config|

--- a/backend/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/base_controller_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# Spree's rpsec controller tests get the Spree::ControllerHacks
-# we don't need those for the anonymous controller here, so
-# we call process directly instead of get
 require 'spec_helper'
 
 describe Spree::Admin::BaseController, type: :controller do
@@ -21,6 +18,24 @@ describe Spree::Admin::BaseController, type: :controller do
     it "redirects to unauthorized" do
       get :index
       expect(response).to redirect_to '/unauthorized'
+    end
+
+    context "when an unauthorized redirect handler is provided" do
+      around do |example|
+        old_redirect_lambda = Spree::Admin::BaseController.unauthorized_redirect
+        Spree.deprecator.silence do
+          Spree::Admin::BaseController.unauthorized_redirect = -> { redirect_to '/custom_unauthorized' }
+        end
+        example.run
+        Spree.deprecator.silence do
+          Spree::Admin::BaseController.unauthorized_redirect = old_redirect_lambda
+        end
+      end
+
+      it "redirects to the custom unauthorized path" do
+        get :index
+        expect(response).to redirect_to '/custom_unauthorized'
+      end
     end
   end
 end

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -124,4 +124,10 @@ RSpec.describe Spree::BackendConfiguration do
       end
     end
   end
+
+  describe "unauthorized_redirect_handler_class" do
+    it "defaults to Spree::UnauthorizedRedirectHandler" do
+      expect(described_class.new.unauthorized_redirect_handler_class).to eq(Spree::UnauthorizedRedirectHandler)
+    end
+  end
 end

--- a/core/app/models/spree/unauthorized_redirect_handler.rb
+++ b/core/app/models/spree/unauthorized_redirect_handler.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Spree
+  # This service object is responsible for handling unauthorized redirects
+  class UnauthorizedRedirectHandler
+    # @param controller [ApplicationController] an instance of ApplicationController
+    #  or its subclasses.
+    def initialize(controller)
+      @controller = controller
+    end
+
+    # This method is responsible for handling unauthorized redirects
+    def call
+      flash[:error] = I18n.t('spree.authorization_failure')
+      redirect_back(fallback_location: "/unauthorized")
+    end
+
+    private
+
+    attr_reader :controller
+
+    delegate :flash, :redirect_back, to: :controller
+  end
+end

--- a/core/lib/generators/solidus/install/app_templates/authentication/custom.rb
+++ b/core/lib/generators/solidus/install/app_templates/authentication/custom.rb
@@ -9,11 +9,6 @@ initializer 'spree_authentication.rb', <<~RUBY
       nil
     end
   end
-
-  # Re-raise the original authorization error on anauthorized access
-  Rails.application.config.to_prepare do
-    Spree::BaseController.unauthorized_redirect = -> { raise "Define the behavior for unauthorized access in \#{__FILE__}." }
-  end
 RUBY
 
 create_file 'app/views/spree/admin/shared/_navigation_footer.html.erb', <<~ERB

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -558,6 +558,13 @@ module Spree
     # Enumerable of taxons adhering to the present_taxon_class interface
     class_name_attribute :taxon_attachment_module, default: "Spree::Taxon::ActiveStorageAttachment"
 
+    # Allows changing the default behavior for redirects when a user is not authorized
+    #
+    # @!attribute [rw] unauthorized_redirect_handler_class
+    # @return [Class] a class with the same public interfaces as
+    #  Spree::UnauthorizedRedirectHandler.
+    class_name_attribute :unauthorized_redirect_handler_class, default: "Spree::UnauthorizedRedirectHandler"
+
     # Set of classes that can be promotion adjustment sources
     add_class_set :adjustment_promotion_source_types, default: []
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -94,6 +94,26 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       get :index
       expect(response).to redirect_to('/unauthorized')
     end
+
+    context "when unauthorized_redirect is set" do
+      before do
+        Spree.deprecator.silence do
+          controller.unauthorized_redirect = -> { render plain: 'unauthorized', status: :unauthorized }
+        end
+      end
+
+      after do
+        Spree.deprecator.silence do
+          controller.unauthorized_redirect = nil
+        end
+      end
+
+      it "executes unauthorized_redirect" do
+        get :index
+        expect(response.body).to eq 'unauthorized'
+        expect(response.status).to eq 401
+      end
+    end
   end
 
   describe "#spree_current_user" do


### PR DESCRIPTION
## Summary

This replaces the `unauthorized_redirect` lambda that can be set on any controller with two configurable classes that are by default both set to the same default `Spree::UnauthorizedRedirectHandler`. Two, because frontend and backend will require different strategies in many cases (not least in the case of the `solidus_auth_devise` extension). 

Care has been taken to maintain the legacy behavior and print out deprecation warnings.

A big part of the reason is that setting the lamda on the controllers requires loading the controllers, making us need to use a `config.to_prepare` block as well as making us inadvertently eager-load a lot of code. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
