### PR TITLE
[v4.4] Fix flaky test errors using chrome 134

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,9 @@ commands:
   setup:
     steps:
       - checkout
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "133.0.6943.53"
+          replace-existing: true
       - run:
           name: Check chrome version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.5.3
   codecov: codecov/codecov@3.3.0
 
 executors:

--- a/admin/lib/solidus_admin/testing_support/feature_helpers.rb
+++ b/admin/lib/solidus_admin/testing_support/feature_helpers.rb
@@ -27,7 +27,10 @@ module SolidusAdmin
       end
 
       def select_row(text)
-        find_row_checkbox(text).check
+        find_row_checkbox(text).tap do |checkbox|
+          checkbox.check
+          checkbox.synchronize { checkbox.checked? }
+        end
       end
     end
   end

--- a/admin/spec/features/adjustment_reasons_spec.rb
+++ b/admin/spec/features/adjustment_reasons_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Adjustment Reasons", :js, type: :feature do
+describe "Adjustment Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists adjustment reasons and allows deleting them" do
+  it "lists adjustment reasons and allows deleting them", :js do
     create(:adjustment_reason, name: "Default-adjustment-reason")
 
     visit "/admin/adjustment_reasons"
@@ -28,10 +28,13 @@ describe "Adjustment Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Adjustment Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -71,10 +74,13 @@ describe "Adjustment Reasons", :js, type: :feature do
       find_row("Good Reason").click
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Adjustment Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/properties_spec.rb
+++ b/admin/spec/features/properties_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Properties", :js, type: :feature do
+describe "Properties", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists properties and allows deleting them" do
+  it "lists properties and allows deleting them", :js do
     create(:property, name: "Type prop", presentation: "Type prop")
     create(:property, name: "Size", presentation: "Size")
 

--- a/admin/spec/features/refund_reasons_spec.rb
+++ b/admin/spec/features/refund_reasons_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Refund Reasons", :js, type: :feature do
+describe "Refund Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists refund reasons and allows deleting them" do
+  it "lists refund reasons and allows deleting them", :js do
     create(:refund_reason, name: "Default-refund-reason")
 
     visit "/admin/refund_reasons"
@@ -28,10 +28,13 @@ describe "Refund Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("New Refund Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -68,10 +71,13 @@ describe "Refund Reasons", :js, type: :feature do
       find_row("Return process").click
       expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("Edit Refund Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/return_reasons_spec.rb
+++ b/admin/spec/features/return_reasons_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Return Reasons", :js, type: :feature do
+describe "Return Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists Return Reasons and allows deleting them" do
+  it "lists Return Reasons and allows deleting them", :js do
     create(:return_reason, name: "Default-return-reason")
 
     visit "/admin/return_reasons"
@@ -28,10 +28,13 @@ describe "Return Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Return Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -70,10 +73,13 @@ describe "Return Reasons", :js, type: :feature do
       find_row("Good Reason").click
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Return Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :flaky, :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/roles_spec.rb
+++ b/admin/spec/features/roles_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe "Roles", :js, type: :feature do
+describe "Roles", type: :feature do
   before do
     sign_in create(:admin_user, email: 'admin@example.com')
   end
@@ -24,7 +24,7 @@ describe "Roles", :js, type: :feature do
     )
   }
 
-  it "lists roles and allows deleting them" do
+  it "lists roles and allows deleting them", :js do
     create(:role, name: "Customer Role" )
     Spree::Role.find_or_create_by(name: 'admin')
 
@@ -56,10 +56,13 @@ describe "Roles", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Role")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -123,12 +126,15 @@ describe "Roles", :js, type: :feature do
       find_row("Reviewer").click
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Role")
-      expect(page).to be_axe_clean
       expect(Spree::Role.find_by(name: "Reviewer").permission_set_ids)
-        .to contain_exactly(settings_edit_permission.id)
+      .to contain_exactly(settings_edit_permission.id)
     end
 
-    it "closing the modal keeps query params" do
+    it "is accessible", :js do
+      expect(page).to be_axe_clean
+    end
+
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/shipping_categories_spec.rb
+++ b/admin/spec/features/shipping_categories_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Shipping Categories", :js, type: :feature do
+describe "Shipping Categories", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists shipping categories and allows deleting them" do
+  it "lists shipping categories and allows deleting them", :js do
     create(:shipping_category, name: "Default-shipping")
 
     visit "/admin/shipping_categories"
@@ -28,10 +28,13 @@ describe "Shipping Categories", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("New Shipping Category")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -68,10 +71,13 @@ describe "Shipping Categories", :js, type: :feature do
       find_row("Letter Mail").click
       expect(page).to have_css("dialog", wait: 5)
       expect(page).to have_content("Edit Shipping Category")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/shipping_methods_spec.rb
