### PR TITLE
feat(CI): Use rspec-github formatter

### DIFF
--- a/.github/workflows/test_solidus.yml
+++ b/.github/workflows/test_solidus.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           cd ${{ inputs.lib_name }}
           bundle exec rake test_app
-          bundle exec rspec --profile 10 --format progress
+          bundle exec rspec --profile 10 --format progress --format RSpec::Github::Formatter
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
         if: ${{ steps.setup-coverage.outputs.coverage == 'true' }}

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,10 @@ gem 'rspec_junit_formatter', require: false
 gem 'yard', require: false
 gem 'db-query-matchers', require: false
 
+if ENV['GITHUB_ACTIONS']
+  gem "rspec-github", "~> 3.0", require: false
+end
+
 # Ensure the requirement is also updated in core/lib/spree/testing_support/factory_bot.rb
 gem 'factory_bot_rails', '>= 4.8', require: false
 

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -87,6 +87,11 @@ DBQueryMatchers.configure do |config|
 end
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.color = true
   config.infer_spec_type_from_file_location!
   config.expect_with :rspec do |c|

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -48,6 +48,11 @@ ActiveJob::Base.queue_adapter = :test
 Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]
   config.color = true
   config.infer_spec_type_from_file_location!

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -65,6 +65,11 @@ ActiveJob::Base.queue_adapter = :test
 Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.color = true
   config.infer_spec_type_from_file_location!
   config.expect_with :rspec do |c|

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -24,6 +24,11 @@ require 'spree/deprecator'
 require 'spree/config'
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.disable_monkey_patching!
   config.color = true
   config.expect_with :rspec do |c|

--- a/legacy_promotions/spec/spec_helper.rb
+++ b/legacy_promotions/spec/spec_helper.rb
@@ -26,6 +26,11 @@ require 'spree/config'
 require "solidus_legacy_promotions"
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.disable_monkey_patching!
   config.color = true
   config.expect_with :rspec do |c|

--- a/promotions/spec/spec_helper.rb
+++ b/promotions/spec/spec_helper.rb
@@ -29,6 +29,11 @@ require "solidus_promotions"
 Spree::Config.promotions = SolidusPromotions.configuration
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.disable_monkey_patching!
   config.color = true
   config.expect_with :rspec do |c|

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -15,6 +15,11 @@ require 'rspec/rails'
 require 'database_cleaner'
 
 RSpec.configure do |config|
+  if ENV["GITHUB_ACTIONS"]
+    require "rspec/github"
+    config.add_formatter RSpec::Github::Formatter
+  end
+
   config.color = true
   config.infer_spec_type_from_file_location!
   config.expect_with :rspec do |c|


### PR DESCRIPTION
## Summary

This adds GitHub Actions annotations for our test runs,
which makes it much easier to find failed specs.

Refs: https://github.com/Drieam/rspec-github

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
