### PR TITLE
Fix Rubocop offense

### DIFF
--- a/legacy_promotions/app/models/spree/promotion/rules/first_order.rb
+++ b/legacy_promotions/app/models/spree/promotion/rules/first_order.rb
@@ -14,7 +14,7 @@ module Spree
           @user = order.try(:user) || options[:user]
           @email = order.email
 
-          if (user || email) && (completed_orders.present? && completed_orders.first != order)
+          if (user || email) && completed_orders.present? && completed_orders.first != order
             eligibility_errors.add(:base, eligibility_error_message(:not_first_order), error_code: :not_first_order)
           end
 

--- a/promotions/app/models/solidus_promotions/conditions/first_order.rb
+++ b/promotions/app/models/solidus_promotions/conditions/first_order.rb
@@ -10,7 +10,7 @@ module SolidusPromotions
         @user = order.try(:user) || options[:user]
         @email = order.email
 
-        if (user || email) && (completed_orders.present? && completed_orders.first != order)
+        if (user || email) && completed_orders.present? && completed_orders.first != order
           eligibility_errors.add(:base, eligibility_error_message(:not_first_order), error_code: :not_first_order)
         end
 


### PR DESCRIPTION
Rubocop updated, and we have new offenses.


- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
