### PR TITLE
GH: Allow backport workflow to trigger actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   backport:
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true


### PR DESCRIPTION
We need this otherwise the created pull request from the backport tool will not trigger any actions (like linting) to run.
