### PR TITLE
[v4.5] Fix flaky test errors using chrome 134

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,9 @@ commands:
   setup:
     steps:
       - checkout
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "133.0.6943.53"
+          replace-existing: true
       - run:
           name: Check chrome version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.5.3
   codecov: codecov/codecov@3.3.0
 
 executors:

--- a/admin/lib/solidus_admin/testing_support/feature_helpers.rb
+++ b/admin/lib/solidus_admin/testing_support/feature_helpers.rb
@@ -27,7 +27,10 @@ module SolidusAdmin
       end
 
       def select_row(text)
-        find_row_checkbox(text).check
+        find_row_checkbox(text).tap do |checkbox|
+          checkbox.check
+          checkbox.synchronize { checkbox.checked? }
+        end
       end
     end
   end

--- a/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_features.rb
+++ b/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_features.rb
@@ -5,7 +5,7 @@ require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 RSpec.shared_examples_for 'promotion categories features' do
   before { sign_in create(:admin_user, email: "admin@example.com") }
 
-  it "lists promotion categories" do
+  it "lists promotion categories", :js do
     create(factory_name, name: "test1", code: "code1")
     create(factory_name, name: "test2", code: "code2")
 
@@ -53,7 +53,7 @@ RSpec.shared_examples_for 'promotion categories features' do
     expect(page).to have_content("exp.2")
   end
 
-  it 'allows to delete promo category' do
+  it 'allows to bulk delete promo category', :js do
     create(factory_name, name: "Soon to expire", code: "ste.1")
     create(factory_name, name: "Expired", code: "exp.2")
 

--- a/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_features.rb
+++ b/admin/lib/solidus_admin/testing_support/shared_examples/promotion_categories_features.rb
@@ -65,8 +65,4 @@ RSpec.shared_examples_for 'promotion categories features' do
     expect(page).not_to have_content("Expired")
     expect(model_class.count).to eq(1)
   end
-
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { factory_name }
-  end
 end

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Adjustment Reasons", :js, type: :feature do
+describe "Adjustment Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists adjustment reasons and allows deleting them" do
+  it "lists adjustment reasons and allows deleting them", :js do
     create(:adjustment_reason, name: "Default-adjustment-reason")
 
     visit "/admin/adjustment_reasons"
@@ -29,10 +29,13 @@ describe "Adjustment Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("New Adjustment Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -72,10 +75,13 @@ describe "Adjustment Reasons", :js, type: :feature do
       click_on "Good Reason"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Adjustment Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -21,11 +21,6 @@ describe "Adjustment Reasons", :js, type: :feature do
     expect(page).to be_axe_clean
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :adjustment_reason }
-    let(:index_path) { "/admin/adjustment_reasons" }
-  end
-
   context "when creating a new adjustment reason" do
     let(:query) { "?page=1&q%5Bname_or_code_cont%5D=new" }
 

--- a/admin/spec/features/properties_spec.rb
+++ b/admin/spec/features/properties_spec.rb
@@ -23,11 +23,6 @@ describe "Properties", :js, type: :feature do
     expect(Spree::Property.count).to eq(1)
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :property }
-    let(:index_path) { "/admin/properties" }
-  end
-
   context "creating a new property" do
     it "creates a new product property" do
       visit "/admin/properties"

--- a/admin/spec/features/properties_spec.rb
+++ b/admin/spec/features/properties_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Properties", :js, type: :feature do
+describe "Properties", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists properties and allows deleting them" do
+  it "lists properties and allows deleting them", :js do
     create(:property, name: "Type prop", presentation: "Type prop")
     create(:property, name: "Size", presentation: "Size")
 

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -21,11 +21,6 @@ describe "Refund Reasons", :js, type: :feature do
     expect(page).to be_axe_clean
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :refund_reason }
-    let(:index_path) { "/admin/refund_reasons" }
-  end
-
   context "when creating a new refund reason" do
     let(:query) { "?page=1&q%5Bname_or_description_cont%5D=Ret" }
 

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Refund Reasons", :js, type: :feature do
+describe "Refund Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists refund reasons and allows deleting them" do
+  it "lists refund reasons and allows deleting them", :js do
     create(:refund_reason, name: "Default-refund-reason")
 
     visit "/admin/refund_reasons"
