### PR TITLE
Add subscribers for inventory cancellation and order cancellation emails

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -845,7 +845,6 @@ module Spree
       cancel_shipments!
       cancel_payments!
 
-      send_cancel_email
       update_column(:canceled_at, Time.current)
       recalculate
 
@@ -863,10 +862,6 @@ module Spree
 
         payment.cancel!
       end
-    end
-
-    def send_cancel_email
-      Spree::Config.order_mailer_class.cancel_email(self).deliver_later
     end
 
     def after_resume

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -40,7 +40,6 @@ class Spree::OrderCancellations
         end
 
         update_shipped_shipments(inventory_units)
-        Spree::Config.order_mailer_class.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
       end
 
       @order.recalculate

--- a/core/app/subscribers/spree/order_cancel_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/order_cancel_mailer_subscriber.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Spree
+  # Mailing after {Spree::Order} is cancelled.
+  class OrderCancelMailerSubscriber
+    include Omnes::Subscriber
+
+    handle :order_canceled,
+           with: :send_cancel_email,
+           id: :spree_order_mailer_send_cancel_email
+
+    # Sends cancellation email to the user.
+    #
+    # @param event [Omnes::UnstructuredEvent]
+    def send_cancel_email(event)
+      order = event[:order]
+
+      Spree::Config.order_mailer_class.cancel_email(order).deliver_later
+    end
+  end
+end

--- a/core/app/subscribers/spree/order_inventory_cancellation_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/order_inventory_cancellation_mailer_subscriber.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Spree
+  # Mailing after inventory units have been cancelled from a {Spree::Order}
+  class OrderInventoryCancellationMailerSubscriber
+    include Omnes::Subscriber
+
+    handle :order_short_shipped,
+           with: :send_inventory_cancellation_email,
+           id: :spree_order_mailer_send_inventory_cancellation_email
+
+    # Sends inventory cancellation email to the user.
+    #
+    # @param event [Omnes::UnstructuredEvent]
+    def send_inventory_cancellation_email(event)
+      return unless Spree::OrderCancellations.send_cancellation_mailer
+
+      order = event[:order]
+      inventory_units = event[:inventory_units]
+
+      Spree::Config
+        .order_mailer_class
+        .inventory_cancellation_email(order, inventory_units.to_a)
+        .deliver_later
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -73,6 +73,7 @@ module Spree
 
           Spree::CartonShippedMailerSubscriber.new.subscribe_to(Spree::Bus)
           Spree::OrderConfirmationMailerSubscriber.new.subscribe_to(Spree::Bus)
+          Spree::OrderCancelMailerSubscriber.new.subscribe_to(Spree::Bus)
           Spree::ReimbursementMailerSubscriber.new.subscribe_to(Spree::Bus)
         end
       end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -71,10 +71,15 @@ module Spree
             reimbursement_errored
           ].each { |event_name| Spree::Bus.register(event_name) }
 
-          Spree::CartonShippedMailerSubscriber.new.subscribe_to(Spree::Bus)
-          Spree::OrderConfirmationMailerSubscriber.new.subscribe_to(Spree::Bus)
-          Spree::OrderCancelMailerSubscriber.new.subscribe_to(Spree::Bus)
-          Spree::ReimbursementMailerSubscriber.new.subscribe_to(Spree::Bus)
+          [
+            Spree::CartonShippedMailerSubscriber,
+            Spree::OrderCancelMailerSubscriber,
+            Spree::OrderConfirmationMailerSubscriber,
+            Spree::OrderInventoryCancellationMailerSubscriber,
+            Spree::ReimbursementMailerSubscriber
+          ].each do |subscriber_class|
+            subscriber_class.new.subscribe_to(Spree::Bus)
+          end
         end
       end
 

--- a/core/spec/subscribers/spree/order_cancel_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/order_cancel_mailer_subscriber_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'action_mailer'
+
+RSpec.describe Spree::OrderCancelMailerSubscriber do
+  let(:bus) { Omnes::Bus.new }
+
+  before do
+    bus.register(:order_canceled)
+
+    described_class.new.subscribe_to(bus)
+  end
+
+  describe 'on :order_canceled' do
+    it 'sends cancellation email' do
+      order = create :order
+
+      expect(Spree::OrderMailer).to receive(:cancel_email).and_call_original
+
+      bus.publish(:order_canceled, order:)
+    end
+  end
+end

--- a/core/spec/subscribers/spree/order_inventory_cancellation_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/order_inventory_cancellation_mailer_subscriber_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'action_mailer'
+
+RSpec.describe Spree::OrderInventoryCancellationMailerSubscriber do
+  let(:bus) { Omnes::Bus.new }
+
+  before do
+    bus.register(:order_short_shipped)
+
+    described_class.new.subscribe_to(bus)
+  end
+
+  describe 'on :order_short_shipped' do
+    context "when order cancellation emails are enabled" do
+      it 'sends cancellation email' do
+        order = create :order
+
+        expect(Spree::OrderMailer)
+          .to receive(:inventory_cancellation_email)
+          .and_call_original
+
+        bus.publish(:order_short_shipped, order:, inventory_units: [])
+      end
+    end
+
+    context "when order cancellation emails are disabled" do
+      around do |example|
+        original_value = Spree::OrderCancellations.send_cancellation_mailer
+        Spree::OrderCancellations.send_cancellation_mailer = false
+        example.run
+      ensure
+        Spree::OrderCancellations.send_cancellation_mailer = original_value
+      end
+
+      it 'does not send cancellation email' do
+        order = create :order
+
+        expect(Spree::OrderMailer).not_to receive(:inventory_cancellation_email)
+
+        bus.publish(:order_short_shipped, order:, inventory_units: [])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This pull request makes the order inventory cancellation and order cancellation emails send via the Solidus event system.

This brings those email processes in line with the existing order confirmation email and reimbursement email processes.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

