### PR TITLE
Match foreign key constraint error causes on exception names

### DIFF
--- a/core/db/migrate/20250530102541_add_addressbook_foreign_key.rb
+++ b/core/db/migrate/20250530102541_add_addressbook_foreign_key.rb
@@ -12,7 +12,7 @@ class AddAddressbookForeignKey < ActiveRecord::Migration[7.0]
     add_foreign_key :spree_user_addresses, :spree_addresses, column: :address_id, null: false
   rescue ActiveRecord::StatementInvalid => e
     if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-      Rails.logger.warn <<~MSG
+      say <<~MSG
         ⚠️ Foreign key constraint failed when adding :spree_user_addresses => :spree_addresses.
         To fix this:
           1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250604072105_add_fk_products_variant_property_rules.rb
+++ b/core/db/migrate/20250604072105_add_fk_products_variant_property_rules.rb
@@ -13,7 +13,7 @@ class AddFkProductsVariantPropertyRules < ActiveRecord::Migration[7.0]
     add_foreign_key :spree_variant_property_rules, :spree_products, column: :product_id, null: false
   rescue ActiveRecord::StatementInvalid => e
     if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-      Rails.logger.warn <<~MSG
+      say <<~MSG
         ⚠️ Foreign key constraint failed when adding :spree_variant_property_rules => :spree_products.
         To fix this:
           1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250604072555_add_fk_to_product_properties.rb
+++ b/core/db/migrate/20250604072555_add_fk_to_product_properties.rb
@@ -13,7 +13,7 @@ class AddFkToProductProperties < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_product_properties, :spree_products, column: :product_id, null: false
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_product_properties => :spree_products.
           To fix this:
             1. Uncomment the code that removes orphaned records.
@@ -33,7 +33,7 @@ class AddFkToProductProperties < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_product_properties, :spree_properties, column: :property_id, null: false
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_product_properties => :spree_properties.
           To fix this:
             1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250604072948_add_fk_to_product_option_types.rb
+++ b/core/db/migrate/20250604072948_add_fk_to_product_option_types.rb
@@ -13,7 +13,7 @@ class AddFkToProductOptionTypes < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_product_option_types, :spree_products, column: :product_id
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_product_option_types => :spree_products.
           To fix this:
             1. Uncomment the code that removes orphaned records.
@@ -33,7 +33,7 @@ class AddFkToProductOptionTypes < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_product_option_types, :spree_option_types, column: :option_type_id
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_product_option_types => :spree_option_types.
           To fix this:
             1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250604073219_add_fk_to_classifications.rb
+++ b/core/db/migrate/20250604073219_add_fk_to_classifications.rb
@@ -13,7 +13,7 @@ class AddFkToClassifications < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_products_taxons, :spree_products, column: :product_id
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_products_taxons => :spree_products.
           To fix this:
             1. Uncomment the code that removes orphaned records.
@@ -33,7 +33,7 @@ class AddFkToClassifications < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_products_taxons, :spree_taxons, column: :taxon_id
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_products_taxons => :spree_taxons.
           To fix this:
             1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250605105424_add_shipping_category_foreign_keys.rb
+++ b/core/db/migrate/20250605105424_add_shipping_category_foreign_keys.rb
@@ -13,7 +13,7 @@ class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_products, :spree_shipping_categories, column: :shipping_category_id, null: false
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_products => :spree_shipping_categories.
           To fix this:
             1. Uncomment the code that removes orphaned records.
@@ -33,7 +33,7 @@ class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_shipping_method_categories, :spree_shipping_methods, column: :shipping_method_id, null: false
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_shipping_method_categories => :spree_shipping_methods.
           To fix this:
             1. Uncomment the code that removes orphaned records.
@@ -53,7 +53,7 @@ class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
       add_foreign_key :spree_shipping_method_categories, :spree_shipping_categories, column: :shipping_category_id, null: false
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-        Rails.logger.warn <<~MSG
+        say <<~MSG
           ⚠️ Foreign key constraint failed when adding :spree_shipping_method_categories => :spree_shipping_categories.
           To fix this:
             1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250626112117_add_foreign_key_to_spree_role_users.rb
+++ b/core/db/migrate/20250626112117_add_foreign_key_to_spree_role_users.rb
@@ -13,7 +13,7 @@ class AddForeignKeyToSpreeRoleUsers < ActiveRecord::Migration[7.0]
     add_foreign_key :spree_roles_users, :spree_roles, column: :role_id, null: false
   rescue ActiveRecord::StatementInvalid => e
     if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-      Rails.logger.warn <<~MSG
+      say <<~MSG
         ⚠️ Foreign key constraint failed when adding :spree_roles_users => :spree_roles.
         To fix this:
           1. Uncomment the code that removes orphaned records.

--- a/core/db/migrate/20250708120317_add_adjustment_reason_foreign_keys.rb
+++ b/core/db/migrate/20250708120317_add_adjustment_reason_foreign_keys.rb
@@ -13,7 +13,7 @@ class AddAdjustmentReasonForeignKeys < ActiveRecord::Migration[7.0]
     add_foreign_key :spree_adjustments, :spree_adjustment_reasons, column: :adjustment_reason_id, null: true, on_delete: :restrict
   rescue ActiveRecord::StatementInvalid => e
     if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
-      Rails.logger.warn <<~MSG
+      say <<~MSG
         ⚠️ Foreign key constraint failed when adding :spree_adjustments => :spree_adjustment_reasons.
         To fix this:
           1. Uncomment the code that removes invalid adjustment reason IDs from the spree_adjustments table.


### PR DESCRIPTION
## Summary

We've added pretty sophisticated error handling to the migrations that add foreign keys. When I first hit one of these errors, though, I found that in a Solidus context, only the error classes for the currently used database adapter will be loaded. Because our migrations need to work with all adapters, this PR changes the matching to be on the string name of the exception, rather than on the exception class. 

Additionally, this changes the messaging to use `ActiveRecord::Migration#say` rather than directly invoking `Rails.logger`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
