### PR TITLE
Remove Display Order from side menu

### DIFF
--- a/admin/config/locales/menu_item.en.yml
+++ b/admin/config/locales/menu_item.en.yml
@@ -6,7 +6,6 @@ en:
       option_types: Option Types
       property_types: Properties
       taxonomies: Taxonomies
-      taxons: Display Order
       promotions: Promotions
       promotion_categories: Promotion Categories
       stock: Stock

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -102,11 +102,6 @@ module SolidusAdmin
               key: "taxonomies",
               route: -> { spree.admin_taxonomies_path },
               position: 30
-            },
-            {
-              key: "taxons",
-              route: -> { spree.admin_taxons_path },
-              position: 40
             }
           ]
         },


### PR DESCRIPTION
## Summary

Removes "Display Order" menu item from side menu as per https://github.com/orgs/solidusio/projects/12/views/1?pane=issue&itemId=52590353

Note: if enabled in initializer, `config.import_menu_items_from_backend!` will still put "Display order" menu item since it is present in legacy backend menu

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).