### PR TITLE
Allows Rails 8, updates sqlite in Gemfile to match what CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ commands:
             mkdir -p /tmp/dummy_extension
             cd /tmp/dummy_extension
             bundle init
-            bundle add rails -v "< 8.0" --skip-install
+            bundle add rails -v "< 8.1" --skip-install
             bundle add sqlite3 -v "~> 2.0" --skip-install
             test -n "<<parameters.extra_gems>>" && bundle add <<parameters.extra_gems>> --skip-install
             bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"
@@ -352,7 +352,7 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.0", "7.1", "7.2"],
+                  rails: ["7.0", "7.1", "7.2", "8.0"],
                   ruby: ["3.1"],
                   database: ["mysql"],
                   paperclip: [true],
@@ -364,7 +364,7 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.0", "7.1", "7.2"],
+                  rails: ["7.0", "7.1", "7.2", "8.0"],
                   ruby: ["3.1"],
                   database: ["postgres"],
                   paperclip: [false],
@@ -388,7 +388,7 @@ workflows:
             {
               parameters:
                 {
-                  rails: ["7.2", "main"],
+                  rails: ["7.2", "8.0", "main"],
                   ruby: ["3.3.5"],
                   database: ["sqlite"],
                   paperclip: [false],

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec require: false
 if /(stable|main)/.match? ENV['RAILS_VERSION']
   gem 'rails', github: 'rails', require: false, branch: ENV['RAILS_VERSION']
 else
-  gem 'rails', ENV['RAILS_VERSION'] || ['> 7.0', '< 8.0.0.beta1'], require: false
+  gem 'rails', ENV['RAILS_VERSION'] || ['> 7.0', '< 8.1.0.beta1'], require: false
 end
 # rubocop:enable Bundler/DuplicatedGem
 

--- a/admin/app/components/solidus_admin/ui/forms/input/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/input/component.rb
@@ -93,13 +93,24 @@ class SolidusAdmin::UI::Forms::Input::Component < SolidusAdmin::BaseComponent
       with_content options_for_select(@attributes.delete(:choices), @attributes.delete(:value))
     end
 
-    tag.public_send(
-      @tag,
-      content,
+    options = {
       "data-controller": stimulus_id,
       "data-#{stimulus_id}-custom-validity-value": @error.presence,
       "data-action": "#{stimulus_id}#clearCustomValidity",
       **@attributes
-    )
+    }
+
+    if tag.method(@tag).parameters.any? { |_type, name| name == :content }
+      tag.public_send(
+        @tag,
+        content,
+        **options
+      )
+    else
+      tag.public_send(
+        @tag,
+        **options
+      )
+    end
   end
 end

--- a/api/spec/requests/spree/api/shipments_spec.rb
+++ b/api/spec/requests/spree/api/shipments_spec.rb
@@ -75,7 +75,7 @@ module Spree::Api
           it 'returns proper error' do
             subject
             expect(response.status).to eq(422)
-            expect(json_response['exception']).to eq("param is missing or the value is empty: stock_location_id")
+            expect(json_response['exception']).to match(/param is missing or the value is empty( or invalid)?: stock_location_id/)
           end
         end
       end

--- a/api/spec/requests/spree/api/stock_items_spec.rb
+++ b/api/spec/requests/spree/api/stock_items_spec.rb
@@ -86,7 +86,7 @@ module Spree::Api
 
       it 'requires a stock_location_id to be passed as a parameter' do
         get spree.api_stock_items_path
-        expect(json_response['exception']).to eq('param is missing or the value is empty: stock_location_id')
+        expect(json_response['exception']).to match(/param is missing or the value is empty( or invalid)?: stock_location_id/)
         expect(response.status).to eq(422)
       end
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 7.0', '< 8.0.0.beta1']
+    s.add_dependency rails_dep, ['>= 7.0', '< 8.1.0.beta1']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->
Bumps `Gemfile` and `solidus_core.gemspec` up to support Rails 8.0. Makes minor changes to update code and tests to deal with Rails 8 changes.

This required bumping `sqlite3` above 2.0 to get specs to pass; note that the circleci config already required this and was not testing Rails 7.0 for sqlite likely due to this compatibility mismatch.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
