### PR TITLE
Fix linting errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -352,6 +352,11 @@ Rails/LexicallyScopedActionFilter:
   Exclude:
     - "backend/app/controllers/**/*"
 
+Rails/HelperInstanceVariable:
+  Exclude:
+    - "backend/app/helpers/**/*"
+    - "core/app/helpers/**/*"
+
 # Since we're writing library code we can't assume that
 # tasks should load the rails environment loaded.
 Rails/RakeEnvironment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -348,6 +348,10 @@ Rails/FindEach:
   Exclude:
     - "db/migrate/**/*"
 
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - "backend/app/controllers/**/*"
+
 # Since we're writing library code we can't assume that
 # tasks should load the rails environment loaded.
 Rails/RakeEnvironment:

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -11,20 +11,58 @@ module Spree
     included do
       extend Spree::DisplayMoney
 
-      has_many :role_users, foreign_key: "user_id", class_name: "Spree::RoleUser", dependent: :destroy
-      has_many :spree_roles, through: :role_users, source: :role, class_name: "Spree::Role"
+      has_many :role_users,
+        foreign_key: "user_id",
+        class_name: "Spree::RoleUser",
+        dependent: :destroy,
+        inverse_of: :user
+      has_many :spree_roles,
+        through: :role_users,
+        source: :role,
+        class_name: "Spree::Role",
+        inverse_of: :users
 
-      has_many :user_stock_locations, foreign_key: "user_id", class_name: "Spree::UserStockLocation"
-      has_many :stock_locations, through: :user_stock_locations
+      has_many :user_stock_locations,
+        foreign_key: "user_id",
+        class_name: "Spree::UserStockLocation",
+        inverse_of: :user,
+        dependent: :destroy
+      has_many :stock_locations,
+        through: :user_stock_locations,
+        inverse_of: :users
 
-      has_many :spree_orders, foreign_key: "user_id", class_name: "Spree::Order"
-      has_many :orders, foreign_key: "user_id", class_name: "Spree::Order"
+      has_many :spree_orders,
+        foreign_key: "user_id",
+        class_name: "Spree::Order",
+        inverse_of: :user,
+        dependent: :nullify
+      has_many :orders,
+        foreign_key: "user_id",
+        class_name: "Spree::Order",
+        inverse_of: :user,
+        dependent: :nullify
 
-      has_many :store_credits, -> { includes(:credit_type) }, foreign_key: "user_id", class_name: "Spree::StoreCredit"
-      has_many :store_credit_events, through: :store_credits
+      has_many :store_credits,
+        -> { includes(:credit_type) },
+        foreign_key: "user_id",
+        class_name: "Spree::StoreCredit",
+        dependent: :nullify,
+        inverse_of: :user
+      has_many :store_credit_events,
+        through: :store_credits,
+        inverse_of: false
 
-      has_many :credit_cards, class_name: "Spree::CreditCard", foreign_key: :user_id
-      has_many :wallet_payment_sources, foreign_key: 'user_id', class_name: 'Spree::WalletPaymentSource', inverse_of: :user
+      has_many :credit_cards,
+        class_name: "Spree::CreditCard",
+        foreign_key: :user_id,
+        dependent: :nullify,
+        inverse_of: :user
+
+      has_many :wallet_payment_sources,
+        foreign_key: 'user_id',
+        class_name: 'Spree::WalletPaymentSource',
+        inverse_of: :user,
+        dependent: :destroy
 
       after_create :auto_generate_spree_api_key
       before_destroy :check_for_deletion

--- a/core/app/models/spree/adjustment_reason.rb
+++ b/core/app/models/spree/adjustment_reason.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class AdjustmentReason < Spree::Base
-    has_many :adjustments, inverse_of: :adjustment_reason
+    has_many :adjustments, inverse_of: :adjustment_reason, dependent: :restrict_with_exception
 
     validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
     validates :code, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -2,9 +2,19 @@
 
 module Spree
   class Country < Spree::Base
-    has_many :states, -> { order(:name) }, dependent: :destroy
-    has_many :addresses, dependent: :nullify
-    has_many :prices, class_name: "Spree::Price", foreign_key: "country_iso", primary_key: "iso"
+    has_many :states,
+      -> { order(:name) },
+      dependent: :destroy,
+      inverse_of: :country
+    has_many :addresses,
+      dependent: :nullify,
+      inverse_of: false
+    has_many :prices,
+      class_name: "Spree::Price",
+      foreign_key: "country_iso",
+      primary_key: "iso",
+      dependent: :destroy,
+      inverse_of: :country
 
     validates :name, :iso_name, presence: true
 

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -4,7 +4,11 @@ module Spree
   # The default `source` of a `Spree::Payment`.
   #
   class CreditCard < Spree::PaymentSource
