### PR TITLE
[Backend] Fix issue refunding uncompleted payments

### DIFF
--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -79,7 +79,7 @@ describe "Return Reasons", :js, type: :feature do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :flaky do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -56,15 +56,19 @@
           </div>
           <div class="editing-hide">
             <% if payment.pending? %>
-              <%= link_to_with_icon 'edit', t('spree.actions.edit'), nil, no_text: true, class: "js-edit", data: {action: 'edit'} %>
+              <%= link_to_with_icon 'edit', t('spree.actions.edit'), nil, no_text: true, class: "js-edit", data: { action: 'edit' } %>
             <% end %>
-            <% allowed_actions = payment.actions.select { |a| can?(a.to_sym, payment) } %>
-            <% allowed_actions.each do |action| %>
+            <% payment.actions.each do |action| %>
+              <% next unless can?(action.to_sym, payment) %>
+
               <% if action == 'credit' %>
-                <%= link_to_with_icon 'mail-reply', t('spree.actions.refund'), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
-              <% elsif action == 'capture' && !@order.completed? %>
-                <%# no capture prior to completion. payments get captured when the order completes. %>
+                <% next if payment.invalid? || payment.failed? || payment.checkout? %>
+
+                <%= link_to_with_icon 'reply', t('spree.refund'), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
               <% else %>
+                <% next if action == 'capture' && !@order.completed? %>
+                <% next if action == 'void' && (payment.invalid? || payment.failed?) %>
+
                 <%= link_to_with_icon action, t(action, scope: 'spree'), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action} %>
               <% end %>
             <% end %>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -37,11 +37,20 @@ describe 'Payments', type: :feature do
         click_icon(:capture)
         expect(page).not_to have_content('Cannot perform requested operation')
         expect(page).to have_content('Payment Updated')
+        within_row(1) do
+          expect(page).to have_selector('.fa-reply')
+        end
       end
 
       it 'voids a check payment from a new order' do
         click_icon(:void)
         expect(page).to have_content('Payment Updated')
+      end
+
+      it 'voids refund option for incomplete payments' do
+        within_row(1) do
+          expect(page).not_to have_selector('.fa-reply')
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- Remove `Refund` button for uncompleted payments
- Remove `Credit` button for payment on `void` and `invalid` state

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
