### PR TITLE
[v4.5] GH: Allow backport workflow to trigger actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   backport:
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.5`:
 - [Merge pull request #6164 from blish/backport-actions-permission](https://github.com/solidusio/solidus/pull/6164)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)