-    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', optional: true
+    belongs_to :user,
+      class_name: Spree::UserClassHandle.new,
+      foreign_key: 'user_id',
+      optional: true,
+      inverse_of: :credit_cards
     belongs_to :address, optional: true
 
     before_save :set_last_digits

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -6,9 +6,14 @@ module Spree
 
     belongs_to :stock_location, optional: true
 
-    has_many :return_items, inverse_of: :customer_return
-    has_many :return_authorizations, through: :return_items
-    has_many :reimbursements, inverse_of: :customer_return
+    has_many :return_items,
+      inverse_of: :customer_return,
+      dependent: :destroy
+    has_many :return_authorizations,
+      through: :return_items
+    has_many :reimbursements,
+      inverse_of: :customer_return,
+      dependent: :nullify
 
     after_create :process_return!
     before_create :generate_number

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -13,10 +13,20 @@ module Spree
     belongs_to :carton, class_name: "Spree::Carton", inverse_of: :inventory_units, optional: true
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units, optional: true
 
-    has_many :return_items, inverse_of: :inventory_unit, dependent: :destroy
-    has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id, dependent: :destroy
-    has_one :unit_cancel, class_name: "Spree::UnitCancel"
-    has_one :order, through: :shipment
+    has_many :return_items,
+      inverse_of: :inventory_unit,
+      dependent: :destroy
+    has_one :original_return_item,
+      class_name: "Spree::ReturnItem",
+      foreign_key: :exchange_inventory_unit_id,
+      dependent: :destroy,
+      inverse_of: :exchange_inventory_unit
+    has_one :unit_cancel,
+      class_name: "Spree::UnitCancel",
+      inverse_of: :inventory_unit,
+      dependent: :restrict_with_exception
+    has_one :order,
+      through: :shipment
 
     delegate :order_id, to: :shipment
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -19,7 +19,7 @@ module Spree
     has_one :product, through: :variant
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :destroy
-    has_many :inventory_units, inverse_of: :line_item
+    has_many :inventory_units, inverse_of: :line_item, dependent: false
 
     before_validation :normalize_quantity
     before_validation :set_required_attributes

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -75,11 +75,19 @@ module Spree
     # Customer info
     belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
 
-    belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address', optional: true
+    belongs_to :bill_address,
+      foreign_key: :bill_address_id,
+      class_name: 'Spree::Address',
+      optional: true,
+      inverse_of: false
     alias_method :billing_address, :bill_address
     alias_method :billing_address=, :bill_address=
 
-    belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address', optional: true
+    belongs_to :ship_address,
+      foreign_key: :ship_address_id,
+      class_name: 'Spree::Address',
+      optional: true,
+      inverse_of: false
     alias_method :shipping_address, :ship_address
     alias_method :shipping_address=, :ship_address=
 
@@ -113,17 +121,22 @@ module Spree
 
     # Payments
     has_many :payments, dependent: :destroy, inverse_of: :order
-    has_many :valid_store_credit_payments, -> { store_credits.valid }, inverse_of: :order, class_name: 'Spree::Payment', foreign_key: :order_id
+    has_many :valid_store_credit_payments,
+      -> { store_credits.valid },
+      inverse_of: :order,
+      class_name: 'Spree::Payment',
+      foreign_key: :order_id,
+      dependent: :destroy
 
     # Returns
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :return_items, through: :inventory_units
     has_many :customer_returns, -> { distinct }, through: :return_items
-    has_many :reimbursements, inverse_of: :order
+    has_many :reimbursements, inverse_of: :order, dependent: :restrict_with_exception
     has_many :refunds, through: :payments
 
     # Logging
-    has_many :state_changes, as: :stateful
+    has_many :state_changes, as: :stateful, dependent: :destroy
     belongs_to :created_by, class_name: Spree::UserClassHandle.new, optional: true
     belongs_to :approver, class_name: Spree::UserClassHandle.new, optional: true
     belongs_to :canceler, class_name: Spree::UserClassHandle.new, optional: true

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -17,10 +17,10 @@ module Spree
     belongs_to :source, polymorphic: true, optional: true
     belongs_to :payment_method, -> { with_discarded }, class_name: 'Spree::PaymentMethod', inverse_of: :payments, optional: true
 
