### PR TITLE
Add email column to stock_locations

### DIFF
--- a/core/db/migrate/20250508145917_add_email_to_stock_locations.rb
+++ b/core/db/migrate/20250508145917_add_email_to_stock_locations.rb
@@ -1,0 +1,5 @@
+class AddEmailToStockLocations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_stock_locations, :email, :string
+  end
+end


### PR DESCRIPTION
> [!NOTE]
> Split from #6160 

## Summary

The "email" field is present on new designs for stock location form, but the column was not in the schema yet.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
