### PR TITLE
Admin users edit tabs

### DIFF
--- a/admin/app/components/solidus_admin/users/addresses/component.html.erb
+++ b/admin/app/components/solidus_admin/users/addresses/component.html.erb
@@ -9,9 +9,7 @@
   <% end %>
 
   <%= page_header do %>
-    <% tabs.each do |tab| %>
-      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
-    <% end %>
+    <%= render component("users/edit/tabs").new(user: @user, current: :addresses) %>
   <% end %>
 
   <%= page_with_sidebar do %>

--- a/admin/app/components/solidus_admin/users/addresses/component.rb
+++ b/admin/app/components/solidus_admin/users/addresses/component.rb
@@ -13,36 +13,6 @@ class SolidusAdmin::Users::Addresses::Component < SolidusAdmin::BaseComponent
     @form_id ||= "#{stimulus_id}--form-#{@user.id}"
   end
 
-  def tabs
-    [
-      {
-        text: t('.account'),
-        href: solidus_admin.user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.addresses'),
-        href: solidus_admin.addresses_user_path(@user),
-        current: true,
-      },
-      {
-        text: t('.order_history'),
-        href: solidus_admin.orders_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.items'),
-        href: spree.items_admin_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.store_credit'),
-        href: spree.admin_user_store_credits_path(@user),
-        current: false,
-      },
-    ]
-  end
-
   def bill_address(address, type)
     if address.present? && type == "bill"
       address

--- a/admin/app/components/solidus_admin/users/addresses/component.yml
+++ b/admin/app/components/solidus_admin/users/addresses/component.yml
@@ -1,10 +1,5 @@
 en:
   title: "Users / %{email} / Addresses"
-  account: Account
-  addresses: Addresses
-  order_history: Order History
-  items: Items
-  store_credit: Store Credit
   last_active: Last Active
   create_order_for_user: Create order for this user
   update: Update

--- a/admin/app/components/solidus_admin/users/addresses/component.yml
+++ b/admin/app/components/solidus_admin/users/addresses/component.yml
@@ -1,6 +1,5 @@
 en:
   title: "Users / %{email} / Addresses"
-  last_active: Last Active
   create_order_for_user: Create order for this user
   update: Update
   cancel: Cancel

--- a/admin/app/components/solidus_admin/users/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/users/edit/component.html.erb
@@ -12,9 +12,7 @@
   <% end %>
 
   <%= page_header do %>
-    <% tabs.each do |tab| %>
-      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
-    <% end %>
+    <%= render component("users/edit/tabs").new(user: @user, current: :account) %>
   <% end %>
 
   <%= page_with_sidebar do %>

--- a/admin/app/components/solidus_admin/users/edit/component.rb
+++ b/admin/app/components/solidus_admin/users/edit/component.rb
@@ -11,38 +11,6 @@ class SolidusAdmin::Users::Edit::Component < SolidusAdmin::BaseComponent
     @form_id ||= "#{stimulus_id}--form-#{@user.id}"
   end
 
-  def tabs
-    [
-      {
-        text: t('.account'),
-        href: solidus_admin.user_path(@user),
-        current: action_name == "edit",
-      },
-      {
-        text: t('.addresses'),
-        href: solidus_admin.addresses_user_path(@user),
-        current: action_name == "addresses",
-      },
-      {
-        text: t('.order_history'),
-        href: solidus_admin.orders_user_path(@user),
-        current: action_name == "orders",
-      },
-      {
-        text: t('.items'),
-        href: spree.items_admin_user_path(@user),
-        # @todo: update this "current" logic once folded into new admin
-        current: action_name != "edit",
-      },
-      {
-        text: t('.store_credit'),
-        href: spree.admin_user_store_credits_path(@user),
-        # @todo: update this "current" logic once folded into new admin
-        current: action_name != "edit",
-      },
-    ]
-  end
-
   def role_options
     Spree::Role.all.map do |role|
       { label: role.name, id: role.id }

--- a/admin/app/components/solidus_admin/users/edit/component.yml
+++ b/admin/app/components/solidus_admin/users/edit/component.yml
@@ -1,10 +1,5 @@
 en:
   title: "Users / %{email}"
-  account: Account
-  addresses: Addresses
-  order_history: Order History
-  items: Items
-  store_credit: Store Credit
   last_active: Last Active
   create_order_for_user: Create order for this user
   update: Update

--- a/admin/app/components/solidus_admin/users/edit/component.yml
+++ b/admin/app/components/solidus_admin/users/edit/component.yml
@@ -1,6 +1,5 @@
 en:
   title: "Users / %{email}"
-  last_active: Last Active
   create_order_for_user: Create order for this user
   update: Update
   cancel: Cancel

