### PR TITLE
Fix shipment state when all units cancelled

### DIFF
--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -51,8 +51,6 @@ class Spree::OrderCancellations
         inventory_units.each do |iu|
           unit_cancels << short_ship_unit(iu, created_by:)
         end
-
-        update_shipped_shipments(inventory_units)
       end
 
       @order.recalculate
@@ -121,19 +119,5 @@ class Spree::OrderCancellations
     inventory_unit.cancel!
 
     unit_cancel
-  end
-
-  # if any shipments are now fully shipped then mark them as such
-  def update_shipped_shipments(inventory_units)
-    shipments = Spree::Shipment.
-      includes(:inventory_units).
-      where(id: inventory_units.map(&:shipment_id)).
-      to_a
-
-    shipments.each do |shipment|
-      if shipment.inventory_units.all? { |iu| iu.shipped? || iu.canceled? }
-        shipment.update!(state: 'shipped', shipped_at: Time.current)
-      end
-    end
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -207,8 +207,8 @@ module Spree
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
     def determine_state(order)
-      return 'canceled' if order.canceled?
       return 'shipped' if shipped?
+      return 'canceled' if order.canceled? || inventory_units.all?(&:canceled?)
       return 'pending' unless order.can_ship?
       if can_transition_from_pending_to_ready?
         'ready'

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -86,14 +86,6 @@ RSpec.describe Spree::OrderCancellations do
       expect { subject }.to change { inventory_unit.state }.to "canceled"
     end
 
-    it "updates the shipment.state" do
-      expect { subject }.to change { shipment.reload.state }.from('ready').to('shipped')
-    end
-
-    it "updates the order.shipment_state" do
-      expect { subject }.to change { order.shipment_state }.from('ready').to('shipped')
-    end
-
     it "publishes an 'order_short_shipped' event" do
       stub_spree_bus
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe Spree::Shipment, type: :model do
       expect(shipment.determine_state(order)).to eq 'canceled'
     end
 
+    it 'returns canceled if all of the inventory units are canceled' do
+      shipment.inventory_units.each(&:cancel!)
+      expect(shipment.determine_state(order)).to eql 'canceled'
+    end
+
     it 'returns pending unless order.can_ship?' do
       allow(order).to receive_messages can_ship?: false
       expect(shipment.determine_state(order)).to eq 'pending'


### PR DESCRIPTION
## Summary

Includes two key changes:

1. Removes logic in `OrderCancellations` to update shipment state. I tracked this logic back to a cherry-pick from some Bonobos code about a decade ago (https://github.com/solidusio/solidus/commit/c98d24762388d139d90b81c52c7ebb33ae2b810f), so the original reasoning for it is unfortunately lost to time. Our commit includes some reasoning around the removal, but essentially I don't think there's any scenario right now where this code makes sense. If we're triggering it because there's a mix of shipped and cancelled items, the shipment should already be "shipped" due to the shipped inventory units. If we're triggering it because all of the items are cancelled, we don't want to mark the shipment as "shipped" anyway.

2. Updates `Shipment#determine_state` to mark shipments as cancelled if all inventory units are cancelled. As mentioned above, marking a shipment as shipped if all of the units are cancelled doesn't make a lot of sense. Since cancelling a unit will result in an order recalculation, we can rely on this method to update the shipment state appropriately.

Alternative for: https://github.com/solidusio/solidus/pull/5220 & https://github.com/solidusio/solidus/pull/4446

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
