### PR TITLE
Use FactoryBot factories

### DIFF
--- a/promotions/spec/models/solidus_promotions/conditions/line_item_product_spec.rb
+++ b/promotions/spec/models/solidus_promotions/conditions/line_item_product_spec.rb
@@ -15,12 +15,11 @@ RSpec.describe SolidusPromotions::Conditions::LineItemProduct, type: :model do
   describe "#eligible?(line_item)" do
     subject { condition.eligible?(line_item, {}) }
 
-    let(:condition_line_item) { Spree::LineItem.new(product: condition_product) }
-    let(:other_line_item) { Spree::LineItem.new(product: other_product) }
+    let(:condition_line_item) { build(:line_item, product: condition_product) }
+    let(:other_line_item) { build(:line_item) }
 
     let(:condition_options) { super().merge(products: [condition_product]) }
-    let(:condition_product) { mock_model(Spree::Product) }
-    let(:other_product) { mock_model(Spree::Product) }
+    let(:condition_product) { build(:product) }
 
     it "is eligible if there are no products" do
       expect(condition).to be_eligible(condition_line_item)

--- a/promotions/spec/models/solidus_promotions/conditions/product_spec.rb
+++ b/promotions/spec/models/solidus_promotions/conditions/product_spec.rb
@@ -188,12 +188,11 @@ RSpec.describe SolidusPromotions::Conditions::Product, type: :model do
   describe "#eligible?(line_item)" do
     subject { condition.eligible?(line_item) }
 
-    let(:condition_line_item) { Spree::LineItem.new(product: condition_product) }
-    let(:other_line_item) { Spree::LineItem.new(product: other_product) }
+    let(:condition_line_item) { build(:line_item, product: condition_product) }
+    let(:other_line_item) { build(:line_item) }
 
     let(:condition_options) { super().merge(products: [condition_product]) }
-    let(:condition_product) { mock_model(Spree::Product) }
-    let(:other_product) { mock_model(Spree::Product) }
+    let(:condition_product) { build(:product) }
 
     it "is eligible if there are no products" do
       expect(condition).to be_eligible(condition_line_item)


### PR DESCRIPTION
## Summary

In our work on the in-memory order updater (#5872), we updated some tests to have more realistic test setup. This is not dependent on that work, so we are splitting it into its own small pull request.

Instead of instantiating new records directly or using `mock_model`, we can use factories, which are more realistically set up objects.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
