### PR TITLE
Move carton shipped emails to subscriber

### DIFF
--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -15,6 +15,13 @@ class Spree::Carton < Spree::Base
   validates :inventory_units, presence: true
   validates :shipped_at, presence: true
 
+  # This accessor is used by the `Spree::CartonShippedMailerSubscriber`
+  # on carton creation to either send or suppress the associated
+  # carton shipped email.
+  #
+  # @return [boolean, NilClass] Whether the email should be suppressed.
+  attr_accessor :suppress_email
+
   make_permalink field: :number, length: 11, prefix: 'C'
 
   scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -56,6 +56,7 @@ class Spree::OrderShipping
         inventory_units:,
         shipped_at:,
         external_number:,
+        suppress_email: suppress_mailer,
         tracking: tracking_number
       )
     end
@@ -68,19 +69,10 @@ class Spree::OrderShipping
       end
     end
 
-    send_shipment_emails(carton) if stock_location.fulfillable? && !suppress_mailer # e.g. digital gift cards that aren't actually shipped
     @order.shipments.reload
     @order.recalculate
 
     Spree::Bus.publish(:carton_shipped, carton:)
     carton
-  end
-
-  private
-
-  def send_shipment_emails(carton)
-    carton.orders.each do |order|
-      Spree::Config.carton_shipped_email_class.shipped_email(order:, carton:).deliver_later
-    end
   end
 end

--- a/core/app/subscribers/spree/carton_shipped_mailer_subscriber.rb
+++ b/core/app/subscribers/spree/carton_shipped_mailer_subscriber.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Spree
+  # Mailing after {Spree::Carton} is created.
+  class CartonShippedMailerSubscriber
+    include Omnes::Subscriber
+
+    handle :carton_shipped,
+           with: :send_carton_shipped_emails,
+           id: :spree_carton_mailer_send_carton_shipped_email
+
+    # Sends carton shipped emails to users.
+    #
+    # @param event [Omnes::UnstructuredEvent]
+    def send_carton_shipped_emails(event)
+      carton = event[:carton]
+
+      return if carton.suppress_email
+
+      # Do not send emails for unfulfillable cartons (i.e. for digital goods).
+      return unless carton.stock_location.fulfillable?
+
+      carton.orders.each do |order|
+        Spree::Config.carton_shipped_email_class
+          .shipped_email(order:, carton:)
+          .deliver_later
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -71,6 +71,7 @@ module Spree
             reimbursement_errored
           ].each { |event_name| Spree::Bus.register(event_name) }
 
+          Spree::CartonShippedMailerSubscriber.new.subscribe_to(Spree::Bus)
           Spree::OrderConfirmationMailerSubscriber.new.subscribe_to(Spree::Bus)
           Spree::ReimbursementMailerSubscriber.new.subscribe_to(Spree::Bus)
         end

--- a/core/spec/subscribers/spree/carton_shipped_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/carton_shipped_mailer_subscriber_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'action_mailer'
+
+RSpec.describe Spree::CartonShippedMailerSubscriber do
+  let(:bus) { Omnes::Bus.new }
+
+  before do
+    bus.register(:carton_shipped)
+
+    described_class.new.subscribe_to(bus)
+  end
+
+  describe 'on :carton_shipped' do
+    context "when the carton's stock location is not fulfillable" do
+      it "does not send an email" do
+        carton = create :carton,
+          stock_location: create(:stock_location, fulfillable: false)
+
+        expect(Spree::CartonMailer).not_to receive(:shipped_email)
+
+        bus.publish(:carton_shipped, carton:)
+      end
+    end
+
+    context "when the carton is configured to suppress mailers" do
+      it "does not send an email" do
+        carton = create :carton, suppress_email: true
+
+        expect(Spree::CartonMailer).not_to receive(:shipped_email)
+
+        bus.publish(:carton_shipped, carton:)
+      end
+    end
+
+    context "when the carton shipped email should be sent" do
+      it "sends an email" do
+        carton = create :carton
+
+        expect(Spree::CartonMailer)
+          .to receive(:shipped_email).and_call_original.once
+
+        bus.publish(:carton_shipped, carton:)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Following the pattern of all of the other order transaction emails sent by Solidus (see #6205 #6199), we'll add a subscriber for carton shipped emails using the "carton_shipped" event.

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
