### PR TITLE
Add primary Taxon to products (#6047)

### DIFF
--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -7,7 +7,7 @@ module Spree
     preference :product_attributes, :array, default: [
       :id, :name, :description, :available_on,
       :slug, :meta_description, :meta_keywords, :shipping_category_id,
-      :taxon_ids, :total_on_hand, :meta_title
+      :taxon_ids, :total_on_hand, :meta_title, :primary_taxon_id
     ]
 
     preference :product_property_attributes, :array, default: [:id, :product_id, :property_id, :value, :property_name]

--- a/api/spec/requests/spree/api/products_spec.rb
+++ b/api/spec/requests/spree/api/products_spec.rb
@@ -316,6 +316,13 @@ module Spree::Api
           expect(json_response["taxon_ids"]).to eq([taxon_1.id])
         end
 
+        it "puts primary taxon for the product" do
+          product_data[:primary_taxon_id] = taxon_1.id.to_s
+          post spree.api_products_path, params: { product: product_data }
+
+          expect(json_response["primary_taxon_id"]).to eq(taxon_1.id)
+        end
+
         # Regression test for https://github.com/spree/spree/issues/4123
         it "puts the created product in the given taxons" do
           product_data[:taxon_ids] = [taxon_1.id, taxon_2.id].join(',')
@@ -402,6 +409,13 @@ module Spree::Api
         it "puts the created product in the given taxon" do
           put spree.api_product_path(product), params: { product: { taxon_ids: taxon_1.id.to_s } }
           expect(json_response["taxon_ids"]).to eq([taxon_1.id])
+        end
+
+        it "puts primary taxon for the updated product" do
+          product.primary_taxon_id = taxon_2.id
+          put spree.api_product_path(product), params: { product: { primary_taxon_id: taxon_1.id } }
+
+          expect(json_response["primary_taxon_id"]).to eq(taxon_1.id)
         end
 
         # Regression test for https://github.com/spree/spree/issues/4123

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -1,25 +1,49 @@
-$.fn.taxonAutocomplete = function () {
+$.fn.taxonAutocomplete = function (options) {
   'use strict';
 
-  this.select2({
-      placeholder: Spree.translations.taxon_placeholder,
-      multiple: true,
-      initSelection: function (element, callback) {
-        var ids = element.val(),
-            count = ids.split(",").length;
+  var defaultOptions = {
+    multiple: true,
+    placeholder: Spree.translations.taxon_placeholder
+  };
 
-        Spree.ajax({
-          type: "GET",
-          url: Spree.pathFor('api/taxons'),
-          data: {
-            ids: ids,
-            per_page: count,
-            without_children: true
-          },
-          success: function (data) {
-            callback(data['taxons']);
-          }
-        });
+  options = $.extend({}, defaultOptions, options);
+
+  this.select2({
+      placeholder: options.placeholder,
+      multiple: options.multiple,
+      initSelection: function (element, callback) {
+        var ids = element.val();
+
+        if (options.multiple) {
+          var count = ids.split(",").length;
+
+          Spree.ajax({
+            type: "GET",
+            url: Spree.pathFor('api/taxons'),
+            data: {
+              ids: ids,
+              per_page: count,
+              without_children: true
+            },
+            success: function (data) {
+              callback(data['taxons']);
+            }
+          });
+        } else {
+
+          Spree.ajax({
+            type: "GET",
+            url: Spree.pathFor('api/taxons'),
+            data: {
+              ids: ids,
+              per_page: 1,
+              without_children: true
+            },
+            success: function (data) {
+              callback(data['taxons'][0]);
+            }
+          });
+        }
       },
       ajax: {
         url: Spree.pathFor('api/taxons'),
@@ -53,5 +77,11 @@ $.fn.taxonAutocomplete = function () {
 };
 
 Spree.ready(function () {
-  $('#product_taxon_ids, .taxon_picker').taxonAutocomplete();
+  $('#product_taxon_ids, .taxon_picker').taxonAutocomplete({
+    multiple: true,
+  });
+
+  $('#product_primary_taxon_id').taxonAutocomplete({
+    multiple: false,
+  });
 });

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -36,6 +36,13 @@
           <% end %>
         </div>
 
+        <div data-hook="admin_product_form_primary_taxons">
+          <%= f.field_container :primary_taxon do %>
+            <%= f.label :primary_taxon_id %><br>
+            <%= f.hidden_field :primary_taxon_id, value: @product.primary_taxon_id %>
+          <% end %>
+        </div>
+
         <div data-hook="admin_product_form_option_types">
           <%= f.field_container :option_types do %>
             <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -26,7 +26,10 @@ describe "Product Display Order", type: :feature do
       visit spree.edit_admin_product_path(product)
 
       assert_selected_taxons([taxon_1])
-      select2_search "Clothing", from: "Taxon"
+      within("[data-hook='admin_product_form_taxons']") do
+        select2_search "Clothing", from: "Taxon"
+      end
+
       assert_selected_taxons([taxon_1, taxon_2])
 
       # Without this line we have a flaky spec probably due to select2 not

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -32,6 +32,7 @@ module Spree
 
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products, optional: true
+    belongs_to :primary_taxon, class_name: 'Spree::Taxon', optional: true
 
     has_one :master,
       -> { where(is_master: true).with_discarded },

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -179,6 +179,8 @@ en:
         name: Name
         on_hand: On Hand
         price: Master Price
+        primary_taxon: Primary Taxon
+        primary_taxon_id: Primary Taxon
         promotionable: Promotable
         shipping_category: Shipping Category
         sku: Master SKU

--- a/core/db/migrate/20250207104016_add_primary_taxon_to_products.rb
+++ b/core/db/migrate/20250207104016_add_primary_taxon_to_products.rb
@@ -1,0 +1,7 @@
+class AddPrimaryTaxonToProducts < ActiveRecord::Migration[7.0]
+  def change
+    change_table :spree_products do |t|
+      t.references :primary_taxon, { to_table: :spree_taxons }
+    end
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -78,7 +78,7 @@ module Spree
       :meta_keywords, :price, :sku, :deleted_at,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,
-      :taxon_ids, :option_type_ids, :cost_currency, :cost_price
+      :taxon_ids, :option_type_ids, :cost_currency, :cost_price, :primary_taxon_id
     ]
 
     @@property_attributes = [:name, :presentation]

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -452,6 +452,22 @@ RSpec.describe Spree::Product, type: :model do
           end
         end
       end
+
+      describe "primary_taxon" do
+        it 'should belong to primary_taxon' do
+          expect(Spree::Product.reflect_on_association(:primary_taxon).macro).to eq(:belongs_to)
+        end
+
+        it 'should be optional' do
+          association = Spree::Product.reflect_on_association(:primary_taxon)
+          expect(association.options[:optional]).to be(true)
+        end
+
+        it 'should have a class_name of Spree::Taxon' do
+          association = Spree::Product.reflect_on_association(:primary_taxon)
+          expect(association.class_name).to eq('Spree::Taxon')
+        end
+      end
     end
   end
 
@@ -708,5 +724,14 @@ RSpec.describe Spree::Product, type: :model do
         expect(product.track_inventory).to be(true)
       end
     end
+  end
+
+  it 'is valid with or without a primary_taxon' do
+    product_with_taxon = create(:product, primary_taxon: create(:taxon))
+
+    product_without_taxon = create(:product, primary_taxon: nil)
+
+    expect(product_with_taxon).to be_valid
+    expect(product_without_taxon).to be_valid
   end
 end


### PR DESCRIPTION
## Summary
Concerns #6047 
Concerns Starter_Frontend [#390](https://github.com/solidusio/solidus_starter_frontend/issues/390) [#450](https://github.com/solidusio/solidus_starter_frontend/issues/405)

> [!CAUTION]
> To implement this feature on starter_frontend also [#418](https://github.com/solidusio/solidus_starter_frontend/pull/418) needs to be merged.

This PR fixes outcome variability on the breadcrumbs rendered on the frontpage and is part of a couple of PRs addressing the lack of some SEO features that became prevalent. 

### Issue: Breadcrumbs are not rendered reliably given that any of multiple taxons can be used
Breadcrumbs are used to tell search engines more about the overal page structure of a website. Currently the starter frontend pulls the first taxon identified on the website and renders that including all ancestors as breadcrumbs terminating the trail with the current page. 

While this renders valid breadcrumbs (opposite to some other pages) it does neccessarily reinforce the desired keyword as the taxon rendered as breadcrumb does not always reflect the keyword desired. 

To solve that issue @shahmayur001 implemented an additional instrument to select the desired breadcrumb taxon in the admin interface. 

Fixes #6047

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
