### PR TITLE
[Admin] Fix tailwindcss-rails Version to v3 for Solidus Admin Compatibility

### DIFF
--- a/admin/lib/solidus_admin/install_tailwindcss.rb
+++ b/admin/lib/solidus_admin/install_tailwindcss.rb
@@ -8,7 +8,7 @@ input_path = "app/assets/stylesheets/solidus_admin/application.tailwind.css"
 output_path = "app/assets/builds/solidus_admin/tailwind.css"
 
 unless bundle_command "show tailwindcss-rails"
-  bundle_command "add tailwindcss-rails"
+  bundle_command "add tailwindcss-rails --version '~>3.0'"
 end
 
 # Copy the Tailwind CSS main file.


### PR DESCRIPTION
## Background

Currently, running `bin/rails solidus_admin:tailwindcss:install` installs the latest v4 of `tailwindcss-rails`. This causes compatibility issues because Solidus Admin expects the Tailwind CSS v3 configuration.

Tailwind CSS v4 introduces CSS First Configuration, which alters the structure and handling of the `tailwind.config.js` file. Using v4 results in a configuration where `tailwind.config.js` does not function properly. Reference: https://tailwindcss.com/blog/tailwindcss-v4#css-first-configuration

While ideally, Solidus Admin should be updated to work with Tailwind CSS v4 and later, we have restricted it to v3 for now to ensure correct functionality. Additionally, the maintainers of `tailwindcss-rails` do not recommend upgrading to v4 at this time (see: https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#you-dont-_have_-to-upgrade).

## Solution

Modified the installation command in `install_tailwindcss.rb` to explicitly install v3:

```ruby
unless bundle_command "show tailwindcss-rails"
  bundle_command "add tailwindcss-rails --version '~>3.0'"
end
```

This change ensures that running bin/rails solidus_admin:tailwindcss:install installs Tailwind CSS v3, which is compatible with Solidus Admin's current configuration.

If there is anything else that should be added or any improvements that can be made, please let me know.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
