### PR TITLE
[Admin] Solidus form builder

### DIFF
--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @adjustment_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @adjustment_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::AdjustmentReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
@@ -4,10 +4,7 @@
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
         <%= f.text_field(:code, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::AdjustmentReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.html.erb
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/adjustment_reasons/edit/component.yml
+++ b/admin/app/components/solidus_admin/adjustment_reasons/edit/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "Edit Adjustment Reason"
   cancel: "Cancel"
-  submit: "Update Adjustment Reason"
   hints:
     active: "When checked, this adjustment reason will be available for selection when adding adjustments to orders."

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @adjustment_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @adjustment_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::AdjustmentReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
@@ -4,10 +4,7 @@
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
         <%= f.text_field(:code, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::AdjustmentReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.html.erb
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/adjustment_reasons/new/component.yml
+++ b/admin/app/components/solidus_admin/adjustment_reasons/new/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "New Adjustment Reason"
   cancel: "Cancel"
-  submit: "Add Adjustment Reason"
   hints:
     active: "When checked, this adjustment reason will be available for selection when adding adjustments to orders."

--- a/admin/app/components/solidus_admin/base_component.rb
+++ b/admin/app/components/solidus_admin/base_component.rb
@@ -9,6 +9,7 @@ module SolidusAdmin
     include SolidusAdmin::ComponentsHelper
     include SolidusAdmin::StimulusHelper
     include SolidusAdmin::VoidElementsHelper
+    include SolidusAdmin::SolidusFormHelper
     include Turbo::FramesHelper
 
     def icon_tag(name, **attrs)

--- a/admin/app/components/solidus_admin/orders/cart/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/component.html.erb
@@ -37,19 +37,18 @@
                   ) %>
                 </td>
                 <td class="px-6 py-4">
-                  <%= form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), html: {
+                  <%= solidus_form_for(line_item, url: solidus_admin.order_line_item_path(@order, line_item), html: {
                     "data-controller": "readonly-when-submitting"
                   }) do |f| %>
-                    <%= render component("ui/forms/input").new(
-                      name: "#{f.object_name}[quantity]",
+                    <%= f.input(
+                      :quantity,
                       type: :number,
-                      value: line_item.quantity,
                       "aria-label": "Quantity",
                       min: 0,
                       class: "!w-16 inline-block",
                       "data-action": "input->#{stimulus_id}#updateLineItem",
                     ) %>
-                    <% render component("ui/button").new(type: :submit, text: "Update", class: "inline-block") %>
+                    <% f.submit("Update", class: "inline-block") %>
                   <% end %>
                 </td>
                 <td class="px-6 py-4">

--- a/admin/app/components/solidus_admin/orders/cart/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/component.html.erb
@@ -48,7 +48,7 @@
                       class: "!w-16 inline-block",
                       "data-action": "input->#{stimulus_id}#updateLineItem",
                     ) %>
-                    <% f.submit("Update", class: "inline-block") %>
+                    <% f.submit(class: "inline-block") %>
                   <% end %>
                 </td>
                 <td class="px-6 py-4">

--- a/admin/app/components/solidus_admin/orders/cart/result/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/cart/result/component.html.erb
@@ -1,9 +1,9 @@
 <%= render component('ui/forms/search/result').new do %>
-  <%= form_for(@order.line_items.build(variant: @variant), url: solidus_admin.order_line_items_path(@order), method: :post, html: {
+  <%= solidus_form_for(@order.line_items.build(variant: @variant), url: solidus_admin.order_line_items_path(@order), method: :post, html: {
     "data-controller": "readonly-when-submitting",
     class: "flex items-center",
   }) do |f| %>
-    <%= hidden_field_tag("#{f.object_name}[variant_id]", @variant.id) %>
+    <%= f.hidden_field(:variant_id) %>
     <div class="flex gap-2 grow">
       <%= render component("ui/thumbnail").new(
         src: @image&.url(:small),

--- a/admin/app/components/solidus_admin/orders/show/address/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/address/component.html.erb
@@ -1,7 +1,7 @@
 <div class="<%= stimulus_id %>" data-controller="<%= stimulus_id %>">
   <%= turbo_frame_tag "edit_order_#{params[:type]}_address_modal" do %>
     <%= render component("ui/modal").new(title: t(".title.#{@type}")) do |modal| %>
-      <%= form_for @order, url: solidus_admin.send("order_#{@type}_address_path", @order), html: { id: form_id } do |form| %>
+      <%= solidus_form_for @order, url: solidus_admin.send("order_#{@type}_address_path", @order), html: { id: form_id } do |form| %>
         <div class="w-full flex flex-col mb-4">
           <div class="flex justify-between items-center mb-4 relative">
             <h2 class="text-sm font-semibold">
@@ -32,9 +32,7 @@
             <% end %>
           </div>
 
-          <%= render component("ui/forms/checkbox").new(
-            object_name: form.object_name,
-            method: use_attribute,
+          <%= form.checkbox(use_attribute,
             checked: @address == (@type == 'ship' ? @order.bill_address : @order.ship_address)
           ) do |checkbox| %>
             <%= checkbox.with_label(text: t(".use_this_address.#{@type}"), size: :xs) %>

--- a/admin/app/components/solidus_admin/orders/show/address/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/address/component.html.erb
@@ -33,10 +33,10 @@
           </div>
 
           <%= form.checkbox(use_attribute,
-            checked: @address == (@type == 'ship' ? @order.bill_address : @order.ship_address)
-          ) do |checkbox| %>
-            <%= checkbox.with_label(text: t(".use_this_address.#{@type}"), size: :xs) %>
-          <% end %>
+            checked: @address == (@type == 'ship' ? @order.bill_address : @order.ship_address),
+            label: t(".use_this_address.#{@type}"),
+            label_options: { size: :xs })
+          %>
         </div>
       <% end %>
 

--- a/admin/app/components/solidus_admin/orders/show/customer_search/result/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/customer_search/result/component.html.erb
@@ -1,10 +1,10 @@
 <%= render component('ui/forms/search/result').new do %>
   <% if @customer %>
-    <%= form_for(@order, url: solidus_admin.order_path(@order), html: {
+    <%= solidus_form_for(@order, url: solidus_admin.order_path(@order), html: {
       "data-controller": "readonly-when-submitting",
       class: "flex items-center",
     }) do |f| %>
-      <%= hidden_field_tag("#{f.object_name}[user_id]", @customer.id) %>
+      <%= f.hidden_field(:user_id, value: @customer.id) %>
       <button type="submit" class="flex gap-2 grow items-center">
         <%= render component("ui/icon").new(name: "user-line", class: 'w-5 h-5 m-2') %>
         <div  class="flex-col text-left">

--- a/admin/app/components/solidus_admin/orders/show/email/component.html.erb
+++ b/admin/app/components/solidus_admin/orders/show/email/component.html.erb
@@ -1,8 +1,8 @@
 <div class="<%= stimulus_id %>">
   <%= turbo_frame_tag "edit_order_email_modal" do %>
     <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-      <%= form_for @order, url: solidus_admin.order_path(@order), html: { id: form_id } do |f| %>
-        <%= render component("ui/forms/field").text_field(f, :email) %>
+      <%= solidus_form_for @order, url: solidus_admin.order_path(@order), html: { id: form_id } do |f| %>
+        <%= f.text_field(:email) %>
         <label class="font-normal text-sm mt-4 block">
           <%= t('.guest_checkout') %>:
           <output class="font-semibold text-sm"><%= @order.user ? t('.no') : t('.yes') %></output>

--- a/admin/app/components/solidus_admin/products/show/component.html.erb
+++ b/admin/app/components/solidus_admin/products/show/component.html.erb
@@ -23,26 +23,21 @@
     <% end %>
   <% end %>
 
-  <%= form_for @product, url: solidus_admin.product_path(@product), html: { id: form_id } do |f| %>
+  <%= solidus_form_for @product, url: solidus_admin.product_path(@product), html: { id: form_id } do |f| %>
     <%= page_with_sidebar do %>
       <%= page_with_sidebar_main do %>
         <%= render component("ui/panel").new do %>
-          <%= render component("ui/forms/field").text_field(f, :name) %>
-          <%= render component("ui/forms/field").text_field(f, :slug) %>
-          <%= render component("ui/forms/field").text_area(f, :description) %>
+          <%= f.text_field(:name) %>
+          <%= f.text_field(:slug) %>
+          <%= f.text_area(:description) %>
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".seo")) do %>
-          <%= render component("ui/forms/field").text_field(f, :meta_title) %>
-          <%= render component("ui/forms/field").text_field(f, :meta_description) %>
-          <%= render component("ui/forms/field").text_area(f, :meta_keywords) %>
-          <%= render component("ui/forms/field").text_field(f, :gtin) %>
-          <%= render component("ui/forms/field").select(
-            f,
-            :condition,
-            condition_options,
-            include_blank: t("spree.unset"),
-          ) %>
+          <%= f.text_field(:meta_title) %>
+          <%= f.text_field(:meta_description) %>
+          <%= f.text_area(:meta_keywords) %>
+          <%= f.text_field(:gtin) %>
+          <%= f.select(:condition, condition_options, include_blank: t("spree.unset")) %>
         <% end %>
         <%= render component("ui/panel").new(title: t(".media")) do |panel| %>
           <% panel.with_action(
@@ -52,15 +47,15 @@
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".pricing")) do %>
-          <%= render component("ui/forms/field").text_field(f, :price) %>
+          <%= f.text_field(:price) %>
           <div class="flex gap-4 justify-items-stretch">
-            <%= render component("ui/forms/field").text_field(f, :cost_price) %>
-            <%= render component("ui/forms/field").text_field(f, :cost_currency) %>
+            <%= f.text_field(:cost_price) %>
+            <%= f.text_field(:cost_currency) %>
           </div>
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".stock")) do |panel| %>
-          <%= render component("ui/forms/field").text_field(f, :sku) %>
+          <%= f.text_field(:sku) %>
 
           <% panel.with_action(
             name: t(".manage_stock"),
@@ -69,14 +64,12 @@
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".shipping")) do %>
-          <%= render component("ui/forms/field").select(
-            f,
+          <%= f.select(
             :shipping_category_id,
             [[t(".none"), nil]] + Spree::ShippingCategory.order(:name).pluck(:name, :id),
             tip: t(".hints.shipping_category_html")
           ) %>
-          <%= render component("ui/forms/field").select(
-            f,
+          <%= f.select(
             :tax_category_id,
             [[t(".none"), nil]] + Spree::TaxCategory.order(:name).pluck(:name, :id),
             tip: t(".hints.tax_category_html")
@@ -84,13 +77,7 @@
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".options")) do %>
-          <%= render component("ui/forms/field").select(
-            f,
-            :option_type_ids,
-            option_type_options,
-            multiple: true,
-            "size" => option_type_options.size,
-          ) %>
+          <%= f.select(:option_type_ids, option_type_options, multiple: true) %>
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".specifications")) do |panel| %>
@@ -103,34 +90,26 @@
 
       <%= page_with_sidebar_aside do %>
         <%= render component("ui/panel").new(title: t(".publishing")) do %>
