### PR TITLE
Admin select component performance

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/select/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.html.erb
@@ -6,7 +6,7 @@
     <%= render component('ui/toggletip').new(text: @tip) if @tip.present? %>
   </div>
 
-  <%= tag.select(options_for_select(@choices, @selected), **@attributes) %>
+  <%= tag.select(@options_collection, **@attributes) %>
 
   <% if @hint.present? || @error.present? %>
     <div class="

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -109,10 +109,12 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
 
     dropdown_content_classes = ["[&_.dropdown-content]:flex [&_.dropdown-content]:flex-col [&_.dropdown-content]:max-h-[200px]
       [&_.dropdown-content]:overflow-x-hidden [&_.dropdown-content]:overflow-y-auto [&_.dropdown-content]:scroll-smooth
-      [&_.no-results]:text-gray-500 [&_.loading]:animate-pulse"]
+      [&_.no-results]:text-gray-500 [&_.no-results]:px-2 [&_.no-results]:py-1
+      [&_.loading]:animate-pulse [&_.loading]:italic [&_.loading]:text-gray-500 [&_.loading]:px-2 [&_.loading]:py-1"]
 
     option_classes = ["[&_.option]:p-2 [&_.option]:rounded-sm [&_.option]:min-w-fit [&_.option.active]:bg-gray-50
       [&_.option.active]:text-gray-700 [&_.option_.highlight]:bg-yellow [&_.option_.highlight]:rounded-[1px]
+      [&_.option.loading-more]:animate-pulse [&_.option.loading-more]:italic [&_.option.loading-more]:text-gray-500 [&_.option.loading-more]:text-center [&_.option.loading-more]:text-xs [&_.option.loading-more]:py-0.5 [&_.option.loading-more]:pointer-events-none
       #{HEIGHTS[:option][size]}"]
 
     @attributes[:class] = [

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -27,18 +27,17 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
 
   # Render custom select component, which uses "solidus_select" custom element
   # @see "admin/app/javascript/solidus_admin/web_components/solidus_select.js"
-  # @param choices [nil, Array<String>, Array<Array<String>>] container with options to be rendered
+  # @param choices [Array<String>, Array<Array<String>>] container with options to be rendered
   #   (see `ActionView::Helpers::FormOptionsHelper#options_for_select`).
-  #   When +nil+, a +:src+ parameter must be provided.
+  #   When +:src+ parameter is provided, use +:choices+ to provide the list of selected options only.
   # @param src [nil, String] URL of a JSON resource with options data to be loaded instead of rendering options in place.
-  #   When +nil+, a +:choices+ parameter must be provided.
   # @option attributes [String] :"data-option-value-field"
   # @option attributes [String] :"data-option-label-field" when +:src+ param is passed, value and label of loaded options
   #   will be mapped to JSON response +"id"+ and +"name"+ by default. Use these parameters to map to different keys.
   # @option attributes [String] :"data-json-path" when +:src+ param is passed and options data is nested in JSON response,
   #   specify path to it with this parameter.
   # @raise [ArgumentError] if both +:choices+ and +:src+ are nil
-  def initialize(label:, name:, choices: nil, src: nil, size: :m, hint: nil, tip: nil, error: nil, **attributes)
+  def initialize(label:, name:, choices:, src: nil, size: :m, hint: nil, tip: nil, error: nil, **attributes)
     @label = label
     @hint = hint
     @tip = tip
@@ -57,18 +56,11 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
   private
 
   def prepare_options(choices:, src:)
-    if choices.nil? && src.nil?
-      raise ArgumentError, 'You must provide either a `choices` or a `src` argument'
-    end
-
-    selected = @attributes.delete(:value)
-
     if src.present?
       @attributes[:"data-src"] = src
-      @attributes[:"data-selected"] = Array.wrap(selected).join(",") if selected.present?
-    else
-      @options_collection = options_for_select(choices, selected)
     end
+
+    @options_collection = options_for_select(choices, @attributes.delete(:value))
   end
 
   def prepare_classes(size:)

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -44,6 +44,12 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
   #   ```
   # @option attributes [String] :"data-no-preload" when +:src+ param is passed, options are preloaded when the component
   #   is initialized. Use this option to disable preload.
+  # @option attributes [String] :"data-loading-message" when +:src+ param is passed, which text to show while loading options.
+  #   Default: "Loading".
+  # @option attributes [String] :"data-loading-more-message" when +:src+ param is passed, which text to show while
+  #   loading next page of results. Default: "Loading more results".
+  # @option attributes [String] :"data-no-results-message" which text to show when there are no search results returned.
+  #   Default: "No results found".
   def initialize(label:, name:, choices:, src: nil, size: :m, hint: nil, tip: nil, error: nil, **attributes)
     @label = label
     @hint = hint
@@ -61,6 +67,13 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
   end
 
   private
+
+  # translations are not available at initialization so need to define them here
+  def before_render
+    @attributes[:"data-loading-message"] ||= t("solidus_admin.solidus_select.loading")
+    @attributes[:"data-loading-more-message"] ||= t("solidus_admin.solidus_select.loading_more")
+    @attributes[:"data-no-results-message"] ||= t("solidus_admin.solidus_select.no_results")
+  end
 
   def prepare_options(choices:, src:)
     if src.present?

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -36,7 +36,14 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
   #   will be mapped to JSON response +"id"+ and +"name"+ by default. Use these parameters to map to different keys.
   # @option attributes [String] :"data-json-path" when +:src+ param is passed and options data is nested in JSON response,
   #   specify path to it with this parameter.
-  # @raise [ArgumentError] if both +:choices+ and +:src+ are nil
+  # @option attributes [String] :"data-query-param" when +:src+ param is passed, use this parameter to specify the name of
+  #   a query parameter to be used with search, e.g.:
+  #   ```
+  #   src: solidus_admin.countries_url,
+  #   "data-query-param": "q[name_cont]",
+  #   ```
+  # @option attributes [String] :"data-no-preload" when +:src+ param is passed, options are preloaded when the component
+  #   is initialized. Use this option to disable preload.
   def initialize(label:, name:, choices:, src: nil, size: :m, hint: nil, tip: nil, error: nil, **attributes)
     @label = label
     @hint = hint

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -25,6 +25,19 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
     },
   }.freeze
 
+  # Render custom select component, which uses "solidus_select" custom element
+  # @see "admin/app/javascript/solidus_admin/web_components/solidus_select.js"
+  # @param choices [nil, Array<String>, Array<Array<String>>] container with options to be rendered
+  #   (see `ActionView::Helpers::FormOptionsHelper#options_for_select`).
+  #   When +nil+, a +:src+ parameter must be provided.
+  # @param src [nil, String] URL of a JSON resource with options data to be loaded instead of rendering options in place.
+  #   When +nil+, a +:choices+ parameter must be provided.
+  # @option attributes [String] :"data-option-value-field"
+  # @option attributes [String] :"data-option-label-field" when +:src+ param is passed, value and label of loaded options
+  #   will be mapped to JSON response +"id"+ and +"name"+ by default. Use these parameters to map to different keys.
+  # @option attributes [String] :"data-json-path" when +:src+ param is passed and options data is nested in JSON response,
+  #   specify path to it with this parameter.
+  # @raise [ArgumentError] if both +:choices+ and +:src+ are nil
   def initialize(label:, name:, choices: nil, src: nil, size: :m, hint: nil, tip: nil, error: nil, **attributes)
     @label = label
     @hint = hint

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/patch_scroll.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/patch_scroll.js
@@ -1,0 +1,19 @@
+const patch = function(fnName) {
+  const originalFn = this[fnName];
+  this.hook("instead", fnName, function() {
+    const originalScrollToOption = this.scrollToOption;
+
+    this.scrollToOption = () => {};
+    originalFn.apply(this, arguments);
+    this.scrollToOption = originalScrollToOption;
+  });
+}
+
+// https://github.com/orchidjs/tom-select/issues/556
+// https://github.com/orchidjs/tom-select/issues/867
+export default function() {
+  this.on("initialize", function() {
+    patch.call(this, "onOptionSelect");
+    patch.call(this, "loadCallback");
+  })
+};

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/patch_scroll.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/patch_scroll.js
@@ -16,4 +16,4 @@ export default function() {
     patch.call(this, "onOptionSelect");
     patch.call(this, "loadCallback");
   })
