### PR TITLE
Revert "Merge pull request #6122 from mamhoff/create-manifest-js-in-g…

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -121,9 +121,6 @@ module Solidus
 
     def add_files
       template 'config/initializers/spree.rb.tt', 'config/initializers/spree.rb'
-      if Rails.version >= "8.0"
-        template "app/assets/config/manifest.js", "app/assets/config/manifest.js", force: true
-      end
     end
 
     def install_file_attachment

--- a/core/lib/generators/solidus/install/templates/app/assets/config/manifest.js
+++ b/core/lib/generators/solidus/install/templates/app/assets/config/manifest.js
@@ -1,3 +1,0 @@
-//= link_tree ../images
-//= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css


### PR DESCRIPTION
…enerated-apps"

This reverts commit bec42f64b9008dda63dc89c69de68fdc0076f293, reversing changes made to 37a5c8a3182e58185a2ec5691a47721c320ad764.

## Summary

This reverts #6122. If Rails 8 runs the install generator, the Rails process won't even start if the file is not present, and consequently our installer won't run either. The actual fix is this: https://github.com/solidusio/solidus_dev_support/pull/229 - The sprockets manifest file *needs* to be present before even starting up a Rails process with Solidus in the Gemfile. 

I guess we need to sort out the Sprockets removal next.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
