### PR TITLE
Admin stores add edit

### DIFF
--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @adjustment_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/adjustment_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/index/component.rb
@@ -18,7 +18,7 @@ class SolidusAdmin::AdjustmentReasons::Index::Component < SolidusAdmin::RefundsA
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_adjustment_reason_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -26,7 +26,7 @@ class SolidusAdmin::AdjustmentReasons::Index::Component < SolidusAdmin::RefundsA
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -52,7 +52,7 @@ class SolidusAdmin::AdjustmentReasons::Index::Component < SolidusAdmin::RefundsA
         data: ->(adjustment_reason) do
           link_to adjustment_reason.name, edit_path(adjustment_reason),
             class: 'body-link',
-            data: { turbo_frame: :resource_modal }
+            data: { turbo_frame: :resource_form }
         end
       },
       {
@@ -60,7 +60,7 @@ class SolidusAdmin::AdjustmentReasons::Index::Component < SolidusAdmin::RefundsA
         data: ->(adjustment_reason) do
           link_to adjustment_reason.code, edit_path(adjustment_reason),
             class: 'body-link',
-            data: { turbo_frame: :resource_modal }
+            data: { turbo_frame: :resource_form }
         end
       },
       {

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @adjustment_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/properties/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @property, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/properties/index/component.rb
+++ b/admin/app/components/solidus_admin/properties/index/component.rb
@@ -22,7 +22,7 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
   end
 
   def turbo_frames
-    %w[resource_modal]
+    %w[resource_form]
   end
 
   def page_actions
@@ -30,7 +30,7 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_property_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
     )
   end
@@ -58,7 +58,7 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
       header: :name,
       data: ->(property) do
         link_to property.name, edit_path(property),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }
@@ -69,7 +69,7 @@ class SolidusAdmin::Properties::Index::Component < SolidusAdmin::UI::Pages::Inde
       header: :presentation,
       data: ->(property) do
         link_to property.presentation, edit_path(property),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }

--- a/admin/app/components/solidus_admin/properties/new/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @property, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @refund_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/refund_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/refund_reasons/index/component.rb
@@ -19,7 +19,7 @@ class SolidusAdmin::RefundReasons::Index::Component < SolidusAdmin::RefundsAndRe
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -28,7 +28,7 @@ class SolidusAdmin::RefundReasons::Index::Component < SolidusAdmin::RefundsAndRe
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_refund_reason_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -51,7 +51,7 @@ class SolidusAdmin::RefundReasons::Index::Component < SolidusAdmin::RefundsAndRe
         header: :name,
         data: ->(refund_reason) do
           link_to refund_reason.name, edit_path(refund_reason),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },
@@ -59,7 +59,7 @@ class SolidusAdmin::RefundReasons::Index::Component < SolidusAdmin::RefundsAndRe
         header: :code,
         data: ->(refund_reason) do
           link_to_if refund_reason.code, refund_reason.code, edit_path(refund_reason),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @refund_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/return_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/return_reasons/index/component.rb
@@ -19,7 +19,7 @@ class SolidusAdmin::ReturnReasons::Index::Component < SolidusAdmin::RefundsAndRe
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -28,7 +28,7 @@ class SolidusAdmin::ReturnReasons::Index::Component < SolidusAdmin::RefundsAndRe
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_return_reason_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -51,7 +51,7 @@ class SolidusAdmin::ReturnReasons::Index::Component < SolidusAdmin::RefundsAndRe
         header: :name,
         data: ->(return_reason) do
           link_to return_reason.name, edit_path(return_reason),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },

--- a/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/roles/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @role, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/roles/index/component.rb
+++ b/admin/app/components/solidus_admin/roles/index/component.rb
@@ -22,14 +22,14 @@ class SolidusAdmin::Roles::Index::Component < SolidusAdmin::UsersAndRoles::Compo
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_role_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
     )
   end
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -61,7 +61,7 @@ class SolidusAdmin::Roles::Index::Component < SolidusAdmin::UsersAndRoles::Compo
         header: :role,
         data: ->(role) do
           link_to role.name, edit_path(role),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: "body-link"
         end,
       },
@@ -69,7 +69,7 @@ class SolidusAdmin::Roles::Index::Component < SolidusAdmin::UsersAndRoles::Compo
         header: :description,
         data: ->(role) do
           link_to_if role.description, role.description, edit_path(role),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: "body-link"
         end
       }

--- a/admin/app/components/solidus_admin/roles/new/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @role, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @shipping_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/shipping_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/shipping_categories/index/component.rb
@@ -10,7 +10,7 @@ class SolidusAdmin::ShippingCategories::Index::Component < SolidusAdmin::Shippin
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_shipping_category_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -18,7 +18,7 @@ class SolidusAdmin::ShippingCategories::Index::Component < SolidusAdmin::Shippin
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -51,7 +51,7 @@ class SolidusAdmin::ShippingCategories::Index::Component < SolidusAdmin::Shippin
         header: :name,
         data: ->(shipping_category) do
           link_to shipping_category.name, edit_url(shipping_category),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: "body-link"
         end
       },

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @shipping_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @stock_item, url: form_url, html: { id: form_id } do |f| %>
       <div

--- a/admin/app/components/solidus_admin/stock_items/index/component.rb
+++ b/admin/app/components/solidus_admin/stock_items/index/component.rb
@@ -91,7 +91,7 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
       header: :name,
       data: ->(stock_item) do
         link_to stock_item.variant.name, edit_path(stock_item),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }
@@ -102,7 +102,7 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
       header: :sku,
       data: ->(stock_item) do
         link_to stock_item.variant.sku, edit_path(stock_item),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }
@@ -172,6 +172,6 @@ class SolidusAdmin::StockItems::Index::Component < SolidusAdmin::UI::Pages::Inde
   end
 
   def turbo_frames
