### PR TITLE
[Admin] Fix Unclosed form_tag in table component

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -88,9 +88,10 @@
   <% end %>
 
   <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "batchToolbar", role: "toolbar", "aria-label": t(".batch_actions"), hidden: true) do %>
-    <%= form_tag '', id: batch_actions_form_id %>
-    <% @data.batch_actions.each do |batch_action| %>
-      <%= render_batch_action_button(batch_action) %>
+    <%= form_tag '', id: batch_actions_form_id do %>
+      <% @data.batch_actions.each do |batch_action| %>
+        <%= render_batch_action_button(batch_action) %>
+      <% end %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
## Summary

This PR fixes an HTML structure break caused by an unclosed form_tag, ensuring that forms added after using ui/table are rendered correctly.

## Background

While customizing the index page to add a new form, I encountered a problem where the added form was not displayed in the browser. Upon investigation, I discovered that the issue stemmed from the form_tag in ui/table/component.html.erb not being explicitly closed, which resulted in subsequent form tags disappearing.

``` rb
<%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "batchToolbar", role: "toolbar", "aria-label": t(".batch_actions"), hidden: true) do %>
  <%= form_tag '', id: batch_actions_form_id %>
  <% @data.batch_actions.each do |batch_action| %>
    <%= render_batch_action_button(batch_action) %>
  <% end %>
<% end %>
```

Due to the lack of a proper block structure closing the form_tag, the HTML became malformed, and any form tags declared afterward were not rendered.

Updated the form_tag to use a block form, ensuring that the opening and closing tags are explicitly defined.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
