### PR TITLE
Separate order mailer subscriber from reimbursement mailer subscriber

### DIFF
--- a/core/app/subscribers/spree/order_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/order_mailer_subscriber.rb
@@ -9,10 +9,6 @@ module Spree
            with: :send_confirmation_email,
            id: :spree_order_mailer_send_confirmation_email
 
-    handle :reimbursement_reimbursed,
-           with: :send_reimbursement_email,
-           id: :spree_order_mailer_send_reimbursement_email
-
     # Sends confirmation email to the user
     #
     # @param event [Omnes::UnstructuredEvent]
@@ -24,12 +20,9 @@ module Spree
       end
     end
 
-    # Sends reimbursement email to the user
-    #
-    # @param event [Omnes::UnstructuredEvent]
-    def send_reimbursement_email(event)
-      reimbursement = event[:reimbursement]
-      Spree::Config.reimbursement_mailer_class.reimbursement_email(reimbursement.id).deliver_later
-    end
+    def send_reimbursement_email(_event) = nil
+    deprecate send_reimbursement_email:
+      "use Spree::ReimbursementMailerSubscriber#send_reimbursement_email instead",
+      deprecator: Spree.deprecator
   end
 end

--- a/core/app/subscribers/spree/reimbursement_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/reimbursement_mailer_subscriber.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Spree
+  # Mailing after a reimbursement is successful for a {Spree::Order}
+  class ReimbursementMailerSubscriber
+    include Omnes::Subscriber
+
+    handle :reimbursement_reimbursed,
+           with: :send_reimbursement_email,
+           id: :spree_order_mailer_send_reimbursement_email
+
+    # Sends reimbursement email to the user
+    #
+    # @param event [Omnes::UnstructuredEvent]
+    def send_reimbursement_email(event)
+      reimbursement = event[:reimbursement]
+      Spree::Config.reimbursement_mailer_class.reimbursement_email(reimbursement.id).deliver_later
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -69,6 +69,7 @@ module Spree
           ].each { |event_name| Spree::Bus.register(event_name) }
 
           Spree::OrderMailerSubscriber.new.subscribe_to(Spree::Bus)
+          Spree::ReimbursementMailerSubscriber.new.subscribe_to(Spree::Bus)
         end
       end
 

--- a/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Spree::OrderMailerSubscriber do
 
   before do
     bus.register(:order_finalized)
-    bus.register(:reimbursement_reimbursed)
 
     described_class.new.subscribe_to(bus)
   end
@@ -39,13 +38,15 @@ RSpec.describe Spree::OrderMailerSubscriber do
     end
   end
 
-  describe 'on :reimbursement_reimbursed' do
-    it 'sends reimbursement email' do
-      reimbursement = build(:reimbursement)
+  describe "#send_reimbursement_email" do
+    subject { described_class.new.send_reimbursement_email({}) }
 
-      expect(Spree::ReimbursementMailer).to receive(:reimbursement_email).and_call_original
-
-      bus.publish(:reimbursement_reimbursed, reimbursement:)
+    it "results in a deprecation warning" do
+      if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
+        expect { subject }.to raise_error(ActiveSupport::DeprecationException)
+      else
+        expect(subject).to eq nil
+      end
     end
   end
 end

--- a/core/spec/subscribers/spree/reimbursement_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/reimbursement_mailer_subscriber_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'action_mailer'
+
+RSpec.describe Spree::ReimbursementMailerSubscriber do
+  let(:bus) { Omnes::Bus.new }
+
+  before do
+    bus.register(:reimbursement_reimbursed)
+
+    described_class.new.subscribe_to(bus)
+  end
+
+  describe 'on :reimbursement_reimbursed' do
+    it 'sends reimbursement email' do
+      reimbursement = build(:reimbursement)
+
+      expect(Spree::ReimbursementMailer).to receive(:reimbursement_email).and_call_original
+
+      bus.publish(:reimbursement_reimbursed, reimbursement:)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The `OrderMailerSubscriber` provided subscribers that depend on both the configurable `OrderMailer` and the `ReimbursementMailer`, which are separate. This change moves the code towards betting  honouring the single responsibility principle.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
