### PR TITLE
Refactor: Move rounding to promotion calculator module

### DIFF
--- a/promotions/app/models/concerns/solidus_promotions/calculators/promotion_calculator.rb
+++ b/promotions/app/models/concerns/solidus_promotions/calculators/promotion_calculator.rb
@@ -6,6 +6,13 @@ module SolidusPromotions
       def description
         self.class.human_attribute_name(:description)
       end
+
+      private
+
+      def round_to_currency(number, currency)
+        currency_exponent = ::Money::Currency.find(currency).exponent
+        number.round(currency_exponent)
+      end
     end
   end
 end

--- a/promotions/app/models/solidus_promotions/calculators/percent.rb
+++ b/promotions/app/models/solidus_promotions/calculators/percent.rb
@@ -10,9 +10,7 @@ module SolidusPromotions
       preference :percent, :decimal, default: 0
 
       def compute(object)
-        preferred_currency = object.order.currency
-        currency_exponent = ::Money::Currency.find(preferred_currency).exponent
-        (object.discountable_amount * preferred_percent / 100).round(currency_exponent)
+        round_to_currency(object.discountable_amount * preferred_percent / 100, object.order.currency)
       end
     end
   end

--- a/promotions/app/models/solidus_promotions/calculators/tiered_percent.rb
+++ b/promotions/app/models/solidus_promotions/calculators/tiered_percent.rb
@@ -34,8 +34,7 @@ module SolidusPromotions
         end
 
         if preferred_currency.casecmp(order.currency).zero?
-          currency_exponent = ::Money::Currency.find(preferred_currency).exponent
-          (object.amount * (percent || preferred_base_percent) / 100).round(currency_exponent)
+          round_to_currency(object.amount * (percent || preferred_base_percent) / 100, preferred_currency)
         else
           0
         end

--- a/promotions/app/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity.rb
+++ b/promotions/app/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity.rb
@@ -23,8 +23,7 @@ module SolidusPromotions
           eligible_line_items_quantity_total(order) >= value
         end
         if preferred_currency.casecmp(order.currency).zero?
-          currency_exponent = ::Money::Currency.find(preferred_currency).exponent
-          (line_item.discountable_amount * (percent || preferred_base_percent) / 100).round(currency_exponent)
+          round_to_currency(line_item.discountable_amount * (percent || preferred_base_percent) / 100, preferred_currency)
         else
           0
         end


### PR DESCRIPTION


## Summary

All promotion calculators need to be able to round correctly, and we can centralize that logic.

Extracted from #6287 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
