### PR TITLE
Add new order events

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -848,6 +848,8 @@ module Spree
       send_cancel_email
       update_column(:canceled_at, Time.current)
       recalculate
+
+      Spree::Bus.publish :order_canceled, order: self
     end
 
     def cancel_shipments!

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -50,6 +50,7 @@ class Spree::OrderCancellations
       end
     end
 
+    Spree::Bus.publish(:order_short_shipped, order: @order, inventory_units:)
     unit_cancels
   end
 

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -72,6 +72,7 @@ class Spree::OrderShipping
     @order.shipments.reload
     @order.recalculate
 
+    Spree::Bus.publish(:carton_shipped, carton:)
     carton
   end
 

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -65,6 +65,7 @@ module Spree
             order_emptied
             order_finalized
             order_recalculated
+            order_short_shipped
             reimbursement_reimbursed
             reimbursement_errored
           ].each { |event_name| Spree::Bus.register(event_name) }

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -61,6 +61,7 @@ module Spree
           Spree::Bus.clear
 
           %i[
+            order_canceled
             order_emptied
             order_finalized
             order_recalculated

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -61,6 +61,7 @@ module Spree
           Spree::Bus.clear
 
           %i[
+            carton_shipped
             order_canceled
             order_emptied
             order_finalized

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -94,6 +94,15 @@ RSpec.describe Spree::OrderCancellations do
       expect { subject }.to change { order.shipment_state }.from('ready').to('shipped')
     end
 
+    it "publishes an 'order_short_shipped' event" do
+      stub_spree_bus
+
+      subject
+
+      expect(:order_short_shipped)
+        .to have_been_published.with(order:, inventory_units: [inventory_unit])
+    end
+
     it "adjusts the order" do
       expect { subject }.to change { order.reload.total }.by(-10.0)
     end

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe Spree::OrderShipping do
       it "sets the external_number" do
         expect(subject.external_number).to eq 'some-external-number'
       end
+
+      it "publishes a 'carton_shipped' event" do
+        stub_spree_bus
+
+        expect(:carton_shipped).to have_been_published.with(carton: subject)
+      end
     end
 
     context "with a tracking number" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -82,8 +82,17 @@ RSpec.describe Spree::Order, type: :model do
   end
 
   describe "#cancel!" do
-    let!(:order) { create(:completed_order_with_totals) }
     subject { order.cancel! }
+
+    let!(:order) { create(:completed_order_with_totals) }
+
+    it "publishes a 'order_canceled' event" do
+      stub_spree_bus
+
+      subject
+
+      expect(:order_canceled).to have_been_published.with(order:)
+    end
 
     it "sends a cancel email" do
       perform_enqueued_jobs { subject }

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -16,6 +16,7 @@ require 'database_cleaner'
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
+require 'spree/testing_support/bus_helpers'
 require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/rake'
@@ -45,6 +46,7 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 
+  config.include Spree::TestingSupport::BusHelpers
   config.include Spree::TestingSupport::JobHelpers
 
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Summary

This pull request adds three new order-related events to the event system:

- `:order_canceled`
- `:order_short_shipped`
- `:carton_shipped`

We were motivated to make this change so that we can, in the future, send transaction emails for these events via subscribers. We already do this for order confirmation emails and reimbursement emails. Aligning all mailers to work the same way seems like an improvement.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

