### PR TITLE
Tax Categories on Line Items respect updates to Variant and Product Tax Categories

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -36,6 +36,7 @@ module Spree
     before_destroy :destroy_inventory_units
 
     delegate :name, :description, :sku, :should_track_inventory?, to: :variant
+    delegate :tax_category, :tax_category_id, to: :variant, prefix: true
     delegate :currency, to: :order, allow_nil: true
 
     attr_accessor :target_shipment, :price_currency
@@ -126,6 +127,24 @@ module Spree
 
     def pricing_options
       Spree::Config.pricing_options_class.from_line_item(self)
+    end
+
+    # @return [Spree::TaxCategory] the variant's tax category
+    #
+    # This returns the variant's tax category if the tax category ID on the line_item is nil. It looks
+    # like an association, but really is an override.
+    #
+    def tax_category
+      super || variant_tax_category
+    end
+
+    # @return [Integer] the variant's tax category ID
+    #
+    # This returns the variant's tax category ID if the tax category ID on the line_id is nil. It looks
+    # like an association, but really is an override.
+    #
+    def tax_category_id
+      super || variant_tax_category_id
     end
 
     private

--- a/core/app/models/spree/order_taxation.rb
+++ b/core/app/models/spree/order_taxation.rb
@@ -28,6 +28,7 @@ module Spree
 
       @order.line_items.each do |item|
         taxed_items = taxes.line_item_taxes.select { |element| element.item_id == item.id }
+        item.tax_category_id = item.variant_tax_category_id
         update_adjustments(item, taxed_items)
       end
 

--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -5,11 +5,22 @@ module Spree
     module TaxHelpers
       private
 
+      # Select active rates matching tax category and address
+      #
+      # @private
+      # @param [Spree::LineItem, Spree::Shipment, Spree::ShippingRate] item
+      #   the line item, shipment, or shipping rate to select rates for
+      # @return [Array<Spree::TaxRate>] the active Tax Rates that match both
+      #   Tax Category and the item's order's tax address
       def rates_for_item(item)
         @rates_for_item ||= Spree::TaxRate.item_level.for_address(item.order.tax_address)
+        # try is used here to ensure that a LineItem has rates selected for the
+        # currently configured Tax Category. Shipments and ShippingRates do not
+        # implement variant_tax_category_id, so try is necessary instead of .&
+        tax_category_id = item.try(:variant_tax_category_id) || item.tax_category_id
 
         @rates_for_item.select do |rate|
-          rate.active? && rate.tax_categories.map(&:id).include?(item.tax_category_id)
+          rate.active? && rate.tax_categories.map(&:id).include?(tax_category_id)
         end
       end
     end

--- a/core/app/models/spree/tax_calculator/default.rb
+++ b/core/app/models/spree/tax_calculator/default.rb
@@ -99,7 +99,7 @@ module Spree
       # @return [Array<Spree::TaxRate>] rates that apply to an order
       def rates_for_order
         tax_category_ids = Set[
-          *@order.line_items.map(&:tax_category_id),
+          *@order.line_items.map(&:variant_tax_category_id),
           *@order.shipments.map(&:tax_category_id)
         ]
         rates = Spree::TaxRate.active.order_level.for_address(@order.tax_address)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -35,7 +35,7 @@ module Spree
     delegate :name, :description, :slug, :available_on, :discontinue_on, :discontinued?,
              :meta_description, :meta_keywords,
              to: :product
-    delegate :tax_category, to: :product, prefix: true
+    delegate :tax_category, :tax_category_id, to: :product, prefix: true
     delegate :shipping_category, :shipping_category_id,
       to: :product, prefix: true
     delegate :tax_rates, to: :tax_category
@@ -148,6 +148,15 @@ module Spree
     #
     def tax_category
       super || product_tax_category
+    end
+
+    # @return [Integer] the variant's tax category ID
+    #
+    # This returns the product's tax category ID if the tax category ID on the variant is nil. It looks
+    # like an association, but really is an override.
+    #
+    def tax_category_id
+      super || product_tax_category_id
     end
 
     # @return [Spree::ShippingCategory] the variant's shipping category

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -43,7 +43,15 @@ FactoryBot.define do
         evaluator.stock_location # must evaluate before creating line items
 
         evaluator.line_items_attributes.each do |attributes|
-          attributes = { order:, price: evaluator.line_items_price }.merge(attributes)
+          attributes = { order:, price: evaluator.line_items_price }.merge(attributes).tap do |attrs|
+            tax_category = attributes.delete(:tax_category)
+            if attrs[:variant] && tax_category
+              attrs[:variant].update(tax_category: )
+            elsif tax_category
+              attrs[:variant] = create(:variant, tax_category: )
+            end
+          end
+
           create(:line_item, attributes)
         end
         order.line_items.reload

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Spree::LineItem, type: :model do
   let(:order) { create :order_with_line_items, line_items_count: 1 }
   let(:line_item) { order.line_items.first }
+  let(:target_shipment) { Spree::Shipment.new }
 
   context '#destroy' do
     it "fetches soft-deleted products" do
