### PR TITLE
Proposal: Create Brand Taxon Column for Schema.org and Brand Driven Promotions

### DIFF
--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -7,7 +7,7 @@ module Spree
     preference :product_attributes, :array, default: [
       :id, :name, :description, :available_on,
       :slug, :meta_description, :meta_keywords, :shipping_category_id,
-      :taxon_ids, :total_on_hand, :meta_title, :primary_taxon_id
+      :taxon_ids, :total_on_hand, :meta_title, :primary_taxon_id, :brand_taxon_id
     ]
 
     preference :product_property_attributes, :array, default: [:id, :product_id, :property_id, :value, :property_name]

--- a/api/spec/requests/spree/api/products_spec.rb
+++ b/api/spec/requests/spree/api/products_spec.rb
@@ -323,6 +323,13 @@ module Spree::Api
           expect(json_response["primary_taxon_id"]).to eq(taxon_1.id)
         end
 
+        it "puts brand taxon for the product" do
+          product_data[:brand_taxon_id] = taxon_1.id.to_s
+          post spree.api_products_path, params: { product: product_data }
+
+          expect(json_response["brand_taxon_id"]).to eq(taxon_1.id)
+        end
+
         # Regression test for https://github.com/spree/spree/issues/4123
         it "puts the created product in the given taxons" do
           product_data[:taxon_ids] = [taxon_1.id, taxon_2.id].join(',')
@@ -416,6 +423,13 @@ module Spree::Api
           put spree.api_product_path(product), params: { product: { primary_taxon_id: taxon_1.id } }
 
           expect(json_response["primary_taxon_id"]).to eq(taxon_1.id)
+        end
+
+        it "puts brand taxon for the updated product" do
+          product.brand_taxon_id = taxon_2.id
+          put spree.api_product_path(product), params: { product: { brand_taxon_id: taxon_1.id } }
+
+          expect(json_response["brand_taxon_id"]).to eq(taxon_1.id)
         end
 
         # Regression test for https://github.com/spree/spree/issues/4123

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -84,4 +84,8 @@ Spree.ready(function () {
   $('#product_primary_taxon_id').taxonAutocomplete({
     multiple: false,
   });
+
+  $('#product_brand_taxon_id').taxonAutocomplete({
+    multiple: false,
+  });
 });

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -43,6 +43,13 @@
           <% end %>
         </div>
 
+        <div data-hook="admin_product_form_brand_taxons">
+        <%= f.field_container :brand_taxon do %>
+          <%= f.label :brand_taxon_id %><br>
+          <%= f.hidden_field :brand_taxon_id, value: @product.brand_taxon_id %>
+        <% end %>
+      </div>
+
         <div data-hook="admin_product_form_option_types">
           <%= f.field_container :option_types do %>
             <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -33,6 +33,7 @@ module Spree
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products, optional: true
     belongs_to :primary_taxon, class_name: 'Spree::Taxon', optional: true
+    belongs_to :brand_taxon, class_name: 'Spree::Taxon', optional: true
 
     has_one :master,
       -> { where(is_master: true).with_discarded },

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -166,6 +166,8 @@ en:
         variant: Variant
       spree/product:
         available_on: Available On
+        brand_taxon: Brand Taxon
+        brand_taxon_id: Brand Taxon
         condition: Master Condition
         cost_currency: Cost Currency
         cost_price: Cost Price

--- a/core/db/migrate/20250408152004_add_brand_taxon_to_products.rb
+++ b/core/db/migrate/20250408152004_add_brand_taxon_to_products.rb
@@ -1,0 +1,7 @@
+class AddBrandTaxonToProducts < ActiveRecord::Migration[7.0]
+  def change
+    change_table :spree_products do |t|
+      t.references :brand_taxon, type: :integer, foreign_key: { to_table: :spree_taxons }
+    end
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -82,7 +82,7 @@ module Spree
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,
       :taxon_ids, :option_type_ids, :cost_currency, :cost_price, :primary_taxon_id,
-      :gtin, :condition
+      :gtin, :condition, :brand_taxon_id
     ]
 
     @@property_attributes = [:name, :presentation]

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -483,6 +483,22 @@ RSpec.describe Spree::Product, type: :model do
           expect(association.class_name).to eq('Spree::Taxon')
         end
       end
+
+      describe "brand_taxon" do
+        it 'should belong to brand_taxon' do
+          expect(Spree::Product.reflect_on_association(:brand_taxon).macro).to eq(:belongs_to)
+        end
+
+        it 'should be optional' do
+          association = Spree::Product.reflect_on_association(:brand_taxon)
+          expect(association.options[:optional]).to be(true)
+        end
+
+        it 'should have a class_name of Spree::Taxon' do
+          association = Spree::Product.reflect_on_association(:brand_taxon)
+          expect(association.class_name).to eq('Spree::Taxon')
+        end
+      end
     end
   end
 
@@ -745,6 +761,14 @@ RSpec.describe Spree::Product, type: :model do
     product_with_taxon = create(:product, primary_taxon: create(:taxon))
 
     product_without_taxon = create(:product, primary_taxon: nil)
+
+    expect(product_with_taxon).to be_valid
+    expect(product_without_taxon).to be_valid
+  end
+  it 'is valid with or without a brand_taxon' do
+    product_with_taxon = create(:product, brand_taxon: create(:taxon))
+
+    product_without_taxon = create(:product, brand_taxon: nil)
 
     expect(product_with_taxon).to be_valid
     expect(product_without_taxon).to be_valid


### PR DESCRIPTION
## Summary
With the introduction of a separate Brand Taxon we save a lot of logic down the line: 
- eventual checks for which taxons could be defined as brands are not neccessary anymore (generation of feed become easier); 
- implementation of brands on frontend for structured data does not require particular logic anymore. 

Credits for most of the solution go to @JustShah 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
