### PR TITLE
[v4.5] [Admin] Fix Unclosed form_tag in table component

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -88,9 +88,10 @@
   <% end %>
 
   <%= render component("ui/table/toolbar").new("data-#{stimulus_id}-target": "batchToolbar", role: "toolbar", "aria-label": t(".batch_actions"), hidden: true) do %>
-    <%= form_tag '', id: batch_actions_form_id %>
-    <% @data.batch_actions.each do |batch_action| %>
-      <%= render_batch_action_button(batch_action) %>
+    <%= form_tag '', id: batch_actions_form_id do %>
+      <% @data.batch_actions.each do |batch_action| %>
+        <%= render_batch_action_button(batch_action) %>
+      <% end %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.5`:
 - [Merge pull request #6172 from swamp09/fix_unclosed_form_tag_in_admin_table_component](https://github.com/solidusio/solidus/pull/6172)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)