-          <%= render component("ui/forms/field").text_field(
-            f,
+          <%= f.text_field(
             :available_on,
             hint: t(".hints.available_on_html"),
             type: :date,
             value: f.object.available_on&.to_date
           ) %>
-          <%= render component("ui/forms/field").text_field(
-            f,
+          <%= f.text_field(
             :discontinue_on,
             hint: t(".hints.discontinue_on_html"),
             type: :date,
             value: f.object.discontinue_on&.to_date
           ) %>
-          <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :promotionable, checked: f.object.promotionable) do |checkbox| %>
+          <%= f.checkbox(:promotionable) do |checkbox| %>
             <%= checkbox.with_label(text: Spree::Product.human_attribute_name(:promotionable), size: :xs) %>
             <%= checkbox.with_hint(text: t(".hints.promotionable_html")) %>
           <% end %>
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".product_organization")) do %>
-          <%= render component("ui/forms/field").select(
-            f,
-            :taxon_ids,
-            taxon_options,
-            multiple: true,
-            "size" => taxon_options.size, # use a string key to avoid setting the size of the component
-          ) %>
+          <%= f.select(:taxon_ids, taxon_options, multiple: true) %>
         <% end %>
       <% end %>
     <% end %>

--- a/admin/app/components/solidus_admin/products/show/component.html.erb
+++ b/admin/app/components/solidus_admin/products/show/component.html.erb
@@ -102,10 +102,7 @@
             type: :date,
             value: f.object.discontinue_on&.to_date
           ) %>