-};
+}

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
@@ -53,15 +53,15 @@ export default function(config) {
   this.settings.searchField = [this.settings.labelField];
   this.settings.jsonPath = config.jsonPath;
   this.settings.queryParam = config.queryParam;
-  this.settings.render = {
+  this.settings.render = Object.assign(this.settings.render, {
     loading: function() {
-      return "<div class='loading'>Loading</div>";
+      return `<div class='loading'>${config.loadingMessage}</div>`;
     },
     loading_more: function() {
-      return "<div class='loading-more'>Loading more results</div>";
+      return `<div class='loading-more'>${config.loadingMoreMessage}</div>`;
     },
     no_more_results: function() {},
-  };
+  });
 
   this.require("virtual_scroll");
 }

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
@@ -1,0 +1,69 @@
+import { parseLinkHeader } from "solidus_admin/utils";
+
+// Fetch all options from remote source and setup pagination if needed
+const loadOptions = async function(query, callback) {
+  const { options, next } = await fetchOptions.call(this, query);
+  if (next) {
+    this.setNextUrl(query, next);
+  }
+
+  callback(options);
+}
+
+// Fetch options from remote source. If options data is nested in json response, specify path to it with "jsonPath"
+// E.g. https://whatcms.org/API/List data is deep nested in json response: `{ result: { list: [...] } }`, so
+//  in order to access it, pass config options to this plugin as follows:
+//  {
+//    src: "https://whatcms.org/API/List",
+//    jsonPath: "result.list"
+//  }
+const fetchOptions = async function(query) {
+  const dataPath = this.settings.jsonPath;
+  const response = await fetch(buildUrl.call(this, query), { headers: { "Accept": "application/json" } });
+  if (!response.ok) {
+    return { options: [] };
+  }
+
+  const next = parseLinkHeader(response.headers.get("Link")).next;
+  const json = await response.json();
+
+  let options;
+  if (!dataPath) {
+    options = json;
+  } else {
+    options = dataPath.split('.').reduce((acc, key) => acc && acc[key], json);
+  }
+
+  return { options, next };
+}
+
+const buildUrl = function(query) {
+  const url = new URL(this.getUrl(query));
+  const queryParam = this.settings.queryParam;
+  if (!query || !queryParam) return url.toString();
+
+  url.searchParams.set(queryParam, query);
+  return url.toString();
+}
+
+export default function(config) {
+  this.settings.firstUrl = () => config.src;
+  this.settings.load = loadOptions.bind(this);
+  this.settings.preload = config.preload;
+  this.settings.valueField = config.valueField || "id";
+  this.settings.labelField = config.labelField || "name";
+  this.settings.searchField = [this.settings.labelField];
+  this.settings.jsonPath = config.jsonPath;
+  this.settings.queryParam = config.queryParam;
+  this.settings.render = {
+    loading: function() {
+      return "<div class='loading'>Loading</div>";
+    },
+    loading_more: function() {
+      return "<div class='loading-more'>Loading more results</div>";
+    },
+    no_more_results: function() {},
+  };
+
+  this.require("virtual_scroll");
+};

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
@@ -66,4 +66,4 @@ export default function(config) {
   };
 
   this.require("virtual_scroll");
