### PR TITLE
Do not download Chrome on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,18 +59,6 @@ commands:
   setup:
     steps:
       - checkout
-      - browser-tools/install-chrome:
-          chrome-version: "133.0.6943.53"
-          replace-existing: true
-      - run:
-          name: Check chrome version
-          command: |
-            google-chrome --version
-      - browser-tools/install-chromedriver
-      - run:
-          name: Check chromedriver version
-          command: |
-            chromedriver --version
       - run:
           name: "Lock dependencies"
           command: |


### PR DESCRIPTION


## Summary

We use firefox for testing, so we should not need Chrome.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
