### PR TITLE
Use Firefox for system specs

### DIFF
--- a/admin/lib/solidus_admin/testing_support/feature_helpers.rb
+++ b/admin/lib/solidus_admin/testing_support/feature_helpers.rb
@@ -19,11 +19,11 @@ module SolidusAdmin
       end
 
       def find_row(text)
-        find('table tbody tr', text:)
+        find('table tbody tr td', text:)
       end
 
       def find_row_checkbox(text)
-        find_row(text).find('td:first-child input[type="checkbox"]')
+        find('table tbody tr', text:).find('td:first-child input[type="checkbox"]')
       end
 
       def select_row(text)

--- a/admin/spec/features/products_spec.rb
+++ b/admin/spec/features/products_spec.rb
@@ -17,7 +17,7 @@ describe "Products", type: :feature do
     expect(page).to have_content("$19.99")
     expect(page).to be_axe_clean
 
-    find('table tbody tr', text: 'Just a product').click
+    find_row('Just a product').click
 
     expect(page).to have_current_path("/admin/products/just-a-prod")
     expect(page).to have_content("Manage images")

--- a/core/lib/spree/testing_support/capybara_driver.rb
+++ b/core/lib/spree/testing_support/capybara_driver.rb
@@ -1,26 +1,9 @@
 # frozen_string_literal: true
 
 require "selenium/webdriver"
+require "capybara-screenshot"
 
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1920,1080'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+Capybara::Screenshot.register_driver(:selenium_headless) do |driver, path|
+  driver.browser.save_screenshot(path)
 end
-
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
+Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_headless).to_sym


### PR DESCRIPTION
## Summary

Chrome seems to consistently get updated with new interesting options,
and our specs have been sometimes more, and sometimes less flaky with
Chrome as the browser that drives our system specs.

This change uses the preconfigured `selenium_headless` driver from the
Selenium gem, which uses Firefox under the hood.

There are a few changes to helpers in the new admin. All of them have to
with clicking table cells rather than the underlying table row. This is
how real users also interact with the respective page, so I think it's a
good change.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
