### PR TITLE
Appease Rubocop

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -106,7 +106,7 @@ module Spree
     def should_touch_variant?
       # the variant_id changes from nil when a new stock location is added
       inventory_cache_threshold &&
-        (saved_change_to_count_on_hand&.any? { |cache| cache < inventory_cache_threshold }) ||
+        saved_change_to_count_on_hand&.any? { |cache| cache < inventory_cache_threshold } ||
         saved_change_to_variant_id?
     end
 


### PR DESCRIPTION
## Summary

On two of my recent PRs, Rubocop got mad at the code in this commit body even though neither of my PRs touched this file. Thanks, Rubocop.

For posterity, here is the failure from [this GitHub Actions run][run]:

[run]: https://github.com/solidusio/solidus/actions/runs/16841521735/job/47713501094?pr=6316

```
Run bin/rake lint:rb
bundle exec rubocop -P -f clang -f junit -o '/home/runner/work/solidus/solidus/tasks/../test-results/rubocop-results.xml' $(git ls-files -co --exclude-standard | grep -E "\.rb$" | grep -v "/templates/")
core/app/models/spree/stock_item.rb:109:9: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around a method call.
        (saved_change_to_count_on_hand&.any? { |cache| cache < inventory_cache_threshold }) ||
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1878 files inspected, 1 offense detected, 1 offense autocorrectable
rake aborted!
Command failed with status (1): [bundle exec rubocop -P -f clang -f junit -o '/home/runner/work/solidus/solidus/tasks/../test-results/rubocop-results.xml' $(git ls-files -co --exclude-standard | grep -E "\.rb$" | grep -v "/templates/")]
/home/runner/work/solidus/solidus/tasks/linting.rake:7:in `block (2 levels) in <top (required)>'
/home/runner/work/solidus/solidus/vendor/bundle/ruby/3.2.0/gems/rake-13.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => lint:rb
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```


## Checklist

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

