### PR TITLE
Add foreign key and handling for stock location deletion to customer returns

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -4,7 +4,7 @@ module Spree
   class CustomerReturn < Spree::Base
     include Metadata
 
-    belongs_to :stock_location, optional: true
+    belongs_to :stock_location
 
     has_many :return_items, inverse_of: :customer_return
     has_many :return_authorizations, through: :return_items
@@ -14,7 +14,6 @@ module Spree
     before_create :generate_number
 
     validates :return_items, presence: true
-    validates :stock_location, presence: true
     validate :return_items_belong_to_same_order
 
     accepts_nested_attributes_for :return_items

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -15,6 +15,7 @@ module Spree
     has_many :stock_movements, through: :stock_items
     has_many :user_stock_locations, dependent: :delete_all
     has_many :users, through: :user_stock_locations
+    has_many :customer_returns, inverse_of: :stock_location, dependent: :restrict_with_error
 
     belongs_to :state, class_name: 'Spree::State', optional: true
     belongs_to :country, class_name: 'Spree::Country', optional: true

--- a/core/db/migrate/20250726220709_add_fk_to_customer_return.rb
+++ b/core/db/migrate/20250726220709_add_fk_to_customer_return.rb
@@ -1,0 +1,30 @@
+# frozent_string_literal: true
+#
+class AddFkToCustomerReturn < ActiveRecord::Migration[7.0]
+  FOREIGN_KEY_VIOLATION_ERRORS = %w[PG::ForeignKeyViolation Mysql2::Error SQLite3::ConstraintException]
+
+  def up
+    # Uncomment the following code to remove orphaned records if this migration fails
+    #
+    # say_with_time "Removing invalid adjustment reason IDs from adjustments table" do
+    #   Spree::CustomerReturn.where.not(stock_location_id: nil).left_joins(:stock_location).where(spree_stock_locations: { id: nil }).delete_all
+    # end
+
+    add_foreign_key :spree_customer_returns, :spree_stock_locations, column: :stock_location_id, null: false, on_delete: :restrict
+  rescue ActiveRecord::StatementInvalid => e
+    if e.cause.class.name.in?(FOREIGN_KEY_VIOLATION_ERRORS)
+      say <<~MSG
+        ⚠️ Foreign key constraint failed when adding :spree_customer_returns => :spree_stock_locations.
+        To fix this:
+          1. Uncomment the code that removes invalid adjustment reason IDs from the spree_customer_returns table.
+          2. Rerun the migration.
+        Offending error: #{e.cause.class} - #{e.cause.message}
+      MSG
+    end
+    raise
+  end
+
+  def down
+    remove_foreign_key :spree_customer_returns, :spree_stock_locations, column: :stock_location_id, null: false, on_delete: :restrict
+  end
+end

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -4,12 +4,20 @@ require 'rails_helper'
 
 module Spree
   RSpec.describe StockLocation, type: :model do
-    subject { create(:stock_location_with_items, backorderable_default: true) }
+    subject(:stock_location) { create(:stock_location_with_items, backorderable_default: true) }
     let(:stock_item) { subject.stock_items.order(:id).first }
     let(:variant) { stock_item.variant }
 
     it 'creates stock_items for all variants' do
       expect(subject.stock_items.count).to eq Variant.count
+    end
+
+    describe "#customer_returns" do
+      let(:customer_return) { create(:customer_return, stock_location: stock_location) }
+
+      it "works" do
+        expect(stock_location.customer_returns).to include(customer_return)
+      end
     end
 
     context "handling stock items" do


### PR DESCRIPTION
## Summary

This PR adds a foreign key constraint such that all customer returns have a stock location ID that refers to an existing stock location. It also restricts deleting stock locations with customer returns present, as customer returns frequently also hold information about reimbursements and generally reflect real-life occurrences. 

In order to provide an o-kay interface deleting a stock location with customer returns present: 

<img width="760" height="262" alt="grafik" src="https://github.com/user-attachments/assets/86c4c010-b961-4bc5-82e2-84d552d94e3f" />

(This is the legacy admin interface, `solidus_admin` does not have a button for deleting stock locations). 


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