--- a/admin/app/components/solidus_admin/users/edit/tabs/component.rb
+++ b/admin/app/components/solidus_admin/users/edit/tabs/component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Users::Edit::Tabs::Component < SolidusAdmin::BaseComponent
+  def initialize(user:, current:)
+    @user = user
+    @current = current
+  end
+
+  def call
+    rendered_tabs = tabs.map do |tab|
+      render component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])
+    end
+
+    safe_join(rendered_tabs)
+  end
+
+  def tabs
+    [
+      {
+        text: t(".account"),
+        href: solidus_admin.user_path(@user),
+        current: @current == :account,
+      },
+      {
+        text: t(".addresses"),
+        href: solidus_admin.addresses_user_path(@user),
+        current: @current == :addresses,
+      },
+      {
+        text: t(".order_history"),
+        href: solidus_admin.orders_user_path(@user),
+        current: @current == :orders,
+      },
+      {
+        text: t(".items"),
+        href: solidus_admin.items_user_path(@user),
+        current: @current == :items,
+      },
+      {
+        text: t(".store_credit"),
+        href: solidus_admin.user_store_credits_path(@user),
+        current: @current == :store_credits,
+      },
+    ]
+  end
+end

--- a/admin/app/components/solidus_admin/users/edit/tabs/component.yml
+++ b/admin/app/components/solidus_admin/users/edit/tabs/component.yml
@@ -1,0 +1,6 @@
+en:
+  account: Account
+  addresses: Addresses
+  order_history: Order History
+  items: Items
+  store_credit: Store Credit

--- a/admin/app/components/solidus_admin/users/items/component.html.erb
+++ b/admin/app/components/solidus_admin/users/items/component.html.erb
@@ -9,9 +9,7 @@
   <% end %>
 
   <%= page_header do %>
-    <% tabs.each do |tab| %>
-      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
-    <% end %>
+    <%= render component("users/edit/tabs").new(user: @user, current: :items) %>
   <% end %>
 
   <%= page_with_sidebar do %>

--- a/admin/app/components/solidus_admin/users/items/component.rb
+++ b/admin/app/components/solidus_admin/users/items/component.rb
@@ -8,36 +8,6 @@ class SolidusAdmin::Users::Items::Component < SolidusAdmin::BaseComponent
     @items = items
   end
 
-  def tabs
-    [
-      {
-        text: t('.account'),
-        href: solidus_admin.user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.addresses'),
-        href: solidus_admin.addresses_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.order_history'),
-        href: solidus_admin.orders_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.items'),
-        href: solidus_admin.items_user_path(@user),
-        current: true,
-      },
-      {
-        text: t('.store_credit'),
-        href: spree.admin_user_store_credits_path(@user),
-        current: false,
-      },
-    ]
-  end
-
   def model_class
     Spree::LineItem
   end

--- a/admin/app/components/solidus_admin/users/items/component.yml
+++ b/admin/app/components/solidus_admin/users/items/component.yml
@@ -1,6 +1,5 @@
 en:
   title: "Users / %{email} / Items Purchased"
-  last_active: Last Active
   create_order_for_user: Create order for this user
   items_purchased: Items Purchased
   no_orders_found: No Orders found.

--- a/admin/app/components/solidus_admin/users/items/component.yml
+++ b/admin/app/components/solidus_admin/users/items/component.yml
@@ -1,10 +1,5 @@
 en:
   title: "Users / %{email} / Items Purchased"
-  account: Account
-  addresses: Addresses
-  order_history: Order History
-  items: Items
-  store_credit: Store Credit
   last_active: Last Active
   create_order_for_user: Create order for this user
   items_purchased: Items Purchased

--- a/admin/app/components/solidus_admin/users/orders/component.html.erb
+++ b/admin/app/components/solidus_admin/users/orders/component.html.erb
@@ -9,9 +9,7 @@
   <% end %>
 
   <%= page_header do %>
-    <% tabs.each do |tab| %>
-      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
-    <% end %>
+    <%= render component("users/edit/tabs").new(user: @user, current: :orders) %>
   <% end %>
 
   <%= page_with_sidebar do %>

--- a/admin/app/components/solidus_admin/users/orders/component.rb
+++ b/admin/app/components/solidus_admin/users/orders/component.rb
@@ -8,36 +8,6 @@ class SolidusAdmin::Users::Orders::Component < SolidusAdmin::BaseComponent
     @orders = orders
   end
 
-  def tabs
-    [
-      {
-        text: t('.account'),
-        href: solidus_admin.user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.addresses'),
-        href: solidus_admin.addresses_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.order_history'),
-        href: solidus_admin.orders_user_path(@user),
-        current: true,
-      },
-      {
-        text: t('.items'),
-        href: spree.items_admin_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.store_credit'),
-        href: spree.admin_user_store_credits_path(@user),
-        current: false,
-      },
-    ]
-  end
-
   def model_class
     Spree::Order
   end

