### PR TITLE
Promotions Percent Calculator: Allow fractional percent

### DIFF
--- a/promotions/lib/views/backend/solidus_promotions/admin/calculator_fields/percent/_fields.html.erb
+++ b/promotions/lib/views/backend/solidus_promotions/admin/calculator_fields/percent/_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%= fields_for "#{prefix}[calculator_attributes]", calculator do |f| %>
     <%= f.label :preferred_percent %>
-    <%= f.number_field :preferred_percent, step: 1, min: 1, max: 100, default: 1, class: "form-control" %>
+    <%= f.number_field :preferred_percent, step: 0.01, min: 1, max: 100, default: 1, class: "form-control" %>
   <% end %>
 </div>


### PR DESCRIPTION


## Summary

Prior to this, it was not possible to create a calculator with e.g. 12.5 percent.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
