### PR TITLE
Restore Puma & SQLite dependency to correct state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,12 +31,7 @@ gem 'simplecov-cobertura', require: false
 gem 'rack', '< 3', require: false
 gem 'rake', require: false, groups: [:lint, :release]
 gem 'rails-controller-testing', require: false
-
-# Temporarily use the master branch of puma until the next release
-# The current release, 6.4.3, has bug that causes Capybara to crash.
-# See https://github.com/puma/puma/pull/3532
-gem 'puma', github: 'puma/puma', branch: 'master', require: false
-
+gem 'puma', '< 7', require: false
 gem 'i18n-tasks', '~> 0.9', require: false
 gem 'rspec_junit_formatter', require: false
 gem 'yard', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ dbs = ENV['DB_ALL'] ? 'all' : ENV.fetch('DB', 'sqlite')
 gem 'mysql2', '~> 0.5.0', require: false if dbs.match?(/all|mysql/)
 gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
-gem 'sqlite3', '~> 1.4', require: false if dbs.match?(/all|sqlite/)
+gem 'sqlite3', '>= 2.1', require: false if dbs.match?(/all|sqlite/)
 
 
 gem 'database_cleaner', '~> 2.0', require: false


### PR DESCRIPTION
## Summary
Fixes two dependency pinnings: 

1. Due to changes in Puma Capybara failed. The solution was to pin Puma to the development branch. Given that the issue has been resolved, I restored the gemfile to a stable puma release. 

2. original reason to pin sqlite: 
> They just released sqlite3 2.0.0, but ActiveRecord's sqlite3 adapter doesn't know about this yet, leading to conflicting sqlite3 gems in specs.

Issue has been solved in the meantime. 

Fixes #6081

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