-          <%= f.checkbox(:promotionable) do |checkbox| %>
-            <%= checkbox.with_label(text: Spree::Product.human_attribute_name(:promotionable), size: :xs) %>
-            <%= checkbox.with_hint(text: t(".hints.promotionable_html")) %>
-          <% end %>
+          <%= f.checkbox(:promotionable, hint: t(".hints.promotionable_html")) %>
         <% end %>
 
         <%= render component("ui/panel").new(title: t(".product_organization")) do %>

--- a/admin/app/components/solidus_admin/properties/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/edit/component.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @property, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @property, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :presentation, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:presentation, class: "required") %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/properties/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/edit/component.html.erb
@@ -9,7 +9,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit(text: t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/properties/new/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/new/component.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @property, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @property, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :presentation, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:presentation, class: "required") %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/properties/new/component.html.erb
+++ b/admin/app/components/solidus_admin/properties/new/component.html.erb
@@ -9,7 +9,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit(text: t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
@@ -4,10 +4,7 @@
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
         <%= f.text_field(:code, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::RefundReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @refund_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @refund_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::RefundReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/refund_reasons/edit/component.yml
+++ b/admin/app/components/solidus_admin/refund_reasons/edit/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "Edit Refund Reason"
   cancel: "Cancel"
-  submit: "Update Refund Reason"
   hints:
     active: "When checked, this refund reason will be available for selection when adding refunds to orders."

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
@@ -4,10 +4,7 @@
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
         <%= f.text_field(:code, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::RefundReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @refund_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @refund_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::RefundReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/refund_reasons/new/component.yml
+++ b/admin/app/components/solidus_admin/refund_reasons/new/component.yml
@@ -1,6 +1,5 @@
 en:
   title: "New Refund Reason"
   cancel: "Cancel"
-  submit: "Add Refund Reason"
   hints:
     active: "When checked, this refund reason will be available for selection when refunding orders."

--- a/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit(text: t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::ReturnReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/edit/component.html.erb
@@ -3,10 +3,7 @@
     <%= solidus_form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::ReturnReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit(text: t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::ReturnReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/return_reasons/new/component.html.erb
@@ -3,10 +3,7 @@
     <%= solidus_form_for @return_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::ReturnReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/roles/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/edit/component.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @role, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @role, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :description) %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:description) %>
       </div>
 
       <% if permission_set_options.present? %>
@@ -12,19 +12,19 @@
         </h3>
       <% end %>
 
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:order], row_title: t('.orders'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:product], row_title: t('.products'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:stock], row_title: t('.stock'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:user], row_title: t('.customers'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:restricted_stock], row_title: t('.restricted_stock'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:configuration], row_title: t('.settings'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:other], row_title: t('.other'), form: f, method: :permission_set_ids, layout: :subsection) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:order], row_title: t('.orders')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:product], row_title: t('.products')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:stock], row_title: t('.stock')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:user], row_title: t('.customers')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:restricted_stock], row_title: t('.restricted_stock')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:configuration], row_title: t('.settings')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:other], row_title: t('.other'), layout: :subsection) %>
 
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/roles/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/edit/component.html.erb
@@ -24,7 +24,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/roles/edit/component.yml
+++ b/admin/app/components/solidus_admin/roles/edit/component.yml
@@ -3,7 +3,6 @@
 en:
   title: "Edit Role"
   cancel: "Cancel"
-  submit: "Update Role"
   edit: "Edit"
   view: "View"
   name_placeholder: "Enter a clear role name"

--- a/admin/app/components/solidus_admin/roles/new/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/new/component.html.erb
@@ -24,7 +24,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/roles/new/component.html.erb
+++ b/admin/app/components/solidus_admin/roles/new/component.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @role, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @role, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required", placeholder: t(".name_placeholder")) %>
-        <%= render component("ui/forms/field").text_field(f, :description, placeholder: t(".description_placeholder")) %>
+        <%= f.text_field(:name, class: "required", placeholder: t(".name_placeholder")) %>
+        <%= f.text_field(:description, placeholder: t(".description_placeholder")) %>
       </div>
 
       <% if permission_set_options.present? %>
@@ -12,19 +12,19 @@
         </h3>
       <% end %>
 
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:order], row_title: t('.orders'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:product], row_title: t('.products'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:stock], row_title: t('.stock'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:user], row_title: t('.customers'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:restricted_stock], row_title: t('.restricted_stock'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:configuration], row_title: t('.settings'), form: f, method: :permission_set_ids) %>
-      <%= render component("ui/checkbox_row").new(options: permission_set_options[:other], row_title: t('.other'), form: f, method: :permission_set_ids, layout: :subsection) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:order], row_title: t('.orders')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:product], row_title: t('.products')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:stock], row_title: t('.stock')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:user], row_title: t('.customers')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:restricted_stock], row_title: t('.restricted_stock')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:configuration], row_title: t('.settings')) %>
+      <%= f.checkbox_row(:permission_set_ids, options: permission_set_options[:other], row_title: t('.other'), layout: :subsection) %>
 
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/roles/new/component.yml
+++ b/admin/app/components/solidus_admin/roles/new/component.yml
@@ -3,7 +3,6 @@
 en:
   title: "New Role"
   cancel: "Cancel"
-  submit: "Add Role"
   edit: "Edit"
   view: "View"
   name_placeholder: "Enter a clear role name"

