### PR TITLE
docs: introduce roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,9 @@
+# Roadmap
+
+This file provides an overview of the direction solidus is heading.
+
+## [Solidus Admin](https://github.com/orgs/solidusio/projects/12)
+
+- Rewrite of old Bootstrap and jQuery based backend into a modern [Rails Hotwire stack](https://hotwired.dev) with [ViewComponent](https://viewcomponent.org) and TailwindCSS
+- Filter mechanisms for lists. E.g. option types on products, sort orders by state
+- A new color theme and modern UI


### PR DESCRIPTION
In order to establish a foundation to discuss future endeavours we introduce documentation that reflects the current core team decisions

## Summary

It is a common pattern in OOS to have a publicly available roadmap. While I won't go into the advantages of that, it is my opinion that as many components in the eCommerce domain are evolving, the question of which direction Solidus is trying to go becomes more important.

In the Solidus Slack @kennyadsl let me know what the only item on the list is the new Admin ui right now. 


As I am not a maintainer (not even writing ruby) I must admit I do not really know what the new admin ui makes it a better ui than the current one. So I wanted get some feeback on :

* Is a publicly documented Roadmap in code something solidus would like to maintain?
* What is the big improvement coming with the new admin ui?

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

