### PR TITLE
[v4.3] Fix unsafe html view component, allow ViewComponent 3.21+

### DIFF
--- a/admin/spec/components/solidus_admin/base_component_spec.rb
+++ b/admin/spec/components/solidus_admin/base_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
         def call
           icon_tag("user-line")
         end
-      end.new
+      end
 
       render_inline(component)
 
@@ -42,7 +42,7 @@ RSpec.describe SolidusAdmin::BaseComponent, type: :component do
 
   describe ".stimulus_id" do
     it "returns the stimulus id for the component" do
-      stub_const("SolidusAdmin::Foo::Bar::Component", Class.new(described_class))
+      mock_component("SolidusAdmin::Foo::Bar::Component") { erb_template "" }
 
       expect(SolidusAdmin::Foo::Bar::Component.stimulus_id).to eq("foo--bar")
       expect(SolidusAdmin::Foo::Bar::Component.new.stimulus_id).to eq("foo--bar")

--- a/admin/spec/support/solidus_admin/component_helpers.rb
+++ b/admin/spec/support/solidus_admin/component_helpers.rb
@@ -11,14 +11,9 @@ module SolidusAdmin
     #      "Rendered"
     #    end
     #  end
-    def mock_component(&definition)
-      Class.new(SolidusAdmin::BaseComponent) do
-        # ViewComponent will complain if we don't fake a class name:
-        # @see https://github.com/ViewComponent/view_component/blob/5decd07842c48cbad82527daefa3fe9c65a4226a/lib/view_component/base.rb#L371
-        def self.name
-          "Foo"
-        end
-      end.tap { |klass| klass.class_eval(&definition) if definition }
+    def mock_component(class_name = "Foo::Component", &definition)
+      component_class = stub_const(class_name, Class.new(described_class, &definition))
+      component_class.new
     end
   end
 end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.3`:
 - [Merge pull request #6055 from mamhoff/fix-unsafe-html-view-component](https://github.com/solidusio/solidus/pull/6055)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)