-    %w[resource_modal]
+    %w[resource_form]
   end
 end

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/store_credit_reasons/index/component.rb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/index/component.rb
@@ -10,7 +10,7 @@ class SolidusAdmin::StoreCreditReasons::Index::Component < SolidusAdmin::Refunds
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_store_credit_reason_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -18,7 +18,7 @@ class SolidusAdmin::StoreCreditReasons::Index::Component < SolidusAdmin::Refunds
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -51,7 +51,7 @@ class SolidusAdmin::StoreCreditReasons::Index::Component < SolidusAdmin::Refunds
         header: :name,
         data: ->(store_credit_reason) do
           link_to store_credit_reason.name, edit_path(store_credit_reason),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/stores/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/edit/component.html.erb
@@ -12,7 +12,18 @@
     <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
 
     <%= page_footer do %>
-      <%= render component("ui/button").save(form: form_id) %>
+      <div class="flex justify-between w-full">
+        <% unless @store.default %>
+          <%= form_for @store, url: solidus_admin.store_path(@store), method: :delete do %>
+            <%= render component("ui/button").delete(
+              "data-controller": "confirm",
+              "data-confirm-text-value": t("spree.are_you_sure")
+            ) %>
+          <% end %>
+        <% end %>
+
+        <%= render component("ui/button").save(form: form_id) %>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/edit/component.html.erb
@@ -1,29 +1,27 @@
-<%= turbo_frame_tag :resource_form, target: "_top" do %>
-  <%= page do %>
-    <%= page_header do %>
-      <%= page_header_back(back_url) %>
-      <%= page_header_title(@store.name) %>
-      <%= page_header_actions do %>
-        <%= render component("ui/button").discard(path: back_url) %>
-        <%= render component("ui/button").save(form: form_id) %>
-      <% end %>
+<%= page id: :resource_form do %>
+  <%= page_header do %>
+    <%= page_header_back(back_url) %>
+    <%= page_header_title(@store.name) %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").discard(path: back_url) %>
+      <%= render component("ui/button").save(form: form_id) %>
     <% end %>
+  <% end %>
 
-    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+  <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
 
-    <%= page_footer do %>
-      <div class="flex justify-between w-full">
-        <% unless @store.default %>
-          <%= form_for @store, url: solidus_admin.store_path(@store), method: :delete do %>
-            <%= render component("ui/button").delete(
-              "data-controller": "confirm",
-              "data-confirm-text-value": t("spree.are_you_sure")
-            ) %>
-          <% end %>
+  <%= page_footer do %>
+    <div class="flex justify-between w-full">
+      <% unless @store.default %>
+        <%= form_for @store, url: solidus_admin.store_path(@store), method: :delete do %>
+          <%= render component("ui/button").delete(
+            "data-controller": "confirm",
+            "data-confirm-text-value": t("spree.are_you_sure")
+          ) %>
         <% end %>
+      <% end %>
 
-        <%= render component("ui/button").save(form: form_id) %>
-      </div>
-    <% end %>
+      <%= render component("ui/button").save(form: form_id) %>
+    </div>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/edit/component.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
+  <%= page do %>
+    <%= page_header do %>
+      <%= page_header_back(back_url) %>
+      <%= page_header_title(@store.name) %>
+      <%= page_header_actions do %>
+        <%= render component("ui/button").discard(path: back_url) %>
+        <%= render component("ui/button").save(form: form_id) %>
+      <% end %>
+    <% end %>
+
+    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+
+    <%= page_footer do %>
+      <%= render component("ui/button").save(form: form_id) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/stores/edit/component.rb
+++ b/admin/app/components/solidus_admin/stores/edit/component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Stores::Edit::Component < SolidusAdmin::Resources::Edit::Component
+  include SolidusAdmin::Layout::PageHelpers
+end

--- a/admin/app/components/solidus_admin/stores/form/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/form/component.html.erb
@@ -1,0 +1,9 @@
+<%= form_for @store, url: @url, html: { id: @id } do |f| %>
+  <%= page_with_sidebar do %>
+    <%= page_with_sidebar_main do %>
+    <% end %>
+
+    <%= page_with_sidebar_aside do %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/stores/form/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/form/component.html.erb
@@ -1,9 +1,90 @@
 <%= form_for @store, url: @url, html: { id: @id } do |f| %>
   <%= page_with_sidebar do %>
     <%= page_with_sidebar_main do %>
