### PR TITLE
[v4.3] CI: Lint code on GH actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,34 +235,6 @@ commands:
             bundle exec rake -rrails -rspree/testing_support/extension_rake -e'Rake::Task["extension:test_app"].invoke'
 
 jobs:
-  lint_code:
-    docker:
-      - image: cimg/ruby:3.2-node
-        environment:
-          BUNDLE_ONLY: "lint"
-          ESLINT_USE_FLAT_CONFIG: false
-    steps:
-      - checkout
-      - run: 'bundle install'
-      - run:
-          name: Check Ruby
-          command: |
-            bundle exec rubocop --parallel --format junit --out "$PWD/test-results/rubocop-results.xml" --format progress
-      - run:
-          name: Check ERB
-          command: |
-            # enable recursive globbing with "**"
-            shopt -s globstar
-
-            # we're only interested in errors
-            bundle exec erb-format **/*.html.erb > /dev/null
-      - run:
-          name: Check JavaScript
-          command: |
-            npx -y eslint "**/*.js"
-      - store_test_results:
-          path: test-results
-
   solidus_installer:
     executor:
       name: sqlite
@@ -345,7 +317,6 @@ jobs:
 workflows:
   build:
     jobs:
-      - lint_code
       - solidus_installer
 
       # Only test with coverage support with the default versions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+name: Lint
+
+on: [pull_request]
+
+concurrency:
+  group: lint-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
+env:
+  BUNDLE_ONLY: "lint"
+
+jobs:
+  ruby:
+    name: Check Ruby
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Lint Ruby files
+        run: bin/rake lint:rb
+      - name: Store test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: rubocop-results
+          path: test-results
+
+  erb:
+    name: Check ERB
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Lint ERB files
+        run: bin/rake lint:erb
+
+  javascript:
+    name: Check JavaScript
+    runs-on: ubuntu-22.04
+    env:
+      ESLINT_USE_FLAT_CONFIG: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Lint JS files
+        run: bin/rake lint:js


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.3`:
 - [Merge pull request #6064 from tvdeyen/lint-on-gh](https://github.com/solidusio/solidus/pull/6064)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)