### PR TITLE
feat(CI): Use Solidus Bot App to create backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
 
+permissions:
+  pull-requests: write
+
 jobs:
   backport:
     runs-on: ubuntu-latest
@@ -17,10 +20,16 @@ jobs:
           (github.event.action == 'closed')
       )
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.SOLIDUS_BOT_APP_ID }}
+          private-key: ${{ secrets.SOLIDUS_BOT_APP_PRIVATE_KEY }}
       - name: Backport Action
         uses: sqren/backport-github-action@v9.5.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           auto_backport_label_prefix: backport-
           add_original_reviewers: true
       - name: Info log
@@ -29,13 +38,3 @@ jobs:
       - name: Debug log
         if: ${{ failure() }}
         run: cat ~/.backport/backport.debug.log
-      - name: Trigger Test Run
-        uses: actions/github-script@v8
-        with:
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'test.yml',
-              ref: context.ref,
-            })


### PR DESCRIPTION
## Summary

We need a repository scoped access token for
automated backport PRs to trigger workflow runs
(our tests). The Solidus Bot GH app which is installed
in this repo has the necessary permissions and will
be used to create the backport PR.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
