### PR TITLE
Fix sandbox command for Rails 8

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -40,6 +40,13 @@ function unbundled {
 echo "~~~> Removing the old sandbox"
 rm -rf ./sandbox
 
+mkdir -p sandbox/app/assets/config
+cat <<MANIFEST > sandbox/app/assets/config/manifest.js
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+MANIFEST
+
 echo "~~~> Creating a pristine Rails app"
 rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
 bundle exec rails _${rails_version}_ new sandbox \


### PR DESCRIPTION
## Summary

Rails 8 does not create a sprockets manifest anymore, but we still depend on it. Since rails commands do not work anymore, because sprockets raises an error if no manifest.js file is present we need to create it in order to be able to run rails new

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
