### PR TITLE
Fix shipment state calculation

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -221,10 +221,10 @@ module Spree
     # ready      all other cases
     def recalculate_state
       self.state =
-        if order.canceled? || inventory_units.all?(&:canceled?)
-          "canceled"
-        elsif shipped?
+        if shipped?
           "shipped"
+        elsif order.canceled? || inventory_units.all?(&:canceled?)
+          "canceled"
         elsif !order.can_ship?
           "pending"
         elsif can_transition_from_pending_to_ready?


### PR DESCRIPTION
## Summary

Adds some missing test coverage to ensure that when all items in a shipment are cancelled, it is correctly marked as cancelled. Unless the shipment has already been shipped, in that case we should maintain the existing state.

Related to https://github.com/solidusio/solidus/pull/6314 and https://github.com/solidusio/solidus/pull/6316.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
