### PR TITLE
Set required line item attributes earlier

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -22,7 +22,7 @@ module Spree
     has_many :inventory_units, inverse_of: :line_item
 
     before_validation :normalize_quantity
-    before_validation :set_required_attributes
+    after_initialize :set_required_attributes
 
     validates :variant, presence: true
     validates :quantity, numericality: {
@@ -159,6 +159,7 @@ module Spree
     # Sets tax category, price-related attributes from
     # its variant if they are nil and a variant is present.
     def set_required_attributes
+      return if persisted?
       return unless variant
       self.tax_category ||= variant.tax_category
       set_pricing_attributes

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -39,31 +39,25 @@ RSpec.describe Spree::LineItem, type: :model do
     end
   end
 
-  describe 'line item creation' do
+  describe '.new' do
     let(:variant) { create :variant }
 
     subject(:line_item) { Spree::LineItem.new(variant:, order:) }
 
-    # Tests for https://github.com/spree/spree/issues/3391
-    context 'before validation' do
-      before { line_item.valid? }
+    it 'copies the variants price' do
+      expect(line_item.price).to eq(variant.price)
+    end
 
-      it 'copies the variants price' do
-        expect(line_item.price).to eq(variant.price)
-      end
+    it 'copies the variants cost_price' do
+      expect(line_item.cost_price).to eq(variant.cost_price)
+    end
 
-      it 'copies the variants cost_price' do
-        expect(line_item.cost_price).to eq(variant.cost_price)
-      end
+    it "copies the order's currency" do
+      expect(line_item.currency).to eq(order.currency)
+    end
 
-      it "copies the order's currency" do
-        expect(line_item.currency).to eq(order.currency)
-      end
-
-      # Test for https://github.com/spree/spree/issues/3481
-      it 'copies the variants tax category' do
-        expect(line_item.tax_category).to eq(line_item.variant.tax_category)
-      end
+    it 'copies the variants tax category' do
+      expect(line_item.tax_category).to eq(line_item.variant.tax_category)
     end
   end
 

--- a/legacy_promotions/spec/models/spree/promotion/rules/product_spec.rb
+++ b/legacy_promotions/spec/models/spree/promotion/rules/product_spec.rb
@@ -130,12 +130,11 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
       rule.actionable?(line_item)
     end
 
-    let(:rule_line_item) { Spree::LineItem.new(product: rule_product) }
-    let(:other_line_item) { Spree::LineItem.new(product: other_product) }
+    let(:rule_line_item) { build :line_item, product: rule_product }
+    let(:other_line_item) { build :line_item }
 
     let(:rule_options) { super().merge(products: [rule_product]) }
-    let(:rule_product) { mock_model(Spree::Product) }
-    let(:other_product) { mock_model(Spree::Product) }
+    let(:rule_product) { build :product }
 
     context "with 'any' match policy" do
       let(:rule_options) { super().merge(preferred_match_policy: 'any') }

--- a/promotions/spec/models/solidus_promotions/conditions/line_item_product_spec.rb
+++ b/promotions/spec/models/solidus_promotions/conditions/line_item_product_spec.rb
@@ -15,12 +15,11 @@ RSpec.describe SolidusPromotions::Conditions::LineItemProduct, type: :model do
   describe "#eligible?(line_item)" do
     subject { condition.eligible?(line_item, {}) }
 
-    let(:condition_line_item) { Spree::LineItem.new(product: condition_product) }
-    let(:other_line_item) { Spree::LineItem.new(product: other_product) }
+    let(:condition_line_item) { build(:line_item, product: condition_product) }
+    let(:other_line_item) { build(:line_item) }
 
     let(:condition_options) { super().merge(products: [condition_product]) }
-    let(:condition_product) { mock_model(Spree::Product) }
-    let(:other_product) { mock_model(Spree::Product) }
+    let(:condition_product) { build(:product) }
 
     it "is eligible if there are no products" do
       expect(condition).to be_eligible(condition_line_item)

--- a/promotions/spec/models/solidus_promotions/conditions/product_spec.rb
+++ b/promotions/spec/models/solidus_promotions/conditions/product_spec.rb
@@ -188,12 +188,11 @@ RSpec.describe SolidusPromotions::Conditions::Product, type: :model do
   describe "#eligible?(line_item)" do
     subject { condition.eligible?(line_item) }
 
-    let(:condition_line_item) { Spree::LineItem.new(product: condition_product) }
-    let(:other_line_item) { Spree::LineItem.new(product: other_product) }
+    let(:condition_line_item) { build(:line_item, product: condition_product) }
+    let(:other_line_item) { build(:line_item) }
 
     let(:condition_options) { super().merge(products: [condition_product]) }
-    let(:condition_product) { mock_model(Spree::Product) }
-    let(:other_product) { mock_model(Spree::Product) }
+    let(:condition_product) { build(:product) }
 
     it "is eligible if there are no products" do
       expect(condition).to be_eligible(condition_line_item)


### PR DESCRIPTION
## Summary

This change makes working with unpersisted line items easier because required attributes are set immediately. This change is in service of creating an in-memory order updater (#5872) but is not dependent on that work and can be merged as a separate small pull request.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

