### PR TITLE
Move OrderMailerSubscriber#send_confirmation_email

### DIFF
--- a/core/app/subscribers/spree/order_confirmation_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/order_confirmation_mailer_subscriber.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  # Mailing after {Spree::Order} is confirmed.
+  class OrderConfirmationMailerSubscriber
+    include Omnes::Subscriber
+
+    handle :order_finalized,
+           with: :send_confirmation_email,
+           id: :spree_order_mailer_send_confirmation_email
+
+    # Sends confirmation email to the user.
+    #
+    # @param event [Omnes::UnstructuredEvent]
+    def send_confirmation_email(event)
+      order = event[:order]
+      unless order.confirmation_delivered?
+        Spree::Config.order_mailer_class.confirm_email(order).deliver_later
+        order.update_column(:confirmation_delivered, true)
+      end
+    end
+  end
+end

--- a/core/app/subscribers/spree/order_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/order_mailer_subscriber.rb
@@ -1,24 +1,13 @@
 # frozen_string_literal: true
 
 module Spree
-  # Mailing after events on a {Spree::Order}
   class OrderMailerSubscriber
     include Omnes::Subscriber
 
-    handle :order_finalized,
-           with: :send_confirmation_email,
-           id: :spree_order_mailer_send_confirmation_email
-
-    # Sends confirmation email to the user
-    #
-    # @param event [Omnes::UnstructuredEvent]
-    def send_confirmation_email(event)
-      order = event[:order]
-      unless order.confirmation_delivered?
-        Spree::Config.order_mailer_class.confirm_email(order).deliver_later
-        order.update_column(:confirmation_delivered, true)
-      end
-    end
+    def send_confirmation_email(_event) = nil
+    deprecate send_confirmation_email:
+      "Use Spree::OrderConfirmationMailerSubscriber#send_confirmation_email instead",
+      deprecator: Spree.deprecator
 
     def send_reimbursement_email(_event) = nil
     deprecate send_reimbursement_email:

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -71,7 +71,7 @@ module Spree
             reimbursement_errored
           ].each { |event_name| Spree::Bus.register(event_name) }
 
-          Spree::OrderMailerSubscriber.new.subscribe_to(Spree::Bus)
+          Spree::OrderConfirmationMailerSubscriber.new.subscribe_to(Spree::Bus)
           Spree::ReimbursementMailerSubscriber.new.subscribe_to(Spree::Bus)
         end
       end

--- a/core/spec/subscribers/spree/order_confirmation_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/order_confirmation_mailer_subscriber_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'action_mailer'
+
+RSpec.describe Spree::OrderConfirmationMailerSubscriber do
+  let(:bus) { Omnes::Bus.new }
+
+  before do
+    bus.register(:order_finalized)
+
+    described_class.new.subscribe_to(bus)
+  end
+
+  describe 'on :on_order_finalized' do
+    it 'sends confirmation email' do
+      order = create(:order, confirmation_delivered: false)
+
+      expect(Spree::OrderMailer).to receive(:confirm_email).and_call_original
+
+      bus.publish(:order_finalized, order:)
+    end
+
+    it 'marks the order as having the confirmation email delivered' do
+      order = create(:order, confirmation_delivered: false)
+
+      bus.publish(:order_finalized, order:)
+
+      expect(order.confirmation_delivered).to be(true)
+    end
+
+    it "doesn't send confirmation email if already sent" do
+      order = build(:order, confirmation_delivered: true)
+
+      expect(Spree::OrderMailer).not_to receive(:confirm_email)
+
+      bus.publish(:order_finalized, order:)
+    end
+  end
+end

--- a/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb
@@ -12,29 +12,15 @@ RSpec.describe Spree::OrderMailerSubscriber do
     described_class.new.subscribe_to(bus)
   end
 
-  describe 'on :on_order_finalized' do
-    it 'sends confirmation email' do
-      order = create(:order, confirmation_delivered: false)
+  describe "#send_confirmation_email" do
+    subject { described_class.new.send_confirmation_email({}) }
 
-      expect(Spree::OrderMailer).to receive(:confirm_email).and_call_original
-
-      bus.publish(:order_finalized, order:)
-    end
-
-    it 'marks the order as having the confirmation email delivered' do
-      order = create(:order, confirmation_delivered: false)
-
-      bus.publish(:order_finalized, order:)
-
-      expect(order.confirmation_delivered).to be(true)
-    end
-
-    it "doesn't send confirmation email if already sent" do
-      order = build(:order, confirmation_delivered: true)
-
-      expect(Spree::OrderMailer).not_to receive(:confirm_email)
-
-      bus.publish(:order_finalized, order:)
+    it "results in a deprecation warning" do
+      if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
+        expect { subject }.to raise_error(ActiveSupport::DeprecationException)
+      else
+        expect(subject).to eq nil
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

We're moving towards having a separate subscriber for each type of transaction email. This commit ensures that `OrderMailerSubscriber` actions are all moved to subscriber classes that more accurately describe the mailer action being taken.

Now, the old `OrderMailerSubscriber` does nothing and can be removed in the next version of Solidus.

In subsequent commits we can now add additional subscribers for:

- Carton shipped transactional emails
- Short ship transactional emails
- Order cancellation transactionals emails

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
