### PR TITLE
[Promotions] Set Flickwerk patches in initializer

### DIFF
--- a/promotions/lib/solidus_promotions/engine.rb
+++ b/promotions/lib/solidus_promotions/engine.rb
@@ -6,7 +6,6 @@ require "solidus_support"
 module SolidusPromotions
   class Engine < Rails::Engine
     include SolidusSupport::EngineExtensions
-    Flickwerk.aliases["Spree::Config.order_recalculator_class"] = Spree::Config.order_recalculator_class_name
 
     isolate_namespace ::SolidusPromotions
 
@@ -15,6 +14,10 @@ module SolidusPromotions
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec
+    end
+
+    initializer "solidus_promotions.flickwerk_alias" do
+      Flickwerk.aliases["Spree::Config.order_recalculator_class"] = Spree::Config.order_recalculator_class_name
     end
 
     initializer "solidus_promotions.assets" do |app|

--- a/promotions/spec/lib/solidus_promotions/engine_spec.rb
+++ b/promotions/spec/lib/solidus_promotions/engine_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusPromotions::Engine do
+  describe "initializer.flickwerk_alias" do
+    it "sets the Flickwerk alias for order_recalculator_class" do
+      Flickwerk.aliases["Spree::Config.order_recalculator_class"] = nil
+
+      require "solidus_promotions/engine"
+      expect(Flickwerk.aliases["Spree::Config.order_recalculator_class"]).to be_nil
+
+      initializer = SolidusPromotions::Engine.initializers.find { |i| i.name == "solidus_promotions.flickwerk_alias" }
+      initializer.run
+      expect(Flickwerk.aliases["Spree::Config.order_recalculator_class"]).to eq("Spree::OrderUpdater")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We need to be sure that the app is fully loaded before setting Flickwerk aliases. Otherwise ie. `Spree::Config` includes default class names even if set differently from the Rails app or extensions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
