### PR TITLE
Fix install_lookbook step

### DIFF
--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -38,7 +38,10 @@ module SolidusAdmin
           gem "actioncable"
         end
 
-        execute_command :bundle, :install
+        require 'bundler'
+        Bundler.with_unbundled_env do
+          execute_command :bundle, :install
+        end
 
         route "mount Lookbook::Engine, at: '#{solidus_mount_point}lookbook' if Rails.env.development?"
       end


### PR DESCRIPTION
## Summary

It appeared that `execute_command :bundle, :install` alone won't install the gems (if for example you switched to a new ruby and run the generator for the first time), since Bundler "locks" the environment after we run the generator and won't install anything, so we need to unbundle.

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
