### PR TITLE
Replace `puts` in tasks and generators with Rails.logger or Logger.new

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -46,7 +46,7 @@ module Spree
       opts[:skip_javascript] = true
       opts[:skip_action_cable] = true
 
-      puts "Generating dummy Rails application..."
+      say "Generating dummy Rails application..."
       invoke Rails::Generators::AppGenerator,
         [File.expand_path(dummy_path, destination_root)], opts
     end

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -6,6 +6,7 @@ class CommonRakeTasks
   include Rake::DSL
 
   def initialize
+    Rails.logger ||= Logger.new($stdout)
     namespace :common do
       task :test_app, :user_class do |_t, args|
         args.with_defaults(user_class: "Spree::LegacyUser")
@@ -45,19 +46,19 @@ class CommonRakeTasks
           sh "bin/rails g solidus_frontend:install --auto-accept"
         end
 
-        puts "Setting up dummy database..."
+        Rails.logger.info "Setting up dummy database..."
 
         sh "bin/rails db:environment:set RAILS_ENV=test"
         sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
 
         if extension_installation_generator_exists?
-          puts 'Running extension installation generator...'
+          Rails.logger.info 'Running extension installation generator...'
           sh "bin/rails generate #{rake_generator_namespace}:install --auto-run-migrations"
         end
       end
 
       task :seed do |_t, _args|
-        puts "Seeding ..."
+        Rails.logger.info "Seeding ..."
 
         sh "bundle exec rake db:seed RAILS_ENV=test"
       end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -10,6 +10,7 @@ require 'action_mailer/railtie'
 require 'active_storage/engine'
 
 Rails.env = 'test'
+Rails.logger ||= Logger.new($stdout)
 
 require 'solidus_core'
 

--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -6,7 +6,7 @@ module DummyApp
 
     def auto_migrate
       if needs_migration?
-        puts "Configuration changed. Re-running migrations"
+        Rails.logger.info "Configuration changed. Re-running migrations"
 
         # Disconnect to avoid "database is being accessed by other users" on postgres
         ActiveRecord::Base.remove_connection
@@ -29,7 +29,7 @@ module DummyApp
     end
 
     def sh(cmd)
-      puts cmd
+      Rails.logger.info cmd
       system cmd
     end
   end

--- a/core/lib/spree/testing_support/translations.rb
+++ b/core/lib/spree/testing_support/translations.rb
@@ -6,8 +6,8 @@ module Spree
       def check_missing_translations(page, example)
         missing_translations = page.body.scan(/translation missing: #{I18n.locale}\.(.*?)[\s<\"&]/)
         if missing_translations.any?
-          puts "Found missing translations: #{missing_translations.inspect}"
-          puts "In spec: #{example.location}"
+          Rails.logger.info "Found missing translations: #{missing_translations.inspect}"
+          Rails.logger.info "In spec: #{example.location}"
         end
       end
     end

--- a/promotions/lib/generators/solidus_promotions/install/install_generator.rb
+++ b/promotions/lib/generators/solidus_promotions/install/install_generator.rb
@@ -41,7 +41,7 @@ module SolidusPromotions
         if run_migrations
           run "bin/rails db:migrate"
         else
-          puts "Skipping bin/rails db:migrate, don't forget to run it!"
+          Rails.logger.info "Skipping bin/rails db:migrate, don't forget to run it!"
         end
       end
 

--- a/promotions/lib/solidus_promotions/promotion_migrator.rb
+++ b/promotions/lib/solidus_promotions/promotion_migrator.rb
@@ -78,7 +78,7 @@ module SolidusPromotions
     def generate_new_benefits(old_promotion_action)
       promo_action_config = promotion_map[:actions][old_promotion_action.class]
       if promo_action_config.nil?
-        puts("#{old_promotion_action.class} is not supported")
+        Rails.logger.info("#{old_promotion_action.class} is not supported")
         return nil
       end
       promo_action_config.call(old_promotion_action)
@@ -87,7 +87,7 @@ module SolidusPromotions
     def generate_new_promotion_conditions(old_promotion_rule)
       new_promo_condition_class = promotion_map[:conditions][old_promotion_rule.class]
       if new_promo_condition_class.nil?
-        puts("#{old_promotion_rule.class} is not supported")
+        Rails.logger.info("#{old_promotion_rule.class} is not supported")
         []
       elsif new_promo_condition_class.respond_to?(:call)
         new_promo_condition_class.call(old_promotion_rule)


### PR DESCRIPTION
## Summary

We should not use `puts` here, but instead the configured Rails logger. A log level of `info` is appropriate for all of these instances.

In the Dummy App generator, Rails is not yet loaded, so we use the normal logger instead.

Extracted from #6240 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

