### PR TITLE
[v4.1] Deprecate `Spree::Deprecation` in favor of `Spree.deprecator`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -341,7 +341,7 @@ Lint/SuppressedException:
 
 Lint/MissingSuper:
   Exclude:
-    - 'core/lib/spree/deprecation.rb' # this is a known class that doesn't require super
+    - 'core/lib/spree/deprecated_instance_variable_proxy.rb' # this is a known class that doesn't require super
     - 'core/lib/spree/preferences/configuration.rb' # this class has no superclass defining `self.inherited`
 
 Rails/FindEach:

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -264,7 +264,7 @@ module Spree
       @recalculator ||= Spree::Config.order_recalculator_class.new(self)
     end
     alias_method :updater, :recalculator
-    deprecate updater: :recalculator, deprecator: Spree::Deprecation
+    deprecate updater: :recalculator, deprecator: Spree.deprecator
 
     def assign_billing_to_shipping_address
       self.ship_address = bill_address if bill_address
@@ -513,7 +513,7 @@ module Spree
     end
 
     alias_method :ensure_updated_shipments, :check_shipments_and_restart_checkout
-    deprecate ensure_updated_shipments: :check_shipments_and_restart_checkout, deprecator: Spree::Deprecation
+    deprecate ensure_updated_shipments: :check_shipments_and_restart_checkout, deprecator: Spree.deprecator
 
     def restart_checkout_flow
       return if state == 'cart'

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -31,7 +31,7 @@ module Spree
       end
     end
     alias_method :update, :recalculate
-    deprecate update: :recalculate, deprecator: Spree::Deprecation
+    deprecate update: :recalculate, deprecator: Spree.deprecator
 
     # Updates the +shipment_state+ attribute according to the following logic:
     #

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -33,6 +33,6 @@ Dummy::Application.configure do
 
   # Raise on deprecation warnings
   if ENV['SOLIDUS_RAISE_DEPRECATIONS'].present?
-    Spree::Deprecation.behavior = :raise
+    Spree.deprecator.behavior = :raise
   end
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -9,6 +9,8 @@ require "active_record/railtie"
 require "active_storage/engine"
 require "sprockets/railtie"
 
+require 'active_support/deprecation'
+require 'spree/deprecated_instance_variable_proxy'
 require 'acts_as_list'
 require 'awesome_nested_set'
 require 'cancan'
@@ -19,13 +21,17 @@ require 'paperclip'
 require 'ransack'
 require 'state_machines-activerecord'
 
-require 'spree/deprecation'
-
 # This is required because ActiveModel::Validations#invalid? conflicts with the
 # invalid state of a Payment. In the future this should be removed.
 StateMachines::Machine.ignore_method_conflicts = true
 
 module Spree
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'Solidus')
+  end
+
+  autoload :Deprecation, 'spree/deprecation'
+
   mattr_accessor :user_class, default: 'Spree::LegacyUser'
 
   def self.user_class

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -75,6 +75,12 @@ module Spree
         ActionMailer::Base.preview_path = app.config.action_mailer.preview_path
       end
 
+      initializer "spree.deprecator" do |app|
+        if app.respond_to?(:deprecators)
+          app.deprecators[:spree] = Spree.deprecator
+        end
+      end
+
       config.after_initialize do
         Spree::Config.check_load_defaults_called('Spree::Config')
         Spree::Config.static_model_preferences.validate!

