### PR TITLE
Keep backorders when splitting part of variant to new shipment with same SL

### DIFF
--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -86,9 +86,9 @@ module Spree
     # we can take from the desired location, we could end up with some items being backordered.
     def run_tracking_inventory
       # Retrieve how many on hand items we can take from desired stock location
-      available_quantity = [desired_shipment.stock_location.count_on_hand(variant), default_on_hand_quantity].max
-
+      available_quantity = get_available_quantity
       new_on_hand_quantity = [available_quantity, quantity].min
+      backordered_quantity = get_backordered_quantity(available_quantity, new_on_hand_quantity)
       unstock_quantity = desired_shipment.stock_location.backorderable?(variant) ? quantity : new_on_hand_quantity
 
       ActiveRecord::Base.transaction do
@@ -105,19 +105,21 @@ module Spree
         # These two statements are the heart of this class. We change the number
         # of inventory units requested from one shipment to the other.
         # We order by state, because `'backordered' < 'on_hand'`.
+        # We start to move the new actual backordered quantity, so the remaining
+        # quantity can be set to on_hand state.
         current_shipment.
           inventory_units.
           where(variant:).
           order(state: :asc).
-          limit(new_on_hand_quantity).
-          update_all(shipment_id: desired_shipment.id, state: :on_hand)
+          limit(backordered_quantity).
+          update_all(shipment_id: desired_shipment.id, state: :backordered)
 
         current_shipment.
           inventory_units.
           where(variant:).
           order(state: :asc).
-          limit(quantity - new_on_hand_quantity).
-          update_all(shipment_id: desired_shipment.id, state: :backordered)
+          limit(quantity - backordered_quantity).
+          update_all(shipment_id: desired_shipment.id, state: :on_hand)
       end
     end
 
@@ -141,11 +143,22 @@ module Spree
       current_shipment.order.completed? && current_stock_location != desired_stock_location
     end
 
-    def default_on_hand_quantity
+    def get_available_quantity
       if current_stock_location != desired_stock_location
-        0
+        desired_location_quantifier.positive_stock
       else
-        current_shipment.inventory_units.where(variant:).on_hand.count
+        sl_availability = current_location_quantifier.positive_stock
+        shipment_availability = current_shipment.inventory_units.where(variant: variant).on_hand.count
+        sl_availability + shipment_availability
+      end
+    end
+
+    def get_backordered_quantity(available_quantity, new_on_hand_quantity)
+      if current_stock_location != desired_stock_location
+        quantity - new_on_hand_quantity
+      else
+        shipment_quantity = current_shipment.inventory_units.where(variant: variant).size
+        shipment_quantity - available_quantity
       end
     end
 
@@ -156,9 +169,17 @@ module Spree
     end
 
     def enough_stock_at_desired_location
-      unless Spree::Stock::Quantifier.new(variant, desired_stock_location).can_supply?(quantity)
+      unless desired_location_quantifier.can_supply?(quantity)
         errors.add(:desired_shipment, :not_enough_stock_at_desired_location)
       end
+    end
+
+    def desired_location_quantifier
+      @desired_location_quantifier ||= Spree::Stock::Quantifier.new(variant, desired_stock_location)
+    end
+
+    def current_location_quantifier
+      @current_location_quantifier ||= Spree::Stock::Quantifier.new(variant, current_stock_location)
     end
 
     def desired_shipment_different_from_current

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -43,9 +43,24 @@ module Spree
         total_on_hand >= required || backorderable?
       end
 
+      def positive_stock
+        return unless stock_location
+
+        on_hand = stock_location.count_on_hand(variant)
+        on_hand.positive? ? on_hand : 0
+      end
+
       private
 
       attr_reader :variant, :stock_location_or_id
+
+      def stock_location
+        @stock_location ||= if stock_location_or_id.is_a?(Spree::StockLocation)
+          stock_location_or_id
+        else
+          Spree::StockLocation.find_by(id: stock_location_or_id)
+        end
+      end
 
       def variant_stock_items
         variant.stock_items.select do |stock_item|

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -11,14 +11,8 @@ module Spree
       #        If unspecified it will check inventory in all available StockLocations
       def initialize(variant, stock_location_or_id = nil)
         @variant = variant
-        @stock_items = variant.stock_items.select do |stock_item|
-          if stock_location_or_id
-            stock_item.stock_location == stock_location_or_id ||
-              stock_item.stock_location_id == stock_location_or_id
-          else
-            stock_item.stock_location.active?
-          end
-        end
+        @stock_location_or_id = stock_location_or_id
+        @stock_items = variant_stock_items
       end
 
       # Returns the total number of inventory units on hand for the variant.
@@ -26,7 +20,7 @@ module Spree
       # @return [Fixnum] number of inventory units on hand, or infinity if
       #   inventory is not tracked on the variant.
       def total_on_hand
-        if @variant.should_track_inventory?
+        if variant.should_track_inventory?
           stock_items.sum(&:count_on_hand)
         else
           Float::INFINITY