@@ -29,10 +29,13 @@ describe "Refund Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_css("dialog")
       expect(page).to have_content("New Refund Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -69,10 +72,13 @@ describe "Refund Reasons", :js, type: :feature do
       click_on "Return process"
       expect(page).to have_css("dialog")
       expect(page).to have_content("Edit Refund Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Return Reasons", :js, type: :feature do
+describe "Return Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists Return Reasons and allows deleting them" do
+  it "lists Return Reasons and allows deleting them", :js do
     create(:return_reason, name: "Default-return-reason")
 
     visit "/admin/return_reasons"
@@ -29,10 +29,13 @@ describe "Return Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("New Return Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -71,10 +74,13 @@ describe "Return Reasons", :js, type: :feature do
       click_on "Good Reason"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Return Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :flaky, :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -21,11 +21,6 @@ describe "Return Reasons", :js, type: :feature do
     expect(page).to be_axe_clean
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :return_reason }
-    let(:index_path) { "/admin/return_reasons" }
-  end
-
   context "when creating a new return reason" do
     let(:query) { "?page=1&q%5Bname_cont%5D=new" }
 

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -25,11 +25,6 @@ describe "Roles", :js, type: :feature do
     )
   }
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :role }
-    let(:index_path) { "/admin/roles" }
-  end
-
   it "lists roles and allows deleting them" do
     create(:role, name: "Customer Role" )
     Spree::Role.find_or_create_by(name: 'admin')

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Roles", :js, type: :feature do
+describe "Roles", type: :feature do
   before do
     sign_in create(:admin_user, email: 'admin@example.com')
   end
@@ -25,7 +25,7 @@ describe "Roles", :js, type: :feature do
     )
   }
 
-  it "lists roles and allows deleting them" do
+  it "lists roles and allows deleting them", :js do
     create(:role, name: "Customer Role" )
     Spree::Role.find_or_create_by(name: 'admin')
 
@@ -57,10 +57,13 @@ describe "Roles", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Role")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -124,12 +127,15 @@ describe "Roles", :js, type: :feature do
       click_on "Reviewer"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Role")
-      expect(page).to be_axe_clean
       expect(Spree::Role.find_by(name: "Reviewer").permission_set_ids)
-        .to contain_exactly(settings_edit_permission.id)
+      .to contain_exactly(settings_edit_permission.id)
     end
 
-    it "closing the modal keeps query params" do
+    it "is accessible", :js do
+      expect(page).to be_axe_clean
+    end
+
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Shipping Categories", :js, type: :feature do
+describe "Shipping Categories", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists shipping categories and allows deleting them" do
+  it "lists shipping categories and allows deleting them", :js do
     create(:shipping_category, name: "Default-shipping")
 
     visit "/admin/shipping_categories"
@@ -29,10 +29,13 @@ describe "Shipping Categories", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_css("dialog")
       expect(page).to have_content("New Shipping Category")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -69,10 +72,13 @@ describe "Shipping Categories", :js, type: :feature do
       click_on "Letter Mail"
       expect(page).to have_css("dialog")
       expect(page).to have_content("Edit Shipping Category")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -21,11 +21,6 @@ describe "Shipping Categories", :js, type: :feature do
     expect(page).to be_axe_clean
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :shipping_category }
-    let(:index_path) { "/admin/shipping_categories" }
-  end
-
   context "when creating a new shipping category" do
     let(:query) { "?page=1&q%5Bname_or_description_cont%5D=What" }
 

--- a/admin/spec/features/shipping_methods_spec.rb
+++ b/admin/spec/features/shipping_methods_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Shipping Methods", :js, type: :feature do
+describe "Shipping Methods", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists shipping methods and allows deleting them" do
+  it "lists shipping methods and allows deleting them", :js do
     create(:shipping_method, name: "FAAAST")
 
     visit "/admin/shipping_methods"

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Store Credit Reasons", :js, type: :feature do
+describe "Store Credit Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists store credit reasons and allows deleting them" do
+  it "lists store credit reasons and allows deleting them", :js do
     create(:store_credit_reason, name: "Default-store-credit-reason")
 
     visit "/admin/store_credit_reasons"
@@ -29,10 +29,13 @@ describe "Store Credit Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("New Store Credit Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)
@@ -69,10 +72,13 @@ describe "Store Credit Reasons", :js, type: :feature do
       click_on "New Customer Reward"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("Edit Store Credit Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -21,11 +21,6 @@ describe "Store Credit Reasons", :js, type: :feature do
     expect(page).to be_axe_clean
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :store_credit_reason }
-    let(:index_path) { "/admin/store_credit_reasons" }
-  end
-
   context "when creating a new store credit reason" do
     let(:query) { "?page=1&q%5Bname_cont%5D=new" }
 

--- a/admin/spec/features/tax_categories_spec.rb
+++ b/admin/spec/features/tax_categories_spec.rb
@@ -23,11 +23,6 @@ describe "Tax categories", :js, type: :feature do
     expect(page).to be_axe_clean
   end
 
-  include_examples 'feature: bulk delete resources' do
-    let(:resource_factory) { :tax_category }
-    let(:index_path) { "/admin/tax_categories" }
-  end
-
   context "when creating a new tax category" do
     let(:query) { "?page=1&q%5Bname_or_description_cont%5D=Cloth" }
 