-    has_many :log_entries, as: :source
-    has_many :state_changes, as: :stateful
-    has_many :capture_events, class_name: 'Spree::PaymentCaptureEvent'
-    has_many :refunds, inverse_of: :payment
+    has_many :log_entries, as: :source, dependent: :destroy
+    has_many :state_changes, as: :stateful, dependent: :destroy
+    has_many :capture_events, class_name: 'Spree::PaymentCaptureEvent', dependent: :destroy
+    has_many :refunds, inverse_of: :payment, dependent: :destroy
 
     before_validation :validate_source, unless: :invalid?
     before_create :set_unique_identifier

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -23,9 +23,9 @@ module Spree
 
     validates :name, :type, presence: true
 
-    has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method
-    has_many :credit_cards, class_name: "Spree::CreditCard"
-    has_many :store_payment_methods, inverse_of: :payment_method
+    has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method, dependent: :restrict_with_exception
+    has_many :credit_cards, class_name: "Spree::CreditCard", dependent: :restrict_with_exception
+    has_many :store_payment_methods, inverse_of: :payment_method, dependent: :destroy
     has_many :stores, through: :store_payment_methods
 
     scope :ordered_by_position, -> { order(:position) }

--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -6,7 +6,7 @@ module Spree
 
     belongs_to :payment_method, optional: true
 
-    has_many :payments, as: :source
+    has_many :payments, as: :source, dependent: :restrict_with_error
     has_many :wallet_payment_sources,
       class_name: 'Spree::WalletPaymentSource',
       as: :payment_source,

--- a/core/app/models/spree/permission_set.rb
+++ b/core/app/models/spree/permission_set.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class PermissionSet < Spree::Base
-    has_many :role_permissions
+    has_many :role_permissions, dependent: :destroy
     has_many :roles, through: :role_permissions
     validates :name, :set, :privilege, :category, presence: true
     scope :display_permissions, -> { where(privilege: "display") }

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -6,8 +6,18 @@ module Spree
 
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 
-    belongs_to :variant, -> { with_discarded }, class_name: 'Spree::Variant', touch: true, optional: true
-    belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso", optional: true
+    belongs_to :variant,
+      -> { with_discarded },
+      class_name: 'Spree::Variant',
+      touch: true,
+      optional: true,
+      inverse_of: :prices
+    belongs_to :country,
+      class_name: "Spree::Country",
+      foreign_key: "country_iso",
+      primary_key: "iso",
+      optional: true,
+      inverse_of: :prices
 
     delegate :product, to: :variant
     delegate :tax_rates, to: :variant

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -5,10 +5,14 @@ module Spree
     include Metadata
 
     belongs_to :payment, inverse_of: :refunds, optional: true
-    belongs_to :reason, class_name: 'Spree::RefundReason', foreign_key: :refund_reason_id, optional: true
+    belongs_to :reason,
+      class_name: 'Spree::RefundReason',
+      foreign_key: :refund_reason_id,
+      optional: true,
+      inverse_of: :refunds
     belongs_to :reimbursement, inverse_of: :refunds, optional: true
 
-    has_many :log_entries, as: :source
+    has_many :log_entries, as: :source, dependent: :destroy
 
     validates :payment, presence: true
     validates :reason, presence: true

--- a/core/app/models/spree/refund_reason.rb
+++ b/core/app/models/spree/refund_reason.rb
@@ -9,7 +9,7 @@ module Spree
 
     RETURN_PROCESSING_REASON = 'Return processing'
 
-    has_many :refunds
+    has_many :refunds, dependent: :restrict_with_error
 
     self.allowed_ransackable_attributes = %w[name code]
 

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -7,10 +7,17 @@ module Spree
     belongs_to :order, inverse_of: :reimbursements, optional: true
     belongs_to :customer_return, inverse_of: :reimbursements, touch: true, optional: true
 
-    has_many :refunds, inverse_of: :reimbursement
-    has_many :credits, inverse_of: :reimbursement, class_name: 'Spree::Reimbursement::Credit'
+    has_many :refunds,
+      inverse_of: :reimbursement,
+      dependent: :restrict_with_error
+    has_many :credits,
+      inverse_of: :reimbursement,
+      class_name: 'Spree::Reimbursement::Credit',
+      dependent: :restrict_with_error
 
-    has_many :return_items, inverse_of: :reimbursement
+    has_many :return_items,
+      inverse_of: :reimbursement,
+      dependent: :restrict_with_error
 
     validates :order, presence: true
     validate :validate_return_items_belong_to_same_order

