### PR TITLE
Admin promotion categories add/edit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -134,6 +134,7 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - "*/spec/**/*"
     - "spec/**/*" # For the benefit of apps that inherit from this config
+    - "**/shared_examples/**/*"
 
 # We use eval to add common_spree_dependencies into the Gemfiles of each of our gems
 Security/Eval:

--- a/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_features.rb
+++ b/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_features.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'promotion categories features' do
+  before { sign_in create(:admin_user, email: "admin@example.com") }
+
+  it "lists promotion categories" do
+    create(factory_name, name: "test1", code: "code1")
+    create(factory_name, name: "test2", code: "code2")
+
+    visit index_path
+    expect(page).to have_content("test1")
+    expect(page).to have_content("test2")
+
+    expect(page).to be_axe_clean
+  end
+
+  it 'allows to create new promo category' do
+    visit index_path
+
+    click_on "Add new"
+    expect(turbo_frame_modal).to have_content("New Promotion Category")
+
+    fill_in "Code", with: "ste.1"
+    click_on "Add Promotion Category"
+
+    expect(turbo_frame_modal).to have_content("can't be blank")
+
+    fill_in "Name", with: "Soon to expire"
+    click_on "Add Promotion Category"
+
+    expect(page).to have_content("Promotion Category was successfully created.")
+    expect(page).to have_content("Soon to expire")
+    expect(page).to have_content("ste.1")
+    expect(model_class.count).to eq(1)
+  end
+
+  it 'allows to update promo category' do
+    create(factory_name, name: "Soon to expire", code: "ste.1")
+
+    visit index_path
+
+    click_on "Soon to expire"
+    expect(turbo_frame_modal).to have_content("Edit Promotion Category")
+
+    fill_in "Name", with: "Expired"
+    fill_in "Code", with: "exp.2"
+    click_on "Update Promotion Category"
+
+    expect(page).to have_content("Promotion Category was successfully updated.")
+    expect(page).to have_content("Expired")
+    expect(page).to have_content("exp.2")
+  end
+
+  it 'allows to delete promo category' do
+    create(factory_name, name: "Soon to expire", code: "ste.1")
+    create(factory_name, name: "Expired", code: "exp.2")
+
+    visit index_path
+
+    select_row("Expired")
+    click_on "Delete"
+    expect(page).to have_content("Promotion Categories were successfully removed.")
+    expect(page).not_to have_content("Expired")
+    expect(model_class.count).to eq(1)
+  end
+end

