### PR TITLE
Fix DummyApp Generator

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -61,7 +61,6 @@ module Spree
       template "rails/application.rb.tt", "#{dummy_path}/config/application.rb", force: true
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true
       template "rails/test.rb", "#{dummy_path}/config/environments/test.rb", force: true
-      template "rails/script/rails", "#{dummy_path}/spec/dummy/script/rails", force: true
     end
 
     def test_dummy_inject_extension_requirements

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -61,6 +61,7 @@ module Spree
       template "rails/application.rb.tt", "#{dummy_path}/config/application.rb", force: true
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true
       template "rails/test.rb", "#{dummy_path}/config/environments/test.rb", force: true
+      template "rails/manifest.js", "#{dummy_path}/app/assets/config/manifest.js", force: true
     end
 
     def test_dummy_inject_extension_requirements

--- a/core/lib/generators/spree/dummy/templates/rails/application.rb.tt
+++ b/core/lib/generators/spree/dummy/templates/rails/application.rb.tt
@@ -2,7 +2,7 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-Bundler.require(*Rails.groups(assets: %w(development test)))
+Bundler.require(*Rails.groups)
 
 require '<%= lib_name %>'
 

--- a/core/lib/generators/spree/dummy/templates/rails/manifest.js
+++ b/core/lib/generators/spree/dummy/templates/rails/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/core/lib/generators/spree/dummy/templates/rails/script/rails
+++ b/core/lib/generators/spree/dummy/templates/rails/script/rails
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
-
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
-require 'rails/commands'


### PR DESCRIPTION
## Summary

Remove some old unused files and add a sprockets manifest so that latest versions of Rails and Solidus main.

Rails stopped creating sprockets files but we still use sprockets. And we need to manifest so that test apps
generated during specs do not fail with a sprockets error.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
