### PR TITLE
Fix misnamed shipping_categories table in 4.6.0 migration comment

### DIFF
--- a/core/db/migrate/20250605105424_add_shipping_category_foreign_keys.rb
+++ b/core/db/migrate/20250605105424_add_shipping_category_foreign_keys.rb
@@ -7,7 +7,7 @@ class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
     # Uncomment the following code to remove orphaned records if the following code fails
     #
     # say_with_time "Removing orphaned products (no corresponding shipping category)" do
-    #   Spree::Product.left_joins(:shipping_category).where(spree_shipping_category: { id: nil }).delete_all
+    #   Spree::Product.left_joins(:shipping_category).where(spree_shipping_categories: { id: nil }).delete_all
     # end
     begin
       add_foreign_key :spree_products, :spree_shipping_categories, column: :shipping_category_id, null: false
@@ -27,7 +27,7 @@ class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
     # Uncomment the following code to remove orphaned records if the following code fails
     #
     # say_with_time "Removing orphaned shipping method categories (no corresponding shipping category)" do
-    #   Spree::ShippingMethodCategory.left_joins(:shipping_category).where(spree_shipping_category: { id: nil }).delete_all
+    #   Spree::ShippingMethodCategory.left_joins(:shipping_category).where(spree_shipping_categories: { id: nil }).delete_all
     # end
     begin
       add_foreign_key :spree_shipping_method_categories, :spree_shipping_methods, column: :shipping_method_id, null: false
@@ -47,7 +47,7 @@ class AddShippingCategoryForeignKeys < ActiveRecord::Migration[7.0]
     # Uncomment the following code to remove orphaned records if the following code fails
     #
     # say_with_time "Removing orphaned shipping method categories (no corresponding shipping method)" do
-    #   Spree::ShippingMethodCategory.left_joins(:shipping_method).where(spree_shipping_method: { id: nil }).delete_all
+    #   Spree::ShippingMethodCategory.left_joins(:shipping_method).where(spree_shipping_methods: { id: nil }).delete_all
     # end
     begin
       add_foreign_key :spree_shipping_method_categories, :spree_shipping_categories, column: :shipping_category_id, null: false


### PR DESCRIPTION


## Summary

If you currently try to uncomment this code and let the migration run, the command will fail because the table name for shipping categories is incorrect.

This fix won't help anyone who's already upgraded to Solidus 4.6 and run into this, but it would help future users trying to upgrade.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
