### PR TITLE
Add not about sprockets manifest before running rails commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ To add Solidus, begin with a newly created Rails application with its database.
 rails new my_store
 ```
 
+> [!CAUTION]
+> Due to [a bug in `sprockets-rails`](https://github.com/rails/sprockets-rails/pull/546) we need to manually add the sprockets manifest into the generated rails app **before** running any rails commands inside the rails app folder.
+
+```bash
+mkdir -p my_store/app/assets/config
+cat <<MANIFEST > my_store/app/assets/config/manifest.js
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+MANIFEST
+```
+
 ### Installing Solidus
 
 In your application's root folder run:
@@ -98,6 +110,9 @@ In your application's root folder run:
 bundle add solidus
 bin/rails g solidus:install
 ```
+
+> [!NOTE]
+> Please make sure to generate the sprockets manifest before running the `solidus:install` generator.
 
 And follow the prompt's instructions.
 ### Accessing Solidus Store


### PR DESCRIPTION
## Summary

Due to a bug in sprockets-rails[1] we need to manually add the sprockets manifest into the generated rails app before running any rails commands inside the rails app folder.

[1](https://github.com/rails/sprockets-rails/pull/546)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
