### PR TITLE
Fix unsafe html view component, allow ViewComponent 3.21+

### DIFF
--- a/admin/lib/solidus_admin/testing_support/component_helpers.rb
+++ b/admin/lib/solidus_admin/testing_support/component_helpers.rb
@@ -12,15 +12,9 @@ module SolidusAdmin
       #      "Rendered"
       #    end
       #  end
-      def mock_component(&definition)
-        location = caller(1, 1).first
-        component_class = Class.new(SolidusAdmin::BaseComponent)
-        # ViewComponent will complain if we don't fake a class name:
-        # @see https://github.com/ViewComponent/view_component/blob/5decd07842c48cbad82527daefa3fe9c65a4226a/lib/view_component/base.rb#L371
-        component_class.define_singleton_method(:name) { "Foo" }
-        component_class.define_singleton_method(:to_s) { "#{name} (#{location})" }
-        component_class.class_eval(&definition) if definition
-        component_class
+      def mock_component(class_name = "Foo::Component", &definition)
+        component_class = stub_const(class_name, Class.new(described_class, &definition))
+        component_class.new
       end
     end
   end

--- a/admin/solidus_admin.gemspec
+++ b/admin/solidus_admin.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '> 4.2'
   s.add_dependency 'stimulus-rails', '~> 1.2'
   s.add_dependency 'turbo-rails', '~> 2.0'
-  s.add_dependency 'view_component', ['~> 3.9', '< 3.21.0']
+  s.add_dependency 'view_component', '~> 3.9'
 end

--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
         def call
           icon_tag("user-line")
         end
-      end.new
+      end
 
       render_inline(component)
 
@@ -42,7 +42,7 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
 
   describe ".stimulus_id" do
     it "returns the stimulus id for the component" do
-      stub_const("SolidusAdmin::Foo::Bar::Component", Class.new(described_class))
+      mock_component("SolidusAdmin::Foo::Bar::Component") { erb_template "" }
 
       expect(SolidusAdmin::Foo::Bar::Component.stimulus_id).to eq("foo--bar")
       expect(SolidusAdmin::Foo::Bar::Component.new.stimulus_id).to eq("foo--bar")
@@ -55,8 +55,7 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
 
       allow(Rails.logger).to receive(:debug) { debug_logs << _1 }
 
-      component_class = stub_const("Foo::Component", Class.new(described_class){ erb_template "" })
-      component = component_class.new
+      component = mock_component { erb_template "" }
       render_inline(component)
       translation = component.translate("foo.bar.baz")
 


### PR DESCRIPTION
## Summary

This fixes the `mock_component` helper to always mock an actual constant, rather than just stubbing the name on it. view_component expects components to be actual things. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
