### PR TITLE
Fix missing options in select tags

### DIFF
--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -7,6 +7,7 @@ module SolidusAdmin
   # BaseComponent is the base class for all components in Solidus Admin.
   class BaseComponent < ViewComponent::Base
     include SolidusAdmin::ComponentsHelper
+    include SolidusAdmin::VoidElementsHelper
     include Turbo::FramesHelper
 
     def icon_tag(name, **attrs)

--- a/admin/app/components/solidus_admin/ui/forms/input/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/input/component.rb
@@ -93,24 +93,24 @@ class SolidusAdmin::UI::Forms::Input::Component < SolidusAdmin::BaseComponent
       with_content options_for_select(@attributes.delete(:choices), @attributes.delete(:value))
     end
 
-    options = {
+    build_tag
+  end
+
+  private
+
+  def build_tag
+    args = [@tag]
+    args << content unless void_element?(@tag)
+
+    tag.public_send(*args, **tag_options)
+  end
+
+  def tag_options
+    @tag_options ||= {
       "data-controller": stimulus_id,
       "data-#{stimulus_id}-custom-validity-value": @error.presence,
       "data-action": "#{stimulus_id}#clearCustomValidity",
       **@attributes
     }
-
-    if tag.method(@tag).parameters.any? { |_type, name| name == :content }
-      tag.public_send(
-        @tag,
-        content,
-        **options
-      )
-    else
-      tag.public_send(
-        @tag,
-        **options
-      )
-    end
   end
 end

--- a/admin/app/helpers/solidus_admin/void_elements_helper.rb
+++ b/admin/app/helpers/solidus_admin/void_elements_helper.rb
@@ -5,9 +5,9 @@ module SolidusAdmin
     # https://github.com/rails/rails/blob/194d697036c61af0caa66de5659721ded2478ce9/actionview/lib/action_view/helpers/tag_helper.rb#L84
     HTML_VOID_ELEMENTS = %i(area base br col embed hr img input keygen link meta source track wbr)
 
-    # @param el [Symbol]
-    def void_element?(el)
-      HTML_VOID_ELEMENTS.include?(el)
+    # @param element [Symbol]
+    def void_element?(element)
+      HTML_VOID_ELEMENTS.include?(element)
     end
   end
 end

--- a/admin/app/helpers/solidus_admin/void_elements_helper.rb
+++ b/admin/app/helpers/solidus_admin/void_elements_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  module VoidElementsHelper
+    # https://github.com/rails/rails/blob/194d697036c61af0caa66de5659721ded2478ce9/actionview/lib/action_view/helpers/tag_helper.rb#L84
+    HTML_VOID_ELEMENTS = %i(area base br col embed hr img input keygen link meta source track wbr)
+
+    # @param el [Symbol]
+    def void_element?(el)
+      HTML_VOID_ELEMENTS.include?(el)
+    end
+  end
+end

--- a/admin/spec/helpers/solidus_admin/void_elements_helper_spec.rb
+++ b/admin/spec/helpers/solidus_admin/void_elements_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::VoidElementsHelper, type: :helper do
+  describe '#void_element?' do
+    subject { helper.void_element?(element) }
+
+    context 'when element is void' do
+      let(:element) { :input }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when element is not void' do
+      let(:element) { :div }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A small improvement on changes from https://github.com/solidusio/solidus/pull/6091 where in Rails 7 calling `tag.method(@tag).parameters.any? { |_type, name| name == :content }` would always return false when @tag == :select, since `tag.select` method's signature has only `*` (:rest) as its parameter, thus not passing any `<option>`s for select tag.

Somehow the problem was not being flagged by CI builds, but admin specs failed locally.

Instead, use explicit void elements list to understand whether given element is void, therefore does not accept `content`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
