### PR TITLE
Require "logger"  as early as possible

### DIFF
--- a/core/lib/solidus_core.rb
+++ b/core/lib/solidus_core.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'spree_core'


### PR DESCRIPTION
Rails 7.0.x has a bug where the `Logger` class is used, but not required. This adds the `require` statement to our codebase so that we have a working test suite. With any luck, this will also work for extensions.

See https://github.com/rails/rails/pull/54264