--- a/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_requests.rb
+++ b/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_requests.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'promotion categories requests' do
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
+  end
+
+  describe "GET /index" do
+    it "renders the index template with a 200 OK status" do
+      get url_helpers.promotion_categories_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /new" do
+    it "renders the new template with a 200 OK status" do
+      get url_helpers.new_promotion_category_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      let(:valid_attributes) { { name: "Expired", code: "exp.1" } }
+      let(:run_request) { post url_helpers.promotion_categories_path, params: { promotion_category: valid_attributes } }
+
+      it "creates a new promotion category" do
+        expect { run_request }.to change(model_class, :count).by(1)
+      end
+
+      it "redirects to the index page with a 303 See Other status" do
+        run_request
+        expect(response).to redirect_to(url_helpers.promotion_categories_path)
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "displays a success flash message" do
+        run_request
+        follow_redirect!
+        expect(response.body).to include("Promotion Category was successfully created.")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { name: "", code: "" } }
+      let(:run_request) { post url_helpers.promotion_categories_path, params: { promotion_category: invalid_attributes } }
+
+      it "does not create a new promotion category" do
+        expect { run_request }.not_to change(model_class, :count)
+      end
+
+      it "renders the new template with unprocessable_entity status" do
+        run_request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "GET /edit" do
+    it "renders the edit template with a 200 OK status" do
+      get url_helpers.edit_promotion_category_path(promotion_category)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:valid_attributes) { { name: "Updated", code: "upd.1" } }
+      let(:run_request) { patch url_helpers.promotion_category_path(promotion_category), params: { promotion_category: valid_attributes } }
+
+      it "updates the promotion category" do
+        run_request
+        promotion_category.reload
+        expect(promotion_category.name).to eq("Updated")
+        expect(promotion_category.code).to eq("upd.1")
+      end
+
+      it "redirects to the index page with a 303 See Other status" do
+        run_request
+        expect(response).to redirect_to(url_helpers.promotion_categories_path)
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "displays a success flash message" do
+        run_request
+        follow_redirect!
+        expect(response.body).to include("Promotion Category was successfully updated.")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { name: "", code: "" } }
+      let(:run_request) { patch url_helpers.promotion_category_path(promotion_category), params: { promotion_category: invalid_attributes } }
+
+      it "does not update the promotion category" do
+        expect { run_request }.not_to change { promotion_category.reload.name }
+      end
+
+      it "renders the edit template with unprocessable_entity status" do
+        run_request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    before { promotion_category }
+
+    let(:run_request) { delete url_helpers.promotion_category_path(promotion_category) }
+
+    it "deletes the promotion category and redirects to the index page with a 303 See Other status" do
+      expect { run_request }.to change(model_class, :count).by(-1)
+
+      expect(response).to redirect_to(url_helpers.promotion_categories_path)
+      expect(response).to have_http_status(:see_other)
+    end
+
+    it "displays a success flash message after deletion" do
+      run_request
+      follow_redirect!
+      expect(response.body).to include("Promotion Categories were successfully removed.")
+    end
+  end
+end

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -8,7 +8,9 @@ if ENV["COVERAGE"]
   end
   SimpleCov.command_name('solidus:admin')
   SimpleCov.merge_timeout(3600)
-  SimpleCov.start('rails')
+  SimpleCov.start('rails') do
+    add_filter '/shared_examples/'
+  end
 end
 
 require 'solidus_admin'

--- a/bin/build
+++ b/bin/build
@@ -41,6 +41,16 @@ echo "* Testing Solidus Sample *"
 echo "**************************"
 bin/rspec sample/spec
 
+echo "**************************"
+echo "* Testing Legacy Promotions *"
+echo "**************************"
+bin/rspec legacy_promotions/spec
+
+echo "**************************"
+echo "* Testing Solidus Promotions *"
+echo "**************************"
+bin/rspec promotions/spec
+
 if [ -n "$COVERAGE" ]; then
   # Generate coverage report
   echo "******************************"

--- a/bin/rspec
+++ b/bin/rspec
@@ -9,6 +9,7 @@ LIBS = %w[
   core
   sample
   legacy_promotions
+  promotions
 ]
 
 # Ignore line info, e.g. foo/bar.rb:123 would become foo/bar.rb

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -110,6 +110,16 @@ module Spree
         # find the original.
         find('label:not(.select2-offscreen)', text: /#{Regexp.escape(text)}/i, match: :one)
       end
+
+      def dialog(parent: 'body', **options)
+        within(parent) do
+          find('dialog', visible: :all, **options)
+        end
+      end
+
+      def turbo_frame_modal
+        dialog(parent: find('turbo-frame', visible: :all))
+      end
     end
   end
 end

--- a/legacy_promotions/config/locales/promotion_categories.en.yml
+++ b/legacy_promotions/config/locales/promotion_categories.en.yml
@@ -2,5 +2,9 @@ en:
   solidus_admin:
     promotion_categories:
       title: "Promotion Categories"
+      create:
+        success: "Promotion Category was successfully created."
+      update:
+        success: "Promotion Category was successfully updated."
       destroy:
         success: "Promotion Categories were successfully removed."

--- a/legacy_promotions/config/routes.rb
+++ b/legacy_promotions/config/routes.rb
@@ -23,6 +23,6 @@ if SolidusSupport.admin_available?
     extend SolidusAdmin::AdminResources
 
     admin_resources :promotions, only: [:index, :destroy]
-    admin_resources :promotion_categories, only: [:index, :destroy]
+    admin_resources :promotion_categories, except: [:show]
   end
 end

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::PromotionCategories::Edit::Component < SolidusAdmin::Resources::Edit::Component
+end

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.yml
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.yml
@@ -1,0 +1,4 @@
+en:
+  title: "Edit Promotion Category"
+  cancel: "Cancel"
+  submit: "Update Promotion Category"

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/index/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/index/component.rb
@@ -5,15 +5,24 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
     Spree::PromotionCategory
   end
 
-  def row_url(promotion_category)
-    spree.edit_admin_promotion_category_path(promotion_category)
+  def title
+    t('solidus_admin.promotion_categories.title')
+  end
+
+  def edit_path(record)
+    solidus_admin.edit_promotion_category_path(record, **search_filter_params)
+  end
+
+  def turbo_frames
+    %w[resource_modal]
   end
 
   def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),
