### PR TITLE
Move LoadPromotions out of OrderAdjuster namespace

### DIFF
--- a/promotions/app/models/solidus_promotions/load_promotions.rb
+++ b/promotions/app/models/solidus_promotions/load_promotions.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module SolidusPromotions
+  class LoadPromotions
+    def initialize(order:, dry_run_promotion: nil)
+      @order = order
+      @dry_run_promotion = dry_run_promotion
+    end
+
+    def call
+      promos = connected_order_promotions | sale_promotions
+      promos << dry_run_promotion if dry_run_promotion
+      promos.flat_map(&:benefits).group_by(&:preload_relations).each do |benefit_preload_relations, benefits|
+        preload(records: benefits, associations: benefit_preload_relations)
+        benefits.flat_map(&:conditions).group_by(&:preload_relations).each do |condition_preload_relations, conditions|
+          preload(records: conditions, associations: condition_preload_relations)
+        end
+      end
+      promos.reject { |promotion| promotion.usage_limit_exceeded?(excluded_orders: [order]) }
+    end
+
+    private
+
+    attr_reader :order, :dry_run_promotion
+
+    def preload(records:, associations:)
+      ActiveRecord::Associations::Preloader.new(records: records, associations: associations).call
+    end
+
+    def connected_order_promotions
+      eligible_connected_promotion_ids = order.solidus_order_promotions.select do |order_promotion|
+        order_promotion.promotion.kept? && (order_promotion.promotion_code.nil? || !order_promotion.promotion_code.usage_limit_exceeded?(excluded_orders: [order]))
+      end.map(&:promotion_id)
+      order.solidus_promotions.active(reference_time).where(id: eligible_connected_promotion_ids).includes(promotion_includes)
+    end
+
+    def sale_promotions
+      SolidusPromotions::Promotion.kept.where(apply_automatically: true).active(reference_time).includes(promotion_includes)
+    end
+
+    def reference_time
+      order.completed_at || Time.current
+    end
+
+    def promotion_includes
+      {
+        benefits: :conditions
+      }
+    end
+  end
+end

--- a/promotions/app/models/solidus_promotions/order_adjuster.rb
+++ b/promotions/app/models/solidus_promotions/order_adjuster.rb
@@ -7,7 +7,10 @@ module SolidusPromotions
     def initialize(order, dry_run_promotion: nil)
       @order = order
       @dry_run = !!dry_run_promotion
-      @promotions = LoadPromotions.new(order: order, dry_run_promotion: dry_run_promotion).call
+      @promotions = SolidusPromotions::LoadPromotions.new(
+        order: order,
+        dry_run_promotion: dry_run_promotion
+      ).call
     end
 
     def call

--- a/promotions/app/models/solidus_promotions/order_adjuster/load_promotions.rb
+++ b/promotions/app/models/solidus_promotions/order_adjuster/load_promotions.rb
@@ -2,51 +2,10 @@
 
 module SolidusPromotions
   class OrderAdjuster
-    class LoadPromotions
-      def initialize(order:, dry_run_promotion: nil)
-        @order = order
-        @dry_run_promotion = dry_run_promotion
-      end
-
-      def call
-        promos = connected_order_promotions | sale_promotions
-        promos << dry_run_promotion if dry_run_promotion
-        promos.flat_map(&:benefits).group_by(&:preload_relations).each do |benefit_preload_relations, benefits|
-          preload(records: benefits, associations: benefit_preload_relations)
-          benefits.flat_map(&:conditions).group_by(&:preload_relations).each do |condition_preload_relations, conditions|
-            preload(records: conditions, associations: condition_preload_relations)
-          end
-        end
-        promos.reject { |promotion| promotion.usage_limit_exceeded?(excluded_orders: [order]) }
-      end
-
-      private
-
-      attr_reader :order, :dry_run_promotion
-
-      def preload(records:, associations:)
-        ActiveRecord::Associations::Preloader.new(records: records, associations: associations).call
-      end
-
-      def connected_order_promotions
-        eligible_connected_promotion_ids = order.solidus_order_promotions.select do |order_promotion|
-          order_promotion.promotion.kept? && (order_promotion.promotion_code.nil? || !order_promotion.promotion_code.usage_limit_exceeded?(excluded_orders: [order]))
-        end.map(&:promotion_id)
-        order.solidus_promotions.active(reference_time).where(id: eligible_connected_promotion_ids).includes(promotion_includes)
-      end
-
-      def sale_promotions
-        SolidusPromotions::Promotion.kept.where(apply_automatically: true).active(reference_time).includes(promotion_includes)
-      end
-
-      def reference_time
-        order.completed_at || Time.current
-      end
-
-      def promotion_includes
-        {
-          benefits: :conditions
-        }
+    class LoadPromotions < SolidusPromotions::LoadPromotions
+      def initialize(...)
+        Spree.deprecator.warn("Please use SolidusPromotions::LoadPromotions instead")
+        super
       end
     end
   end

