### PR TITLE
Rubocop: Ignore Rails/Delegate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,10 @@ Style/TrailingCommaInHashLiteral:
 Style/SymbolArray:
   Enabled: false
 
+# In some circumstances, this looks really unintuitive
+Rails/Delegate:
+  Enabled: false
+
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_param


### PR DESCRIPTION
This rule makes code shorter, but much less understandable.
