### PR TITLE
Coupon Code Case Sensitive

### DIFF
--- a/promotions/README.md
+++ b/promotions/README.md
@@ -70,6 +70,13 @@ SolidusPromotions.configure do |config|
 end
 ```
 
+### Coupon Code Normalization
+
+Solidus Promotions provides a configurable coupon code normalizer that controls how coupon codes are processed before saving and lookup. By default, codes are case-insensitive (e.g., "SAVE20" and "save20" are treated as the same). 
+You can customize this behavior to support case-sensitive codes, remove special characters, apply formatting rules, or implement other normalization strategies based on your business requirements.
+
+See the `coupon_code_normalizer_class` configuration option for implementation details.
+
 ## Installation
 
 Add solidus_promotions to your Gemfile:

--- a/promotions/app/models/concerns/solidus_promotions/coupon_code_normalizer.rb
+++ b/promotions/app/models/concerns/solidus_promotions/coupon_code_normalizer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SolidusPromotions
+  # Normalizes coupon codes before saving or looking up promotions.
+  #
+  # By default, this class strips whitespace and downcases the code
+  # to ensure case-insensitive behavior. You can override this class
+  # or provide a custom normalizer class to change behavior (e.g.,
+  # case-sensitive codes) via:
+  #
+  #   SolidusPromotions.configure do |config|
+  #     config.coupon_code_normalizer_class = YourCustomNormalizer
+  #   end
+  #
+  # @example Default usage
+  #   CouponCodeNormalizer.call(" SAVE20 ") # => "save20"
+  #
+  # @example Custom case-sensitive usage
+  #   class CaseSensitiveNormalizer
+  #     def self.call(value)
+  #       value&.strip
+  #     end
+  #   end
+  #
+  #   SolidusPromotions.configure do |config|
+  #     config.coupon_code_normalizer_class = CaseSensitiveNormalizer
+  #   end
+  class CouponCodeNormalizer
+    # Normalizes the given coupon code.
+    #
+    # @param value [String, nil] the coupon code to normalize
+    # @return [String, nil] the normalized coupon code
+    def self.call(value)
+      value&.strip&.downcase
+    end
+  end
+end

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -46,7 +46,9 @@ module SolidusPromotions
 
     def self.with_coupon_code(val)
       joins(:codes).where(
-        SolidusPromotions::PromotionCode.arel_table[:value].eq(val.downcase)
+        SolidusPromotions::PromotionCode.arel_table[:value].eq(
+          SolidusPromotions.config.coupon_code_normalizer_class.call(val)
+        )
       ).first
     end
 

--- a/promotions/app/models/solidus_promotions/promotion_code.rb
+++ b/promotions/app/models/solidus_promotions/promotion_code.rb
@@ -50,7 +50,7 @@ module SolidusPromotions
     private
 
     def normalize_code
-      self.value = value.downcase.strip
+      self.value = SolidusPromotions.config.coupon_code_normalizer_class.call(value)
     end
   end
 end

--- a/promotions/app/models/solidus_promotions/promotion_handler/coupon.rb
+++ b/promotions/app/models/solidus_promotions/promotion_handler/coupon.rb
@@ -9,7 +9,7 @@ module SolidusPromotions
       def initialize(order)
         @order = order
         @errors = []
-        @coupon_code = order&.coupon_code&.downcase
+        @coupon_code = SolidusPromotions.config.coupon_code_normalizer_class.call(order&.coupon_code)
       end
 
       def apply

--- a/promotions/app/patches/models/solidus_promotions/order_patch.rb
+++ b/promotions/app/patches/models/solidus_promotions/order_patch.rb
@@ -36,6 +36,14 @@ module SolidusPromotions
       !line_item.managed_by_order_benefit
     end
 
+    def coupon_code=(code)
+      @coupon_code = begin
+                       SolidusPromotions.config.coupon_code_normalizer_class.call(code)
+      rescue StandardError
+                       nil
+      end
+    end
+
     Spree::Order.singleton_class.prepend self::ClassMethods
     Spree::Order.prepend self
   end

--- a/promotions/db/migrate/20251104170913_update_promotion_code_value_collation.rb
+++ b/promotions/db/migrate/20251104170913_update_promotion_code_value_collation.rb
@@ -1,0 +1,38 @@
+class UpdatePromotionCodeValueCollation < ActiveRecord::Migration[7.0]
+  def up
+    return unless mysql?
+
+    collation = use_accent_sensitive_collation? ? 'utf8mb4_0900_as_cs' : 'utf8mb4_bin'
+    change_column :solidus_promotions_promotion_codes, :value, :string,
+                  collation: collation
+  end
+
+  def down
+    return unless mysql?
+
+    change_column :solidus_promotions_promotion_codes, :value, :string,
+                  collation: 'utf8mb4_general_ci'
+  end
+
+  private
+
+  def mysql?
+    ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
+  end
+
+  def use_accent_sensitive_collation?
+    !mariadb? && mysql_version >= 8.0
+  end
+
+  def mariadb?
+    version_string.include?('mariadb')
+  end
+
+  def mysql_version
+    version_string.to_f
+  end
+
+  def version_string
+    @version_string ||= ActiveRecord::Base.connection.select_value('SELECT VERSION()').downcase
+  end
+end

--- a/promotions/lib/solidus_promotions/configuration.rb
+++ b/promotions/lib/solidus_promotions/configuration.rb
@@ -10,6 +10,15 @@ module SolidusPromotions
 
     class_name_attribute :coupon_code_handler_class, default: "SolidusPromotions::PromotionHandler::Coupon"
 
+    # The class used to normalize coupon codes before saving or lookup.
+    # By default, this normalizes codes to lowercase for case-insensitive matching.
+    # You can customize this by creating your own normalizer class or by overriding
+    # the existing SolidusPromotions::CouponCodeNormalizer class using a decorator.
+    # @!attribute [rw] coupon_code_normalizer_class
+    #   @return [String] The class used to normalize coupon codes.
+    #   Defaults to "SolidusPromotions::CouponCodeNormalizer".
+    class_name_attribute :coupon_code_normalizer_class, default: "SolidusPromotions::CouponCodeNormalizer"
+
     class_name_attribute :promotion_finder_class, default: "SolidusPromotions::PromotionFinder"
 
     # Allows providing a different promotion advertiser.
@@ -107,7 +116,6 @@ module SolidusPromotions
     preference :sync_order_promotions, :boolean, default: false
 
     preference :use_new_admin, :boolean, default: false
-
     def use_new_admin?
       SolidusSupport.admin_available? && preferred_use_new_admin
     end

--- a/promotions/spec/models/concerns/solidus_promotions/coupon_code_normalizer_spec.rb
+++ b/promotions/spec/models/concerns/solidus_promotions/coupon_code_normalizer_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SolidusPromotions::CouponCodeNormalizer do
+  describe '.call' do
+    context 'when case is insensitive' do
+      it 'downcases the value' do
+        expect(described_class.call('10FFF')).to eq('10fff')
+      end
+
+      it "strips leading and trailing whitespace" do
+        expect(described_class.call("  10oFF  ")).to eq("10off")
+      end
+
+      it 'downcases mixed cases' do
+        expect(described_class.call('10OfF')).to eq('10off')
+      end
+
+      it 'handles already normalized values' do
+        expect(described_class.call('10off')).to eq('10off')
+      end
+
+      it 'returns nil with nil input' do
+        expect(described_class.call(nil)).to be_nil
+      end
+
+      it 'returns empty string with empty string input' do
+        expect(described_class.call('')).to eq('')
+      end
+
+      it 'returns empty string with whitespace only input' do
+        expect(described_class.call('   ')).to eq('')
+      end
+    end
+
+    context 'when case is sensitive' do
+      before do
+        stub_const("CaseSensitiveNormalizer", Class.new do
+          def self.call(value)
+            value&.strip
+          end
+        end)
+
+        stub_spree_preferences(
+          SolidusPromotions.configuration,
+          coupon_code_normalizer_class: CaseSensitiveNormalizer
+        )
+      end
+
+      it 'preserves the original cases' do
+        expect(CaseSensitiveNormalizer.call('10OFF')).to eq('10OFF')
+      end
+
+      it 'does not downcase the value' do
+        expect(CaseSensitiveNormalizer.call('10OFF')).not_to eq('10off')
+      end
+
+      it 'strips leading and trailing whitespace' do
+        expect(CaseSensitiveNormalizer.call(' 10OFF ')).to eq('10OFF')
+      end
+
+      it 'preserves lower case' do
+        expect(CaseSensitiveNormalizer.call('10off')).to eq('10off')
+      end
+
+      it 'preserves mixed case' do
+        expect(CaseSensitiveNormalizer.call('10OfF')).to eq('10OfF')
+      end
+
+      it 'returns nil with nil input' do
+        expect(CaseSensitiveNormalizer.call(nil)).to be_nil
+      end
+
+      it 'returns empty string with empty string input' do
+        expect(CaseSensitiveNormalizer.call('')).to eq('')
+      end
+
+      it 'returns empty string with whitespace only input' do
+        expect(CaseSensitiveNormalizer.call('   ')).to eq('')
+      end
+    end
+  end
+end

--- a/promotions/spec/models/spree/order_spec.rb
+++ b/promotions/spec/models/spree/order_spec.rb
@@ -39,4 +39,39 @@ RSpec.describe Spree::Order do
 
     it { is_expected.to include("solidus_promotions", "solidus_order_promotions") }
   end
+
+  describe "#coupon_code=" do
+    let(:order) { create(:order) }
+    let(:promotion) { create(:promotion, code: "10off") }
+    let(:coupon_code) { "10OFF" }
+
+    subject { order.coupon_code = coupon_code }
+
+    context "when coupon code is case-insensitive (default)" do
+      it "converts coupon codes to lowercase" do
+        subject
+        expect(order.coupon_code).to eq("10off")
+      end
+    end
+
+    context "when coupon code is case-sensitive" do
+      before do
+        stub_const("CaseSensitiveNormalizer", Class.new do
+          def self.call(value)
+            value&.strip
+          end
+        end)
+
+        stub_spree_preferences(
+          SolidusPromotions.configuration,
+          coupon_code_normalizer_class: CaseSensitiveNormalizer
+        )
+      end
+
+      it "preserves case in coupon codes" do
+        subject
+        expect(order.coupon_code).to eq("10OFF")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This pull request introduces configurable coupon code normalization to Solidus Promotions.
It allows to customize how coupon codes are normalized before saving, lookup, or application, enabling behaviors such as case-insensitive, case-sensitive, or other custom normalization.

By default, coupon codes remain case-insensitive, so promo code like SAVE20, save20, or Save20 will all apply the promotion successfully. Using a custom normalizer or overriding the default class, you can implement strict case-sensitive behavior or any other normalization logic required by your application.

### Key changes

-  Added a new configurable normalization class `SolidusPromotions::CouponCodeNormalizer` .
- Updated promotion handlers and models to delegate all coupon code normalization to the configured normalizer class.  
- Added detailed documentation:  
  - **README** section describing default behavior, customization options, and examples.
  - **YARD** documentation for `CouponCodeNormalizer` and the configuration preference.  
- Clarified behavior for code normalization, lookups, and promotion application.  
- Updated specs to reflect the new configurable normalizer, including tests for custom behavior.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- ✅ I have added automated tests to cover my changes.
