### PR TITLE
Fix flaky specs

### DIFF
--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -51,6 +51,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   browser_options.args << '--window-size=1920,1080'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
@@ -60,6 +61,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
   # Sandbox cannot be used inside unprivileged Docker container
   browser_options.args << '--no-sandbox'
   browser_options.args << '--window-size=1240,1400'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -35,6 +35,7 @@ describe "Shipping Methods", type: :feature do
       end
 
       click_on "Create"
+      expect(page).to have_content("Shipping Method \"bullock cart\" has been successfully created!")
       expect(current_path).to eql(spree.edit_admin_shipping_method_path(Spree::ShippingMethod.last))
 
       visit spree.new_admin_shipping_method_path

--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -33,25 +33,14 @@ describe 'Customer returns', type: :feature do
       end
     end
 
-    it 'disables the button at submit', :js do
-      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-
-      create_customer_return('receive')
-
-      expect(page).to have_button("Create", disabled: true)
+    it 'disables the button at submit' do
+      expect(page).to have_css('input[type="submit"][data-disable-with="Create"]')
     end
 
     context 'when creating a return with state "In Transit" and then marking it as "Received"' do
       it 'disables the "Receive" button at submit', :js do
         create_customer_return('in_transit')
-
-        page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-
-        within('[data-hook="rejected_return_items"] tbody tr:nth-child(1)') do
-          click_button('Receive')
-
-          expect(page).to have_button("Receive", disabled: true, wait: 5)
-        end
+        expect(page).to have_css('input[type="submit"][data-disable-with="Receive"]')
       end
 
       it 'marks the order as returned', :js do

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -47,11 +47,14 @@ describe "New Order", type: :feature do
 
     click_on "Payments"
     click_on "Update"
+    expect(page).to have_content("Payment has been successfully created!")
 
     expect(current_path).to eql(spree.admin_order_payments_path(Spree::Order.last))
 
     click_on "Confirm"
     click_on "Complete Order"
+
+    expect(page).to have_content("Order completed")
 
     expect(current_path).to eql(spree.edit_admin_order_path(Spree::Order.last))
 

--- a/backend/spec/features/admin/orders/return_payment_state_spec.rb
+++ b/backend/spec/features/admin/orders/return_payment_state_spec.rb
@@ -67,14 +67,9 @@ describe "Return payment state spec" do
     )
   end
 
-  it 'disables the "Create Reimbursement" button at submit', :js do
+  it 'disables the "Create Reimbursement" button at submit' do
     create_customer_return
 
-    page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-
-    # Create reimbursement
-    click_on 'Create reimbursement'
-
-    expect(page).to have_button("Create reimbursement", disabled: true)
+    expect(page).to have_css("input[type='submit'][data-disable-with='Create reimbursement']")
   end
 end

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -98,6 +98,7 @@ describe "Product Images", type: :feature do
         end
 
         click_button "Update"
+        expect(page).to have_content("Image has been successfully created!")
         invalidate_attachment(Spree::Image.first.attachment)
         visit current_path
         expect(page).to have_xpath("//img[contains(@src, 'assets/noimage/mini')]")

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -58,6 +58,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   browser_options.args << '--window-size=1920,1080'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
@@ -67,6 +68,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
   # Sandbox cannot be used inside unprivileged Docker container
   browser_options.args << '--no-sandbox'
   browser_options.args << '--window-size=1240,1400'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 

--- a/legacy_promotions/spec/features/backend/promotion_adjustments_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotion_adjustments_spec.rb
@@ -167,13 +167,8 @@ RSpec.describe "Promotion Adjustments", type: :feature, js: true do
       expect(promotion.actions.first).to be_a(Spree::Promotion::Actions::FreeShipping)
     end
 
-    it "disables the button at submit", :js do
-      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-      fill_in "Name", with: "SAVE SAVE SAVE"
-      choose "Apply to all orders"
-      click_button "Create"
-
-      expect(page).to have_button("Create", disabled: true)
+    it "disables the button at submit" do
+      expect(page).to have_css("input[type='submit'][data-disable-with='Create']")
     end
 
     it "should allow an admin to create an automatic promotion" do

--- a/legacy_promotions/spec/features/backend/promotions/option_value_rule_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/option_value_rule_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "rails_helper"
 
 RSpec.feature 'Promotion with option value rule' do
   stub_authorization!

--- a/legacy_promotions/spec/features/backend/promotions/product_rule_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/product_rule_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "rails_helper"
 
 RSpec.feature 'Promotion with product rule', js: true do
   stub_authorization!

