### PR TITLE
Add 500ms delay before AJAX in Select2

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -23,6 +23,7 @@ $.fn.optionValueAutocomplete = function (options) {
     },
     ajax: {
       url: Spree.pathFor('api/option_values'),
+      quietMillis: 500,
       datatype: 'json',
       data: function (term, page) {
         var productId = typeof(productSelect) !== 'undefined' ? $(productSelect).select2('val') : null;

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -35,6 +35,7 @@ $.fn.productAutocomplete = function (options) {
   this.select2({
     minimumInputLength: 3,
     multiple: multiple,
+    quietMillis: 500,
     initSelection: function (element, callback) {
       $.get(Spree.pathFor('admin/search/products'), {
         ids: element.val().split(','),

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -47,6 +47,7 @@ $.fn.taxonAutocomplete = function (options) {
       },
       ajax: {
         url: Spree.pathFor('api/taxons'),
+        quietMillis: 500,
         datatype: 'json',
         data: function (term, page) {
           return {


### PR DESCRIPTION

## Summary

We have four select2 Ajax pickers in `solidus_backend`:
- Option Value Picker
- Product Picker
- Taxon Autocomplete
- Variant Autocomplete

The Variant autocomplete already has a 500ms delay between the user finishing typing and the Ajax request firing. This is good, because it stops requests happening at every keypress. This commit extends that behavior to the option value, product and taxon pickers.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