--- a/admin/app/components/solidus_admin/users/orders/component.yml
+++ b/admin/app/components/solidus_admin/users/orders/component.yml
@@ -1,10 +1,6 @@
 en:
   title: "Users / %{email} / Order History"
-  account: Account
-  addresses: Addresses
   order_history: Order History
-  items: Items
-  store_credit: Store Credit
   last_active: Last Active
   create_order_for_user: Create order for this user
   no_orders_found: No Orders found.

--- a/admin/app/components/solidus_admin/users/orders/component.yml
+++ b/admin/app/components/solidus_admin/users/orders/component.yml
@@ -1,7 +1,6 @@
 en:
   title: "Users / %{email} / Order History"
   order_history: Order History
-  last_active: Last Active
   create_order_for_user: Create order for this user
   no_orders_found: No Orders found.
   create_one: Create One

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.html.erb
@@ -17,9 +17,7 @@
   <% end %>
 
   <%= page_header do %>
-    <% tabs.each do |tab| %>
-      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
-    <% end %>
+    <%= render component("users/edit/tabs").new(user: @user, current: :store_credits) %>
   <% end %>
 
   <%= page_with_sidebar do %>

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.rb
@@ -12,36 +12,6 @@ class SolidusAdmin::Users::StoreCredits::Index::Component < SolidusAdmin::BaseCo
     Spree::StoreCredit
   end
 
-  def tabs
-    [
-      {
-        text: t('.account'),
-        href: solidus_admin.user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.addresses'),
-        href: solidus_admin.addresses_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.order_history'),
-        href: solidus_admin.orders_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.items'),
-        href: spree.items_admin_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.store_credit'),
-        href: solidus_admin.user_store_credits_path(@user),
-        current: true,
-      },
-    ]
-  end
-
   def rows
     @store_credits
   end

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.yml
@@ -1,9 +1,5 @@
 en:
   title: "Users / %{email} / Store Credit"
-  account: Account
-  addresses: Addresses
-  order_history: Order History
-  items: Items
   store_credit: Store Credit
   last_active: Last Active
   add_store_credit: Add Store Credit

--- a/admin/app/components/solidus_admin/users/store_credits/index/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/index/component.yml
@@ -1,7 +1,6 @@
 en:
   title: "Users / %{email} / Store Credit"
   store_credit: Store Credit
-  last_active: Last Active
   add_store_credit: Add Store Credit
   no_credits_found: No Store Credits found.
   create_one: Create One

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.html.erb
@@ -5,9 +5,7 @@
   <% end %>
 
   <%= page_header do %>
-    <% tabs.each do |tab| %>
-      <%= render(component("ui/button").new(tag: :a, scheme: :ghost, text: tab[:text], 'aria-current': tab[:current], href: tab[:href])) %>
-    <% end %>
+    <%= render component("users/edit/tabs").new(user: @user, current: :store_credits) %>
   <% end %>
 
   <%= page_with_sidebar do %>

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.rb
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.rb
@@ -18,36 +18,6 @@ class SolidusAdmin::Users::StoreCredits::Show::Component < SolidusAdmin::BaseCom
     Spree::StoreCreditEvent
   end
 
-  def tabs
-    [
-      {
-        text: t('.account'),
-        href: solidus_admin.user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.addresses'),
-        href: solidus_admin.addresses_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.order_history'),
-        href: solidus_admin.orders_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.items'),
-        href: spree.items_admin_user_path(@user),
-        current: false,
-      },
-      {
-        text: t('.store_credit'),
-        href: solidus_admin.user_store_credits_path(@user),
-        current: true,
-      },
-    ]
-  end
-
   def form_id
     @form_id ||= "#{stimulus_id}--form-#{@store_credit.id}"
   end

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.yml
@@ -1,9 +1,5 @@
 en:
   title: "Users / %{email} / Store Credit / %{amount}"
-  account: Account
-  addresses: Addresses
-  order_history: Order History
-  items: Items
   store_credit: Store Credit
   last_active: Last Active
   add_store_credit: Add Store Credit

--- a/admin/app/components/solidus_admin/users/store_credits/show/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/show/component.yml
@@ -1,7 +1,6 @@
 en:
   title: "Users / %{email} / Store Credit / %{amount}"
   store_credit: Store Credit
-  last_active: Last Active
   add_store_credit: Add Store Credit
   edit_amount: Edit Amount
   edit_memo: Edit Memo


### PR DESCRIPTION
Closes #6242 

## Summary

Moved tabs from user edit pages into its own component. This allows to remove repetitive `tabs` definitions and translations.
Also removed a redundant translation that has been moved to a different component.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).