--- a/admin/spec/features/tax_categories_spec.rb
+++ b/admin/spec/features/tax_categories_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'solidus_admin/testing_support/shared_examples/bulk_delete_resources'
 
-describe "Tax categories", :js, type: :feature do
+describe "Tax categories", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists tax categories and allows deleting them" do
+  it "lists tax categories and allows deleting them", :js do
     create(:tax_category, name: "Clothing")
     create(:tax_category, name: "Food")
 
@@ -31,10 +31,13 @@ describe "Tax categories", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog")
       expect(page).to have_content("New Tax Category")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog")
       expect(page.current_url).to include(query)

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -42,29 +42,11 @@ Rails.application.config.i18n.raise_on_missing_translations = true
 # CAPYBARA & SELENIUM
 require "capybara/rspec"
 require 'capybara-screenshot/rspec'
-require "selenium/webdriver"
+require "spree/testing_support/capybara_driver"
+
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 Capybara.disable_animation = true
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
 Capybara.enable_aria_label = true
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -51,28 +51,7 @@ require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 
-require "selenium/webdriver"
-
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
+require "spree/testing_support/capybara_driver"
 
 Rails.application.config.i18n.raise_on_missing_translations = true
 

--- a/core/lib/spree/testing_support/capybara_driver.rb
+++ b/core/lib/spree/testing_support/capybara_driver.rb
@@ -6,6 +6,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
   browser_options.args << '--window-size=1920,1080'
   browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)

--- a/core/lib/spree/testing_support/capybara_driver.rb
+++ b/core/lib/spree/testing_support/capybara_driver.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "selenium/webdriver"
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--window-size=1920,1080'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
+Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  # Sandbox cannot be used inside unprivileged Docker container
+  browser_options.args << '--no-sandbox'
+  browser_options.args << '--window-size=1240,1400'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
+Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym

--- a/legacy_promotions/spec/features/solidus_admin/promotion_categories_spec.rb
+++ b/legacy_promotions/spec/features/solidus_admin/promotion_categories_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'solidus_admin/testing_support/shared_examples/promotion_categories_features'
 
-RSpec.describe "Promotion Categories", :js, type: :feature, solidus_admin: true do
+RSpec.describe "Promotion Categories", type: :feature, solidus_admin: true do
   include_examples 'promotion categories features' do
     let(:factory_name) { :promotion_category }
     let(:model_class) { Spree::PromotionCategory }

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -43,36 +43,16 @@ require 'solidus_legacy_promotions/testing_support/factory_bot'
 require 'cancan/matchers'
 require 'spree/testing_support/capybara_ext'
 
-require "selenium/webdriver"
-
 ActiveJob::Base.queue_adapter = :test
 
 Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
+require "spree/testing_support/capybara_driver"
 
 # AXE - ACCESSIBILITY
 require 'axe-rspec'
 require 'axe-capybara'
 
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.enable_aria_label = true
 
 # VIEW COMPONENTS

--- a/promotions/spec/rails_helper.rb
+++ b/promotions/spec/rails_helper.rb
@@ -61,7 +61,6 @@ require "spree/testing_support/controller_requests"
 require "cancan/matchers"
 require "spree/testing_support/capybara_ext"
 
-require "selenium/webdriver"
 # Requires factories defined in Solidus core and this extension.
 # See: lib/solidus_promotions/testing_support/factories.rb
 require "spree/testing_support/factory_bot"
@@ -75,27 +74,8 @@ Spree::Config.order_contents_class = "Spree::SimpleOrderContents"
 Spree::Config.promotions = SolidusPromotions.configuration
 ActiveJob::Base.queue_adapter = :test
 
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
+require "spree/testing_support/capybara_driver"
 
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  browser_options.args << '--disable-backgrounding-occluded-windows'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 # Allow Capybara to find elements by aria-label attributes
 Capybara.enable_aria_label = true
 

--- a/promotions/spec/system/solidus_promotions/admin/promotion_categories_spec.rb
+++ b/promotions/spec/system/solidus_promotions/admin/promotion_categories_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'solidus_admin/testing_support/shared_examples/promotion_categories_features'
 
-RSpec.describe "Promotion Categories", :js, type: :feature, solidus_admin: true do
+RSpec.describe "Promotion Categories", type: :feature, solidus_admin: true do
   include_examples 'promotion categories features' do
     let(:factory_name) { :solidus_promotion_category }
     let(:model_class) { SolidusPromotions::PromotionCategory }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.5`:
 - [Merge pull request #6203 from blish/fix-chrome-errors](https://github.com/solidusio/solidus/pull/6203)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)