### PR TITLE
Remove Rubocop.yml deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 inherit_from: .rubocop_todo.yml
 
 # Relaxed.Ruby.Style
-
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
+require:
   - ./tasks/linting/wrong_migration_version.rb
 
 AllCops:


### PR DESCRIPTION


## Summary

We can now use plugins, and require only local modules.

This really cleans up the output of Rubocop, while we still use it. 

Extracted from #6240.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
