### PR TITLE
Create state changes in background job

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -38,7 +38,6 @@ require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/job_helpers'
 
 require 'spree/api/testing_support/caching'
 require 'spree/api/testing_support/helpers'
@@ -65,7 +64,7 @@ RSpec.configure do |config|
   config.include Spree::Api::TestingSupport::Helpers, type: :controller
   config.extend Spree::Api::TestingSupport::Setup, type: :controller
   config.include Spree::TestingSupport::Preferences
-  config.include Spree::TestingSupport::JobHelpers
+  config.include ActiveJob::TestHelper
 
   config.before(:each) do
     Rails.cache.clear

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -47,7 +47,6 @@ require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/capybara_ext'
 require 'spree/testing_support/precompiled_assets'
 require 'spree/testing_support/translations'
-require 'spree/testing_support/job_helpers'
 require 'spree/testing_support/blacklist_urls'
 require 'spree/testing_support/silence_deprecations'
 
@@ -99,7 +98,7 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
   config.include Spree::TestingSupport::Translations
-  config.include Spree::TestingSupport::JobHelpers
+  config.include ActiveJob::TestHelper
   config.include Spree::TestingSupport::BlacklistUrls
 
   config.example_status_persistence_file_path = "./spec/examples.txt"

--- a/core/app/jobs/spree/base_job.rb
+++ b/core/app/jobs/spree/base_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Spree
+  # Base class for all Solidus background jobs
+  class BaseJob < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
+    # Automatically retry jobs that encountered a deadlock
+    retry_on ActiveRecord::Deadlocked
+
+    # Most jobs are safe to ignore if the underlying records are no longer available
+    discard_on ActiveJob::DeserializationError
+  end
+end

--- a/core/app/jobs/spree/state_change_tracking_job.rb
+++ b/core/app/jobs/spree/state_change_tracking_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Spree
+  # Background job to track state changes asynchronously
+  # This avoids performance impact during checkout and prevents
+  # callback-related issues with recent versions of the state_machines gem.
+  class StateChangeTrackingJob < BaseJob
+    # @param stateful [GlobalId] The stateful object to track changes for
+    # @param previous_state [String] The previous state of the order
+    # @param current_state [String] The current state of the order
+    # @param transition_timestamp [Time] When the state transition occurred
+    def perform(stateful, previous_state, current_state, transition_timestamp)
+      Spree::StateChange.create!(
+        name: stateful.class.model_name.element,
+        stateful: stateful,
+        previous_state: previous_state,
+        next_state: current_state,
+        created_at: transition_timestamp,
+        updated_at: transition_timestamp,
+        user_id: stateful.try(:user_id) || stateful.try(:order)&.user_id
+      )
+    end
+  end
+end

--- a/core/app/models/concerns/spree/state_change_tracking.rb
+++ b/core/app/models/concerns/spree/state_change_tracking.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Spree
+  module StateChangeTracking
+    extend ActiveSupport::Concern
+
+    included do
+      after_update :enqueue_state_change_tracking, if: :saved_change_to_state?
+    end
+
+    private
+
+    # Enqueue background job to track state changes asynchronously
+    def enqueue_state_change_tracking
+      previous_state, current_state = saved_changes['state']
+
+      # Enqueue the job to track this state change
+      StateChangeTrackingJob.perform_later(
+        self,
+        previous_state,
+        current_state,
+        Time.current
+      )
+    end
+  end
+end

--- a/core/app/models/spree/core/state_machines/order.rb
+++ b/core/app/models/spree/core/state_machines/order.rb
@@ -6,6 +6,7 @@ module Spree
       module Order
         def self.included(klass)
           klass.extend ClassMethods
+          klass.include StateChangeTracking
         end
 
         def checkout_steps

--- a/core/app/models/spree/core/state_machines/order/class_methods.rb
+++ b/core/app/models/spree/core/state_machines/order/class_methods.rb
@@ -38,22 +38,6 @@ module Spree
             state_machine :state, initial: :cart, use_transactions: false do
               klass.next_event_transitions.each { |state| transition(state.merge(on: :next)) }
 
-              # Persist the state on the order
-              after_transition do |order, transition|
-                # Hard to say if this is really necessary, it was introduced in this commit:
-                # https://github.com/mamhoff/solidus/commit/fa1d66c42e4c04ee7cd1c20d87e4cdb74a226d3d
-                # But it seems to be harmless, so we'll keep it for now.
-                order.state = order.state # rubocop:disable Lint/SelfAssignment
-
-                order.state_changes.create(
-                  previous_state: transition.from,
-                  next_state:     transition.to,
-                  name:           'order',
-                  user_id:        order.user_id
-                )
-                order.save
-              end
-
               event :cancel do
                 transition to: :canceled, if: :allow_cancel?, from: :complete
               end

