### PR TITLE
Move Taxon -> Promotion Rule association to legacy promotions

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -13,9 +13,6 @@ module Spree
     has_many :classifications, -> { order(:position) }, dependent: :delete_all, inverse_of: :taxon
     has_many :products, through: :classifications
 
-    has_many :promotion_rule_taxons
-    has_many :promotion_rules, through: :promotion_rule_taxons
-
     before_save :set_permalink
     after_update :update_child_permalinks, if: :saved_change_to_permalink?
 

--- a/legacy_promotions/app/patches/models/solidus_legacy_promotions/spree_taxon_patch.rb
+++ b/legacy_promotions/app/patches/models/solidus_legacy_promotions/spree_taxon_patch.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SolidusLegacyPromotions
+  module SpreeTaxonPatch
+    def self.prepended(base)
+      base.has_many :promotion_rule_taxons, dependent: :destroy
+      base.has_many :promotion_rules, through: :promotion_rule_taxons
+    end
+
+    ::Spree::Taxon.prepend self
+  end
+end


### PR DESCRIPTION


## Summary

This was forgotten when extracting the legacy_promotions gem. Also adds a dependent: :destroy.

Extracted from #6240 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