@@ -47,6 +41,21 @@ module Spree
       #   variant is backorderable, otherwise false
       def can_supply?(required)
         total_on_hand >= required || backorderable?
+      end
+
+      private
+
+      attr_reader :variant, :stock_location_or_id
+
+      def variant_stock_items
+        variant.stock_items.select do |stock_item|
+          if stock_location_or_id
+            stock_item.stock_location == stock_location_or_id ||
+              stock_item.stock_location_id == stock_location_or_id
+          else
+            stock_item.stock_location.active?
+          end
+        end
       end
     end
   end

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe Spree::FulfilmentChanger do
   let(:current_shipment) { order.shipments.first }
   let!(:desired_shipment) { order.shipments.create!(stock_location: desired_stock_location) }
   let(:desired_stock_location) { current_shipment.stock_location }
-  let(:current_shipment_inventory_unit_count) { 1 }
-  let(:quantity) { current_shipment_inventory_unit_count }
 
   let(:shipment_splitter) do
     described_class.new(
@@ -41,6 +39,9 @@ RSpec.describe Spree::FulfilmentChanger do
   end
 
   context "when the current shipment stock location is the same of the target shipment" do
+    let(:current_shipment_inventory_unit_count) { 1 }
+    let(:quantity) { current_shipment_inventory_unit_count }
+
     context "when the stock location is empty" do
       before do
         variant.stock_items.first.update_column(:count_on_hand, 0)

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Spree::FulfilmentChanger do
 
   context "when the current shipment is emptied out by the transfer" do
     let(:current_shipment_inventory_unit_count) { 30 }
-    let(:quantity) { 30 }
+    let(:quantity) { current_shipment_inventory_unit_count }
 
     it_behaves_like "moves inventory units between shipments"
 

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -350,9 +350,7 @@ RSpec.describe Spree::FulfilmentChanger do
     let(:current_shipment_inventory_unit_count) { 30 }
     let(:quantity) { 30 }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
-    end
+    it_behaves_like "moves inventory units between shipments"
 
     it "removes the current shipment" do
       expect { subject }.to change { Spree::Shipment.count }.by(-1)
@@ -365,9 +363,7 @@ RSpec.describe Spree::FulfilmentChanger do
 
     let(:desired_shipment) { order.shipments.build(stock_location: current_shipment.stock_location) }
 
-    it "adds the desired inventory units to the desired shipment" do
-      expect { subject }.to change { Spree::Shipment.count }.by(1)
-    end
+    it_behaves_like "moves inventory units between shipments"
 
     context "if the desired shipment is invalid" do
       let(:desired_shipment) { order.shipments.build(stock_location_id: 99_999_999) }

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::FulfilmentChanger do
   let(:variant) { create(:variant) }
   let(:track_inventory) { true }
 
-  let(:order) do
+  let!(:order) do
     create(
       :completed_order_with_totals,
       line_items_attributes: [
@@ -19,7 +19,7 @@ RSpec.describe Spree::FulfilmentChanger do
   end
 
   let(:current_shipment) { order.shipments.first }
-  let(:desired_shipment) { order.shipments.create!(stock_location: desired_stock_location) }
+  let!(:desired_shipment) { order.shipments.create!(stock_location: desired_stock_location) }
   let(:desired_stock_location) { current_shipment.stock_location }
   let(:current_shipment_inventory_unit_count) { 1 }
   let(:quantity) { current_shipment_inventory_unit_count }
@@ -37,7 +37,6 @@ RSpec.describe Spree::FulfilmentChanger do
   subject { shipment_splitter.run! }
 
   before do
-    order && desired_shipment
     variant.stock_items.first.update_column(:count_on_hand, 100)
   end
 

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -2,17 +2,16 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples_for 'unlimited supply' do
-  it 'can_supply? any amount' do
-    expect(subject.can_supply?(1)).to eq true
-    expect(subject.can_supply?(101)).to eq true
-    expect(subject.can_supply?(100_001)).to eq true
-  end
-end
-
 module Spree
   module Stock
     RSpec.describe Quantifier, type: :model do
+      shared_examples_for 'unlimited supply' do
+        it 'can_supply? any amount' do
+          expect(subject.can_supply?(1)).to eq true
+          expect(subject.can_supply?(101)).to eq true
+          expect(subject.can_supply?(100_001)).to eq true
+        end
+      end
       let(:target_stock_location) { nil }
       let!(:stock_location) { create :stock_location_with_items }
       let!(:stock_item) { stock_location.stock_items.order(:id).first }


### PR DESCRIPTION
## Summary

Rebased version of https://github.com/solidusio/solidus/pull/5670, because GitHub won't let me push to that branch.

> Fixes https://github.com/solidusio/solidus/issues/5669
>
> When splitting a shipment to the same stock location, when not the whole quantity for the variant is moved it may happen, if there are backordered items, that these disappear (they become on hand).
>
> This PR first reworks and adds further coverage to specs for the Spree::FulfilmentChanger service to expose the issue, then addresses it in the last commit.

Closes #5670.