+      <%= render component('ui/panel').new do |panel| %>
+        <% panel.with_section(class: "flex flex-col gap-4") do %>
+          <div class="flex flex-col gap-4 w-full">
+            <%= render component("ui/forms/field").text_field(f, :name) %>
+            <%= render component("ui/forms/field").text_field(f, :code) %>
+            <%= render component("ui/forms/field").text_field(f, :url) %>
+            <%= render component("ui/forms/field").text_field(f, :mail_from_address) %>
+          </div>
+        <% end %>
+      <% end %>
+      <%= render component('ui/panel').new(title: t('.localization')) do |panel| %>
+        <% panel.with_section(class: "flex flex-col gap-4") do %>
+          <div class="flex flex-col gap-4 w-full">
+            <%= render component("ui/forms/field").select(f, :default_currency, Spree::Config.available_currencies.map(&:iso_code)) %>
+            <%= render component("ui/forms/field").select(f, :cart_tax_country_iso, Spree::Country.order(:name).map { |c| [c.name, c.iso] },
+              include_blank: t(".tax_country.no_taxes_without_address")
+            ) %>
+            <%= render component("ui/forms/field").select(f, :available_locales, available_locales, multiple: true) %>
+          </div>
+          <%= render component('ui/panel').new do |inner_panel| %>
+            <% inner_panel.with_section(class: "flex justify-between") do %>
+              <div class="flex gap-2 items-center">
+                <div class="p-1 border border-gray-100 rounded-sm">
+                  <%= render component("ui/icon").new(name: "github-fill", class: "w-9 h-9 fill-gray-500") %>
+                </div>
+                <div class="flex flex-col">
+                  <div class="flex gap-1">
+                    <div class="font-semibold"><%= t(".plugins.solidus_i18n.title") %></div>
+                    <%= render component("ui/badge").new(name: t(".plugins.plugin"), color: :blue, size: :s) %>
+                  </div>
+                  <div class="text-sm text-gray-500"><%= t(".plugins.solidus_i18n.desc") %></div>
+                </div>
+              </div>
+              <div class="flex items-center">
+                <%= render component("ui/button").new(
+                  tag: :a,
+                  text: t(".plugins.install"),
+                  scheme: :secondary,
+                  href: t(".plugins.solidus_i18n.href"),
+                  target: "_blank"
+                ) %>
+              </div>
+            <% end %>
+          <% end %>
+
+          <%= render component('ui/panel').new do |inner_panel| %>
+            <% inner_panel.with_section(class: "flex justify-between") do %>
+              <div class="flex gap-2 items-center">
+                <div class="p-1 border border-gray-100 rounded-sm">
+                  <%= render component("ui/icon").new(name: "github-fill", class: "w-9 h-9 fill-gray-500") %>
+                </div>
+                <div class="flex flex-col">
+                  <div class="flex gap-1">
+                    <div class="font-semibold"><%= t(".plugins.solidus_globalize.title") %></div>
+                    <%= render component("ui/badge").new(name: t(".plugins.plugin"), color: :blue, size: :s) %>
+                  </div>
+                  <div class="text-sm text-gray-500"><%= t(".plugins.solidus_globalize.desc") %></div>
+                </div>
+              </div>
+              <div class="flex items-center">
+                <%= render component("ui/button").new(
+                  tag: :a,
+                  text: t(".plugins.install"),
+                  scheme: :secondary,
+                  href: t(".plugins.solidus_globalize.href"),
+                  target: "_blank"
+                ) %>
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
 
     <%= page_with_sidebar_aside do %>
+      <%= render component('ui/panel').new(title: t('.seo')) do |panel| %>
+        <% panel.with_section(class: "flex flex-col gap-4") do %>
+          <div class="flex flex-col gap-4 w-full">
+            <%= render component("ui/forms/field").text_field(f, :seo_title) %>
+            <%= render component("ui/forms/field").text_field(f, :meta_keywords) %>
+            <%= render component("ui/forms/field").text_field(f, :meta_description) %>
+          </div>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/form/component.rb
+++ b/admin/app/components/solidus_admin/stores/form/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Stores::Form::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(store:, id:, url:)
+    @store = store
+    @id = id
+    @url = url
+  end
+end

--- a/admin/app/components/solidus_admin/stores/form/component.rb
+++ b/admin/app/components/solidus_admin/stores/form/component.rb
@@ -8,4 +8,10 @@ class SolidusAdmin::Stores::Form::Component < SolidusAdmin::BaseComponent
     @id = id
     @url = url
   end
+
+  def available_locales
+    Spree.i18n_available_locales.map do |locale|
+      [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+    end.sort
+  end
 end

--- a/admin/app/components/solidus_admin/stores/form/component.yml
+++ b/admin/app/components/solidus_admin/stores/form/component.yml
@@ -1,0 +1,16 @@
+en:
+  localization: Localization
+  plugins:
+    install: Install
+    plugin: Plugin
+    solidus_i18n:
+      href: https://github.com/solidusio/solidus_i18n
+      desc: Translate Solidus Admin in every language
+      title: Solidus i18n
+    solidus_globalize:
+      href: https://github.com/solidusio-contrib/solidus_globalize
+      desc: Translate your store content in every language
+      title: Solidus Globalize
+  seo: SEO
+  tax_country:
+    no_taxes_without_address: No taxes on carts without address

--- a/admin/app/components/solidus_admin/stores/index/component.rb
+++ b/admin/app/components/solidus_admin/stores/index/component.rb
@@ -14,14 +14,14 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
   end
 
   def edit_path(store)
-    spree.edit_admin_store_path(store)
+    solidus_admin.edit_store_path(store)
   end
 
   def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t('.add'),
-      href: spree.new_admin_store_path,
+      href: solidus_admin.new_store_path,
       icon: "add-line",
     )
   end

--- a/admin/app/components/solidus_admin/stores/index/component.rb
+++ b/admin/app/components/solidus_admin/stores/index/component.rb
@@ -13,7 +13,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
     solidus_admin.stores_path
   end
 
-  def row_url(store)
+  def edit_path(store)
     spree.edit_admin_store_path(store)
   end
 
@@ -33,26 +33,55 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
         action: solidus_admin.stores_path,
         method: :delete,
         icon: 'delete-bin-7-line',
+        require_confirmation: true,
       },
     ]
   end
 
   def columns
     [
-      :name,
-      :url,
-      {
-        header: :slug,
-        data: ->(store) do
-          content_tag :div, store.code
-        end
-      },
-      {
-        header: :default,
-        data: ->(store) do
-          store.default? ? component('ui/badge').yes : component('ui/badge').no
-        end
-      },
+      name_column,
+      url_column,
+      slug_column,
+      default_column,
     ]
+  end
+
+  private
+
+  def name_column
+    {
+      header: :name,
+      data: ->(store) do
+        link_to store.name, edit_path(store), class: 'body-link'
+      end
+    }
+  end
+
+  def url_column
+    {
+      header: :url,
+      data: ->(store) do
+        link_to store.url, edit_path(store), class: 'body-link'
+      end
+    }
+  end
+
+  def slug_column
+    {
+      header: :slug,
+      data: ->(store) do
+        link_to store.code, edit_path(store), class: 'body-link'
+      end
+    }
+  end
+
+  def default_column
+    {
+      header: :default,
+      data: ->(store) do
+        store.default? ? component('ui/badge').yes : component('ui/badge').no
+      end
+    }
   end
 end

