### PR TITLE
Disallow migrations with the wrong versions

### DIFF
--- a/.github/workflows/test_solidus_rubocops.yml
+++ b/.github/workflows/test_solidus_rubocops.yml
@@ -1,0 +1,21 @@
+name: Test Solidus Rubocops
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run Solidus Rubocop tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec tasks/linting/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-performance
   - rubocop-rails
+  - ./tasks/linting/wrong_migration_version.rb
 
 AllCops:
   Exclude:

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -5,6 +5,8 @@ module Spree
 
   def self.solidus_version = VERSION
 
+  def self.minimum_required_rails_version = "7.0"
+
   def self.previous_solidus_minor_version = "4.5"
 
   def self.solidus_gem_version = Gem::Version.new(solidus_version)

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -3,15 +3,9 @@
 module Spree
   VERSION = "4.6.0.dev"
 
-  def self.solidus_version
-    VERSION
-  end
+  def self.solidus_version = VERSION
 
-  def self.previous_solidus_minor_version
-    '4.5'
-  end
+  def self.previous_solidus_minor_version = "4.5"
 
-  def self.solidus_gem_version
-    Gem::Version.new(solidus_version)
-  end
+  def self.solidus_gem_version = Gem::Version.new(solidus_version)
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,7 +27,10 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 7.0', '< 8.1.0.beta1']
+    s.add_dependency rails_dep, [
+      ">= #{Spree.minimum_required_rails_version}",
+      "< 8.1.0.beta1"
+    ]
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'

--- a/tasks/linting/wrong_migration_version.rb
+++ b/tasks/linting/wrong_migration_version.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../../core/lib/spree/core/version'
+
+module Solidus
+  class WrongMigrationVersion < RuboCop::Cop::Base
+    MSG = "Subclasses of ActiveRecord::Migration must use a migration version " \
+      "of <= #{Spree.minimum_required_rails_version}"
+
+    def on_class(node)
+      return unless (superclass = node.parent_class)
+      return unless superclass.source&.start_with?("ActiveRecord::Migration")
+      return unless (given_version_arg = superclass.arguments.first&.value)
+
+      unless meets_solidus_minimum_required_rails_version? given_version_arg
+        add_offense node, message: MSG
+      end
+    end
+
+    private
+
+    def meets_solidus_minimum_required_rails_version?(version_argument)
+      Gem::Version.new(version_argument) <=
+        Gem::Version.new(Spree.minimum_required_rails_version)
+    end
+  end
+end

--- a/tasks/linting/wrong_migration_version_spec.rb
+++ b/tasks/linting/wrong_migration_version_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/rspec/support"
+
+require_relative "wrong_migration_version"
+
+RSpec.describe Solidus::WrongMigrationVersion do
+  include RuboCop::RSpec::ExpectOffense
+
+  subject(:cop) { described_class.new RuboCop::Config.new }
+
+  it "finds migration versions greater than the Solidus minimum required Rails version offensive" do
+    greater_than_minimum_version = Gem::Version
+      .new(Spree.minimum_required_rails_version)
+      .bump
+      .to_s
+
+    expect_offense(<<~RUBY)
+      class TestMigration < ActiveRecord::Migration[#{greater_than_minimum_version}]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Solidus/WrongMigrationVersion: Subclasses of ActiveRecord::Migration must use a migration version of <= 7.0
+      end
+    RUBY
+  end
+
+  it "finds migration versions less than the Solidus minimum required Rails version inoffensive" do
+    expect_no_offenses(<<~RUBY)
+      class TestMigration < ActiveRecord::Migration[3.0]
+      end
+    RUBY
+  end
+
+  it "finds migration versions equal to the Solidus minimum required Rails version inoffensive" do
+    expect_no_offenses(<<~RUBY)
+      class TestMigration < ActiveRecord::Migration[#{Spree.minimum_required_rails_version}]
+      end
+    RUBY
+  end
+
+  it "finds non-migration classes inoffensive" do
+    expect_no_offenses(<<~RUBY)
+      class NotAMigration
+      end
+    RUBY
+  end
+
+  it "finds non-migration subclasses inoffensive" do
+    expect_no_offenses(<<~RUBY)
+      class SubclassOfNotAMigration < NotAMigration
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
## Summary

This custom Rubocop ensures that we don't end up with migrations that are too new for Solidus's minimum required Rails version.

This has happened a few times lately. See #6192 and #6220 for more context. It would be nice to avoid conflicts like these in an automated way.

## Request for comment

While the work to support this Rubocop is all done here, it's possible there is a better place for this cop to live. I didn't see any existing custom Rubocops in the Solidus codebase or in the `.rubocop.yml` configuration, but it's possible I missed something.

The `solidus` metagem doesn't have a test suite, but maybe we should add something so the tests added in the PR can be run.

## Testing

You can manually run the test files included in this pull request to verify the cop is working.

You can also create a new migration's (or change an existing migration's) version argument and then run Rubocop against it:

    bundle exec rubocop <path-to-invalid-migration>

I pushed a temporary commit that changed an existing migration to use a 7.2 migration version argument and verified that CI runs would fail when this happens[^1]. Output:

```
bin/rake lint:rb
bundle exec rubocop -P -f clang -f junit -o '/home/runner/work/solidus/solidus/tasks/../test-results/rubocop-results.xml' $(git ls-files -co --exclude-standard | grep -E "\.rb$" | grep -v "/templates/")
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /home/runner/work/solidus/solidus/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /home/runner/work/solidus/solidus/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
core/db/migrate/20250221152004_add_metadata_to_users.rb:1:1: C: Solidus/WrongMigrationVersion: Subclasses of ActiveRecord::Migration must use a migration version of <= 7.0
class AddMetadataToUsers < ActiveRecord::Migration[7.2] ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1804 files inspected, 1 offense detected
rake aborted!
Command failed with status (1): [bundle exec rubocop -P -f clang -f junit -o '/home/runner/work/solidus/solidus/tasks/../test-results/rubocop-results.xml' $(git ls-files -co --exclude-standard | grep -E "\.rb$" | grep -v "/templates/")]
/home/runner/work/solidus/solidus/tasks/linting.rake:7:in `block (2 levels) in <top (required)>'
/home/runner/work/solidus/solidus/vendor/bundle/ruby/3.2.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => lint:rb
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).


[^1]: The link to this CI run probably won't be a 200 forever, but here it is anyway: https://github.com/solidusio/solidus/actions/runs/14525089163/job/40754781351?pr=6221

