### PR TITLE
Change migration version to 7.0

### DIFF
--- a/core/db/migrate/20250214094207_add_reverse_charge_status_to_store.rb
+++ b/core/db/migrate/20250214094207_add_reverse_charge_status_to_store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReverseChargeStatusToStore < ActiveRecord::Migration[7.2]
+class AddReverseChargeStatusToStore < ActiveRecord::Migration[7.0]
   def change
     add_column :spree_stores, :reverse_charge_status, :integer, default: 0, null: false,
                 comment: "Enum values: 0 = disabled, 1 = enabled, 2 = not_validated"


### PR DESCRIPTION
## Summary

Similar to https://github.com/solidusio/solidus/pull/6192

We want to use the migration version from the oldest supported version of rails so that everyone on a supported version can run migrations.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
