### PR TITLE
Revert "GH: Allow backport workflow to trigger actions"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,10 +5,6 @@ on:
 
 jobs:
   backport:
-    permissions:
-      contents: read
-      pull-requests: write
-      actions: write
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true


### PR DESCRIPTION
Reverts solidusio/solidus#6164

From my comment on #6179 

> This does not help. It only triggers the workflow when a user with workflow permissions create the PR (me in this case). But it does not work if another action creates a PR with the default GITHUB_TOKEN github creates.

See https://github.com/sorenlouv/backport-github-action/issues/79 for background