### PR TITLE
Use new configuration setting for item total class

### DIFF
--- a/legacy_promotions/app/patches/models/solidus_legacy_promotions/spree_order_updater_patch.rb
+++ b/legacy_promotions/app/patches/models/solidus_legacy_promotions/spree_order_updater_patch.rb
@@ -17,7 +17,7 @@ module SolidusLegacyPromotions
 
     def update_item_totals
       [*line_items, *shipments].each do |item|
-        Spree::ItemTotal.new(item).recalculate!
+        Spree::Config.item_total_class.new(item).recalculate!
 
         # The cancellation_total isn't persisted anywhere but is included in
         # the adjustment_total.


### PR DESCRIPTION
## Summary

In our work on the in-memory order updater (#5872), we created a new configuration point `item_total_class`, but we did not use this configuration class in the `solidus_legacy_promotions` gem.

This pull request simply starts using the configuration point instead of calling the built-in `Spree::ItemTotal` class directly.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