--- a/core/lib/spree/deprecated_instance_variable_proxy.rb
+++ b/core/lib/spree/deprecated_instance_variable_proxy.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'active_support/deprecation'
+
+module Spree
+  # This DeprecatedInstanceVariableProxy transforms instance variable to
+  # deprecated instance variable.
+  #
+  # It differs from ActiveSupport::DeprecatedInstanceVariableProxy since
+  # it allows to define a custom message.
+  #
+  #   class Example
+  #     def initialize(deprecator)
+  #       @request = Spree::DeprecatedInstanceVariableProxy.new(self, :request, :@request, deprecator, "Please, do not use this thing.")
+  #       @_request = :a_request
+  #     end
+  #
+  #     def request
+  #       @_request
+  #     end
+  #
+  #     def old_request
+  #       @request
+  #     end
+  #   end
+  #
+  # When someone execute any method on @request variable this will trigger
+  # +warn+ method on +deprecator_instance+ and will fetch <tt>@_request</tt>
+  # variable via +request+ method and execute the same method on non-proxy
+  # instance variable.
+  #
+  # Default deprecator is <tt>Spree.deprecator</tt>.
+  class DeprecatedInstanceVariableProxy < ActiveSupport::Deprecation::DeprecationProxy
+    def initialize(instance, method_or_var, var = "@#{method}", deprecator = Spree.deprecator, message = nil)
+      @instance = instance
+      @method_or_var = method_or_var
+      @var = var
+      @deprecator = deprecator
+      @message = message
+    end
+
+    private
+
+    def target
+      return @instance.instance_variable_get(@method_or_var) if @instance.instance_variable_defined?(@method_or_var)
+
+      @instance.__send__(@method_or_var)
+    end
+
+    def warn(callstack, called, args)
+      message = @message || "#{@var} is deprecated! Call #{@method_or_var}.#{called} instead of #{@var}.#{called}."
+      message = [message, "Args: #{args.inspect}"].join(" ") unless args.empty?
+
+      @deprecator.warn(message, callstack)
+    end
+  end
+end

--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -35,9 +35,9 @@ module Spree
   # variable via +request+ method and execute the same method on non-proxy
   # instance variable.
   #
-  # Default deprecator is <tt>Spree::Deprecation</tt>.
+  # Default deprecator is <tt>Spree.deprecator</tt>.
   class DeprecatedInstanceVariableProxy < ActiveSupport::Deprecation::DeprecationProxy
-    def initialize(instance, method, var = "@#{method}", deprecator = Spree::Deprecation, message = nil)
+    def initialize(instance, method_or_var, var = "@#{method}", deprecator = Spree.deprecator, message = nil)
       @instance = instance
       @method = method
       @var = var

--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -3,7 +3,11 @@
 require 'active_support/deprecation'
 
 module Spree
-  Deprecation = ActiveSupport::Deprecation.new('5.0', 'Solidus')
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'Solidus')
+  end
+
+  Deprecation = Spree.deprecator
 
   # This DeprecatedInstanceVariableProxy transforms instance variable to
   # deprecated instance variable.

--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -1,61 +1,9 @@
 # frozen_string_literal: true
 
-require 'active_support/deprecation'
+require 'spree/core'
 
 module Spree
-  def self.deprecator
-    @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'Solidus')
-  end
-
   Deprecation = Spree.deprecator
 
-  # This DeprecatedInstanceVariableProxy transforms instance variable to
-  # deprecated instance variable.
-  #
-  # It differs from ActiveSupport::DeprecatedInstanceVariableProxy since
-  # it allows to define a custom message.
-  #
-  #   class Example
-  #     def initialize(deprecator)
-  #       @request = Spree::DeprecatedInstanceVariableProxy.new(self, :request, :@request, deprecator, "Please, do not use this thing.")
-  #       @_request = :a_request
-  #     end
-  #
-  #     def request
-  #       @_request
-  #     end
-  #
-  #     def old_request
-  #       @request
-  #     end
-  #   end
-  #
-  # When someone execute any method on @request variable this will trigger
-  # +warn+ method on +deprecator_instance+ and will fetch <tt>@_request</tt>
-  # variable via +request+ method and execute the same method on non-proxy
-  # instance variable.
-  #
-  # Default deprecator is <tt>Spree.deprecator</tt>.
-  class DeprecatedInstanceVariableProxy < ActiveSupport::Deprecation::DeprecationProxy
-    def initialize(instance, method_or_var, var = "@#{method}", deprecator = Spree.deprecator, message = nil)
-      @instance = instance
-      @method = method
-      @var = var
-      @deprecator = deprecator
-      @message = message
-    end
-
-    private
-
-    def target
-      @instance.__send__(@method)
-    end
-
-    def warn(callstack, called, args)
-      message = @message || "#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}."
-      message = [message, "Args: #{args.inspect}"].join(" ")
-
-      @deprecator.warn(message, callstack)
-    end
-  end
+  Spree.deprecator.warn "Spree::Deprecation is deprecated. Please use Spree.deprecator instead.", caller(2)
 end

