### PR TITLE
Use `human_attribute_name` for promo calculator labels

### DIFF
--- a/promotions/config/locales/en.yml
+++ b/promotions/config/locales/en.yml
@@ -311,6 +311,7 @@ en:
         preferred_currency: Currency
       solidus_promotions/calculators/percent:
         description: Provides a discount calculated by percent of the discountable amount of the item being discounted
+        preferred_percent: Percent
       solidus_promotions/calculators/distributed_amount:
         description: Distributes the configured amount among all eligible line items of the order.
         explanation: |
@@ -350,6 +351,7 @@ en:
             </tbody>
           </table>
         preferred_amount: Amount
+        preferred_currency: Currency
 
     errors:
       models:

--- a/promotions/lib/views/backend/solidus_promotions/admin/calculator_fields/_default_fields.html.erb
+++ b/promotions/lib/views/backend/solidus_promotions/admin/calculator_fields/_default_fields.html.erb
@@ -2,5 +2,5 @@
   <%= render "solidus_promotions/admin/shared/preference_fields/#{calculator.preference_type(name)}",
     name: "#{prefix}[calculator_attributes][preferred_#{name}]",
     value: calculator.get_preference(name),
-    label: t(name.to_s, scope: 'spree', default: name.to_s.humanize) %>
+    label: calculator.class.human_attribute_name("preferred_#{name}", default: I18n.t(name, scope: :spree, default: name.humanize)) %>
 <% end %>


### PR DESCRIPTION

## Summary

Promotion calculators have preferences, and these need to be translated with the correct scope.

When you specify a preference for a calculator, a virtual attribute is generated. For example:

```
class MyCalculator < Spree::Calculator
  preference :percent, :integer, default: 10
end
```

In this scenario, we get a virtual attribute `preferred_percent` on the `MyCalculator` class. The expectation is that then one can translated that attribute by calling `MyCalculator.human_attribute_name(:preferred_percent)`, and - crucially - that this attribute is used in form labels.

While all other calculator forms use this (through `form.label :preferred_percent`) or similar, the default form did not, and instead used `I18n.t(:percent, scope: :spree)`, which is not specific to the calculator, and might lead to mistranslations.


- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
