### PR TITLE
Inherit from ActiveRecord::Migration version for all supported Rails

### DIFF
--- a/core/db/migrate/20250129061658_add_metadata_to_spree_resources.rb
+++ b/core/db/migrate/20250129061658_add_metadata_to_spree_resources.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMetadataToSpreeResources < ActiveRecord::Migration[7.2]
+class AddMetadataToSpreeResources < ActiveRecord::Migration[7.0]
   def change
     # List of Resources to add metadata columns to
     %i[


### PR DESCRIPTION
## Summary

When attempting to run this migration on Rails 7.0 or Rails 7.1, an error is produced if the version of the migration is `7.2`

```
ArgumentError: Unknown migration version "7.2"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0", "6.1", "7.0", "7.1" (ArgumentError)
```

Since Rails versions 7.0, 7.1, and 7.2 are currently supported, this migration should conform to, and inherit from, Rails 7.0 migrations.

This issue causes failures in some [extension tests](https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_globalize/353/workflows/ef8b07fb-f999-4cb2-b47c-4c8a58cbbe40/jobs/769) that load Solidus main against Rails 7.1.

In this case, it appears to be triggered via the [`test_app` rake task](https://github.com/solidusio/solidus/blob/main/core/lib/spree/testing_support/common_rake.rb#L51).
We don't quite do the same in our `.circleci` against this repo, which is probably why we're not seeing this failure here.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