--- a/admin/app/components/solidus_admin/stores/new/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/new/component.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
+  <%= page do %>
+    <%= page_header do %>
+      <%= page_header_back(back_url) %>
+      <%= page_header_title(t('.title')) %>
+      <%= page_header_actions do %>
+        <%= render component("ui/button").discard(path: back_url) %>
+        <%= render component("ui/button").save(form: form_id) %>
+      <% end %>
+    <% end %>
+
+    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+
+    <%= page_footer do %>
+      <%= render component("ui/button").save(form: form_id) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/stores/new/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/new/component.html.erb
@@ -1,18 +1,16 @@
-<%= turbo_frame_tag :resource_form, target: "_top" do %>
-  <%= page do %>
-    <%= page_header do %>
-      <%= page_header_back(back_url) %>
-      <%= page_header_title(t('.title')) %>
-      <%= page_header_actions do %>
-        <%= render component("ui/button").discard(path: back_url) %>
-        <%= render component("ui/button").save(form: form_id) %>
-      <% end %>
-    <% end %>
-
-    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
-
-    <%= page_footer do %>
+<%= page id: :resource_form do %>
+  <%= page_header do %>
+    <%= page_header_back(back_url) %>
+    <%= page_header_title(t('.title')) %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").discard(path: back_url) %>
       <%= render component("ui/button").save(form: form_id) %>
     <% end %>
+  <% end %>
+
+  <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+
+  <%= page_footer do %>
+    <%= render component("ui/button").save(form: form_id) %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/new/component.rb
+++ b/admin/app/components/solidus_admin/stores/new/component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Stores::New::Component < SolidusAdmin::Resources::New::Component
+  include SolidusAdmin::Layout::PageHelpers
+end

--- a/admin/app/components/solidus_admin/stores/new/component.yml
+++ b/admin/app/components/solidus_admin/stores/new/component.yml
@@ -1,0 +1,2 @@
+en:
+  title: "New Store"

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @tax_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/tax_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/tax_categories/index/component.rb
@@ -18,7 +18,7 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_tax_category_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -26,7 +26,7 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
 
   def turbo_frames
     %w[
-      resource_modal
+      resource_form
     ]
   end
 
@@ -51,7 +51,7 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
         header: :name,
         data: ->(tax_category) do
           link_to tax_category.name, edit_path(tax_category),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },
@@ -59,7 +59,7 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
         header: :tax_code,
         data: ->(tax_category) do
           link_to_if tax_category.tax_code, tax_category.tax_code, edit_path(tax_category),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },
@@ -67,7 +67,7 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
         header: :description,
         data: ->(tax_category) do
           link_to_if tax_category.description, tax_category.description, edit_path(tax_category),
-            data: { turbo_frame: :resource_modal },
+            data: { turbo_frame: :resource_form },
             class: 'body-link'
         end
       },

--- a/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @tax_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -63,6 +63,31 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
     },
   }
 
+  def self.back(path:, **options)
+    new(
+      tag: :a,
+      title: t(".back"),
+      icon: "arrow-left-line",
+      scheme: :secondary,
+      href: path,
+      **options
+    )
+  end
+
+  def self.discard(path:, **options)
+    new(
+      tag: :a,
+      text: t(".discard"),
+      scheme: :secondary,
+      href: path,
+      **options
+    )
+  end
+
+  def self.save(**options)
+    new(text: t(".save"), **options)
+  end
+
   def initialize(
     tag: :button,
     text: nil,

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -74,6 +74,15 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
     )
   end
 
