### PR TITLE
Promotions: Add a PercentWithCap calculator

### DIFF
--- a/promotions/app/models/solidus_promotions/calculators/percent_with_cap.rb
+++ b/promotions/app/models/solidus_promotions/calculators/percent_with_cap.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusPromotions
+  module Calculators
+    class PercentWithCap < Percent
+      preference :max_amount, :integer, default: 100
+
+      def compute(line_item)
+        percent_discount = super
+        max_discount = DistributedAmount.new(
+          calculable:,
+          preferred_amount: preferred_max_amount
+        ).compute_line_item(line_item)
+
+        [percent_discount, max_discount].min
+      end
+    end
+  end
+end

--- a/promotions/config/locales/en.yml
+++ b/promotions/config/locales/en.yml
@@ -312,6 +312,9 @@ en:
       solidus_promotions/calculators/percent:
         description: Provides a discount calculated by percent of the discountable amount of the item being discounted
         preferred_percent: Percent
+      solidus_promotions/calculators/percent_with_cap:
+        description: Calculates a discount by percent of the discountable amount of the item being discounted, with a cap on the maximum discount.
+        preferred_max_amount: Maximum Amount
       solidus_promotions/calculators/distributed_amount:
         description: Distributes the configured amount among all eligible line items of the order.
         explanation: |

--- a/promotions/spec/models/solidus_promotions/calculators/percent_with_cap_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/percent_with_cap_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SolidusPromotions::Calculators::PercentWithCap, type: :model do
+  context "applied to an order" do
+    let(:calculator) { described_class.new(preferred_percent: 15, preferred_max_amount: 50) }
+    let(:promotion) do
+      create(
+        :solidus_promotion,
+        name: "15% off order. Cap of $30",
+        apply_automatically: true
+      )
+    end
+
+    let(:order) { create(:order) }
+
+    let(:variant_1) { create(:variant, price: 120) }
+    let(:variant_2) { create(:variant, price: 230) }
+    let(:variant_3) { create(:variant, price: 300) }
+
+    before do
+      SolidusPromotions::Benefits::AdjustLineItem.create!(calculator: calculator, promotion: promotion)
+      [variant_1, variant_2, variant_3].each do |variant|
+        order.contents.add(variant, 1)
+      end
+    end
+
+    it "correctly distributes the entire discount" do
+      expect(order.promo_total).to eq(-50)
+      expect(order.line_items.map(&:adjustment_total)).to eq([-9.24, -17.69, -23.07])
+    end
+
+    context "with a less expensive order" do
+      let(:variant_1) { create(:variant, price: 12) }
+      let(:variant_2) { create(:variant, price: 23) }
+      let(:variant_3) { create(:variant, price: 10) }
+
+      it "correctly calculates 15%" do
+        # 15% of 45 is 6.75, which is less than the max amount of 50
+        expect(order.promo_total).to eq(-6.75)
+        # 1.8 + 3.45 + 1.5 = 6.75
+        expect(order.line_items.map(&:adjustment_total)).to eq([-1.8, -3.45, -1.5])
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Summary

This promotion calculator allows creating a promotion that will give a percentage off all orders, with a cap on the total amount. (So something like "15% of all orders up to a maximum discount of 50 USD).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