+++ b/admin/spec/features/shipping_methods_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Shipping Methods", :js, type: :feature do
+describe "Shipping Methods", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists shipping methods and allows deleting them" do
+  it "lists shipping methods and allows deleting them", :js do
     create(:shipping_method, name: "FAAAST")
 
     visit "/admin/shipping_methods"

--- a/admin/spec/features/store_credit_reasons_spec.rb
+++ b/admin/spec/features/store_credit_reasons_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Store Credit Reasons", :js, type: :feature do
+describe "Store Credit Reasons", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists store credit reasons and allows deleting them" do
+  it "lists store credit reasons and allows deleting them", :js do
     create(:store_credit_reason, name: "Default-store-credit-reason")
 
     visit "/admin/store_credit_reasons"
@@ -28,10 +28,13 @@ describe "Store Credit Reasons", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Store Credit Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)
@@ -68,10 +71,13 @@ describe "Store Credit Reasons", :js, type: :feature do
       find_row("New Customer Reward").click
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("Edit Store Credit Reason")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/features/tax_categories_spec.rb
+++ b/admin/spec/features/tax_categories_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe "Tax categories", :js, type: :feature do
+describe "Tax categories", type: :feature do
   before { sign_in create(:admin_user, email: 'admin@example.com') }
 
-  it "lists tax categories and allows deleting them" do
+  it "lists tax categories and allows deleting them", :js do
     create(:tax_category, name: "Clothing")
     create(:tax_category, name: "Food")
 
@@ -30,10 +30,13 @@ describe "Tax categories", :js, type: :feature do
       click_on "Add new"
       expect(page).to have_selector("dialog", wait: 5)
       expect(page).to have_content("New Tax Category")
+    end
+
+    it "is accessible", :js do
       expect(page).to be_axe_clean
     end
 
-    it "closing the modal keeps query params" do
+    it "closing the modal keeps query params", :js do
       within("dialog") { click_on "Cancel" }
       expect(page).not_to have_selector("dialog", wait: 5)
       expect(page.current_url).to include(query)

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -39,27 +39,11 @@ Rails.application.config.i18n.raise_on_missing_translations = true
 # CAPYBARA & SELENIUM
 require "capybara/rspec"
 require 'capybara-screenshot/rspec'
-require "selenium/webdriver"
+require "spree/testing_support/capybara_driver"
+
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 Capybara.disable_animation = true
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
 Capybara.enable_aria_label = true
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -51,26 +51,7 @@ require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 
-require "selenium/webdriver"
-
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
+require "spree/testing_support/capybara_driver"
 
 Rails.application.config.i18n.raise_on_missing_translations = true
 

--- a/core/lib/spree/testing_support/capybara_driver.rb
+++ b/core/lib/spree/testing_support/capybara_driver.rb
@@ -6,6 +6,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
   browser_options.args << '--window-size=1920,1080'
   browser_options.args << '--disable-backgrounding-occluded-windows'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)

--- a/core/lib/spree/testing_support/capybara_driver.rb
+++ b/core/lib/spree/testing_support/capybara_driver.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "selenium/webdriver"
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--window-size=1920,1080'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
+Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  # Sandbox cannot be used inside unprivileged Docker container
+  browser_options.args << '--no-sandbox'
+  browser_options.args << '--window-size=1240,1400'
+  browser_options.args << '--disable-backgrounding-occluded-windows'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
+Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -43,34 +43,16 @@ require 'solidus_legacy_promotions/testing_support/factory_bot'
 require 'cancan/matchers'
 require 'spree/testing_support/capybara_ext'
 
-require "selenium/webdriver"
-
 ActiveJob::Base.queue_adapter = :test
 
 Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
-Capybara.register_driver :selenium_chrome_headless do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1920,1080'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
-Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << '--headless'
-  browser_options.args << '--disable-gpu'
-  # Sandbox cannot be used inside unprivileged Docker container
-  browser_options.args << '--no-sandbox'
-  browser_options.args << '--window-size=1240,1400'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
+require "spree/testing_support/capybara_driver"
 
 # AXE - ACCESSIBILITY
 require 'axe-rspec'
 require 'axe-capybara'
 
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.enable_aria_label = true
 
 # VIEW COMPONENTS

--- a/promotions/spec/rails_helper.rb
+++ b/promotions/spec/rails_helper.rb
@@ -61,7 +61,7 @@ require "spree/testing_support/controller_requests"
 require "cancan/matchers"
 require "spree/testing_support/capybara_ext"
 
-require "selenium/webdriver"
+require "spree/testing_support/capybara_driver"
 # Requires factories defined in Solidus core and this extension.
 # See: lib/solidus_promotions/testing_support/factories.rb
 require "spree/testing_support/factory_bot"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.4`:
 - [Merge pull request #6203 from blish/fix-chrome-errors](https://github.com/solidusio/solidus/pull/6203)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)