### PR TITLE
Addressbook: Add foreign key, dependent/inverse_of options

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -5,7 +5,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :user_addresses, foreign_key: "user_id", class_name: "Spree::UserAddress" do
+      has_many :user_addresses, foreign_key: "user_id", class_name: "Spree::UserAddress", inverse_of: :user, dependent: :destroy do
         def find_first_by_address_values(address_attrs)
           detect { |ua| ua.address == Spree::Address.new(address_attrs) }
         end
@@ -32,11 +32,29 @@ module Spree
 
       has_many :addresses, through: :user_addresses
 
-      has_one :default_user_bill_address, ->{ default_billing }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
-      has_one :bill_address, through: :default_user_bill_address, source: :address
+      has_one :default_user_bill_address,
+        ->{ default_billing },
+        class_name: 'Spree::UserAddress',
+        foreign_key: 'user_id',
+        inverse_of: false,
+        dependent: false
+      has_one :bill_address,
+        through: :default_user_bill_address,
+        source: :address,
+        inverse_of: false,
+        dependent: false
 
-      has_one :default_user_ship_address, ->{ default_shipping }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
-      has_one :ship_address, through: :default_user_ship_address, source: :address
+      has_one :default_user_ship_address,
+        ->{ default_shipping },
+        class_name: 'Spree::UserAddress',
+        foreign_key: 'user_id',
+        inverse_of: false,
+        dependent: false
+      has_one :ship_address,
+        through: :default_user_ship_address,
+        source: :address,
+        inverse_of: false,
+        dependent: false
 
       accepts_nested_attributes_for :ship_address
       accepts_nested_attributes_for :bill_address

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class UserAddress < Spree::Base
-    belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id", optional: true, inverse_of: :user_addresses
-    belongs_to :address, class_name: "Spree::Address", optional: true
+    belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id", inverse_of: :user_addresses
+    belongs_to :address, class_name: "Spree::Address"
 
     validates_uniqueness_of :address_id, scope: :user_id
     validates_uniqueness_of :user_id, conditions: -> { default_shipping }, message: :default_address_exists, if: :default?

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class UserAddress < Spree::Base
-    belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id", optional: true
+    belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id", optional: true, inverse_of: :user_addresses
     belongs_to :address, class_name: "Spree::Address", optional: true
 
     validates_uniqueness_of :address_id, scope: :user_id

--- a/core/db/migrate/20250530102541_add_addressbook_foreign_key.rb
+++ b/core/db/migrate/20250530102541_add_addressbook_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAddressbookForeignKey < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :spree_user_addresses, :spree_addresses, column: :address_id, null: false
+  end
+end


### PR DESCRIPTION
## Summary

This makes the user address book a little more reliable by adding a foreign key constraint between addresses and address book entries, and making sure that address book entries have both an address and a user. 

I think the `optional: true` made it in here when the default changed in Rails for `belongs_to` associations, but these were never optional. 

Extracted from #6240 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
