### PR TITLE
Add Ruby 3.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,3 +394,15 @@ workflows:
                   paperclip: [false],
                 },
             }
+      - test_solidus:
+          name: *name
+          matrix:
+            {
+              parameters:
+                {
+                  rails: ["7.2", "8.0"],
+                  ruby: ["3.4.1"],
+                  database: ["postgres"],
+                  paperclip: [false],
+                },
+            }

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Spree::LogEntry, type: :model do
 
       expect(details.success?).to eq(true)
       expect(details.message).to eq("[WARNING: An error occurred while trying to serialize the payment response] FooBar")
-      expect(details.params['data']).to include(':bar=>"Symbol keys are not allowed"')
+      expect(details.params['data']).to include('"Symbol keys are not allowed"')
       expect(details.params['error']).to include('Tried to dump unspecified class: Symbol')
     end
   end

--- a/legacy_promotions/solidus_legacy_promotions.gemspec
+++ b/legacy_promotions/solidus_legacy_promotions.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1.0'
   s.required_rubygems_version = '>= 1.8.23'
 
+  s.add_dependency 'csv', '~> 3.0'
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
   s.add_dependency 'solidus_support', '>= 0.12.0'

--- a/promotions/solidus_promotions.gemspec
+++ b/promotions/solidus_promotions.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   files = Dir.chdir(__dir__) { `git ls-files -z`.split("\x0") }
   spec.files = files.grep_v(%r{^(spec|bin)/})
 
+  spec.add_dependency "csv", "~> 3.0"
   spec.add_dependency "importmap-rails", "~> 1.2"
   spec.add_dependency "ransack-enum", "~> 1.0"
   spec.add_dependency "solidus_core", [">= 4.0.0", "< 5"]


### PR DESCRIPTION
## Summary

We need to add `csv` because it has been extracted into a separate gem.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
