### PR TITLE
Replace `Shipment#determine_state`

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -217,6 +217,21 @@ module Spree
       end
     end
 
+    def recalculate_state
+      self.state =
+        if order.canceled?
+          "canceled"
+        elsif shipped?
+          "shipped"
+        elsif !order.can_ship?
+          "pending"
+        elsif can_transition_from_pending_to_ready?
+          "ready"
+        else
+          "pending"
+        end
+    end
+
     def set_up_inventory(state, variant, _order, line_item)
       inventory_units.create(
         state:,

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -200,23 +200,12 @@ module Spree
       end
     end
 
-    # Determines the appropriate +state+ according to the following logic:
+    # Assigns the appropriate +state+ according to the following logic:
     #
     # canceled   if order is canceled
     # pending    unless order is complete and +order.payment_state+ is +paid+
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
-    def determine_state(order)
-      return 'canceled' if order.canceled?
-      return 'shipped' if shipped?
-      return 'pending' unless order.can_ship?
-      if can_transition_from_pending_to_ready?
-        'ready'
-      else
-        'pending'
-      end
-    end
-
     def recalculate_state
       self.state =
         if order.canceled?
@@ -307,12 +296,9 @@ module Spree
     # called.
     def update_state
       old_state = state
-      new_state = determine_state(order)
+      new_state = recalculate_state
       if new_state != old_state
-        update_columns(
-          state: new_state,
-          updated_at: Time.current
-        )
+        update_columns state: new_state, updated_at: Time.current
         after_ship if new_state == 'shipped'
       end
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -76,6 +76,47 @@ RSpec.describe Spree::Shipment, type: :model do
     end
   end
 
+  context '#recalculate_state' do
+    subject(:recalculate_state) { shipment.recalculate_state }
+
+    it "assigns the new state to the shipment" do
+      allow(order).to receive_messages canceled?: true
+      expect {
+        recalculate_state
+      }.to change { shipment.state }.from("pending").to("canceled")
+    end
+
+    it "returns canceled if order is canceled?" do
+      allow(order).to receive_messages canceled?: true
+      expect(recalculate_state).to eq "canceled"
+    end
+
+    it "returns pending unless order.can_ship?" do
+      allow(order).to receive_messages can_ship?: false
+      expect(recalculate_state).to eq "pending"
+    end
+
+    it "returns pending if backordered" do
+      allow(shipment).to receive_messages inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false, shipped?: false)]
+      expect(recalculate_state).to eq "pending"
+    end
+
+    it "returns shipped when already shipped" do
+      allow(shipment).to receive_messages state: "shipped"
+      expect(recalculate_state).to eq "shipped"
+    end
+
+    it "returns pending when unpaid" do
+      allow(order).to receive_messages paid?: false
+      expect(recalculate_state).to eq "pending"
+    end
+
+    it "returns ready when paid" do
+      allow(order).to receive_messages paid?: true
+      expect(recalculate_state).to eq "ready"
+    end
+  end
+
   context "display_amount" do
     it "retuns a Spree::Money" do
       shipment.cost = 21.22

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -44,38 +44,6 @@ RSpec.describe Spree::Shipment, type: :model do
     expect(shipment).to be_backordered
   end
 
-  context '#determine_state' do
-    it 'returns canceled if order is canceled?' do
-      allow(order).to receive_messages canceled?: true
-      expect(shipment.determine_state(order)).to eq 'canceled'
-    end
-
-    it 'returns pending unless order.can_ship?' do
-      allow(order).to receive_messages can_ship?: false
-      expect(shipment.determine_state(order)).to eq 'pending'
-    end
-
-    it 'returns pending if backordered' do
-      allow(shipment).to receive_messages inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false, shipped?: false)]
-      expect(shipment.determine_state(order)).to eq 'pending'
-    end
-
-    it 'returns shipped when already shipped' do
-      allow(shipment).to receive_messages state: 'shipped'
-      expect(shipment.determine_state(order)).to eq 'shipped'
-    end
-
-    it 'returns pending when unpaid' do
-      allow(order).to receive_messages paid?: false
-      expect(shipment.determine_state(order)).to eq 'pending'
-    end
-
-    it 'returns ready when paid' do
-      allow(order).to receive_messages paid?: true
-      expect(shipment.determine_state(order)).to eq 'ready'
-    end
-  end
-
   context '#recalculate_state' do
     subject(:recalculate_state) { shipment.recalculate_state }
 
@@ -370,11 +338,21 @@ RSpec.describe Spree::Shipment, type: :model do
 
     context "when shipment state changes to shipped" do
       it "should call after_ship" do
+        allow(shipment).to receive(:shipped?).and_return(true)
+        allow(shipment).to receive :after_ship
+        allow(shipment).to receive :update_columns
+
         shipment.state = 'pending'
-        expect(shipment).to receive :after_ship
-        allow(shipment).to receive_messages determine_state: 'shipped'
-        expect(shipment).to receive(:update_columns).with(state: 'shipped', updated_at: kind_of(Time))
-        shipment.update_state
+
+        expect { shipment.update_state }
+          .to change { shipment.state }
+          .from("pending")
+          .to("shipped")
+
+        expect(shipment).to have_received(:after_ship).once
+        expect(shipment)
+          .to have_received(:update_columns)
+          .with(state: 'shipped', updated_at: kind_of(Time))
       end
 
       # Regression test for https://github.com/spree/spree/issues/4347


### PR DESCRIPTION
## Summary

While working on a new in-memory order updater (#5872), we identified that having a `Shipment#recalculate_state` method that assigns but does not persist a new shipment state is advantageous for application developers.

After making this change, it became clear that the `Shipment#determine_state` method doesn't provide a lot of value. So we have decided to replace it entirely and instead use `#recalculate_state` everywhere.

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
