### PR TITLE
Fix preferences serialization compatibility with Rails version check

### DIFF
--- a/core/lib/spree/preferences/persistable.rb
+++ b/core/lib/spree/preferences/persistable.rb
@@ -8,7 +8,7 @@ module Spree
       included do
         include Spree::Preferences::Preferable
 
-        if method(:serialize).parameters.include?([:key, :type]) # Rails 7.1+
+        if Rails.gem_version >= Gem::Version.new('7.1')
           serialize :preferences, type: Hash, coder: YAML
         else
           serialize :preferences, Hash, coder: YAML


### PR DESCRIPTION
This PR modifies the Persistable module in Solidus to check the Rails version using Rails.gem_version instead of inspecting the serialize method parameters. This change is necessary only when using Solidus Globalize, ensuring compatibility with Rails 7.2.

## Background
Solidus itself does not have any issues with the current implementation:

```
if method(:serialize).parameters.include?([:key, :type]) # Rails 7.1+
  serialize :preferences, type: Hash, coder: YAML
else
  serialize :preferences, Hash, coder: YAML
end
```

However, when using Solidus Globalize, which relies on globalize, an issue arises in Rails 7.2 due to globalize overriding the serialize method:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
```

This occurs because the serialize method signature is modified by globalize, causing a mismatch when Solidus inspects its parameters. For reference, see the globalize implementation here: https://github.com/globalize/globalize/blob/main/lib/patches/active_record/rails7_2/serialization.rb

## Solution
To avoid conflicts, this PR replaces the method introspection with a Rails version check:
```
if Rails.gem_version >= Gem::Version.new('7.1')
  serialize :preferences, type: Hash, coder: YAML
else
  serialize :preferences, Hash, coder: YAML
end
```
This approach ensures compatibility while keeping Solidus independent from dependency-specific overrides.

This issue is currently blocking the CI of the following PR in the solidus_globalize repository: https://github.com/solidusio-contrib/solidus_globalize/pull/153 Fixing this in Solidus will help unblock that PR.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
