### PR TITLE
4.2: Limit `concurrent-ruby` to < 1.3.5

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -35,6 +35,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.3'
   s.add_dependency 'cancancan', ['>= 2.2', '< 4.0']
   s.add_dependency 'carmen', '~> 1.1.0'
+  # Adding a constraint here to make sure Rails 7.0 does not crash on startup
+  # https://github.com/rails/rails/pull/54264
+  s.add_dependency 'concurrent-ruby', '< 1.3.5'
   s.add_dependency 'discard', '~> 1.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'image_processing', '~> 1.10'


### PR DESCRIPTION
The `concurrent-ruby` gem drops a dependency on the `logger` gem, which
Rails 7.0 implicitly depends on. Rails 7.0 is out of bugfix maintenance,
so we won't see another release that has this bug fixed, so for Solidus
4.2 and 4.1 let's just limit `concurrent-ruby` to versions that *do*
depend on `logger`.

See https://github.com/rails/rails/pull/54264

This approach has the advantage that we don't have to change the spec setup for every extension, because Solidus 4.2's dependencies take care of the problem.
