### PR TITLE
[v4.3] CI: Actually run solidus installer test with Rails 7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,8 +176,8 @@ commands:
           name: "Prepare the rails application"
           command: |
             cd /tmp
-            test -d my_app || (gem install rails -v "< 7.1" && gem install solidus)
-            test -d my_app || rails new my_app --skip-git
+            test -d my_app || (gem install rails -v "< 7.2" && gem install solidus)
+            test -d my_app || rails _7.1_ new my_app --skip-git
       - save_cache:
           key: solidus-installer-v9-{{ checksum "/tmp/.ruby-versions" }}-{{ checksum "/tmp/.gems-versions" }}
           paths:
@@ -227,7 +227,7 @@ commands:
             mkdir -p /tmp/dummy_extension
             cd /tmp/dummy_extension
             bundle init
-            bundle add rails -v "< 7.1" --skip-install
+            bundle add rails -v "< 7.2" --skip-install
             bundle add sqlite3 -v "~> 1.3" --skip-install
             test -n "<<parameters.extra_gems>>" && bundle add <<parameters.extra_gems>> --skip-install
             bundle add solidus --path "$(ruby -e"puts File.expand_path ENV['CIRCLE_WORKING_DIRECTORY']")"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,14 +120,14 @@ commands:
       - run:
           name: Setup Coverage Env Vars
           command: |
-              echo 'export COVERAGE_FILE=$COVERAGE_DIR/coverage.xml' >> $BASH_ENV
-              source $BASH_ENV
+            echo 'export COVERAGE_FILE=$COVERAGE_DIR/coverage.xml' >> $BASH_ENV
+            source $BASH_ENV
       - run:
           name: Verify Coverage Env Vars
           command: |
-              echo $COVERAGE
-              echo $COVERAGE_DIR
-              echo $COVERAGE_FILE
+            echo $COVERAGE
+            echo $COVERAGE_DIR
+            echo $COVERAGE_FILE
       - run:
           name: Setup Coverage Directory
           command: mkdir -p $COVERAGE_DIR
@@ -195,10 +195,10 @@ commands:
     parameters:
       app_root:
         type: string
-        default: '/tmp/my_app'
+        default: "/tmp/my_app"
       path:
         type: string
-        default: '/'
+        default: "/"
       expected_text:
         type: string
 
@@ -295,7 +295,7 @@ jobs:
         default: postgres
       ruby:
         type: string
-        default: '3.2'
+        default: "3.2"
       rails:
         type: string
         default: "7.0"
@@ -321,13 +321,13 @@ jobs:
         default: postgres
       ruby:
         type: string
-        default: '3.1'
+        default: "3.1"
     executor:
       name: << parameters.database >>
       ruby: << parameters.ruby >>
     parallelism: &parallelism 3
     environment:
-      COVERAGE: 'true'
+      COVERAGE: "true"
       COVERAGE_DIR: /tmp/coverage
       DISABLE_ACTIVE_STORAGE: false
     steps:
@@ -349,10 +349,37 @@ workflows:
       # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html.
       - test_solidus:
           name: &name "test-rails-<<matrix.rails>>-ruby-<<matrix.ruby>>-<<matrix.database>>-<<#matrix.paperclip>>paperclip<</matrix.paperclip>><<^matrix.paperclip>>activestorage<</matrix.paperclip>>"
-          matrix: { parameters: { rails: ['7.0', '7.1'], ruby: ['3.0'], database: ['mysql'], paperclip: [true] } }
+          matrix:
+            {
+              parameters:
+                {
+                  rails: ["7.0", "7.1"],
+                  ruby: ["3.0"],
+                  database: ["mysql"],
+                  paperclip: [true],
+                },
+            }
       - test_solidus:
           name: *name
-          matrix: { parameters: { rails: ['7.0', '7.1'], ruby: ['3.1'], database: ['postgres'], paperclip: [false] } }
+          matrix:
+            {
+              parameters:
+                {
+                  rails: ["7.0", "7.1"],
+                  ruby: ["3.1"],
+                  database: ["postgres"],
+                  paperclip: [false],
+                },
+            }
       - test_solidus:
           name: *name
-          matrix: { parameters: { rails: ['7.0', '7.1'], ruby: ['3.2'], database: ['sqlite'], paperclip: [false] } }
+          matrix:
+            {
+              parameters:
+                {
+                  rails: ["7.0", "7.1"],
+                  ruby: ["3.2"],
+                  database: ["sqlite"],
+                  paperclip: [false],
+                },
+            }


### PR DESCRIPTION
## Summary

In 66b325fb62a2031e8403c0d2dbfee416cb2c7bda we wanted to run the
    installer test with Rails 7.1 but forgot to change this line as well.