--- a/promotions/spec/models/solidus_promotions/load_promotions_spec.rb
+++ b/promotions/spec/models/solidus_promotions/load_promotions_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SolidusPromotions::LoadPromotions do
+  describe "selecting promotions" do
+    subject { described_class.new(order: order).call }
+
+    let(:order) { create(:order) }
+
+    let!(:active_promotion) { create(:solidus_promotion, :with_adjustable_benefit, apply_automatically: true) }
+    let!(:inactive_promotion) do
+      create(:solidus_promotion, :with_adjustable_benefit, expires_at: 2.days.ago, apply_automatically: true)
+    end
+    let!(:connectable_promotion) { create(:solidus_promotion, :with_adjustable_benefit) }
+    let!(:connectable_inactive_promotion) do
+      create(:solidus_promotion, :with_adjustable_benefit, expires_at: 2.days.ago)
+    end
+
+    context "no promo is connected to the order" do
+      it "returns only active promotions" do
+        expect(subject).to eq([active_promotion])
+      end
+    end
+
+    context "an active promo is connected to the order" do
+      before do
+        order.solidus_promotions << connectable_promotion
+      end
+
+      it "checks active and connected promotions" do
+        expect(subject).to include(active_promotion, connectable_promotion)
+      end
+    end
+
+    context "an inactive promo is connected to the order" do
+      before do
+        order.solidus_promotions << connectable_inactive_promotion
+      end
+
+      it "does not check connected inactive promotions" do
+        expect(subject).not_to include(connectable_inactive_promotion)
+        expect(subject).to eq([active_promotion])
+      end
+    end
+
+    context "discarded promotions" do
+      let!(:discarded_promotion) { create(:solidus_promotion, :with_adjustable_benefit, deleted_at: 1.hour.ago, apply_automatically: true) }
+
+      it "does not check discarded promotions" do
+        expect(subject).not_to include(discarded_promotion)
+      end
+
+      context "a discarded promo is connected to the order" do
+        before do
+          order.solidus_promotions << discarded_promotion
+        end
+
+        it "does not check connected discarded promotions" do
+          expect(subject).not_to include(discarded_promotion)
+          expect(subject).to eq([active_promotion])
+        end
+      end
+    end
+  end
+
+  context "promotions in the past" do
+    let(:order) { create(:order, completed_at: 7.days.ago) }
+    let(:currently_active_promotion) { create(:solidus_promotion, :with_adjustable_benefit, starts_at: 1.hour.ago) }
+    let(:past_promotion) { create(:solidus_promotion, :with_adjustable_benefit, starts_at: 1.year.ago, expires_at: 11.months.ago) }
+    let(:order_promotion) { create(:solidus_promotion, :with_adjustable_benefit, starts_at: 8.days.ago, expires_at: 6.days.ago) }
+
+    before do
+      order.solidus_promotions << past_promotion
+      order.solidus_promotions << order_promotion
+      order.solidus_promotions << currently_active_promotion
+    end
+
+    subject { described_class.new(order: order).call }
+
+    it "only evaluates the past promotion that was active when the order was completed" do
+      expect(subject).to eq([order_promotion])
+    end
+  end
+end

