### PR TITLE
Setup generator namespace in generator

### DIFF
--- a/admin/lib/generators/solidus_admin/component/component_generator.rb
+++ b/admin/lib/generators/solidus_admin/component/component_generator.rb
@@ -12,6 +12,10 @@ module SolidusAdmin
     class_option :spec, type: :boolean, default: true
     class_option :preview, type: :boolean, default: true
 
+    def setup_namespace
+      Rails::Generators.namespace = SolidusAdmin
+    end
+
     def setup_inflections
       # This is needed because the generator won't run the initialization process,
       # in order to ensure that UI is not rendered as Ui we need to setup inflections

--- a/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
+++ b/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
@@ -37,7 +37,4 @@ SolidusAdmin::Config.configure do |config|
   #     }
   #   ]
   # }
-
-  # Define namespace for component generator
-  ::Rails::Generators.namespace = SolidusAdmin
 end


### PR DESCRIPTION
## Summary

#6237 introduced setting the generator namespace in an initializer - however, that broke the sandbox and `rails server`, because in that initializer `Rails::Generator` would only be defined if we're actually running a generator, but not when running `rails server` or `rails console`. 

This PR reverts that commit, and instead proposes moving setting the generator namespace to the generator itself. That way, we control a little better what's going on. 

I'm not sure this is the best solution out there. My questions are: 

- do we need to namespace things in `SolidusAdmin`? Should we assume that all components ever defined for the new admin live in that namespace?
- How is `Rails::Generators.namespace` usually set? Should we even set it?

I do not have answers to these questions. But this PR allows us to run both the component generator and `rails server`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
