### PR TITLE
[Admin] fix table sorting

### DIFF
--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -69,13 +69,10 @@ export default class extends Controller {
 
   selectRow(event) {
     if (this.checkboxTargets.some((checkbox) => checkbox.checked)) {
+      this.previousMode = this.modeValue;
       this.modeValue = "batch"
-    } else if (this.hasSearchFieldTarget && this.searchFieldTarget.value !== "") {
-      this.modeValue = "search"
-    } else if (this.hasScopesToolbarTarget) {
-      this.modeValue = "scopes"
     } else {
-      this.modeValue = "search"
+      this.modeValue = this.previousMode;
     }
 
     this.render()
@@ -83,13 +80,10 @@ export default class extends Controller {
 
   selectAllRows(event) {
     if (event.target.checked) {
+      this.previousMode = this.modeValue;
       this.modeValue = "batch"
-    } else if (this.hasSearchFieldTarget && this.searchFieldTarget.value !== "") {
-      this.modeValue = "search"
-    } else if (this.hasScopesToolbarTarget) {
-      this.modeValue = "scopes"
     } else {
-      this.modeValue = "search"
+      this.modeValue = this.previousMode;
     }
 
     this.checkboxTargets.forEach((checkbox) => (checkbox.checked = event.target.checked))

--- a/admin/app/components/solidus_admin/ui/table/component.js
+++ b/admin/app/components/solidus_admin/ui/table/component.js
@@ -32,7 +32,9 @@ export default class extends Controller {
   }
 
   // Determine if sortable should be enabled
-  modeValueChanged() {
+  modeValueChanged(_current, previous) {
+    this.previousMode = previous;
+
     const shouldSetSortable = this.sortableValue && this.modeValue !== "batch" && this.modeValue !== "search"
 
     if (shouldSetSortable) {
@@ -69,8 +71,7 @@ export default class extends Controller {
 
   selectRow(event) {
     if (this.checkboxTargets.some((checkbox) => checkbox.checked)) {
-      this.previousMode = this.modeValue;
-      this.modeValue = "batch"
+      this.modeValue = "batch";
     } else {
       this.modeValue = this.previousMode;
     }
@@ -80,8 +81,7 @@ export default class extends Controller {
 
   selectAllRows(event) {
     if (event.target.checked) {
-      this.previousMode = this.modeValue;
-      this.modeValue = "batch"
+      this.modeValue = "batch";
     } else {
       this.modeValue = this.previousMode;
     }

--- a/admin/app/components/solidus_admin/ui/table/component.rb
+++ b/admin/app/components/solidus_admin/ui/table/component.rb
@@ -185,6 +185,8 @@ class SolidusAdmin::UI::Table::Component < SolidusAdmin::BaseComponent
   end
 
   def should_enable_sortable?
-    @sortable && @search&.on_default_scope?
+    return false if @sortable.nil?
+    return true if @search.nil?
+    @search.on_default_scope?
   end
 end

--- a/admin/app/javascript/solidus_admin/controllers/sortable_controller.js
+++ b/admin/app/javascript/solidus_admin/controllers/sortable_controller.js
@@ -4,7 +4,7 @@ import { patch } from '@rails/request.js'
 
 export default class extends Controller {
   static values = {
-    param: { type: String, default: 'postion' },
+    param: { type: String, default: 'position' },
     handle: { type: String, default: null },
     animation: { type: Number, default: 150 },
   }


### PR DESCRIPTION
## Summary

Fixes bug with sorting, where leaving "batch" mode (i.e unselecting checkboxes) in UI table caused sorting to be disabled in tables with no search/filters/scopes present.
Instead of determining appropriate table mode we just revert to pre-batch mode.

**Before**

https://github.com/user-attachments/assets/48800a75-4f15-4000-8e74-69f34d5b70b1

**After**

https://github.com/user-attachments/assets/2eb27593-cb09-4934-9772-e03ffec15b45

**Mode preserved**

https://github.com/user-attachments/assets/2c56e832-3c0a-45fc-99b9-26933e17a9c9





## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