--- a/core/app/models/spree/core/state_machines/payment.rb
+++ b/core/app/models/spree/core/state_machines/payment.rb
@@ -15,6 +15,7 @@ module Spree
       #
       module Payment
         extend ActiveSupport::Concern
+        include StateChangeTracking
 
         included do
           state_machine initial: :checkout do
@@ -44,14 +45,6 @@ module Spree
             # when the card brand isnt supported
             event :invalidate do
               transition from: [:checkout], to: :invalid
-            end
-
-            after_transition do |payment, transition|
-              payment.state_changes.create!(
-                previous_state: transition.from,
-                next_state:     transition.to,
-                name:           'payment'
-              )
             end
           end
         end

--- a/core/app/models/spree/core/state_machines/shipment.rb
+++ b/core/app/models/spree/core/state_machines/shipment.rb
@@ -15,6 +15,7 @@ module Spree
       #
       module Shipment
         extend ActiveSupport::Concern
+        include StateChangeTracking
 
         included do
           state_machine initial: :pending, use_transactions: false do
@@ -42,14 +43,6 @@ module Spree
               transition from: :canceled, to: :pending
             end
             after_transition from: :canceled, to: [:pending, :ready, :shipped], do: :after_resume
-
-            after_transition do |shipment, transition|
-              shipment.state_changes.create!(
-                previous_state: transition.from,
-                next_state:     transition.to,
-                name:           'shipment'
-              )
-            end
           end
         end
       end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -185,11 +185,11 @@ module Spree
       yield
       new_state = order.public_send(state)
       if old_state != new_state