--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
@@ -8,7 +8,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @shipping_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @shipping_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name) %>
+        <%= f.text_field(:name) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/shipping_categories/edit/component.yml
+++ b/admin/app/components/solidus_admin/shipping_categories/edit/component.yml
@@ -3,4 +3,3 @@
 en:
   title: "Edit Shipping Category"
   cancel: "Cancel"
-  submit: "Update Shipping Category"

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
@@ -8,7 +8,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @shipping_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @shipping_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name) %>
+        <%= f.text_field(:name) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/shipping_categories/new/component.yml
+++ b/admin/app/components/solidus_admin/shipping_categories/new/component.yml
@@ -3,4 +3,3 @@
 en:
   title: "New Shipping Category"
   cancel: "Cancel"
-  submit: "Add Shipping Category"

--- a/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stock_items/edit/component.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @stock_item, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @stock_item, url: form_url, html: { id: form_id } do |f| %>
       <div
         class="flex flex-col gap-6 pb-4"
         data-controller="<%= stimulus_id %>"
@@ -35,8 +35,7 @@
           <% end %>
         </div>
 
-        <%= render component("ui/forms/field").text_field(
-          f,
+        <%= f.text_field(
           :count_on_hand,
           readonly: true,
           value: @stock_item.count_on_hand_was || @stock_item.count_on_hand,
@@ -55,12 +54,10 @@
           ) %>
         <% end %>
 
-        <%= render component("ui/forms/switch_field").new(
-          name: "#{f.object_name}[backorderable]",
+        <%= f.switch_field(
+          :backorderable,
           label: Spree::StockItem.human_attribute_name(:backorderable),
-          error: f.object.errors[:backorderable],
           hint: t(".backorderable_hint_html"),
-          checked: f.object.backorderable?,
           include_hidden: true,
         ) %>
       </div>

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
@@ -3,10 +3,7 @@
     <%= solidus_form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::StoreCreditReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::StoreCreditReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/store_credit_reasons/edit/component.yml
+++ b/admin/app/components/solidus_admin/store_credit_reasons/edit/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "Edit Store Credit Reason"
   cancel: "Cancel"
-  submit: "Update Store Credit Reason"
   hints:
     active: "When checked, this store credit reason will be available for selection when adding store credit to orders."

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
@@ -3,10 +3,7 @@
     <%= solidus_form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
         <%= f.text_field(:name, class: "required") %>
-        <%= f.checkbox(:active) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::StoreCreditReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.active")) %>
-        <% end %>
+        <%= f.checkbox(:active, hint: t(".hints.active")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @store_credit_reason, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active) do |checkbox| %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.checkbox(:active) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::StoreCreditReason.human_attribute_name(:active), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.active")) %>
         <% end %>
@@ -12,7 +12,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/store_credit_reasons/new/component.yml
+++ b/admin/app/components/solidus_admin/store_credit_reasons/new/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "New Store Credit Reason"
   cancel: "Cancel"
-  submit: "Add Store Credit Reason"
   hints:
     active: "When checked, this store credit reason will be available for selection when adding store credit to orders."

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
@@ -14,7 +14,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @tax_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @tax_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name) %>
-        <%= render component("ui/forms/field").text_field(f, :tax_code) %>
-        <%= render component("ui/forms/field").text_field(f, :description) %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :is_default, checked: f.object.is_default) do |checkbox| %>
+        <%= f.text_field(:name) %>
+        <%= f.text_field(:tax_code) %>
+        <%= f.text_field(:description) %>
+        <%= f.checkbox(:is_default) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::TaxCategory.human_attribute_name(:is_default), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.is_default")) %>
         <% end %>
@@ -14,7 +14,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
@@ -5,10 +5,7 @@
         <%= f.text_field(:name) %>
         <%= f.text_field(:tax_code) %>
         <%= f.text_field(:description) %>
-        <%= f.checkbox(:is_default) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::TaxCategory.human_attribute_name(:is_default), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.is_default")) %>
-        <% end %>
+        <%= f.checkbox(:is_default, hint: t(".hints.is_default")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/tax_categories/edit/component.yml
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "Edit Tax Category"
   cancel: "Cancel"
-  submit: "Update Tax Category"
   hints:
     is_default: "When checked, this tax category will be selected by default when creating new products or variants."

--- a/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
@@ -14,7 +14,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @tax_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @tax_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name) %>
-        <%= render component("ui/forms/field").text_field(f, :tax_code) %>
-        <%= render component("ui/forms/field").text_field(f, :description) %>
-        <%= render component("ui/forms/checkbox").new(object_name: f.object_name, method: :is_default, checked: f.object.is_default) do |checkbox| %>
+        <%= f.text_field(:name) %>
+        <%= f.text_field(:tax_code) %>
+        <%= f.text_field(:description) %>
+        <%= f.checkbox(:is_default) do |checkbox| %>
           <%= checkbox.with_label(text: Spree::TaxCategory.human_attribute_name(:is_default), weight: :semibold, size: :xs, classes: 'ml-2') %>
           <%= checkbox.with_hint(text: t(".hints.is_default")) %>
         <% end %>
@@ -14,7 +14,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
@@ -5,10 +5,7 @@
         <%= f.text_field(:name) %>
         <%= f.text_field(:tax_code) %>
         <%= f.text_field(:description) %>
-        <%= f.checkbox(:is_default) do |checkbox| %>
-          <%= checkbox.with_label(text: Spree::TaxCategory.human_attribute_name(:is_default), weight: :semibold, size: :xs, classes: 'ml-2') %>
-          <%= checkbox.with_hint(text: t(".hints.is_default")) %>
-        <% end %>
+        <%= f.checkbox(:is_default, hint: t(".hints.is_default")) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">

--- a/admin/app/components/solidus_admin/tax_categories/new/component.yml
+++ b/admin/app/components/solidus_admin/tax_categories/new/component.yml
@@ -3,6 +3,5 @@
 en:
   title: "New Tax Category"
   cancel: "Cancel"
-  submit: "Add Tax Category"
   hints:
     is_default: "When checked, this tax category will be selected by default when creating new products or variants."

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -117,8 +117,10 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
   end
 
   def self.submit(resource:, **attrs)
