### PR TITLE
Fix libvips install in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,10 +138,15 @@ commands:
   libvips:
     steps:
       - run:
+          name: Fix APT mirrors
+          command: |
+            sudo sed -i 's|http://archive.ubuntu.com|http://ubuntu.cs.utah.edu|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.ubuntu.com|http://ubuntu.cs.utah.edu|g' /etc/apt/sources.list
+            sudo apt-get update
+      - run:
           name: Install libvips
           command: |
-            sudo apt-get update
-            sudo apt-get install -yq libvips-dev
+            sudo apt-get install -y libvips-dev
 
   install_solidus:
     parameters:


### PR DESCRIPTION
There is an ongoing issue with circle ci and
ubuntu mirrors

See https://support.circleci.com/hc/en-us/articles/37474192881179-Resolving-Unable-to-connect-to-archive-ubuntu-com-Error-in-CircleCI