### PR TITLE
Dummy app generator: Only configure app/assets/javascripts if present

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -54,6 +54,7 @@ module Spree
     def test_dummy_config
       @lib_name = options[:lib_name]
       @database = options[:database]
+      @has_javascripts = Dir.exist?("#{dummy_path}/app/assets/javascripts")
 
       template "rails/database.yml", "#{dummy_path}/config/database.yml", force: true
       template "rails/storage.yml", "#{dummy_path}/config/storage/test.yml", force: true

--- a/core/lib/generators/spree/dummy/templates/rails/manifest.js.tt
+++ b/core/lib/generators/spree/dummy/templates/rails/manifest.js.tt
@@ -1,3 +1,5 @@
 //= link_tree ../images
+<% if @has_javascripts %>
 //= link_directory ../javascripts .js
+<% end %>
 //= link_directory ../stylesheets .css


### PR DESCRIPTION
Newer versions of Rails generators do not generate the `app/assets/javascripts` directory. Let's not add it to the Sprockets config if it's not there.
