### PR TITLE
Respect Spree.user_class' table name in metadata migration

### DIFF
--- a/core/db/migrate/20250129061658_add_metadata_to_spree_resources.rb
+++ b/core/db/migrate/20250129061658_add_metadata_to_spree_resources.rb
@@ -11,17 +11,16 @@ class AddMetadataToSpreeResources < ActiveRecord::Migration[7.2]
       spree_refunds
       spree_customer_returns
       spree_store_credit_events
-      spree_users
       spree_return_authorizations
     ].each do |table_name|
       change_table table_name do |t|
         # Check if the database supports jsonb for efficient querying
         if t.respond_to?(:jsonb)
-          add_column table_name, :customer_metadata, :jsonb, default: {}
-          add_column table_name, :admin_metadata, :jsonb, default: {}
+          t.jsonb(:customer_metadata, default: {}) unless t.column_exists?(:customer_metadata)
+          t.jsonb(:admin_metadata, default: {}) unless t.column_exists?(:admin_metadata)
         else
-          add_column table_name, :customer_metadata, :json
-          add_column table_name, :admin_metadata, :json
+          t.json(:customer_metadata) unless t.column_exists?(:customer_metadata)
+          t.json(:admin_metadata) unless t.column_exists?(:admin_metadata)
         end
       end
     end

--- a/core/db/migrate/20250221152004_add_metadata_to_users.rb
+++ b/core/db/migrate/20250221152004_add_metadata_to_users.rb
@@ -1,0 +1,13 @@
+class AddMetadataToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table Spree.user_class.table_name do |t|
+      if t.respond_to?(:jsonb)
+        t.jsonb(:customer_metadata, default: {}) unless t.column_exists?(:customer_metadata)
+        t.jsonb(:admin_metadata, default: {}) unless t.column_exists?(:admin_metadata)
+      else
+        t.json(:customer_metadata) unless t.column_exists?(:customer_metadata)
+        t.json(:admin_metadata) unless t.column_exists?(:admin_metadata)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A `Spree.user_class` might have a different `table_name` than `spree_users`. In order to support this we need to ask the class for it's `table_name`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