-    resource_name = resource.model_name.human
-    text = resource.new_record? ? t('.submit.create', resource_name:) : t('.submit.update', resource_name:)
+    unless (text = attrs.delete(:text))
+      resource_name = resource.model_name.human
+      text = resource.new_record? ? t('.submit.create', resource_name:) : t('.submit.update', resource_name:)
+    end
     new(text:, type: :submit, **attrs)
   end
 

--- a/admin/app/components/solidus_admin/ui/forms/input/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/input/component.rb
@@ -34,6 +34,7 @@ class SolidusAdmin::UI::Forms::Input::Component < SolidusAdmin::BaseComponent
     week
     search
     time
+    hidden
   ]).freeze
 
   def initialize(tag: :input, size: :m, error: nil, **attributes)

--- a/admin/app/components/solidus_admin/users/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/users/edit/component.html.erb
@@ -33,7 +33,7 @@
             <%= f.checkbox_row(:spree_role_ids, options: role_options, row_title: "Roles", layout: :subsection) %>
           </div>
           <div class="py-1.5 text-center">
-            <%= f.submit(t(".update")) %>
+            <%= f.submit(text: t(".update")) %>
             <%= render component("ui/button").new(tag: :a, text: t(".cancel"), href: solidus_admin.user_path(@user), scheme: :secondary) %>
           </div>
         <% end %>

--- a/admin/app/components/solidus_admin/users/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/users/edit/component.html.erb
@@ -19,21 +19,21 @@
     <%= page_with_sidebar_main do %>
 
       <%= render component('ui/panel').new(title: Spree.user_class.model_name.human) do %>
-        <%= form_for @user, url: solidus_admin.user_path(@user), html: { id: form_id, autocomplete: "off" } do |f| %>
+        <%= solidus_form_for @user, url: solidus_admin.user_path(@user), html: { id: form_id, autocomplete: "off" } do |f| %>
           <div class="py-1.5">
-            <%= render component("ui/forms/field").text_field(f, :email) %>
+            <%= f.text_field(:email) %>
           </div>
           <div class="py-1.5">
-            <%= render component("ui/forms/field").text_field(f, :password) %>
+            <%= f.text_field(:password) %>
           </div>
           <div class="py-1.5">
-            <%= render component("ui/forms/field").text_field(f, :password_confirmation) %>
+            <%= f.text_field(:password_confirmation) %>
           </div>
           <div class="py-1.5">
-            <%= render component("ui/checkbox_row").new(options: role_options, row_title: "Roles", form: f, method: "spree_role_ids", layout: :subsection) %>
+            <%= f.checkbox_row(:spree_role_ids, options: role_options, row_title: "Roles", layout: :subsection) %>
           </div>
           <div class="py-1.5 text-center">
-            <%= render component("ui/button").new(tag: :button, text: t(".update"), form: form_id) %>
+            <%= f.submit(t(".update")) %>
             <%= render component("ui/button").new(tag: :a, text: t(".cancel"), href: solidus_admin.user_path(@user), scheme: :secondary) %>
           </div>
         <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
@@ -14,7 +14,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.html.erb
@@ -1,10 +1,9 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :amount, class: "required") %>
-        <%= render component("ui/forms/field").select(
-          f,
+        <%= f.text_field(:amount, class: "required") %>
+        <%= f.select(
           :store_credit_reason_id,
           @store_credit_reasons.map { [_1.name, _1.id] },
           include_blank: t('.choose_reason'),
@@ -15,7 +14,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_amount/component.yml
@@ -1,5 +1,4 @@
 en:
   title: Edit Store Credit Amount
   cancel: Cancel
-  submit: Update Store Credit
   choose_reason: Choose Reason For Changing Amount

--- a/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :memo) %>
+        <%= f.text_field(:memo) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.html.erb
@@ -8,7 +8,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_memo/component.yml
@@ -1,4 +1,3 @@
 en:
   title: Edit Store Credit Memo
   cancel: Cancel
-  submit: Update Store Credit

--- a/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
@@ -1,9 +1,8 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @store_credit, url: form_url, method: :put, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").select(
-          f,
+        <%= f.select(
           :store_credit_reason_id,
           @store_credit_reasons.map { [_1.name, _1.id] },
           include_blank: t('.choose_reason'),
@@ -14,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, scheme: :danger, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit'), scheme: :danger) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/edit_validity/component.html.erb
@@ -13,7 +13,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit'), scheme: :danger) %>
+        <%= f.submit(text: t('.submit'), scheme: :danger) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
@@ -1,30 +1,28 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @store_credit, url: form_url, method: :post, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @store_credit, url: form_url, method: :post, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :amount, class: "required") %>
-        <%= render component("ui/forms/field").select(
-          f,
+        <%= f.text_field(:amount, class: "required") %>
+        <%= f.select(
           :currency,
           Spree::Config.available_currencies.map { [_1.iso_code, _1.iso_code] },
           placeholder: t("spree.currency"),
           value: Spree::Config.currency,
           html: { required: true }
         ) %>
-        <%= render component("ui/forms/field").select(
-          f,
+        <%= f.select(
           :category_id,
           @store_credit_categories.map { [_1.name, _1.id] },
           include_blank: t(".choose_category"),
           html: { required: true }
         ) %>
-        <%= render component("ui/forms/field").text_field(f, :memo) %>
+        <%= f.text_field(:memo) %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t(".cancel")) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t(".submit")) %>
+        <%= f.submit(t(".submit")) %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.html.erb
@@ -22,7 +22,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t(".cancel")) %>
         </form>
-        <%= f.submit(t(".submit")) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/admin/app/components/solidus_admin/users/store_credits/new/component.yml
+++ b/admin/app/components/solidus_admin/users/store_credits/new/component.yml
@@ -1,5 +1,4 @@
 en:
   title: New Store Credit
   cancel: Cancel
-  submit: Create
   choose_category: Choose Store Credit Category

