### PR TITLE
feat(Promotion): Make ordered lanes an array

### DIFF
--- a/promotions/app/models/solidus_promotions/order_adjuster/discount_order.rb
+++ b/promotions/app/models/solidus_promotions/order_adjuster/discount_order.rb
@@ -14,7 +14,7 @@ module SolidusPromotions
       def call
         return order if order.shipped?
 
-        SolidusPromotions::Promotion.ordered_lanes.each_key do |lane|
+        SolidusPromotions::Promotion.ordered_lanes.each do |lane|
           lane_promotions = promotions.select { |promotion| promotion.lane == lane }
           lane_benefits = eligible_benefits_for_promotable(lane_promotions.flat_map(&:benefits), order)
           perform_order_benefits(lane_benefits, lane) unless dry_run

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -55,13 +55,13 @@ module SolidusPromotions
     end
 
     def self.lane_options
-      ordered_lanes.map do |lane_name, _index|
-        [human_enum_name(:lane, lane_name), lane_name]
+      ordered_lanes.map do |lane|
+        [human_enum_name(:lane, lane), lane]
       end
     end
 
     def self.ordered_lanes
-      lanes.sort_by(&:last).to_h
+      lanes.keys.sort_by { |lane| lanes[lane] }
     end
 
     def self.order_activatable?(order)

--- a/promotions/spec/models/solidus_promotions/promotion_spec.rb
+++ b/promotions/spec/models/solidus_promotions/promotion_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe SolidusPromotions::Promotion, type: :model do
   describe ".ordered_lanes" do
     subject { described_class.ordered_lanes }
 
-    it { is_expected.to eq({ "pre" => 0, "default" => 1, "post" => 2 }) }
+    it { is_expected.to eq(%w[pre default post]) }
   end
 
   describe "validations" do


### PR DESCRIPTION
## Summary

We always use this method as an array anyway (ignoring the index value in all cases).

Let's remove the cognitive overhead to keep in mind that this is a sorted hash and make it more natural to use.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
