### PR TITLE
Handle failing foreign key additions

### DIFF
--- a/core/db/migrate/20250530102541_add_addressbook_foreign_key.rb
+++ b/core/db/migrate/20250530102541_add_addressbook_foreign_key.rb
@@ -1,7 +1,28 @@
 # frozen_string_literal: true
 
 class AddAddressbookForeignKey < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    # Uncomment the following code to remove orphaned records if this migration fails
+    #
+    # say_with_time "Removing orphaned address book entries (no corresponding address)" do
+    #   Spree::UserAddress.left_joins(:address).where(spree_addresses: { id: nil }).delete_all
+    # end
+
     add_foreign_key :spree_user_addresses, :spree_addresses, column: :address_id, null: false
+  rescue ActiveRecord::StatementInvalid => e
+    if e.cause.is_a?(PG::ForeignKeyViolation) || e.cause.is_a?(Mysql2::Error) || e.cause.is_a?(SQLite3::ConstraintException)
+      Rails.logger.warn <<~MSG
+        ⚠️ Foreign key constraint failed when adding :spree_user_addresses => :spree_addresses.
+        To fix this:
+          1. Uncomment the code that removes orphaned records.
+          2. Rerun the migration.
+        Offending error: #{e.cause.class} - #{e.cause.message}
+      MSG
+    end
+    raise
+  end
+
+  def down
+    remove_foreign_key :spree_user_addresses, :spree_addresses, column: :address_id, null: false
   end
 end

--- a/core/db/migrate/20250605105424_add_shipping_category_foreign_keys.rb
+++ b/core/db/migrate/20250605105424_add_shipping_category_foreign_keys.rb
@@ -2,8 +2,70 @@
 
 class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
   def change
-    add_foreign_key :spree_products, :spree_shipping_categories, column: :shipping_category_id, null: false
-    add_foreign_key :spree_shipping_method_categories, :spree_shipping_methods, column: :shipping_method_id, null: false
-    add_foreign_key :spree_shipping_method_categories, :spree_shipping_categories, column: :shipping_category_id, null: false
+    # Uncomment the following code to remove orphaned records if the following code fails
+    #
+    # say_with_time "Removing orphaned products (no corresponding shipping category)" do
+    #   Spree::Product.left_joins(:shipping_category).where(spree_shipping_category: { id: nil }).delete_all
+    # end
+    begin
+      add_foreign_key :spree_products, :spree_shipping_categories, column: :shipping_category_id, null: false
+    rescue ActiveRecord::StatementInvalid => e
+      if e.cause.is_a?(PG::ForeignKeyViolation) || e.cause.is_a?(Mysql2::Error) || e.cause.is_a?(SQLite3::ConstraintException)
+        Rails.logger.warn <<~MSG
+          ⚠️ Foreign key constraint failed when adding :spree_products => :spree_shipping_categories.
+          To fix this:
+            1. Uncomment the code that removes orphaned records.
+            2. Rerun the migration.
+          Offending error: #{e.cause.class} - #{e.cause.message}
+        MSG
+      end
+      raise
+    end
+
+    # Uncomment the following code to remove orphaned records if the following code fails
+    #
+    # say_with_time "Removing orphaned shipping method categories (no corresponding shipping category)" do
+    #   Spree::ShippingMethodCategory.left_joins(:shipping_category).where(spree_shipping_category: { id: nil }).delete_all
+    # end
+    begin
+      add_foreign_key :spree_shipping_method_categories, :spree_shipping_methods, column: :shipping_method_id, null: false
+    rescue ActiveRecord::StatementInvalid => e
+      if e.cause.is_a?(PG::ForeignKeyViolation) || e.cause.is_a?(Mysql2::Error) || e.cause.is_a?(SQLite3::ConstraintException)
+        Rails.logger.warn <<~MSG
+          ⚠️ Foreign key constraint failed when adding :spree_shipping_method_categories => :spree_shipping_methods.
+          To fix this:
+            1. Uncomment the code that removes orphaned records.
+            2. Rerun the migration.
+          Offending error: #{e.cause.class} - #{e.cause.message}
+        MSG
+      end
+      raise
+    end
+
+    # Uncomment the following code to remove orphaned records if the following code fails
+    #
+    # say_with_time "Removing orphaned shipping method categories (no corresponding shipping method)" do
+    #   Spree::ShippingMethodCategory.left_joins(:shipping_method).where(spree_shipping_method: { id: nil }).delete_all
+    # end
+    begin
+      add_foreign_key :spree_shipping_method_categories, :spree_shipping_categories, column: :shipping_category_id, null: false
+    rescue ActiveRecord::StatementInvalid => e
+      if e.cause.is_a?(PG::ForeignKeyViolation) || e.cause.is_a?(Mysql2::Error) || e.cause.is_a?(SQLite3::ConstraintException)
+        Rails.logger.warn <<~MSG
+          ⚠️ Foreign key constraint failed when adding :spree_shipping_method_categories => :spree_shipping_categories.
+          To fix this:
+            1. Uncomment the code that removes orphaned records.
+            2. Rerun the migration.
+          Offending error: #{e.cause.class} - #{e.cause.message}
+        MSG
+      end
+      raise
+    end
+  end
+
+  def down
+    remove_foreign_key :spree_products, :spree_shipping_categories, column: :shipping_category_id, null: false
+    remove_foreign_key :spree_shipping_method_categories, :spree_shipping_methods, column: :shipping_method_id, null: false
+    remove_foreign_key :spree_shipping_method_categories, :spree_shipping_categories, column: :shipping_category_id, null: false
   end
 end


### PR DESCRIPTION

## Summary

We've added some foreign key constraints recently, and have since come up with a nicer way of guiding users towards fixing their data intentionally.

This change gives them a nice error message and allows them to change the migration to remove offending records.

Co-Authored-By: thomas@vondeyen.com


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