--- a/admin/app/components/solidus_admin/zones/form/component.html.erb
+++ b/admin/app/components/solidus_admin/zones/form/component.html.erb
@@ -1,25 +1,21 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title:) do |modal| %>
-    <%= form_for @zone, url: @form_url, html: { id: @form_id, **stimulus_controller, **stimulus_value(name: :kind, value: @zone.kind) } do |f| %>
+    <%= solidus_form_for @zone, url: @form_url, html: { id: @form_id, **stimulus_controller, **stimulus_value(name: :kind, value: @zone.kind) } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
         <div class="hidden" <%= tag.attributes(stimulus_target("countriesWrapper")) %>>
-          <%= render component("ui/forms/field").select(
-            f,
+          <%= f.select(
             :country_ids,
             Spree::Country.order(:name).map { |c| [c.name, c.id] },
-            object: @zone,
             multiple: true,
             class: "required",
             **stimulus_target("countriesSelect")
           ) %>
         </div>
         <div class="hidden" <%= tag.attributes(stimulus_target("statesWrapper")) %>>
-          <%= render component("ui/forms/field").select(
-            f,
+          <%= f.select(
             :state_ids,
             Spree::State.where(id: @zone.state_ids).map { |s| [s.state_with_country, s.id] },
-            object: @zone,
             multiple: true,
             class: "required",
             src: solidus_admin.states_url(view: :state_with_country),
@@ -27,12 +23,10 @@
             **stimulus_target("statesSelect")
           ) %>
         </div>
-        <%= render component("ui/forms/field").text_field(f, :description, class: "required") %>
-        <%= render component("ui/forms/field").select(
-          f,
+        <%= f.text_field(:description, class: "required") %>
+        <%= f.select(
           :kind,
           [[t(".kinds.country"), :country], [t(".kinds.state"), :state]],
-          object: @zone,
           value: @zone.kind || :state,
           **stimulus_action("toggleKind", on: "change")
         ) %>

--- a/admin/app/helpers/solidus_admin/solidus_form_helper.rb
+++ b/admin/app/helpers/solidus_admin/solidus_form_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusAdmin
+  module SolidusFormHelper
+    def solidus_form_for(*args, **kwargs, &block)
+      form_for(*args, **kwargs, builder: SolidusAdmin::FormBuilder, &block)
+    end
+  end
+end

--- a/admin/app/lib/solidus_admin/form_builder.rb
+++ b/admin/app/lib/solidus_admin/form_builder.rb
@@ -37,12 +37,12 @@ class SolidusAdmin::FormBuilder < ActionView::Helpers::FormBuilder
     input(method, type: :hidden, autocomplete: "off", **options)
   end
 
-  def switch_field(method, label: nil, **options)
+  def switch_field(method, label: nil, include_hidden: true, **options)
     label = @object.class.human_attribute_name(method) if label.nil?
     name = "#{@object_name}[#{method}]"
     error = @object.errors[method]
     checked = @object.public_send(method)
-    render component("ui/forms/switch_field").new(label:, name:, error:, checked:, **options)
+    render component("ui/forms/switch_field").new(label:, name:, error:, checked:, include_hidden:, **options)
   end
 
   def submit(**options)

--- a/admin/app/lib/solidus_admin/form_builder.rb
+++ b/admin/app/lib/solidus_admin/form_builder.rb
@@ -17,10 +17,17 @@ class SolidusAdmin::FormBuilder < ActionView::Helpers::FormBuilder
     render component("ui/forms/field").select(self, method, choices, **options)
   end
 
-  def checkbox(method, checked: nil, **options, &block)
+  def checkbox(method, label: nil, checked: nil, hint: nil, **options)
+    label = @object.class.human_attribute_name(method) if label.nil?
+    label_options = options.delete(:label_options) || {}
     checked = @object.public_send(method) if checked.nil?
+    hint_options = options.delete(:hint_options) || {}
+
     component_instance = component("ui/forms/checkbox").new(object_name: @object_name, checked:, method:, **options)
-    render component_instance, &block
+    render component_instance do |checkbox|
+      checkbox.with_label(text: label, **label_options)
+      checkbox.with_hint(text: hint, **hint_options) if hint
+    end
   end
 
   def checkbox_row(method, options:, row_title:, **attrs)

--- a/admin/app/lib/solidus_admin/form_builder.rb
+++ b/admin/app/lib/solidus_admin/form_builder.rb
@@ -44,7 +44,7 @@ class SolidusAdmin::FormBuilder < ActionView::Helpers::FormBuilder
     render component("ui/forms/switch_field").new(label:, name:, error:, checked:, **options)
   end
 
-  def submit(text, **options)
-    render component("ui/button").new(type: :submit, text:, form: id, **options)
+  def submit(**options)
+    render component("ui/button").submit(resource: @object, form: id, **options)
   end
 end

--- a/admin/app/lib/solidus_admin/form_builder.rb
+++ b/admin/app/lib/solidus_admin/form_builder.rb
@@ -37,7 +37,8 @@ class SolidusAdmin::FormBuilder < ActionView::Helpers::FormBuilder
     input(method, type: :hidden, autocomplete: "off", **options)
   end
 
-  def switch_field(method, label:, **options)
+  def switch_field(method, label: nil, **options)
+    label = @object.class.human_attribute_name(method) if label.nil?
     name = "#{@object_name}[#{method}]"
     error = @object.errors[method]
     checked = @object.public_send(method)

--- a/admin/app/lib/solidus_admin/form_builder.rb
+++ b/admin/app/lib/solidus_admin/form_builder.rb
@@ -18,7 +18,7 @@ class SolidusAdmin::FormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def checkbox(method, checked: nil, **options, &block)
-    checked = checked.nil? ? @object.public_send(method) : checked
+    checked = @object.public_send(method) if checked.nil?
     component_instance = component("ui/forms/checkbox").new(object_name: @object_name, checked:, method:, **options)
     render component_instance, &block
   end

--- a/admin/app/lib/solidus_admin/form_builder.rb
+++ b/admin/app/lib/solidus_admin/form_builder.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::FormBuilder < ActionView::Helpers::FormBuilder
+  include SolidusAdmin::ComponentsHelper
+
+  delegate :render, to: :@template
+
+  def text_field(method, **options)
+    render component("ui/forms/field").text_field(self, method, **options)
+  end
+
+  def text_area(method, **options)
+    render component("ui/forms/field").text_area(self, method, **options)
+  end
+
+  def select(method, choices, **options)
+    render component("ui/forms/field").select(self, method, choices, **options)
+  end
+
+  def checkbox(method, checked: nil, **options, &block)
+    checked = checked.nil? ? @object.public_send(method) : checked
+    component_instance = component("ui/forms/checkbox").new(object_name: @object_name, checked:, method:, **options)
+    render component_instance, &block
+  end
+
+  def checkbox_row(method, options:, row_title:, **attrs)
+    render component("ui/checkbox_row").new(form: self, method:, options:, row_title:, **attrs)
+  end
+
+  def input(method, **options)
+    name = "#{@object_name}[#{method}]"
+    value = @object.public_send(method) if options[:value].nil?
+    render component("ui/forms/input").new(name:, value:, **options)
+  end
+
+  def hidden_field(method, **options)
+    input(method, type: :hidden, autocomplete: "off", **options)
+  end
+
+  def switch_field(method, label:, **options)
+    name = "#{@object_name}[#{method}]"
+    error = @object.errors[method]
+    checked = @object.public_send(method)
+    render component("ui/forms/switch_field").new(label:, name:, error:, checked:, **options)
+  end
+
+  def submit(text, **options)
+    render component("ui/button").new(type: :submit, text:, form: id, **options)
+  end
+end

--- a/admin/spec/features/store_credits_spec.rb
+++ b/admin/spec/features/store_credits_spec.rb
@@ -40,7 +40,7 @@ describe "StoreCredits", :js, type: :feature do
       within("dialog") do
         fill_in "Amount", with: ""
         solidus_select "Gift Card", from: "Category"
-        click_on "Create"
+        click_on "Add Store Credit"
         expect(page).to have_content("must be greater than 0")
         click_on "Cancel"
       end
@@ -54,7 +54,7 @@ describe "StoreCredits", :js, type: :feature do
         fill_in "Amount", with: "666.66"
         solidus_select "Gift Card", from: "Category"
         fill_in "Memo", with: "A brand new store credit, how nice!"
-        click_on "Create"
+        click_on "Add Store Credit"
       end
 
       expect(page).to have_content("Store credit was successfully created.")

--- a/admin/spec/helpers/solidus_admin/solidus_form_helper_spec.rb
+++ b/admin/spec/helpers/solidus_admin/solidus_form_helper_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::SolidusFormHelper, :helper do
+  describe '#solidus_form_for' do
+    it "renders form" do
+      result = helper.solidus_form_for(Spree::Product.new, url: "/products") {}
+      expect(result).to include("<form")
+    end
+  end
+end

--- a/admin/spec/solidus_admin/form_builder_spec.rb
+++ b/admin/spec/solidus_admin/form_builder_spec.rb
@@ -98,11 +98,16 @@ RSpec.describe SolidusAdmin::FormBuilder do
 
   describe "#submit" do
     it "renders submit button" do
-      result = builder.submit("Save")
+      result = builder.submit
       expect(result).to include("<button")
       expect(result).to include("type=\"submit\"")
       expect(result).to include("form=\"_form\"")
-      expect(result).to include("Save")
+    end
+
+    context "when custom text passed" do
+      it "renders custom text" do
+        expect(builder.submit(text: "Submit")).to include("Submit")
+      end
     end
   end
 end

--- a/admin/spec/solidus_admin/form_builder_spec.rb
+++ b/admin/spec/solidus_admin/form_builder_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe SolidusAdmin::FormBuilder do
         expect(builder.checkbox(:promotionable)).to include("checked=\"checked\"")
       end
     end
+
+    context "with custom label" do
+      it "renders with custom label" do
+        expect(builder.checkbox(:promotionable, label: "Promo-able")).to include("Promo-able")
+      end
+    end
+
+    context "with hint" do
+      it "renders with hint" do
+        expect(builder.checkbox(:promotionable, hint: "Helpful info")).to include("Helpful info")
+      end
+    end
   end
 
   describe "#checkbox_row" do

--- a/admin/spec/solidus_admin/form_builder_spec.rb
+++ b/admin/spec/solidus_admin/form_builder_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusAdmin::FormBuilder do
+  let(:object) { Spree::Product.new }
+  let(:builder) do
+    described_class.new(:product, object, ActionView::Base.empty, { html: { id: "_form" } })
+  end
+
+  describe "#text_field" do
+    it "renders a text input" do
+      result = builder.text_field(:name)
+      expect(result).to include("<input")
+    end
+  end
+
+  describe "#text_area" do
+    it "renders a text area" do
+      expect(builder.text_area(:description)).to include("<textarea")
+    end
+  end
+
+  describe "#select" do
+    it "renders a select box" do
+      expect(builder.select(:condition, [])).to include("<select")
+    end
+  end
+
+  describe "#checkbox" do
+    it "renders a checkbox" do
+      result = builder.checkbox(:promotionable, checked: false)
+      expect(result).to include("<input")
+      expect(result).to include("type=\"checkbox\"")
+      expect(result).not_to include("checked=\"checked\"")
+    end
+
+    context "when :checked is not passed" do
+      it "renders with correct checked value" do
+        builder.object.promotionable = false
+        expect(builder.checkbox(:promotionable)).not_to include("checked=\"checked\"")
+
+        builder.object.promotionable = true
+        expect(builder.checkbox(:promotionable)).to include("checked=\"checked\"")
+      end
+    end
+  end
+
+  describe "#checkbox_row" do
+    it "renders checkboxes" do
+      result = builder.checkbox_row(
+        :taxon_ids,
+        options: [{ id: 1, label: "One" }, { id: 2, label: "Two" }],
+        row_title: "Taxons"
+      )
+      expect(result).to include("<input").twice
+      expect(result).to include("type=\"checkbox\"").twice
+      expect(result).to include("One")
+      expect(result).to include("Two")
+      expect(result).to include("Taxons")
+    end
+  end
+
+  describe "#input" do
+    it "renders an input of given type" do
+      object.name = "Product"
+      result = builder.input(:name, type: :text)
+      expect(result).to match(%r{<input.+type="text"})
+      expect(result).to include("value=\"Product\"")
+      expect(result).to include("name=\"product[name]\"")
+    end
+
+    context "with value passed" do
+      it "renders with correct value" do
+        expect(builder.input(:name, value: "Cap")).to include("value=\"Cap\"")
+      end
+    end
+  end
+
+  describe "#hidden_field" do
+    it "renders a hidden input" do
+      result = builder.hidden_field(:tax_category_id)
+      expect(result).to match(%r{<input.+type="hidden"})
+    end
+  end
+
+  describe "#switch_field" do
+    it "renders a switch field" do
+      object.promotionable = false
+      object.errors.add(:promotionable, :invalid, message: "cannot be on")
+      result = builder.switch_field(:promotionable, label: "Promotionable")
+      expect(result).to include("<input")
+      expect(result).to include("type=\"checkbox\"")
+      expect(result).not_to include("checked=\"checked\"")
+      expect(result).to include("cannot be on")
+    end
+  end
+
+  describe "#submit" do
+    it "renders submit button" do
+      result = builder.submit("Save")
+      expect(result).to include("<button")
+      expect(result).to include("type=\"submit\"")
+      expect(result).to include("form=\"_form\"")
+      expect(result).to include("Save")
+    end
+  end
+end

--- a/admin/spec/solidus_admin/form_builder_spec.rb
+++ b/admin/spec/solidus_admin/form_builder_spec.rb
@@ -89,10 +89,18 @@ RSpec.describe SolidusAdmin::FormBuilder do
       object.promotionable = false
       object.errors.add(:promotionable, :invalid, message: "cannot be on")
       result = builder.switch_field(:promotionable, label: "Promotionable")
+      expect(result).to include("Promotionable")
       expect(result).to include("<input")
       expect(result).to include("type=\"checkbox\"")
       expect(result).not_to include("checked=\"checked\"")
       expect(result).to include("cannot be on")
+    end
+
+    context "with default label" do
+      it "renders label with default name for field" do
+        result = builder.switch_field(:promotionable)
+        expect(result).to include("Promotable")
+      end
     end
   end
 

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.html.erb
@@ -9,7 +9,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.yml
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/edit/component.yml
@@ -1,4 +1,3 @@
 en:
   title: "Edit Promotion Category"
   cancel: "Cancel"
-  submit: "Update Promotion Category"

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.html.erb
@@ -9,7 +9,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.yml
+++ b/legacy_promotions/lib/components/admin/solidus_admin/promotion_categories/new/component.yml
@@ -1,4 +1,3 @@
 en:
   title: "New Promotion Category"
   cancel: "Cancel"
-  submit: "Add Promotion Category"

--- a/promotions/config/locales/en.yml
+++ b/promotions/config/locales/en.yml
@@ -217,6 +217,9 @@ en:
       solidus_promotions/conditions/user: User
       solidus_promotions/conditions/user_logged_in: User Logged In
       solidus_promotions/conditions/user_role: User Role(s)
+      solidus_promotions/promotion_category:
+        one: Promotion Category
+        other: Promotion Categories
       solidus_promotions/promotion_code_batch:
         one: Code batch
         other: Code batches

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.html.erb
@@ -9,7 +9,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.yml
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/edit/component.yml
@@ -1,4 +1,3 @@
 en:
   title: "Edit Promotion Category"
   cancel: "Cancel"
-  submit: "Update Promotion Category"

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :resource_form, target: "_top" do %>
   <%= render component("ui/modal").new(title: t(".title")) do |modal| %>
-    <%= form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
+    <%= solidus_form_for @promotion_category, url: form_url, html: { id: form_id } do |f| %>
       <div class="flex flex-col gap-6 pb-4">
-        <%= render component("ui/forms/field").text_field(f, :name, class: "required") %>
-        <%= render component("ui/forms/field").text_field(f, :code, class: "required") %>
+        <%= f.text_field(:name, class: "required") %>
+        <%= f.text_field(:code, class: "required") %>
       </div>
       <% modal.with_actions do %>
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')) %>
+        <%= f.submit(t('.submit')) %>
       <% end %>
     <% end %>
   <% end %>

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.html.erb
@@ -9,7 +9,7 @@
         <form method="dialog">
           <%= render component("ui/button").new(scheme: :secondary, text: t('.cancel')) %>
         </form>
-        <%= f.submit(t('.submit')) %>
+        <%= f.submit %>
       <% end %>
     <% end %>
   <% end %>

--- a/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.yml
+++ b/promotions/lib/components/admin/solidus_promotions/promotion_categories/new/component.yml
@@ -1,4 +1,3 @@
 en:
   title: "New Promotion Category"
   cancel: "Cancel"
-  submit: "Add Promotion Category"


### PR DESCRIPTION
## Summary

Adds a convenient SolidusAdmin::FormBuilder with shortcuts for all currently used form elements, such as:
- raw input field
- text field (with labels etc.)
- hidden field
- text area
- select
- checkbox
- checkbox row
- switch field
- submit button

**Before:**
```ruby
form_for(@product, ...) do |f|
  render component("ui/forms/field").text_field(f, :name)
```
**After:**
```ruby
solidus_form_for(@product, ...) do |f|
  f.text_field(:name)
```

Lots of boilerplate code and logic is now contained in the builder, e.g. object name and "checked" attribute for checkboxes:

```ruby
# before
form_for(@product, ...) do |f|
  render component("ui/forms/checkbox").new(object_name: f.object_name, method: :active, checked: f.object.active)

# after
solidus_form_for(@product, ...) do |f|
  f.checkbox(:active)
```

Submit button together with UI/Button's component `#submit` has now become a powerful "no-args-required" thing - component chooses a correct button text depending on a record passed to the form builder.
So this:
```ruby
render component("ui/button").new(form: form_id, type: :submit, text: t('.submit')
```

becomes this:
```ruby
f.submit
```

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

