### PR TITLE
Use semantic links to edit option types

### DIFF
--- a/admin/app/components/solidus_admin/option_types/index/component.rb
+++ b/admin/app/components/solidus_admin/option_types/index/component.rb
@@ -5,10 +5,6 @@ class SolidusAdmin::OptionTypes::Index::Component < SolidusAdmin::UI::Pages::Ind
     Spree::OptionType
   end
 
-  def row_url(option_type)
-    spree.edit_admin_option_type_path(option_type)
-  end
-
   def sortable_options
     {
       url: ->(option_type) { solidus_admin.move_option_type_path(option_type) },
@@ -55,7 +51,8 @@ class SolidusAdmin::OptionTypes::Index::Component < SolidusAdmin::UI::Pages::Ind
     {
       header: :name,
       data: ->(option_type) do
-        content_tag :div, option_type.name
+        link_to option_type.name, edit_path(option_type),
+        class: 'body-link'
       end
     }
   end
@@ -63,9 +60,11 @@ class SolidusAdmin::OptionTypes::Index::Component < SolidusAdmin::UI::Pages::Ind
   def presentation_column
     {
       header: :presentation,
-      data: ->(option_type) do
-        content_tag :div, option_type.presentation
-      end
+      data: ->(option_type) { option_type.presentation }
     }
+  end
+
+  def edit_path(option_type)
+    spree.edit_admin_option_type_path(option_type)
   end
 end


### PR DESCRIPTION
## Summary

This brings the index component to the new style introduced in https://github.com/solidusio/solidus/pull/6046.

This is a small change in preparation for further work that will be done as part of https://github.com/solidusio/solidus/issues/6125.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