-      href: spree.new_admin_promotion_category_path,
+      href: solidus_admin.new_promotion_category_path(**search_filter_params),
+      data: { turbo_frame: :resource_modal },
       icon: "add-line",
     )
   end
@@ -22,7 +31,7 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
     [
       {
         label: t('.batch_actions.delete'),
-        action: solidus_admin.promotion_categories_path,
+        action: solidus_admin.promotion_categories_path(**search_filter_params),
         method: :delete,
         icon: 'delete-bin-7-line',
       },
@@ -39,8 +48,10 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
   def name_column
     {
       header: :name,
-      data: ->(promotion_category) do
-        content_tag :div, promotion_category.name
+      data: ->(record) do
+        link_to record.name, edit_path(record),
+          data: { turbo_frame: :resource_modal },
+          class: 'body-link'
       end
     }
   end
@@ -48,8 +59,10 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
   def code_column
     {
       header: :code,
-      data: ->(promotion_category) do
-        content_tag :div, promotion_category.code
+      data: ->(record) do
+        link_to record.code, edit_path(record),
+          data: { turbo_frame: :resource_modal },
+          class: 'body-link'
       end
     }
   end

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::PromotionCategories::New::Component < SolidusAdmin::Resources::New::Component
+end

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.yml
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.yml
@@ -1,0 +1,4 @@
+en:
+  title: "New Promotion Category"
+  cancel: "Cancel"
+  submit: "Add Promotion Category"

--- a/legacy_promotions/lib/controllers/admin/solidus_admin/promotion_categories_controller.rb
+++ b/legacy_promotions/lib/controllers/admin/solidus_admin/promotion_categories_controller.rb
@@ -1,29 +1,15 @@
 # frozen_string_literal: true
 
 module SolidusAdmin
-  class PromotionCategoriesController < SolidusAdmin::BaseController
-    include SolidusAdmin::ControllerHelpers::Search
+  class PromotionCategoriesController < SolidusAdmin::ResourcesController
+    private
 
-    def index
-      promotion_categories = apply_search_to(
-        Spree::PromotionCategory.all,
-        param: :q,
-      )
+    def resource_class = Spree::PromotionCategory
 
-      set_page_and_extract_portion_from(promotion_categories)
-
-      respond_to do |format|
-        format.html { render component('promotion_categories/index').new(page: @page) }
-      end
+    def permitted_resource_params
+      params.require(:promotion_category).permit(:name, :code)
     end
 
-    def destroy
-      @promotion_categories = Spree::PromotionCategory.where(id: params[:id])
-
-      Spree::PromotionCategory.transaction { @promotion_categories.destroy_all }
-
-      flash[:notice] = t('.success')
-      redirect_back_or_to promotion_categories_path, status: :see_other
-    end
+    def resources_collection = Spree::PromotionCategory.unscoped
   end
 end

--- a/legacy_promotions/spec/features/solidus_admin/promotion_categories_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/promotion_categories_spec.rb
@@ -1,24 +1,12 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'solidus_admin/testing_support/shared_examples/promotion_categories_features'
 
 RSpec.describe "Promotion Categories", :js, type: :feature, solidus_admin: true do
-  before { sign_in create(:admin_user, email: 'admin@example.com') }
-
-  it "lists promotion categories and allows deleting them" do
-    create(:promotion_category, name: "test1", code: "code1")
-    create(:promotion_category, name: "test2", code: "code2")
-
-    visit "/admin/promotion_categories"
-    expect(page).to have_content("test1")
-    expect(page).to have_content("test2")
-
-    expect(page).to be_axe_clean
-
-    select_row("test1")
-    click_on "Delete"
-    expect(page).to have_content("Promotion Categories were successfully removed.")
-    expect(page).not_to have_content("test1")
-    expect(Spree::PromotionCategory.count).to eq(1)
+  include_examples 'promotion categories features' do
+    let(:factory_name) { :promotion_category }
+    let(:model_class) { Spree::PromotionCategory }
+    let(:index_path) { "/admin/promotion_categories" }
   end
 end

--- a/legacy_promotions/spec/requests/solidus_admin/promotion_categories_spec.rb
+++ b/legacy_promotions/spec/requests/solidus_admin/promotion_categories_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'solidus_admin/testing_support/shared_examples/promotion_categories_requests'
+
+RSpec.describe 'SolidusAdmin::PromotionCategoriesController', :solidus_admin, type: :request do
+  include_examples 'promotion categories requests' do
+    let(:promotion_category) { create(:promotion_category) }
+    let(:url_helpers) { solidus_admin }
+    let(:model_class) { Spree::PromotionCategory }
+  end
+end

--- a/promotions/MIGRATING.md
+++ b/promotions/MIGRATING.md
@@ -44,7 +44,7 @@ bundle exec rails solidus_promotions:migrate_existing_promotions
 
 This will create equivalents of the legacy promotion configuration in SolidusPromotions.
 
-Now, change `config/initializers/solidus_promotions.rb` to use your new promotion configuration:
+Now, change `config/initializers/spree.rb` to use your new promotion configuration:
 
 ## Change store behavior to use SolidusPromotions
 

--- a/promotions/config/locales/promotion_categories.en.yml
+++ b/promotions/config/locales/promotion_categories.en.yml
@@ -1,6 +1,13 @@
 en:
+  solidus_admin:
+    promotion_categories:
+      title: "Promotion Categories"
   solidus_promotions:
     promotion_categories:
       title: "Promotion Categories"
+      create:
+        success: "Promotion Category was successfully created."
+      update:
+        success: "Promotion Category was successfully updated."
       destroy:
         success: "Promotion Categories were successfully removed."

--- a/promotions/config/locales/promotions.en.yml
+++ b/promotions/config/locales/promotions.en.yml
@@ -1,4 +1,7 @@
 en:
+  solidus_admin:
+    promotions:
+      title: "Promotions"
   solidus_promotions:
     promotions:
       title: "Promotions"

--- a/promotions/config/routes.rb
+++ b/promotions/config/routes.rb
@@ -12,7 +12,7 @@ SolidusPromotions::Engine.routes.draw do
                 }) do
       scope :admin do
         scope :solidus do