--- a/core/app/models/spree/reimbursement_type.rb
+++ b/core/app/models/spree/reimbursement_type.rb
@@ -9,7 +9,7 @@ module Spree
 
     ORIGINAL = 'original'
 
-    has_many :return_items
+    has_many :return_items, dependent: :restrict_with_error
 
     self.allowed_ransackable_attributes = %w[name]
 

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -13,7 +13,11 @@ module Spree
     has_many :customer_returns, through: :return_items
 
     belongs_to :stock_location, optional: true
-    belongs_to :reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id, optional: true
+    belongs_to :reason,
+      class_name: 'Spree::ReturnReason',
+      foreign_key: :return_reason_id,
+      optional: true,
+      inverse_of: :return_authorizations
 
     before_create :generate_number
 

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -37,7 +37,11 @@ module Spree
     belongs_to :reimbursement, inverse_of: :return_items, optional: true
     belongs_to :preferred_reimbursement_type, class_name: 'Spree::ReimbursementType', optional: true
     belongs_to :override_reimbursement_type, class_name: 'Spree::ReimbursementType', optional: true
-    belongs_to :return_reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id, optional: true
+    belongs_to :return_reason,
+      class_name: 'Spree::ReturnReason',
+      foreign_key: :return_reason_id,
+      optional: true,
+      inverse_of: false
 
     validate :eligible_exchange_variant
     validate :belongs_to_same_customer_order

--- a/core/app/models/spree/return_reason.rb
+++ b/core/app/models/spree/return_reason.rb
@@ -7,7 +7,7 @@ module Spree
 
     validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
-    has_many :return_authorizations
+    has_many :return_authorizations, dependent: :restrict_with_error
 
     self.allowed_ransackable_attributes = %w[name]
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -13,7 +13,7 @@ module Spree
     has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
     has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy, inverse_of: :shipment
     has_many :shipping_methods, through: :shipping_rates
-    has_many :state_changes, as: :stateful
+    has_many :state_changes, as: :stateful, dependent: :destroy
     has_many :cartons, -> { distinct }, through: :inventory_units
     has_many :line_items, -> { distinct }, through: :inventory_units
 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -9,18 +9,23 @@ module Spree
 
     has_many :shipping_method_categories, dependent: :destroy
     has_many :shipping_categories, through: :shipping_method_categories
-    has_many :shipping_rates, inverse_of: :shipping_method
+    has_many :shipping_rates, inverse_of: :shipping_method, dependent: :restrict_with_error
     has_many :shipments, through: :shipping_rates
-    has_many :cartons, inverse_of: :shipping_method
+    has_many :cartons, inverse_of: :shipping_method, dependent: :restrict_with_error
 
     has_many :shipping_method_zones, dependent: :destroy
     has_many :zones, through: :shipping_method_zones
 
-    belongs_to :tax_category, -> { with_discarded }, class_name: 'Spree::TaxCategory', optional: true
+    belongs_to :tax_category,
+      -> { with_discarded },
+      class_name: 'Spree::TaxCategory',
+      optional: true,
+      inverse_of: false
+
     has_many :shipping_method_stock_locations, dependent: :destroy, class_name: "Spree::ShippingMethodStockLocation"
     has_many :stock_locations, through: :shipping_method_stock_locations
 
-    has_many :store_shipping_methods, inverse_of: :shipping_method
+    has_many :store_shipping_methods, inverse_of: :shipping_method, dependent: :destroy
     has_many :stores, through: :store_shipping_methods
 
     validates :name, presence: true

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -6,7 +6,7 @@ module Spree
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items, optional: true
     belongs_to :variant, -> { with_discarded }, class_name: 'Spree::Variant', inverse_of: :stock_items, optional: true
-    has_many :stock_movements, inverse_of: :stock_item
+    has_many :stock_movements, inverse_of: :stock_item, dependent: :destroy
 
     validates :stock_location, :variant, presence: true
     validates :variant_id, uniqueness: { scope: [:stock_location_id, :deleted_at] }, allow_blank: true, unless: :deleted_at

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -9,9 +9,9 @@ module Spree
 
     acts_as_list
 
-    has_many :shipments
+    has_many :shipments, dependent: :restrict_with_error
     has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location
-    has_many :cartons, inverse_of: :stock_location
+    has_many :cartons, inverse_of: :stock_location, dependent: :restrict_with_error
     has_many :stock_movements, through: :stock_items
     has_many :user_stock_locations, dependent: :delete_all
     has_many :users, through: :user_stock_locations

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -9,13 +9,13 @@ module Spree
   # hosted by a single Solidus implementation can be built.
   #
   class Store < Spree::Base
