### PR TITLE
Fix field container identifier on admin stock location

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -24,7 +24,7 @@
     <fieldset class="no-border-bottom">
       <legend><%= t('.address') %></legend>
 
-      <%= f.field_container :check_stock_on_transfer do %>
+      <%= f.field_container :address1 do %>
         <%= f.label :address1 %>
         <%= f.text_field :address1, class: 'fullwidth' %>
       <% end %>


### PR DESCRIPTION
## Summary

The `address1` container incorrectly had the same identifier as the
"Check stock on transfer" input checkbox. This fixes the typo, so this
container can be referenced in Deface overrides, etc.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
