### PR TITLE
Fix ui/forms/input component for tag: :textarea

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/input/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/input/component.rb
@@ -91,6 +91,8 @@ class SolidusAdmin::UI::Forms::Input::Component < SolidusAdmin::BaseComponent
   def call
     if @tag == :select && @attributes[:choices]
       with_content options_for_select(@attributes.delete(:choices), @attributes.delete(:value))
+    elsif @tag == :textarea && @attributes[:value]
+      with_content @attributes.delete(:value)
     end
 
     build_tag

--- a/admin/spec/components/solidus_admin/ui/forms/input/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/forms/input/component_spec.rb
@@ -41,4 +41,34 @@ RSpec.describe SolidusAdmin::UI::Forms::Input::Component, type: :component do
       expect(page).to have_css("input[type='date'][name='name'][value='2020-01-01']")
     end
   end
+
+  describe "with `tag: :textarea`" do
+    let(:element) { page.find("textarea") }
+
+    context "with value passed" do
+      let(:component) { described_class.new(tag: :textarea, name: "name", value: "Text inside a textarea") }
+
+      it "renders textarea with value" do
+        render_inline(component)
+
+        aggregate_failures do
+          expect(element).to have_content("Text inside a textarea")
+          expect(element.value).to eq("Text inside a textarea")
+        end
+      end
+    end
+
+    context "without value passed" do
+      let(:component) { described_class.new(tag: :textarea, name: "name") }
+
+      it "renders textarea" do
+        render_inline(component)
+
+        aggregate_failures do
+          expect(element.text).to be_blank
+          expect(element.value).to be_blank
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #6167
## Summary
From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea):
> In HTML, the initial content of a <textarea> is specified between its opening and closing tags, not as a `value` attribute.

Therefore we must set `content`, rather than passing `value` for text areas.

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