--- a/promotions/spec/models/solidus_promotions/order_adjuster/load_promotions_spec.rb
+++ b/promotions/spec/models/solidus_promotions/order_adjuster/load_promotions_spec.rb
@@ -3,83 +3,12 @@
 require "rails_helper"
 
 RSpec.describe SolidusPromotions::OrderAdjuster::LoadPromotions do
-  describe "selecting promotions" do
-    subject { described_class.new(order: order).call }
+  let(:order) { Spree::Order.new }
 
-    let(:order) { create(:order) }
+  subject { described_class.new(order:) }
 
-    let!(:active_promotion) { create(:solidus_promotion, :with_adjustable_benefit, apply_automatically: true) }
-    let!(:inactive_promotion) do
-      create(:solidus_promotion, :with_adjustable_benefit, expires_at: 2.days.ago, apply_automatically: true)
-    end
-    let!(:connectable_promotion) { create(:solidus_promotion, :with_adjustable_benefit) }
-    let!(:connectable_inactive_promotion) do
-      create(:solidus_promotion, :with_adjustable_benefit, expires_at: 2.days.ago)
-    end
-
-    context "no promo is connected to the order" do
-      it "returns only active promotions" do
-        expect(subject).to eq([active_promotion])
-      end
-    end
-
-    context "an active promo is connected to the order" do
-      before do
-        order.solidus_promotions << connectable_promotion
-      end
-
-      it "checks active and connected promotions" do
-        expect(subject).to include(active_promotion, connectable_promotion)
-      end
-    end
-
-    context "an inactive promo is connected to the order" do
-      before do
-        order.solidus_promotions << connectable_inactive_promotion
-      end
-
-      it "does not check connected inactive promotions" do
-        expect(subject).not_to include(connectable_inactive_promotion)
-        expect(subject).to eq([active_promotion])
-      end
-    end
-
-    context "discarded promotions" do
-      let!(:discarded_promotion) { create(:solidus_promotion, :with_adjustable_benefit, deleted_at: 1.hour.ago, apply_automatically: true) }
-
-      it "does not check discarded promotions" do
-        expect(subject).not_to include(discarded_promotion)
-      end
-
-      context "a discarded promo is connected to the order" do
-        before do
-          order.solidus_promotions << discarded_promotion
-        end
-
-        it "does not check connected discarded promotions" do
-          expect(subject).not_to include(discarded_promotion)
-          expect(subject).to eq([active_promotion])
-        end
-      end
-    end
-  end
-
-  context "promotions in the past" do
-    let(:order) { create(:order, completed_at: 7.days.ago) }
-    let(:currently_active_promotion) { create(:solidus_promotion, :with_adjustable_benefit, starts_at: 1.hour.ago) }
-    let(:past_promotion) { create(:solidus_promotion, :with_adjustable_benefit, starts_at: 1.year.ago, expires_at: 11.months.ago) }
-    let(:order_promotion) { create(:solidus_promotion, :with_adjustable_benefit, starts_at: 8.days.ago, expires_at: 6.days.ago) }
-
-    before do
-      order.solidus_promotions << past_promotion
-      order.solidus_promotions << order_promotion
-      order.solidus_promotions << currently_active_promotion
-    end
-
-    subject { described_class.new(order: order).call }
-
-    it "only evaluates the past promotion that was active when the order was completed" do
-      expect(subject).to eq([order_promotion])
-    end
+  it "tells the user to use SolidusPromotions::LoadPromotions instead" do
+    expect(Spree.deprecator).to receive(:warn).with("Please use SolidusPromotions::LoadPromotions instead")
+    expect(subject).to be_a(SolidusPromotions::LoadPromotions)
   end
 end


### PR DESCRIPTION


## Summary

Loading the currently available promotions can be quite useful outside of the order adjuster. This moves the LoadPromotions class out of there and into the main `SolidusPromotions` namespace so that it's clear that this class can be used elsewhere.


Extracted from #6287 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