-          admin_resources :promotion_categories, only: [:index, :destroy]
+          admin_resources :promotion_categories, except: [:show]
           admin_resources :promotions, only: [:index, :destroy]
         end
       end

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SolidusPromotions::PromotionCategories::Edit::Component < SolidusAdmin::BaseComponent
+  def initialize(record)
+    super
+    @promotion_category = record
+  end
+
+  def form_id
+    dom_id(@promotion_category, "#{stimulus_id}_edit_promotion_category_form")
+  end
+
+  def form_url
+    solidus_promotions.promotion_category_path(@promotion_category, **search_filter_params)
+  end
+end

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.yml
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.yml
@@ -1,0 +1,4 @@
+en:
+  title: "Edit Promotion Category"
+  cancel: "Cancel"
+  submit: "Update Promotion Category"

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/index/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/index/component.rb
@@ -5,15 +5,24 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
     SolidusPromotions::PromotionCategory
   end
 
-  def row_url(promotion_category)
-    solidus_promotions.edit_admin_promotion_category_path(promotion_category)
+  def title
+    t('solidus_promotions.promotion_categories.title')
+  end
+
+  def edit_path(record)
+    solidus_promotions.edit_promotion_category_path(record, **search_filter_params)
+  end
+
+  def turbo_frames
+    %w[resource_modal]
   end
 
   def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t(".add"),
