### PR TITLE
Better Spree::UserAddress scope deprecation warnings

### DIFF
--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -15,13 +15,13 @@ module Spree
     end
 
     scope :all_historical, -> {
-      Spree::Deprecation.warn("This scope does not do anything and will be removed from Solidus 5.")
+      Spree.deprecator.warn("The 'Spree::UserAddress.all_historical` scope does not do anything and will be removed from Solidus 5.")
       all
     }
     scope :default_shipping, -> { where(default: true) }
     scope :default_billing, -> { where(default_billing: true) }
     scope :active, -> {
-      Spree::Deprecation.warn("This scope does not do anything and will be removed from Solidus 5.")
+      Spree.deprecator.warn("The 'Spree::UserAddress.active` scope does not do anything and will be removed from Solidus 5.")
       all
     }
 

--- a/legacy_promotions/app/models/spree/promotion.rb
+++ b/legacy_promotions/app/models/spree/promotion.rb
@@ -204,11 +204,7 @@ module Spree
 
       if eligible?(order, promotion_code:)
         rules = eligible_rules(order)
-        if rules.blank?
-          true
-        else
-          rules.all? { |rule| rule.actionable? line_item }
-        end
+        rules.blank? || rules.all? { |rule| rule.actionable? line_item }
       else
         false
       end


### PR DESCRIPTION
Without the class and scope name it is very hard to find the offending code.
