### PR TITLE
Fix migration typo (missing keyword `foreign_key`)

### DIFF
--- a/core/db/migrate/20250207104016_add_primary_taxon_to_products.rb
+++ b/core/db/migrate/20250207104016_add_primary_taxon_to_products.rb
@@ -1,7 +1,7 @@
 class AddPrimaryTaxonToProducts < ActiveRecord::Migration[7.0]
   def change
     change_table :spree_products do |t|
-      t.references :primary_taxon, { to_table: :spree_taxons }
+      t.references :primary_taxon, type: :integer, foreign_key: { to_table: :spree_taxons }
     end
   end
 end


### PR DESCRIPTION
Linter failure unrelated, fixed in https://github.com/solidusio/solidus/pull/6128

So apparently without `foreign_key:` keyword, the migration will just create another column called `{ to_table: :spree_taxons }_id` (i didn't even know this was a valid syntax for the column name haha)

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