--- a/legacy_promotions/spec/features/backend/promotions/promotion_categories_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/promotion_categories_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "rails_helper"
 
 RSpec.describe 'Promotion Categories', type: :feature do
   stub_authorization!

--- a/legacy_promotions/spec/features/backend/promotions/promotion_code_batches_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/promotion_code_batches_spec.rb
@@ -23,18 +23,14 @@ RSpec.feature "Promotion Code Batches", partial_double_verification: false do
       expect(page).to_not have_field("promotion_per_code_usage_limit")
     end
 
-    it "creates a new promotion code batch and disables the submit button", :js do
+    it "creates a new promotion code batch and disables the submit button" do
       create_code_batch
 
       expect(page).to have_content "Promotion Code Batch has been successfully created!"
 
       visit spree.new_admin_promotion_promotion_code_batch_path(promotion)
 
-      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-
-      create_code_batch
-
-      expect(page).to have_button("Create", disabled: true)
+      expect(page).to have_css("input[type='submit'][data-disable-with='Create']")
     end
   end
 end

--- a/legacy_promotions/spec/features/backend/promotions/promotion_code_batches_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/promotion_code_batches_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.feature "Promotion Code Batches", partial_double_verification: false do
   stub_authorization!

--- a/legacy_promotions/spec/features/backend/promotions/promotion_code_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/promotion_code_spec.rb
@@ -19,13 +19,8 @@ RSpec.feature "Promotion Codes" do
       expect(page).to have_content "Promotion Code has been successfully created!"
     end
 
-    it "disables the button at submit", :js do
-      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-
-      fill_in "Value", with: "XYZ"
-      click_button "Create"
-
-      expect(page).to have_button("Create", disabled: true)
+    it "disables the button at submit" do
+      expect(page).to have_css("input[type='submit'][data-disable-with='Create']")
     end
   end
 end

--- a/legacy_promotions/spec/features/backend/promotions/promotion_code_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/promotion_code_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.feature "Promotion Codes" do
   stub_authorization!

--- a/legacy_promotions/spec/features/backend/promotions/tiered_calculator_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/tiered_calculator_spec.rb
@@ -34,6 +34,8 @@ RSpec.feature "Tiered Calculator Promotions" do
 
     within('#actions_container') { click_button "Update" }
 
+    expect(page).to have_content("Promotion \"#{promotion.name}\" has been successfully updated!")
+
     first_action = promotion.actions.first
     expect(first_action.class).to eq Spree::Promotion::Actions::CreateAdjustment
 

--- a/legacy_promotions/spec/features/backend/promotions/tiered_calculator_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/tiered_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.feature "Tiered Calculator Promotions" do
   stub_authorization!

--- a/legacy_promotions/spec/features/backend/promotions/user_rule_spec.rb
+++ b/legacy_promotions/spec/features/backend/promotions/user_rule_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "rails_helper"
 
 RSpec.feature 'Promotion with user rule', js: true do
   stub_authorization!

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -54,6 +54,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   browser_options.args << '--window-size=1920,1080'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
@@ -63,6 +64,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
   # Sandbox cannot be used inside unprivileged Docker container
   browser_options.args << '--no-sandbox'
   browser_options.args << '--window-size=1240,1400'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 

--- a/promotions/spec/rails_helper.rb
+++ b/promotions/spec/rails_helper.rb
@@ -80,6 +80,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
   browser_options.args << '--window-size=1920,1080'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
@@ -90,6 +91,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
   # Sandbox cannot be used inside unprivileged Docker container
   browser_options.args << '--no-sandbox'
   browser_options.args << '--window-size=1240,1400'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 

--- a/promotions/spec/system/solidus_promotions/backend/promotions_spec.rb
+++ b/promotions/spec/system/solidus_promotions/backend/promotions_spec.rb
@@ -127,6 +127,7 @@ RSpec.feature "Promotions admin" do
         fill_in("benefit_calculator_attributes_preferred_amount", with: 30)
         click_button("Update")
       end
+      expect(page).to have_content("Benefit has been successfully updated!")
       expect(benefit.reload.calculator.preferred_amount).to eq(30)
 
       click_link("Add Condition")


### PR DESCRIPTION
## Summary

We're experiencing another wave of flaky specs, most likely because chrome or Selenium have become faster. These changes make our test suite wait in appropriate places and stop testing Rails behaviour that we don't need to test. 

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
