### PR TITLE
fix admin component generator namespace

### DIFF
--- a/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
+++ b/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
@@ -37,4 +37,7 @@ SolidusAdmin::Config.configure do |config|
   #     }
   #   ]
   # }
+
+  # Define namespace for component generator
+  ::Rails::Generators.namespace = SolidusAdmin
 end


### PR DESCRIPTION
This PR is sponsored by :volcano: [MagmaLabs](https://github.com/magma-labs)

## Summary

Admin component generator is failing on a clean solidus installation. 

```
$ ./bin/rails g solidus_admin:component event
[WARNING Spree] Missing migrations.
[WARNING Spree] - add_reverse_charge_status_to_store
[WARNING Spree] - add_vat_id_email_and_reverse_charge_status_to_addresses
[WARNING Spree]
[WARNING Spree] Run `bin/rails railties:install:migrations` to get them.
[WARNING Spree] You can silence this warning by setting the `SOLIDUS_SKIP_MIGRATIONS_CHECK` environment variable.
      create  app/components/event/component.html.erb
/home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/railties-8.0.2/lib/rails/generators/base.rb:321:in `namespace_dirs': undefined method `name' for nil (NoMethodError)

          @namespace_dirs ||= namespace.name.split("::").map(&:underscore)
                                       ^^^^^
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/railties-8.0.2/lib/rails/generators/base.rb:325:in `namespaced_path'
	from /home/yoh/tmp/solidus/admin/lib/generators/solidus_admin/component/templates/component.rb.tt:3:in `template'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/erb-5.0.1/lib/erb.rb:427:in `eval'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/erb-5.0.1/lib/erb.rb:427:in `result'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/file_manipulation.rb:128:in `block in template'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/create_file.rb:54:in `render'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/create_file.rb:64:in `block (2 levels) in invoke!'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/create_file.rb:64:in `open'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/create_file.rb:64:in `block in invoke!'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/empty_directory.rb:117:in `invoke_with_conflict_check'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/create_file.rb:61:in `invoke!'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions.rb:93:in `action'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/create_file.rb:25:in `create_file'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/actions/file_manipulation.rb:124:in `template'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/railties-8.0.2/lib/rails/generators/named_base.rb:25:in `block in template'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/railties-8.0.2/lib/rails/generators/named_base.rb:45:in `inside_template'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/railties-8.0.2/lib/rails/generators/named_base.rb:24:in `template'
	from /home/yoh/tmp/solidus/admin/lib/generators/solidus_admin/component/component_generator.rb:29:in `create_component_files'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `block in invoke_all'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `each'
	from /home/yoh/.rvm/gems/ruby-3.3.7@commerze/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `map'
```

Error comes from https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/railties/lib/rails/generators/base.rb#L321 due to `namespace` is returning `nil`.

This method was called from `component.rb` template
https://github.com/solidusio/solidus/blob/main/admin/lib/generators/solidus_admin/component/templates/component.rb.tt#L3
https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/railties/lib/rails/generators/base.rb#L324

So we need to define namespace into gem or host app to fix it. For now, I think would be easier to fix by adding into initializer template.

Let me know what you think?

Looking into specs found that are passing because we already seated namespace for generators specs
https://github.com/solidusio/solidus/blob/main/admin/spec/spec_helper.rb#L115

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