-};
+}

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/remote_with_pagination.js
@@ -50,8 +50,6 @@ export default function(config) {
   this.settings.firstUrl = () => config.src;
   this.settings.load = loadOptions.bind(this);
   this.settings.preload = config.preload;
-  this.settings.valueField = config.valueField || "id";
-  this.settings.labelField = config.labelField || "name";
   this.settings.searchField = [this.settings.labelField];
   this.settings.jsonPath = config.jsonPath;
   this.settings.queryParam = config.queryParam;

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/stash_on_search.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/stash_on_search.js
@@ -2,27 +2,25 @@
 //  an option selected shows both selected option and the search term.
 // Instead, hide the selected option when typing and bring it back when leaving the field.
 class Stash {
-  constructor() {
-    this.content = {};
-  }
+  #content = {};
 
   put(value, data) {
-    this.content["value"] = value;
-    this.content["data"] = data;
+    this.#content["value"] = value;
+    this.#content["data"] = data;
   }
 
   pop() {
-    const { value, data } = this.content;
+    const { value, data } = this.#content;
     this.clear();
     return { value, data };
   }
 
   clear() {
-    this.content = {};
+    this.#content = {};
   }
 
-  isEmpty() {
-    return Object.keys(this.content).length === 0;
+  get isEmpty() {
+    return Object.keys(this.#content).length === 0;
   }
 }
 
@@ -32,7 +30,7 @@ export default function() {
   this.stash = new Stash();
 
   this.stashSelected = function() {
-    if (!this.stash.isEmpty()) return;
+    if (!this.stash.isEmpty) return;
     if (!this.items.length) return;
 
     const currentValue = this.items[0];
@@ -41,7 +39,7 @@ export default function() {
   };
 
   this.unstashSelected = function() {
-    if (this.stash.isEmpty()) return;
+    if (this.stash.isEmpty) return;
 
     const { value, data } = this.stash.pop();
     // In case this is a select with remote source, options are refreshed on each search, so we need to put the option

--- a/admin/app/javascript/solidus_admin/tom-select/plugins/stash_on_search.js
+++ b/admin/app/javascript/solidus_admin/tom-select/plugins/stash_on_search.js
@@ -1,0 +1,70 @@
+// Substitute default TomSelect functionality for single selects, where typing in the select field while there is
+//  an option selected shows both selected option and the search term.
+// Instead, hide the selected option when typing and bring it back when leaving the field.
+class Stash {
+  constructor() {
+    this.content = {};
+  }
+
+  put(value, data) {
+    this.content["value"] = value;
+    this.content["data"] = data;
+  }
+
+  pop() {
+    const { value, data } = this.content;
+    this.clear();
+    return { value, data };
+  }
+
+  clear() {
+    this.content = {};
+  }
+
+  isEmpty() {
+    return Object.keys(this.content).length === 0;
+  }
+}
+
+export default function() {
+  if (this.settings.mode === 'multi') return;
+
+  this.stash = new Stash();
+
+  this.stashSelected = function() {
+    if (!this.stash.isEmpty()) return;
+    if (!this.items.length) return;
+
+    const currentValue = this.items[0];
+    this.stash.put(currentValue, this.options[currentValue]);
+    this.clear(true);
+  };
+
+  this.unstashSelected = function() {
+    if (this.stash.isEmpty()) return;
+
+    const { value, data } = this.stash.pop();
+    // In case this is a select with remote source, options are refreshed on each search, so we need to put the option
+    //  back in the list for TomSelect to pick it as a selected item.
+    // If the option is already in the list, it will be ignored.
+    this.addOption(data);
+    this.setValue(value, true);
+  };
+
+  // save current selected option in case user won't select anything
+  this.on("type", function() {
+    this.stashSelected();
+  });
+
+  // new option has been selected, no need to hold on to previous option
+  this.on("item_add", function() {
+    this.stash.clear();
+  });
+
+  // if nothing has been selected restore previous option
+  this.on("blur", function() {
+    if (this.items.length) return;
+
+    this.unstashSelected();
+  });
+}

--- a/admin/app/javascript/solidus_admin/tom-select/tom-select.js
+++ b/admin/app/javascript/solidus_admin/tom-select/tom-select.js
@@ -1,0 +1,11 @@
+import TomSelect from "tom-select";
+
+import patchScroll from "./plugins/patch_scroll.js";
+import stashOnSearch from "./plugins/stash_on_search.js";
+import remoteWithPagination from "./plugins/remote_with_pagination.js";
+
+TomSelect.define("patch_scroll", patchScroll);
+TomSelect.define("stash_on_search", stashOnSearch);
+TomSelect.define("remote_with_pagination", remoteWithPagination);
+
+export default TomSelect;

--- a/admin/app/javascript/solidus_admin/utils.js
+++ b/admin/app/javascript/solidus_admin/utils.js
@@ -30,3 +30,19 @@ export const setValidity = (element, error) => {
 
   element.addEventListener(clearOn, clearValidity, { once: true });
 };
+
+export function parseLinkHeader(header) {
+  if (!header) return {};
+
+  const links = {};
+  header.split(",").forEach((link) => {
+    // match against something like this '<https://example.com>; rel="next"'
+    const match = link.match(/<([^>]+)>\s*;\s*rel="([^"]+)"/);
+    if (match) {
+      const [, url, rel] = match;
+      links[rel] = url;
+    }
+  });
+
+  return links;
+}

--- a/admin/app/javascript/solidus_admin/web_components/solidus_select.js
+++ b/admin/app/javascript/solidus_admin/web_components/solidus_select.js
@@ -58,11 +58,12 @@ class SolidusSelect extends HTMLSelectElement {
     };
 
     if (this.getAttribute("data-src")) {
+      settings.valueField = this.getAttribute("data-option-value-field") || "id";
+      settings.labelField = this.getAttribute("data-option-label-field") || "name";
+
       settings.plugins.remote_with_pagination = {
         src: this.getAttribute("data-src"),
         preload: this.getAttribute("data-no-preload") !== "true",
-        valueField: this.getAttribute("data-option-value-field"),
-        labelField: this.getAttribute("data-option-label-field"),
         jsonPath: this.getAttribute("data-json-path"),
         queryParam: this.getAttribute("data-query-param"),
       };

--- a/admin/app/javascript/solidus_admin/web_components/solidus_select.js
+++ b/admin/app/javascript/solidus_admin/web_components/solidus_select.js
@@ -105,9 +105,18 @@ class SolidusSelect extends HTMLSelectElement {
     this.tomselect.settings.load = null;
   }
 
+  // Fetch options from remote source. If options data is nested in json response, specify path to it with "data-json-path"
+  // E.g. https://whatcms.org/API/List data is deep nested in json response: `{ result: { list: [...] } }`, so
+  //  in order to access it, specify attributes as follows:
+  //  "data-src"="https://whatcms.org/API/List"
+  //  "data-json-path"="result.list"
   async fetchOptions() {
+    const dataPath = this.getAttribute("data-json-path");
     const response = await fetch(this.getAttribute("data-src"));
-    return await response.json();
+    const json = await response.json();
+    if (!dataPath) return json;
+
+    return dataPath.split('.').reduce((acc, key) => acc && acc[key], json);
   }
 }
 

--- a/admin/app/javascript/solidus_admin/web_components/solidus_select.js
+++ b/admin/app/javascript/solidus_admin/web_components/solidus_select.js
@@ -5,7 +5,7 @@ class SolidusSelect extends HTMLSelectElement {
   static observedAttributes = ["synced"];
 
   connectedCallback() {
-    const tomselect = new TomSelect(this, this.getTomSelectSettings());
+    const tomselect = new TomSelect(this, this.tomSelectSettings);
 
     this.setAttribute("synced", "true");
 
@@ -37,7 +37,7 @@ class SolidusSelect extends HTMLSelectElement {
     }
   }
 
-  getTomSelectSettings() {
+  get tomSelectSettings() {
     const settings = {
       controlClass: "control",
       dropdownClass: "dropdown",

--- a/admin/app/javascript/solidus_admin/web_components/solidus_select.js
+++ b/admin/app/javascript/solidus_admin/web_components/solidus_select.js
@@ -55,6 +55,12 @@ class SolidusSelect extends HTMLSelectElement {
         patch_scroll: true,
         stash_on_search: true,
       },
+      render: {
+        no_results: function() {
+          const message = this.input.getAttribute("data-no-results-message");
+          return `<div class='no-results'>${message}</div>`;
+        },
+      },
     };
 
     if (this.getAttribute("data-src")) {
@@ -66,6 +72,8 @@ class SolidusSelect extends HTMLSelectElement {
         preload: this.getAttribute("data-no-preload") !== "true",
         jsonPath: this.getAttribute("data-json-path"),
         queryParam: this.getAttribute("data-query-param"),
+        loadingMessage: this.getAttribute("data-loading-message"),
+        loadingMoreMessage: this.getAttribute("data-loading-more-message"),
       };
     }
 

--- a/admin/config/importmap.rb
+++ b/admin/config/importmap.rb
@@ -11,6 +11,7 @@ pin "@rails/request.js", to: "https://cdn.jsdelivr.net/npm/@rails/request.js@0.0
 
 pin "solidus_admin/application", preload: true
 pin "solidus_admin/utils"
+pin "solidus_admin/tom-select", to: "solidus_admin/tom-select/tom-select.js"
 pin "vendor/custom_elements", preload: true
 
 pin_all_from SolidusAdmin::Engine.root.join("app/javascript/solidus_admin/controllers"), under: "solidus_admin/controllers"

--- a/admin/config/locales/solidus_select.yml
+++ b/admin/config/locales/solidus_select.yml
@@ -1,0 +1,6 @@
+en:
+  solidus_admin:
+    solidus_select:
+      loading: Loading
+      loading_more: Loading more results
+      no_results: No results found

--- a/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview.rb
@@ -10,15 +10,17 @@ class SolidusAdmin::UI::Forms::Select::ComponentPreview < ViewComponent::Preview
 
   # @param multiple toggle
   # @param latency toggle "Simulate request latency (2000ms)"
-  def remote(multiple: false, latency: false)
-    args = { label: "Label", name: "select", multiple: }
+  def remote_with_pagination(multiple: false, latency: false)
+    args = { label: "Search", name: "select", multiple:, choices: [], placeholder: "Type to search" }
     delay_url = "app.requestly.io/delay/2000/" if latency
-    src = "https://#{delay_url}whatcms.org/API/List"
+    src = "https://#{delay_url}api.github.com/search/repositories"
     args.merge!(
       src:,
       "data-option-value-field": "id",
-      "data-option-label-field": "label",
-      "data-json-path": "result.list",
+      "data-option-label-field": "full_name",
+      "data-json-path": "items",
+      "data-query-param": "q",
+      "data-no-preload": "true",
     )
 
     render component("ui/forms/select").new(**args)

--- a/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview.rb
@@ -8,6 +8,22 @@ class SolidusAdmin::UI::Forms::Select::ComponentPreview < ViewComponent::Preview
     render_with_template
   end
 
+  # @param multiple toggle
+  # @param latency toggle "Simulate request latency (2000ms)"
+  def remote(multiple: false, latency: false)
+    args = { label: "Label", name: "select", multiple: }
+    delay_url = "app.requestly.io/delay/2000/" if latency
+    src = "https://#{delay_url}whatcms.org/API/List"
+    args.merge!(
+      src:,
+      "data-option-value-field": "id",
+      "data-option-label-field": "label",
+      "data-json-path": "result.list",
+    )
+
+    render component("ui/forms/select").new(**args)
+  end
+
   # @param size select { choices: [s, m, l] }
   # @param options number
   # @param multiple toggle

--- a/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview.rb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview.rb
@@ -10,7 +10,10 @@ class SolidusAdmin::UI::Forms::Select::ComponentPreview < ViewComponent::Preview
 
   # @param multiple toggle
   # @param latency toggle "Simulate request latency (2000ms)"
-  def remote_with_pagination(multiple: false, latency: false)
+  # @param loading_message text
+  # @param loading_more_message text
+  # @param no_results_message text
+  def remote_with_pagination(multiple: false, latency: false, loading_message: nil, loading_more_message: nil, no_results_message: nil)
     args = { label: "Search", name: "select", multiple:, choices: [], placeholder: "Type to search" }
     delay_url = "app.requestly.io/delay/2000/" if latency
     src = "https://#{delay_url}api.github.com/search/repositories"
@@ -21,6 +24,9 @@ class SolidusAdmin::UI::Forms::Select::ComponentPreview < ViewComponent::Preview
       "data-json-path": "items",
       "data-query-param": "q",
       "data-no-preload": "true",
+      "data-loading-message": loading_message,
+      "data-loading-more-message": loading_more_message,
+      "data-no-results-message": no_results_message,
     )
 
     render component("ui/forms/select").new(**args)

--- a/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview/overview.html.erb
@@ -29,6 +29,16 @@
         <h6 class="text-gray-500 mb-3 mt-0">Disabled filled</h6>
         <%= render current_component.new(id: "single-disabled-filled", value: "Sweden", disabled: true, **default_params) %>
       </div>
+
+      <div class="mb-8">
+        <h6 class="text-gray-500 mb-3 mt-0">Remote options</h6>
+        <%= render current_component.new(id: "single-src-empty", src: "/admin/countries/1/states", label: "State", name: "state") %>
+      </div>
+
+      <div class="mb-8">
+        <h6 class="text-gray-500 mb-3 mt-0">Remote options (preselected)</h6>
+        <%= render current_component.new(id: "single-src-selected", src: "/admin/countries/1/states", label: "State", name: "state", value: "1") %>
+      </div>
     </div>
 
     <div class="flex flex-col flex-grow gap-2">
@@ -59,6 +69,16 @@
       <div class="mb-8">
         <h6 class="text-gray-500 mb-3 mt-0">Disabled filled</h6>
         <%= render current_component.new(id: "multiple-disabled-filled", value: "Sweden", disabled: true, **default_params) %>
+      </div>
+
+      <div class="mb-8">
+        <h6 class="text-gray-500 mb-3 mt-0">Remote options</h6>
+        <%= render current_component.new(id: "multiple-src-empty", src: "/admin/countries/1/states", label: "State", name: "state", multiple: true) %>
+      </div>
+
+      <div class="mb-8">
+        <h6 class="text-gray-500 mb-3 mt-0">Remote options (preselected)</h6>
+        <%= render current_component.new(id: "multiple-src-selected", src: "/admin/countries/1/states", label: "State", name: "state", multiple: true, value: "1,2,3") %>
       </div>
     </div>
   </div>

--- a/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview/overview.html.erb
+++ b/admin/spec/components/previews/solidus_admin/ui/forms/select/component_preview/overview.html.erb
@@ -32,12 +32,19 @@
 
       <div class="mb-8">
         <h6 class="text-gray-500 mb-3 mt-0">Remote options</h6>
-        <%= render current_component.new(id: "single-src-empty", src: "/admin/countries/1/states", label: "State", name: "state") %>
+        <%= render current_component.new(id: "single-src-empty", choices: [], src: solidus_admin.country_states_url(country_id: 1), label: "State", name: "state") %>
       </div>
 
       <div class="mb-8">
         <h6 class="text-gray-500 mb-3 mt-0">Remote options (preselected)</h6>
-        <%= render current_component.new(id: "single-src-selected", src: "/admin/countries/1/states", label: "State", name: "state", value: "1") %>
+        <%= render current_component.new(
+          id: "single-src-selected",
+          choices: Spree::State.where(id: 1).map { [_1.name, _1.id] },
+          src: solidus_admin.country_states_url(country_id: 1),
+          label: "State",
+          name: "state",
+          value: "1"
+        ) %>
       </div>
     </div>
 
@@ -73,12 +80,20 @@
 
       <div class="mb-8">
         <h6 class="text-gray-500 mb-3 mt-0">Remote options</h6>
-        <%= render current_component.new(id: "multiple-src-empty", src: "/admin/countries/1/states", label: "State", name: "state", multiple: true) %>
+        <%= render current_component.new(id: "multiple-src-empty", choices: [], src: solidus_admin.country_states_url(country_id: 1), label: "State", name: "state", multiple: true) %>
       </div>
 
       <div class="mb-8">
         <h6 class="text-gray-500 mb-3 mt-0">Remote options (preselected)</h6>
-        <%= render current_component.new(id: "multiple-src-selected", src: "/admin/countries/1/states", label: "State", name: "state", multiple: true, value: "1,2,3") %>
+        <%= render current_component.new(
+          id: "multiple-src-selected",
+          choices: Spree::State.where(id: [1,2,3]).map { [_1.name, _1.id] },
+          src: solidus_admin.country_states_url(country_id: 1),
+          label: "State",
+          name: "state",
+          multiple: true,
+          value: [1,2,3]
+        ) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Allows to fetch options from remote resource, rather than rendering all options in place. Additionally, if the endpoint provides pagination, loads options page by page (using "Link" response header `rel="next"`)

### Usage
#### `:src` attribute
When initialising select component pass `:src` attribute with a url to JSON resource, for `:choices` pass the values you want to be preselected or an empty array.
#### Mapping fields
Maps fields "id" and "name" from JSON data to be value and text of an option accordingly. If the fields have different names, map them with `:"data-option-value-field"` and `:"data-option-label-field"` when initialising select component, e.g.:
```js
// JSON response
[
  { "key": "ruby", "text": "Ruby" },
  { "key": "js", "text": "JavaScript" }
]
```
```ruby
# to render these as options use:
component("ui/forms/select").new(
  ...,
  "data-option-value-field": "key",
  "data-option-label-field": "text",
)
```
#### Nested JSON data
If data in response JSON is nested, you can specify `:"data-json-path"` parameter to retrieve the data by given path signature, e.g.:
```js
// JSON response
{
    "request": "https:\/\/whatcms.org\/API\/List",
    "result": {
        "code": 200,
        "msg": "Success",
        "list": [
            {
                "id": 1,
                "label": "WordPress",
                "type": [
                    "Blog",
                    "CMS"
                ]
            },
            {
                "id": 2,
                "label": "Joomla",
                "type": [
                    "Other CMS",
                    "CMS"
                ]
            },
    ...
```
```ruby
# to access data specify path:
component("ui/forms/select").new(
  ...,
  src: "https://whatcms.org/API/List"
  "data-option-label-field": "label",
  "data-json-path": "result.list"
)
```
### Loading template
A nice little "Loading" template placeholder is there to be displayed while the options are being loaded.

https://github.com/user-attachments/assets/1feaa1fb-49ff-4373-87a6-2c1acca58e01



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).