--- a/core/lib/spree/preferences/configuration.rb
+++ b/core/lib/spree/preferences/configuration.rb
@@ -59,7 +59,7 @@ module Spree::Preferences
       return if load_defaults_called || !Spree::Core.has_install_generator_been_run?
 
       target_name = instance_constant_name || "#{self.class.name}.new"
-      Spree::Deprecation.warn <<~MSG
+      Spree.deprecator.warn <<~MSG
         It's recommended that you explicitly load the default configuration for
         your current Solidus version. You can do it by adding the following call
         to your Solidus initializer within the #{target_name} block:

--- a/core/lib/spree/preferences/preferable_class_methods.rb
+++ b/core/lib/spree/preferences/preferable_class_methods.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/deprecation'
 require 'spree/encryptor'
 
 module Spree::Preferences

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -142,5 +142,5 @@ end
 
 # Raise on deprecation warnings
 if ENV['SOLIDUS_RAISE_DEPRECATIONS'].present?
-  Spree::Deprecation.behavior = :raise
+  Spree.deprecator.behavior = :raise
 end

--- a/core/lib/spree/testing_support/factory_bot.rb
+++ b/core/lib/spree/testing_support/factory_bot.rb
@@ -30,7 +30,7 @@ module Spree
           MSG
         end
       end
-      deprecate :check_version, deprecator: Spree::Deprecation
+      deprecate :check_version, deprecator: Spree.deprecator
 
       def self.add_definitions!
         ::FactoryBot.definition_file_paths.unshift(*definition_file_paths).uniq!

--- a/core/lib/spree/testing_support/silence_deprecations.rb
+++ b/core/lib/spree/testing_support/silence_deprecations.rb
@@ -2,7 +2,7 @@
 
 RSpec.configure do |config|
   config.around(:each, silence_deprecations: true) do |example|
-    Spree::Deprecation.silence do
+    Spree.deprecator.silence do
       example.run
     end
   end

--- a/core/spec/lib/spree/migration_helpers_spec.rb
+++ b/core/spec/lib/spree/migration_helpers_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Spree::MigrationHelpers do
     context "when the column exists" do
       context "and the index does" do
         it "passes compatible arguments to index_exists?" do
-          expect { subject }.to_not raise_error(ArgumentError)
+          expect { subject }.to raise_error(NotImplementedError) # not ArgumentError
         end
       end
 
@@ -27,7 +27,7 @@ RSpec.describe Spree::MigrationHelpers do
         end
 
         it "passes compatible arguments to add_index" do
-          expect { subject }.to_not raise_error(ArgumentError)
+          expect { subject }.to raise_error(TypeError) # not ArgumentError
         end
       end
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Spree::Order, type: :model do
     let(:subject) { order.ensure_updated_shipments }
 
     it "is deprecated" do
-      expect(Spree::Deprecation).to receive(:warn).with(/ensure_updated_shipments is deprecated.*use check_shipments_and_restart_checkout instead/, any_args)
+      expect(Spree.deprecator).to receive(:warn).with(/ensure_updated_shipments is deprecated.*use check_shipments_and_restart_checkout instead/, any_args)
 
       subject
     end

--- a/core/spec/models/spree/preferences/configuration_spec.rb
+++ b/core/spec/models/spree/preferences/configuration_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Spree::Preferences::Configuration, type: :model do
       it 'does not emit a warning' do
         config.load_defaults '3.1'
 
-        expect(Spree::Deprecation).not_to receive(:warn)
+        expect(Spree.deprecator).not_to receive(:warn)
 
         config.check_load_defaults_called
       end
@@ -72,13 +72,13 @@ RSpec.describe Spree::Preferences::Configuration, type: :model do
 
     context 'when load_defaults_called is false' do
       it 'emits a warning' do
-        expect(Spree::Deprecation).to receive(:warn).with(/adding.*load_defaults/m)
+        expect(Spree.deprecator).to receive(:warn).with(/adding.*load_defaults/m)
 
         config.check_load_defaults_called
       end
 
       it 'includes constant name in the message when given' do
-        expect(Spree::Deprecation).to receive(:warn).with(/Spree::Config/, any_args)
+        expect(Spree.deprecator).to receive(:warn).with(/Spree::Config/, any_args)
 
         config.check_load_defaults_called('Spree::Config')
       end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.1`:
 - [Merge pull request #5289 from nebulab/kennyadsl/deprecation-updates](https://github.com/solidusio/solidus/pull/5289)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)