### PR TITLE
Require spree/config in spree/core

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -101,6 +101,7 @@ require 'spree/core/environment'
 require 'spree/migrations'
 require 'spree/migration_helpers'
 require 'spree/bus'
+require 'spree/config'
 require 'spree/core/engine'
 
 require 'spree/i18n'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spree/config'
+require 'spree/core'
 
 module Spree
   module Core


### PR DESCRIPTION


## Summary

We need to load the app configuration when we load spree/core. Otherwise `bin/rails generate migration` in the `core/` directory fails.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
