### PR TITLE
[v4.5] [Docs] Fix Meta Data Restriction Comment to reflect default setting

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -222,7 +222,7 @@ module Spree
     #   - The maximum number of keys that can be added to the metadata columns (meta_data_max_keys).
     #   - The maximum length of each key in the metadata columns (meta_data_max_key_length).
     #   - The maximum length of each value in the metadata columns (meta_data_max_value_length).
-    #   (default: +true+)
+    #   (default: +false+)
     preference :meta_data_validation_enabled, :boolean, default: false
 
     # @!attribute [rw] meta_data_max_keys


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.5`:
 - [Merge pull request #6171 from fthobe/fix-default-meta-data-config](https://github.com/solidusio/solidus/pull/6171)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)