### PR TITLE
[Docs] Fix Meta Data Restriction Comment to reflect default setting

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -222,7 +222,7 @@ module Spree
     #   - The maximum number of keys that can be added to the metadata columns (meta_data_max_keys).
     #   - The maximum length of each key in the metadata columns (meta_data_max_key_length).
     #   - The maximum length of each value in the metadata columns (meta_data_max_value_length).
-    #   (default: +true+)
+    #   (default: +false+)
     preference :meta_data_validation_enabled, :boolean, default: false
 
     # @!attribute [rw] meta_data_max_keys


### PR DESCRIPTION
The comment was inconsistent with the default setting.  No functional changes have been made.

## Summary

The comment related to the configuration of meta data was incorrect. 
No functional changes have been made. 
 
## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