+  def self.delete(**options)
+    new(
+      tag: :button,
+      text: t(".delete"),
+      scheme: :danger,
+      **options
+    )
+  end
+
   def self.discard(path:, **options)
     new(
       tag: :a,

--- a/admin/app/components/solidus_admin/ui/button/component.yml
+++ b/admin/app/components/solidus_admin/ui/button/component.yml
@@ -1,5 +1,8 @@
 en:
+  back: "Back"
   cancel: "Cancel"
+  discard: "Discard"
+  save: "Save"
   submit:
     create: "Add %{resource_name}"
     update: "Update %{resource_name}"

--- a/admin/app/components/solidus_admin/ui/button/component.yml
+++ b/admin/app/components/solidus_admin/ui/button/component.yml
@@ -1,6 +1,7 @@
 en:
   back: "Back"
   cancel: "Cancel"
+  delete: "Delete"
   discard: "Discard"
   save: "Save"
   submit:

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -31,6 +31,7 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
   #   (see `ActionView::Helpers::FormOptionsHelper#options_for_select`).
   #   When +:src+ parameter is provided, use +:choices+ to provide the list of selected options only.
   # @param src [nil, String] URL of a JSON resource with options data to be loaded instead of rendering options in place.
+  # @option attributes [nil, String, Integer, Array<String, Integer>] :value which option should be selected
   # @option attributes [String] :"data-option-value-field"
   # @option attributes [String] :"data-option-label-field" when +:src+ param is passed, value and label of loaded options
   #   will be mapped to JSON response +"id"+ and +"name"+ by default. Use these parameters to map to different keys.

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.html.erb
@@ -8,7 +8,7 @@
         tag: :a,
         href: new_store_credit_path,
         data: {
-          turbo_frame: :resource_modal
+          turbo_frame: :resource_form
         },
         text: t(".add_store_credit"),
         icon: "add-line"
@@ -45,7 +45,7 @@
           <%= render component("ui/button").new(
             tag: :a,
             data: {
-              turbo_frame: :resource_modal
+              turbo_frame: :resource_form
             },
             href: new_store_credit_path,
             text: t(".create_one"),
@@ -59,5 +59,5 @@
     <% end %>
   <% end %>
 
-  <%= turbo_frame_tag :resource_modal, target: "_top" %>
+  <%= turbo_frame_tag :resource_form, target: "_top" %>
 <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @store_credit, url: form_url, method: :post, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
@@ -29,7 +29,7 @@
                 tag: :a,
                 scheme: :danger,
                 data: {
-                  turbo_frame: :resource_modal
+                  turbo_frame: :resource_form
                 },
                 href: edit_validity_url,
                 text: t(".invalidate"),
@@ -39,7 +39,7 @@
             <%= render component("ui/button").new(
               tag: :a,
               data: {
-                turbo_frame: :resource_modal
+                turbo_frame: :resource_form
               },
               href: edit_memo_url,
               text: t(".edit_memo"),
@@ -49,7 +49,7 @@
               <%= render component("ui/button").new(
                 tag: :a,
                 data: {
-                  turbo_frame: :resource_modal
+                  turbo_frame: :resource_form
                 },
                 href: edit_amount_url,
                 text: t(".edit_amount"),
@@ -77,5 +77,5 @@
     <% end %>
   <% end %>
 
-  <%= turbo_frame_tag :resource_modal, target: "_top" %>
+  <%= turbo_frame_tag :resource_form, target: "_top" %>
 <% end %>

--- a/admin/app/components/solidus_admin/zones/form/component.html.erb
+++ b/admin/app/components/solidus_admin/zones/form/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title:) do |modal| %>
     <%= form_for @zone, url: @form_url, html: { id: @form_id, **stimulus_controller, **stimulus_value(name: :kind, value: @zone.kind) } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/admin/app/components/solidus_admin/zones/index/component.rb
+++ b/admin/app/components/solidus_admin/zones/index/component.rb
@@ -22,7 +22,7 @@ class SolidusAdmin::Zones::Index::Component < SolidusAdmin::UI::Pages::Index::Co
   end
 
   def turbo_frames
-    %w[resource_modal]
+    %w[resource_form]
   end
 
   def page_actions
@@ -30,7 +30,7 @@ class SolidusAdmin::Zones::Index::Component < SolidusAdmin::UI::Pages::Index::Co
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_zone_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
       class: "align-self-end w-full",
     )
@@ -69,7 +69,7 @@ class SolidusAdmin::Zones::Index::Component < SolidusAdmin::UI::Pages::Index::Co
       header: :name,
       data: ->(zone) do
         link_to zone.name, edit_path(zone),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }
@@ -80,7 +80,7 @@ class SolidusAdmin::Zones::Index::Component < SolidusAdmin::UI::Pages::Index::Co
       header: :description,
       data: ->(zone) do
         link_to zone.description, edit_path(zone),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }

--- a/admin/app/controllers/solidus_admin/adjustments_controller.rb
+++ b/admin/app/controllers/solidus_admin/adjustments_controller.rb
@@ -20,7 +20,7 @@ class SolidusAdmin::AdjustmentsController < SolidusAdmin::BaseController
   def lock
     @adjustments = @order.all_adjustments.not_finalized.where(id: params[:id])
     @adjustments.each(&:finalize!)
-    flash[:success] = t('.success')
+    flash[:notice] = t('.success')
 
     redirect_to order_adjustments_path(@order), status: :see_other
   end
@@ -28,7 +28,7 @@ class SolidusAdmin::AdjustmentsController < SolidusAdmin::BaseController
   def unlock
     @adjustments = @order.all_adjustments.finalized.where(id: params[:id])
     @adjustments.each(&:unfinalize!)
-    flash[:success] = t('.success')
+    flash[:notice] = t('.success')
 
     redirect_to order_adjustments_path(@order), status: :see_other
   end
@@ -36,7 +36,7 @@ class SolidusAdmin::AdjustmentsController < SolidusAdmin::BaseController
   def destroy
     @adjustments = @order.all_adjustments.where(id: params[:id])
     @adjustments.destroy_all
-    flash[:success] = t('.success')
+    flash[:notice] = t('.success')
 
     redirect_to order_adjustments_path(@order), status: :see_other
   end

--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -19,6 +19,7 @@ module SolidusAdmin
 
     helper 'solidus_admin/components'
     helper 'solidus_admin/layout'
+    helper 'solidus_admin/flash'
 
     private
 

--- a/admin/app/controllers/solidus_admin/customers_controller.rb
+++ b/admin/app/controllers/solidus_admin/customers_controller.rb
@@ -13,7 +13,7 @@ class SolidusAdmin::CustomersController < SolidusAdmin::BaseController
 
   def destroy
     if @order.update(user: nil)
-      flash[:success] = t('.success')
+      flash[:notice] = t('.success')
     else
       flash[:error] = t('.error')
     end

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -43,7 +43,7 @@ module SolidusAdmin
       @product = Spree::Product.friendly.find(params[:id])
 
       if @product.update(product_params)