@@ -18,7 +19,8 @@ RSpec.describe Spree::LineItem, type: :model do
     end
 
     it "returns inventory when a line item is destroyed" do
-      expect_any_instance_of(Spree::OrderInventory).to receive(:verify)
+      line_item.target_shipment = target_shipment
+      expect_any_instance_of(Spree::OrderInventory).to receive(:verify).with(target_shipment)
       line_item.destroy
     end
 
@@ -30,8 +32,8 @@ RSpec.describe Spree::LineItem, type: :model do
   context "#save" do
     context "target_shipment is provided" do
       it "verifies inventory" do
-        line_item.target_shipment = Spree::Shipment.new
-        expect_any_instance_of(Spree::OrderInventory).to receive(:verify)
+        line_item.target_shipment = target_shipment
+        expect_any_instance_of(Spree::OrderInventory).to receive(:verify).with(target_shipment)
         line_item.save
       end
     end


### PR DESCRIPTION
## Summary

This PR was initiated in response to this reported issue:
Fixes #4683

We discovered that the `LineItem`'s `tax_category_id` is currently being set in a [`before_validation` in the `LineItem` model.](https://github.com/solidusio/solidus/blob/main/core/app/models/spree/line_item.rb#L142)
This means that the `tax_category_id` on the `LineItem` is set only **once**, when the `LineItem` is validated on the first save.

Upon investigation, we found that the `tax_category_id` was added on `LineItem`s for performance reasons long in Spree's past:
https://github.com/spree/spree/pull/3481 (This PR doesn't display the correct commits, but in the comments the associated commits are linked)

We wanted to be cognizent of performance here, but additionally attempt to fix the issue, so benchmarks and methodology are included below.


### Fixing the issue

The underlying issue here has to do with setting the `tax_category_id` only once when the `LineItem` is created.
This means that changing the Tax Category on a Variant or Product will only have an effect on new Line Items created after the change.
If the associated Tax Category is soft deleted, the Line Item will be considered by the adjuster to have no Tax Category, no matter which Tax Categories exist on the associated Variant or Product.

To solve this issue, we decided to ensure that the Variant or Product's Tax Categories are considered when computing taxes.
The `tax_category_id` on the `LineItem` model still exists, and it's value is set at the same time that adjustments are created. This means that the `tax_category_id` that is present on a `LineItem`
always points to the Tax Category that was used to create the tax adjustments that exist for the `LineItem`.
If the Variant's Tax Category is changed, the next time tax adjustments are computed for the `LineItem` (i.e. during `recalculate`), the `LineItem`s `tax_category_id` will be updated to reflect the
new relevant Tax Category.

If the Tax Category associated with some `LineItem`s is soft-deleted, taxes will not be calculated based on this soft-deleted Tax Category, but will defer to the `variant_tax_category_id`.
On the other hand if taxes are not recalculated for that `LineItem`, the `LineItem`'s `tax_category_id` will still point to that record and will represent the Tax Category that was used when taxes were calculated. These records can then be retrieved with `.with_discarded` if needed.

### Benchmarking

I made temporary changes to our `order_updater_spec` `tax_recalculation` context:

```ruby
        before do
          50.times do
            create(:line_item, order:, variant: create(:variant, tax_category:), price: 10)
          end
        end

        it 'benchmarks recalculate' do
          Benchmark.bm { |x| x.report { 50.times { order.recalculate } } }
        end 
```

And I ran the test 10 times before and after the changes:

On `main`:

        user     system      total        real
        1.519667   0.015154   1.534821 (  1.633398)
        1.539250   0.014212   1.553462 (  1.656476)
        1.486230   0.023042   1.509272 (  1.609028)
        1.496671   0.024544   1.521215 (  1.621268)
        1.517082   0.018463   1.535545 (  1.619166)
        1.515210   0.019308   1.534518 (  1.605963)
        1.496039   0.024313   1.520352 (  1.614227)
        1.498017   0.026294   1.524311 (  1.621422)
        1.522568   0.018466   1.541034 (  1.685498)
        1.474430   0.020689   1.495119 (  1.591637)
        avg real (  1.625808)
        avg real per recalculate (  0.032516)


After Changes (this branch):

       user     system      total        real
       1.598846   0.020576   1.619422 (  1.725181)
       1.575519   0.020300   1.595819 (  1.700659)
       1.584723   0.020872   1.605595 (  1.710245)
       1.607924   0.014587   1.622511 (  1.698217)
       1.556669   0.025032   1.581701 (  1.684801)
       1.581550   0.025173   1.606723 (  1.714748)
       1.608484   0.018360   1.626844 (  1.731001)
       1.596435   0.020785   1.617220 (  1.723850)
       1.610086   0.022443   1.632529 (  1.742005)
       1.606265   0.032092   1.638357 (  1.726858)
       avg real (  1.715757)
       avg real per recalculate (  0.034315)


An average increase of 1.799ms per `recalculate` call on orders with 50 Line Items.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