-        order.state_changes.new(
-          previous_state: old_state,
-          next_state:     new_state,
-          name:,
-          user_id:        order.user_id
+        StateChangeTrackingJob.perform_later(
+          order,
+          old_state,
+          new_state,
+          Time.current
         )
       end
     end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -24,6 +24,10 @@ class ApplicationRecord < ActiveRecord::Base
 end
 
 # @private
+class ApplicationJob < ActiveJob::Base
+end
+
+# @private
 class ApplicationMailer < ActionMailer::Base
 end
 
@@ -93,6 +97,9 @@ module DummyApp
 
     # We don't want to send email in the test environment.
     config.action_mailer.delivery_method = :test
+
+    # Do not actually run background jobs
+    config.active_job.queue_adapter = :test
 
     # No need to use credentials file in a test environment.
     config.secret_key_base = 'SECRET_TOKEN'

--- a/core/lib/spree/testing_support/job_helpers.rb
+++ b/core/lib/spree/testing_support/job_helpers.rb
@@ -3,21 +3,12 @@
 module Spree
   module TestingSupport
     module JobHelpers
-      def perform_enqueued_jobs
-        adapter = ActiveJob::Base.queue_adapter
-
-        old = adapter.perform_enqueued_jobs
-        old_at = adapter.perform_enqueued_at_jobs
-
-        begin
-          adapter.perform_enqueued_jobs = true
-          adapter.perform_enqueued_at_jobs = true
-
-          yield
-        ensure
-          adapter.perform_enqueued_jobs = old
-          adapter.perform_enqueued_at_jobs = old_at
-        end
+      def self.included(base)
+        Spree.deprecator.warn <<~WARN
+          Including `Spree::TestingSupport::JobHelpers` is deprecated and will be removed in Solidus 5.0.
+          Please `include ActiveJob::TestHelper` instead.
+        WARN
+        base.include(ActiveJob::TestHelper)
       end
     end
   end

--- a/core/spec/jobs/spree/state_change_tracking_job_spec.rb
+++ b/core/spec/jobs/spree/state_change_tracking_job_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::StateChangeTrackingJob, type: :job do
+  let(:order) { create(:order, user: user) }
+  let(:user) { create(:user) }
+  let(:transition_timestamp) { Time.current }
+
+  describe '#perform' do
+    it 'creates a state change record with correct attributes' do
+      expect {
+        described_class.perform_now(
+          order,
+          'cart',
+          'address',
+          transition_timestamp
+        )
+      }.to change(Spree::StateChange, :count).by(1)
+
+      state_change = Spree::StateChange.last
+      expect(state_change.previous_state).to eq('cart')
+      expect(state_change.next_state).to eq('address')
+      expect(state_change.name).to eq('order')
+      expect(state_change.user_id).to eq(user.id)
+      expect(state_change.stateful_id).to eq(order.id)
+      expect(state_change.stateful_type).to eq('Spree::Order')
+      expect(state_change.created_at).to be_within(1.second).of(transition_timestamp)
+      expect(state_change.updated_at).to be_within(1.second).of(transition_timestamp)
+    end
+
+    it 'stores all state transitions in correct order' do
+      transitions = [
+        ['cart', 'address'],
+        ['address', 'delivery'],
+        ['delivery', 'payment'],
+        ['payment', 'confirm'],
+        ['confirm', 'complete'],
+        ['complete', 'canceled'],
+        ['canceled', 'resumed']
+      ]
+
+      transitions.each do |from_state, to_state|
+        described_class.perform_now(
+          order,
+          from_state,
+          to_state,
+          transition_timestamp
+        )
+
+        state_change = Spree::StateChange.last
+        expect(state_change.previous_state).to eq(from_state)
+        expect(state_change.next_state).to eq(to_state)
+        expect(state_change.stateful_id).to eq(order.id)
+        expect(state_change.stateful_type).to eq('Spree::Order')
+      end
+
+      expect(Spree::StateChange.count).to eq(transitions.length)
+      expect(Spree::StateChange.order(:created_at).pluck(:previous_state, :next_state)).to eq(transitions)
+    end
+
+    it 'preserves the exact transition timestamp' do
+      specific_time = Time.zone.parse('2023-12-25 10:30:45')
+
+      described_class.perform_now(
+        order,
+        'cart',
+        'address',
+        specific_time
+      )
+
+      state_change = Spree::StateChange.last
+      expect(state_change.created_at).to eq(specific_time)
+      expect(state_change.updated_at).to eq(specific_time)
+    end
+
+    context 'when the order has no user' do
+      let(:order) { create(:order, user: nil) }
+
+      it 'sets user_id to nil in the state change record' do
+        described_class.perform_now(
+          order,
+          'cart',
+          'address',
+          transition_timestamp
+        )
+
+        state_change = Spree::StateChange.last
+        expect(state_change.user_id).to be_nil
+      end
+    end
+
+    context 'when the object has a order association' do
+      let(:payment) { create(:payment, order: order) }
+
+      it 'uses the order user_id if available' do
+        described_class.perform_now(
+          payment,
+          'checkout',
+          'completed',
+          transition_timestamp
+        )
+
+        state_change = Spree::StateChange.last
+        expect(state_change.user_id).to eq(order.user_id)
+      end
+    end
+
+    it 'stores stateful name' do
+      described_class.perform_now(
+        order,
+        'cart',
+        'address',
+        transition_timestamp
+      )
+
+      state_change = Spree::StateChange.last
+      expect(state_change.name).to eq('order')
+    end
+  end
+end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -184,7 +184,7 @@ module Spree
     end
 
     context "updating payment state" do
-      let(:order) { build(:order) }
+      let(:order) { create(:order) }
       let(:updater) { order.recalculator }
       before { allow(order).to receive(:refund_total).and_return(0) }
 

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -20,7 +20,6 @@ require 'spree/testing_support/bus_helpers'
 require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/rake'
-require 'spree/testing_support/job_helpers'
 require 'cancan/matchers'
 
 ActiveJob::Base.queue_adapter = :test
@@ -47,7 +46,7 @@ RSpec.configure do |config|
   end
 
   config.include Spree::TestingSupport::BusHelpers
-  config.include Spree::TestingSupport::JobHelpers
+  config.include ActiveJob::TestHelper
 
   config.include FactoryBot::Syntax::Methods
 end

--- a/legacy_promotions/spec/rails_helper.rb
+++ b/legacy_promotions/spec/rails_helper.rb
@@ -86,7 +86,7 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
 
-  config.include Spree::TestingSupport::JobHelpers
+  config.include ActiveJob::TestHelper
   config.include SolidusAdmin::TestingSupport::FeatureHelpers, type: :feature
   config.include FactoryBot::Syntax::Methods
   config.include Spree::Api::TestingSupport::Helpers, type: :request


### PR DESCRIPTION
## Summary

In many state machines (order, payment and shipment)
we record state changes in the `spree_state_changes` table
as well as in the `OrderUpdater`.

This happens in the same transaction as the model change
itself. In the latest `state_machines` gem version (`> 0.30`)
these record creations cause validation errors and an
infinite validation loop.

Since the state changes are for debugging / analyse purposes
only and are not critical to the actual process of buying
we can easily background them.

In order to keep the correct timeline of events we make sure
that the time is stored on the event time and not background
job runtime.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