-        flash[:success] = t('spree.successfully_updated', resource: [
+        flash[:notice] = t('spree.successfully_updated', resource: [
           Spree::Product.model_name.human,
           @product.name.inspect,
         ].join(' '))

--- a/admin/app/controllers/solidus_admin/resources_controller.rb
+++ b/admin/app/controllers/solidus_admin/resources_controller.rb
@@ -133,7 +133,7 @@ module SolidusAdmin
           render page_component, status: :unprocessable_entity
         end
         format.turbo_stream do
-          render turbo_stream: turbo_stream.replace(:resource_modal, page_component),
+          render turbo_stream: turbo_stream.replace(resource_form_frame, page_component),
             status: :unprocessable_entity
         end
       end
@@ -164,6 +164,10 @@ module SolidusAdmin
     def blueprint_view
       raise NotImplementedError,
         "You must implement the blueprint_view method in #{self.class}"
+    end
+
+    def resource_form_frame
+      :resource_form
     end
   end
 end

--- a/admin/app/controllers/solidus_admin/stores_controller.rb
+++ b/admin/app/controllers/solidus_admin/stores_controller.rb
@@ -2,6 +2,20 @@
 
 module SolidusAdmin
   class StoresController < SolidusAdmin::ResourcesController
+    def destroy
+      @resource = resource_class.where(id: params[:id])
+
+      failed = @resource.destroy_all.reject(&:destroyed?)
+      if failed.present?
+        desc = failed.map { t(".error.description", name: _1.name, reason: _1.errors.full_messages.join(" ")) }.join("<br>")
+        flash[:alert] = { danger: { title: t(".error.title"), description: desc } }
+      else
+        flash[:notice] = t('.success')
+      end
+
+      redirect_to after_destroy_path, status: :see_other
+    end
+
     private
 
     def resource_class = Spree::Store

--- a/admin/app/controllers/solidus_admin/stores_controller.rb
+++ b/admin/app/controllers/solidus_admin/stores_controller.rb
@@ -1,35 +1,26 @@
 # frozen_string_literal: true
 
 module SolidusAdmin
-  class StoresController < SolidusAdmin::BaseController
-    include SolidusAdmin::ControllerHelpers::Search
-
-    def index
-      stores = apply_search_to(
-        Spree::Store.order(id: :desc),
-        param: :q
-      )
-
-      set_page_and_extract_portion_from(stores)
-
-      respond_to do |format|
-        format.html { render component('stores/index').new(page: @page) }
-      end
-    end
-
-    def destroy
-      @stores = Spree::Store.where(id: params[:id])
-
-      Spree::Store.transaction { @stores.destroy_all }
-
-      flash[:notice] = t('.success')
-      redirect_back_or_to stores_path, status: :see_other
-    end
-
+  class StoresController < SolidusAdmin::ResourcesController
     private
 
-    def store_params
-      params.require(:store).permit(:store_id, permitted_store_attributes)
+    def resource_class = Spree::Store
+
+    def resources_collection = Spree::Store
+
+    def permitted_resource_params
+      params.require(:store).permit(
+        :name,
+        :url,
+        :code,
+        :meta_description,
+        :meta_keywords,
+        :seo_title,
+        :mail_from_address,
+        :default_currency,
+        :cart_tax_country_iso,
+        available_locales: [],
+      )
     end
   end
 end

--- a/admin/app/controllers/solidus_admin/users_controller.rb
+++ b/admin/app/controllers/solidus_admin/users_controller.rb
@@ -37,7 +37,7 @@ module SolidusAdmin
       set_address_from_params
 
       if @address.valid? && @user.update(user_params)
-        flash[:success] = t(".#{@type}.success")
+        flash[:notice] = t(".#{@type}.success")
 
         respond_to do |format|
           format.turbo_stream { render turbo_stream: '<turbo-stream action="refresh" />' }

--- a/admin/app/helpers/solidus_admin/flash_helper.rb
+++ b/admin/app/helpers/solidus_admin/flash_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Reserve :alert for messages that should go in UI alert component. Everything else will be shown in UI toast.
+module SolidusAdmin
+  module FlashHelper
+    def toasts
+      flash.to_hash.with_indifferent_access.except(:alert)
+    end
+
+    # Construct alert flashes like +flash[:alert] = { <alert_type>: { title: "", description: "" } }+.
+    # See +SolidusAdmin::UI::Alert::Component::SCHEMES+ for available alert types.
+    def alerts
+      flash.to_hash.with_indifferent_access.fetch(:alert, {}).slice(*SolidusAdmin::UI::Alert::Component::SCHEMES.keys)
+    end
+  end
+end

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -31,6 +31,14 @@
       </main>
     </div>
 
+    <div class="flex items-center justify-center">
+      <div class="fixed w-2/3 top-3 flex flex-col gap-3 pointer-events-none" role="alert">
+        <% alerts.each do |key, text| %>
+          <%= render component("ui/alert").new(title: text[:title], description: text[:description], scheme: key.to_sym) %>
+        <% end %>
+      </div>
+    </div>
+
     <div class="fixed inset-x-0 bottom-3 flex items-center justify-center flex-col gap-3 pointer-events-none" role="alert">
       <% toasts.each do |key, message| %>
         <%= render component("ui/toast").new(text: message, scheme: key.to_sym == :error ? :error : :default) %>

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -32,7 +32,7 @@
     </div>
 
     <div class="fixed inset-x-0 bottom-3 flex items-center justify-center flex-col gap-3 pointer-events-none" role="alert">
-      <% flash.each do |key, message| %>
+      <% toasts.each do |key, message| %>
         <%= render component("ui/toast").new(text: message, scheme: key.to_sym == :error ? :error : :default) %>
       <% end %>
     </div>

--- a/admin/config/locales/stores.en.yml
+++ b/admin/config/locales/stores.en.yml
@@ -1,4 +1,19 @@
 en:
+  activerecord:
+    attributes:
+      spree/store:
+        available_locales: Storefront Languages
+        bcc_email: BCC Email
+        cart_tax_country_iso: Tax Country
+        code: Slug
+        default: Default
+        default_currency: Default Currency
+        mail_from_address: Store Email
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        name: Store Name
+        seo_title: Page Title
+        url: URL
   solidus_admin:
     stores:
       title: "Stores"

--- a/admin/config/locales/stores.en.yml
+++ b/admin/config/locales/stores.en.yml
@@ -17,5 +17,12 @@ en:
   solidus_admin:
     stores:
       title: "Stores"
+      create:
+        success: "Store was successfully created."
       destroy:
+        error:
+          title: "Some Stores could not be removed"
+          description: "%{name}: %{reason}"
         success: "Stores were successfully removed."
+      update:
+        success: "Store was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -79,7 +79,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :shipping_methods, only: [:index, :destroy]
   admin_resources :shipping_categories, except: [:show]
   admin_resources :stock_locations, only: [:index, :destroy]
-  admin_resources :stores, only: [:index, :destroy]
+  admin_resources :stores, except: [:show]
   admin_resources :zones, except: [:show]
   admin_resources :refund_reasons, except: [:show]
   admin_resources :reimbursement_types, only: [:index]

--- a/admin/docs/index_pages.md
+++ b/admin/docs/index_pages.md
@@ -94,7 +94,7 @@ end
 def delete
   @users = Spree.user_class.where(id: params[:id])
   @users.destroy_all
-  flash[:success] = "Admin users deleted"
+  flash[:notice] = "Admin users deleted"
   redirect_to solidus_admin.users_path, status: :see_other
 end
 ```

--- a/admin/lib/solidus_admin/testing_support/feature_helpers.rb
+++ b/admin/lib/solidus_admin/testing_support/feature_helpers.rb
@@ -61,6 +61,10 @@ module SolidusAdmin
           find('button[aria-label="Clear"]').click
         end
       end
+
+      def solidus_select_control(field)
+        find_field(field, visible: :all).ancestor(".control")
+      end
     end
   end
 end

--- a/admin/spec/components/solidus_admin/ui/button/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/button/component_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe SolidusAdmin::UI::Button::Component, type: :component do
     end
   end
 
+  describe ".delete" do
+    let(:component) { described_class.delete }
+
+    it "renders Delete button" do
+      render_inline(component)
+      expect(page).to have_button("Delete")
+    end
+  end
+
   describe ".discard" do
     let(:component) { described_class.discard(path: "/index") }
 

--- a/admin/spec/components/solidus_admin/ui/button/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/button/component_spec.rb
@@ -39,4 +39,32 @@ RSpec.describe SolidusAdmin::UI::Button::Component, type: :component do
       expect(page).to have_content("Cancel")
     end
   end
+
+  describe ".back" do
+    let(:component) { described_class.back(path: "/index") }
+
+    it "renders Back button" do
+      render_inline(component)
+      expect(page).to have_link(href: '/index', title: 'Back')
+    end
+  end
+
+  describe ".discard" do
+    let(:component) { described_class.discard(path: "/index") }
+
+    it "renders Discard button" do
+      render_inline(component)
+      expect(page).to have_link(href: '/index')
+      expect(page).to have_content("Discard")
+    end
+  end
+
+  describe ".save" do
+    let(:component) { described_class.save }
+
+    it "renders Save button" do
+      render_inline(component)
+      expect(page).to have_button("Save")
+    end
+  end
 end

--- a/admin/spec/features/stores_spec.rb
+++ b/admin/spec/features/stores_spec.rb
@@ -5,20 +5,120 @@ require 'spec_helper'
 describe "Stores", :js, type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists stores and allows deleting them" do
-    create(:store, name: "B2C Store")
-    create(:store, name: "B2B Store")
+  describe "index page" do
+    before do
+      create(:store, name: "B2C Store")
+      create(:store, name: "B2B Store", default: true)
+      visit "/admin/stores"
+      expect(page).to have_content("B2C Store")
+      expect(page).to have_content("B2B Store")
+      expect(page).to be_axe_clean
+    end
 
-    visit "/admin/stores"
-    expect(page).to have_content("B2C Store")
-    expect(page).to have_content("B2B Store")
-    expect(page).to be_axe_clean
+    it "lists stores and allows deleting them" do
+      select_row("B2C Store")
 
-    select_row("B2C Store")
-    click_on "Delete"
-    expect(page).to have_content("Stores were successfully removed.")
-    expect(page).not_to have_content("B2C Store")
-    expect(Spree::Store.count).to eq(1)
-    expect(page).to be_axe_clean
+      accept_confirm("Are you sure you want to delete 1 store?") do
+        click_button("Delete")
+      end
+
+      expect(page).to have_content("Stores were successfully removed.")
+      expect(page).not_to have_content("B2C Store")
+      expect(page).to be_axe_clean
+    end
+
+    it "does not allow to delete default store" do
+      select_row("B2B Store")
+
+      accept_confirm("Are you sure you want to delete 1 store?") do
+        click_button("Delete")
+      end
+
+      expect(page).not_to have_content("Stores were successfully removed.")
+      expect(page).to have_content("B2B Store")
+      expect(page).to have_content("Some Stores could not be removed")
+      expect(page).to have_content("B2B Store: Cannot destroy the default Store")
+      expect(page).to be_axe_clean
+    end
+  end
+
+  describe "creating new store" do
+    before do
+      visit "/admin/stores"
+      click_on "Add new"
+      expect(page).to be_axe_clean
+    end
+
+    context "with valid form" do
+      it "saves store" do
+        fill_in "Store Name", with: "New Store"
+        fill_in "Slug", with: "new-store"
+        fill_in "URL", with: "www.new-store.com"
+        fill_in "Store Email", with: "mail@new-stores.com"
+
+        within("header") { click_on "Save" }
+
+        expect(page).to have_content("Store was successfully created")
+        expect(page).to have_content("New Store")
+        expect(page).to have_content("new-store")
+        expect(page).to have_content("www.new-store.com")
+      end
+    end
+
+    context "with invalid form" do
+      it "saves store" do
+        within("header") { click_on "Save" }
+
+        expect(page).to have_content("can't be blank", count: 4)
+      end
+    end
+  end
+
+  describe "editing existing store" do
+    before do
+      create(:store,
+        name: "B2C Store",
+        default_currency: "GBP",
+        cart_tax_country_iso: create(:country, iso: "GB").iso,
+        available_locales: %w[en])
+
+      create(:country, iso: "US")
+      visit "/admin/stores"
+      click_on "B2C Store"
+      expect(page).to be_axe_clean
+    end
+
+    it "updates store" do
+      expect(solidus_select_control("Default Currency")).to have_content("GBP")
+      expect(solidus_select_control("Tax Country")).to have_content("United Kingdom")
+      expect(solidus_select_control("Storefront Languages")).to have_content("English (US)")
+
+      fill_in "Store Name", with: "Updated Store"
+      fill_in "Slug", with: "updated-store"
+      fill_in "URL", with: "www.updated-store.com"
+      fill_in "Store Email", with: "updated-mail@new-stores.com"
+      solidus_select("USD", from: "Default Currency")
+      solidus_select("United States", from: "Tax Country")
+
+      within("header") { click_on "Save" }
+
+      expect(page).to have_content("Store was successfully updated")
+      expect(page).to have_content("Updated Store")
+      expect(page).to have_content("updated-store")
+      expect(page).to have_content("www.updated-store.com")
+
+      click_on "Updated Store"
+      expect(solidus_select_control("Default Currency")).to have_content("USD")
+      expect(solidus_select_control("Tax Country")).to have_content("United States")
+    end
+  end
+
+  describe "clicking Discard" do
+    it "redirects back to index" do
+      visit "/admin/stores"
+      click_on "Add new"
+      click_on "Discard"
+      expect(page).to have_current_path("/admin/stores")
+    end
   end
 end

--- a/admin/spec/requests/solidus_admin/stores_spec.rb
+++ b/admin/spec/requests/solidus_admin/stores_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require 'solidus_admin/testing_support/shared_examples/crud_resource_requests'
+
+RSpec.describe "SolidusAdmin::StoresController", type: :request do
+  before { create(:store, default: true) } # create a default store so that we operate on a non-default one
+
+  include_examples 'CRUD resource requests', 'store' do
+    let(:resource_class) { Spree::Store }
+    let(:valid_attributes) { { name: "Store", code: "store", url: "store.com", mail_from_address: "store@example.com" } }
+    let(:invalid_attributes) { { name: "" } }
+  end
+end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -25,7 +25,7 @@ module Spree
     self.allowed_ransackable_attributes = %w[name url code]
 
     before_save :ensure_default_exists_and_is_unique
-    before_destroy :validate_not_default
+    before_destroy :validate_not_default, prepend: true
 
     enum :reverse_charge_status, {
       disabled: 0,
@@ -73,6 +73,7 @@ module Spree
     def validate_not_default
       if default
         errors.add(:base, :cannot_destroy_default_store)
+        throw :abort
       end
     end
   end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -136,4 +136,24 @@ RSpec.describe Spree::Store, type: :model do
       expect { Spree::Store.new(reverse_charge_status: :invalid_status) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#validate_not_default" do
+    context "when deleting a default store" do
+      it "prevents deletion" do
+        store = create(:store, default: true)
+        expect(store.destroy).to eq false
+        expect(store.errors.full_messages.join).to match /Cannot destroy/
+        expect { store.reload }.not_to raise_error
+      end
+    end
+
+    context "when deleting a non-default store" do
+      it "allows deletion" do
+        create(:store, default: true)
+        store = create(:store, default: false)
+        expect(store.destroy).to be_truthy
+        expect { store.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/index/component.rb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/index/component.rb
@@ -14,7 +14,7 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
   end
 
   def turbo_frames
-    %w[resource_modal]
+    %w[resource_form]
   end
 
   def page_actions
@@ -22,7 +22,7 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
       tag: :a,
       text: t('.add'),
       href: solidus_admin.new_promotion_category_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line",
     )
   end
@@ -50,7 +50,7 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
       header: :name,
       data: ->(record) do
         link_to record.name, edit_path(record),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }
@@ -61,7 +61,7 @@ class SolidusAdmin::PromotionCategories::Index::Component < SolidusAdmin::UI::Pa
       header: :code,
       data: ->(record) do
         link_to record.code, edit_path(record),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/index/component.rb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/index/component.rb
@@ -14,7 +14,7 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
   end
 
   def turbo_frames
-    %w[resource_modal]
+    %w[resource_form]
   end
 
   def page_actions
@@ -22,7 +22,7 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
       tag: :a,
       text: t(".add"),
       href: solidus_promotions.new_promotion_category_path(**search_filter_params),
-      data: { turbo_frame: :resource_modal },
+      data: { turbo_frame: :resource_form },
       icon: "add-line"
     )
   end
@@ -50,7 +50,7 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
       header: :name,
       data: ->(record) do
         link_to record.name, edit_path(record),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }
@@ -61,7 +61,7 @@ class SolidusPromotions::PromotionCategories::Index::Component < SolidusAdmin::U
       header: :code,
       data: ->(record) do
         link_to record.code, edit_path(record),
-          data: { turbo_frame: :resource_modal },
+          data: { turbo_frame: :resource_form },
           class: 'body-link'
       end
     }

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :resource_modal, target: "_top" do %>
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
     <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">


### PR DESCRIPTION
## Summary

Implement interface to create/edit stores.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/ace6b207-e3b3-4469-b9bc-af11f8f4436a" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/60c63bf7-ed9e-4123-93e4-c9492421abd0" />

### Other changes

- Rename `:resource_modal` turbo frame to `:resource_form` and add an overridable method `#resource_form_frame` in resources_controller, that returns default frame name `:resource_form`.
- ~UI select component: add support for `:include_blank` option. Component now will only accept array for `choices`. Updated usage in a few places where a string has been passed instead of an array (user store credits)~ - split to #6279.
- ~Updated layout to accommodate alerts display. Added FlashHelper to differentiate between toast flashes and alert flashes~ - split to #6280.
- ~Updated usages of `flash[:success]` to `flash[:notice]` to be consistent~ - split to #6280.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
