### PR TITLE
Pin state_machines to 0.6.0

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -48,7 +48,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'psych', ['>= 4.0.1', '< 6.0']
   s.add_dependency 'ransack', ['~> 4.0', '< 5']
   s.add_dependency 'sprockets-rails', '!= 3.5.0'
-  s.add_dependency 'state_machines-activerecord', '~> 0.6'
+  s.add_dependency 'state_machines', ['~> 0.6', '< 0.10.0']
+  s.add_dependency 'state_machines-activerecord', ['~> 0.6', '< 0.10.0']
   s.add_dependency 'omnes', '~> 0.2.2'
 
   s.post_install_message = <<-MSG


### PR DESCRIPTION
The recently released state_machines gem 0.10.0
causes infinite recursions (StackLevelTooDeep).