-    has_many :store_payment_methods, inverse_of: :store
+    has_many :store_payment_methods, inverse_of: :store, dependent: :destroy
     has_many :payment_methods, through: :store_payment_methods
 
-    has_many :store_shipping_methods, inverse_of: :store
+    has_many :store_shipping_methods, inverse_of: :store, dependent: :destroy
     has_many :shipping_methods, through: :store_shipping_methods
 
-    has_many :orders, class_name: "Spree::Order"
+    has_many :orders, class_name: "Spree::Order", dependent: :restrict_with_error
 
     validates :code, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :name, presence: true

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -15,8 +15,13 @@ class Spree::StoreCredit < Spree::PaymentSource
   belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
   belongs_to :created_by, class_name: Spree::UserClassHandle.new, optional: true
   belongs_to :category, class_name: "Spree::StoreCreditCategory", optional: true
-  belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id', optional: true
-  has_many :store_credit_events
+  belongs_to :credit_type,
+    class_name: 'Spree::StoreCreditType',
+    foreign_key: 'type_id',
+    optional: true,
+    inverse_of: :store_credits
+  has_many :store_credit_events,
+    dependent: :restrict_with_error
 
   validates :user_id, :category_id, :type_id, :created_by_id, :currency, presence: true
   validates :amount, numericality: { greater_than: 0 }

--- a/core/app/models/spree/store_credit_reason.rb
+++ b/core/app/models/spree/store_credit_reason.rb
@@ -6,7 +6,7 @@ class Spree::StoreCreditReason < Spree::Base
 
   validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
-  has_many :store_credit_events, inverse_of: :store_credit_reason
+  has_many :store_credit_events, inverse_of: :store_credit_reason, dependent: :restrict_with_error
 
   self.allowed_ransackable_attributes = %w[name]
 end

--- a/core/app/models/spree/store_credit_type.rb
+++ b/core/app/models/spree/store_credit_type.rb
@@ -5,6 +5,10 @@ module Spree
     EXPIRING = 'Expiring'
     NON_EXPIRING = 'Non-expiring'
     DEFAULT_TYPE_NAME = EXPIRING
-    has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: 'type_id'
+    has_many :store_credits,
+      class_name: 'Spree::StoreCredit',
+      foreign_key: 'type_id',
+      inverse_of: :credit_type,
+      dependent: :restrict_with_error
   end
 end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -27,8 +27,8 @@ module Spree
       class_name: 'Spree::TaxCategory',
       inverse_of: :tax_rates
 
-    has_many :adjustments, as: :source
-    has_many :shipping_rate_taxes, class_name: "Spree::ShippingRateTax"
+    has_many :adjustments, as: :source, dependent: :restrict_with_error
+    has_many :shipping_rate_taxes, class_name: "Spree::ShippingRateTax", dependent: :restrict_with_error
 
     validates :amount, presence: true, numericality: true
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -45,18 +45,23 @@ module Spree
     delegate :tax_rates, to: :tax_category
     delegate :price_for_options, to: :price_selector
 
-    has_many :inventory_units, inverse_of: :variant
-    has_many :line_items, inverse_of: :variant
+    has_many :inventory_units, inverse_of: :variant, dependent: :restrict_with_error
+    has_many :line_items, inverse_of: :variant, dependent: :restrict_with_error
     has_many :orders, through: :line_items
 
     has_many :stock_items, dependent: :destroy, inverse_of: :variant
     has_many :stock_locations, through: :stock_items
     has_many :stock_movements, through: :stock_items
 
-    has_many :option_values_variants
+    has_many :option_values_variants, dependent: :destroy
     has_many :option_values, through: :option_values_variants
 
-    has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
+    has_many :images,
+      -> { order(:position) },
+      as: :viewable,
+      dependent: :destroy,
+      class_name: "Spree::Image",
+      inverse_of: :viewable
 
     has_many :prices,
       -> { with_discarded },

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -15,7 +15,7 @@ module Spree
       klass
     rescue NameError
       @shell.say "Couldn't find #{class_name}. Are you sure that this class exists within your application and is loaded?", :red
-      exit(1)
+      exit(1) # rubocop: disable Rails/Exit
     end
 
     def generate


### PR DESCRIPTION
## Summary

This fixes the linting errors introduced by yet another release of Rubocop.

I've chosen to actually do the `inverse_of`/`dependent` dance because it does improve the software.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