-      href: solidus_promotions.new_admin_promotion_category_path,
+      href: solidus_promotions.new_promotion_category_path(**search_filter_params),
+      data: { turbo_frame: :resource_modal },
       icon: "add-line"
     )
   end
@@ -22,7 +31,7 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
     [
       {
         label: t(".batch_actions.delete"),
-        action: solidus_promotions.promotion_categories_path,
+        action: solidus_promotions.promotion_categories_path(**search_filter_params),
         method: :delete,
         icon: "delete-bin-7-line"
       }
@@ -39,8 +48,10 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
   def name_column
     {
       header: :name,
-      data: ->(promotion_category) do
-        content_tag :div, promotion_category.name
+      data: ->(record) do
+        link_to record.name, edit_path(record),
+          data: { turbo_frame: :resource_modal },
+          class: 'body-link'
       end
     }
   end
@@ -48,8 +59,10 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
   def code_column
     {
       header: :code,
-      data: ->(promotion_category) do
-        content_tag :div, promotion_category.code
+      data: ->(record) do
+        link_to record.code, edit_path(record),
+          data: { turbo_frame: :resource_modal },
+          class: 'body-link'
       end
     }
   end

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+  <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
+    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+      <div class="flex flex-col gap-6 pb-4">
+        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+      </div>
+      <% modal.with_actions do %>
+        <form method="dialog">
+          <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
+        </form>
+        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SolidusPromotions::PromotionCategories::New::Component < SolidusAdmin::BaseComponent
+  def initialize(record)
+    super
+    @promotion_category = record
+  end
+
+  def form_id
+    dom_id(@promotion_category, "#{stimulus_id}_new_promotion_category_form")
+  end
+
+  def form_url
+    solidus_promotions.promotion_categories_path(**search_filter_params)
+  end
+end

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.yml
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.yml
@@ -1,0 +1,4 @@
+en:
+  title: "New Promotion Category"
+  cancel: "Cancel"
+  submit: "Add Promotion Category"

--- a/promotions/lib/controllers/admin/solidus_promotions/promotion_categories_controller.rb
+++ b/promotions/lib/controllers/admin/solidus_promotions/promotion_categories_controller.rb
@@ -1,32 +1,40 @@
 # frozen_string_literal: true
 
 module SolidusPromotions
-  class PromotionCategoriesController < SolidusAdmin::BaseController
-    include SolidusAdmin::ControllerHelpers::Search
-
-    def index
-      promotion_categories = apply_search_to(
-        SolidusPromotions::PromotionCategory.all,
-        param: :q
-      )
-
-      set_page_and_extract_portion_from(promotion_categories)
-
-      respond_to do |format|
-        format.html { render component("solidus_promotions/categories/index").new(page: @page) }
-      end
-    end
-
-    def destroy
-      @promotion_categories = SolidusPromotions::PromotionCategory.where(id: params[:id])
-
-      SolidusPromotions::PromotionCategory.transaction { @promotion_categories.destroy_all }
-
-      flash[:notice] = t(".success")
-      redirect_back_or_to solidus_promotions.promotion_categories_path, status: :see_other
-    end
-
+  class PromotionCategoriesController < SolidusAdmin::ResourcesController
     private
+
+    def resource_class = SolidusPromotions::PromotionCategory
+
+    def permitted_resource_params
+      params.require(:promotion_category).permit(:name, :code)
+    end
+
+    def resources_collection = SolidusPromotions::PromotionCategory.unscoped
+
+    def index_component
+      component("solidus_promotions/categories/index")
+    end
+
+    def new_component
+      component("solidus_promotions/categories/new")
+    end
+
+    def edit_component
+      component("solidus_promotions/categories/edit")
+    end
+
+    def after_create_path
+      solidus_promotions.promotion_categories_path(**search_filter_params)
+    end
+
+    def after_update_path
+      solidus_promotions.promotion_categories_path(**search_filter_params)
+    end
+
+    def after_destroy_path
+      solidus_promotions.promotion_categories_path(**search_filter_params)
+    end
 
     def authorization_subject
       SolidusPromotions::PromotionCategory

--- a/promotions/lib/solidus_promotions/engine.rb
+++ b/promotions/lib/solidus_promotions/engine.rb
@@ -60,6 +60,8 @@ module SolidusPromotions
 
         SolidusAdmin::Config.components["solidus_promotions/promotions/index"] = "SolidusPromotions::Promotions::Index::Component"
         SolidusAdmin::Config.components["solidus_promotions/categories/index"] = "SolidusPromotions::PromotionCategories::Index::Component"
+        SolidusAdmin::Config.components["solidus_promotions/categories/new"] = "SolidusPromotions::PromotionCategories::New::Component"
+        SolidusAdmin::Config.components["solidus_promotions/categories/edit"] = "SolidusPromotions::PromotionCategories::Edit::Component"
       end
     end
 

--- a/promotions/spec/requests/solidus_promotions/admin/promotion_categories_spec.rb
+++ b/promotions/spec/requests/solidus_promotions/admin/promotion_categories_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'solidus_admin/testing_support/shared_examples/promotion_categories_requests'
+
+RSpec.describe 'SolidusPromotions::PromotionCategoriesController', :solidus_admin, type: :request do
+  include_examples 'promotion categories requests' do
+    let(:promotion_category) { create(:solidus_promotion_category) }
+    let(:url_helpers) { solidus_promotions }
+    let(:model_class) { SolidusPromotions::PromotionCategory }
+  end
+end

--- a/promotions/spec/system/solidus_promotions/admin/promotion_categories_spec.rb
+++ b/promotions/spec/system/solidus_promotions/admin/promotion_categories_spec.rb
@@ -1,24 +1,12 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
+require 'solidus_admin/testing_support/shared_examples/promotion_categories_features'
 
 RSpec.describe "Promotion Categories", :js, type: :feature, solidus_admin: true do
-  before { sign_in create(:admin_user, email: "admin@example.com") }
-
-  it "lists promotion categories and allows deleting them" do
-    create(:solidus_promotion_category, name: "test1", code: "code1")
-    create(:solidus_promotion_category, name: "test2", code: "code2")
-
-    visit "/admin/solidus/promotion_categories"
-    expect(page).to have_content("test1")
-    expect(page).to have_content("test2")
-
-    expect(page).to be_axe_clean
-
-    select_row("test1")
-    click_on "Delete"
-    expect(page).to have_content("Promotion Categories were successfully removed.")
-    expect(page).not_to have_content("test1")
-    expect(SolidusPromotions::PromotionCategory.count).to eq(1)
+  include_examples 'promotion categories features' do
+    let(:factory_name) { :solidus_promotion_category }
+    let(:model_class) { SolidusPromotions::PromotionCategory }
+    let(:index_path) { "/admin/solidus/promotion_categories" }
   end
 end

--- a/promotions/spec/system/solidus_promotions/backend/promotion_categories_spec.rb
+++ b/promotions/spec/system/solidus_promotions/backend/promotion_categories_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Promotion Categories", type: :system do
+RSpec.feature "Promotion Categories" do
   stub_authorization!
 
   context "index" do

--- a/promotions/spec/system/solidus_promotions/backend/promotions_spec.rb
+++ b/promotions/spec/system/solidus_promotions/backend/promotions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Promotions admin", type: :system do
+RSpec.feature "Promotions admin" do
   stub_authorization!
 
   describe "#index" do


### PR DESCRIPTION
## Summary

Addresses https://github.com/solidusio/solidus/issues/6102

Continuation of the work on new Admin UI, to convert add/edit pages into modal forms, this will add modal forms for both old and new promotion categories, as well as changing index page to render turbo-links to items

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/2a653437-ff3e-4184-87cc-59542a26cf30" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a31b811a-1fc0-43ea-89c0-045a7c525fa9" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0e4ffbd3-847b-4d68-80d6-65c778fd71dc" />

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- [x] ✅ I have added automated tests to cover my changes.
- [x] 📸 I have attached screenshots to demo visual changes.
