### PR TITLE
Flat Rate calculator: Do not override #compute

### DIFF
--- a/promotions/app/models/solidus_promotions/calculators/flat_rate.rb
+++ b/promotions/app/models/solidus_promotions/calculators/flat_rate.rb
@@ -4,20 +4,45 @@ require_dependency "spree/calculator"
 
 module SolidusPromotions
   module Calculators
+    # A calculator that applies a flat rate discount amount.
+    #
+    # This calculator returns a fixed discount amount if the item's order currency
+    # matches the preferred currency, otherwise it returns zero.
     class FlatRate < Spree::Calculator
       include PromotionCalculator
 
-      preference :amount, :decimal, default: 0
+      preference :amount, :decimal, default: Spree::ZERO
       preference :currency, :string, default: -> { Spree::Config[:currency] }
 
-      def compute(object = nil)
-        currency = object.order.currency
-        if object && preferred_currency.casecmp(currency).zero?
+      # Computes the discount amount for an item.
+      #
+      # Returns the preferred amount if the item's order currency matches the
+      # preferred currency, otherwise returns 0.
+      #
+      # @param item [Object] The item to calculate the discount for (e.g., LineItem, Shipment, ShippingRate)
+      #
+      # @return [BigDecimal] The discount amount (preferred_amount if currency matches, 0 otherwise)
+      #
+      # @example Computing discount for a line item with matching currency
+      #   calculator = FlatRate.new(preferred_amount: 10, preferred_currency: 'USD')
+      #   line_item.order.currency # => 'USD'
+      #   calculator.compute_item(line_item) # => 10.0
+      #
+      # @example Computing discount for a line item with non-matching currency
+      #   calculator = FlatRate.new(preferred_amount: 10, preferred_currency: 'USD')
+      #   line_item.order.currency # => 'EUR'
+      #   calculator.compute_item(line_item) # => 0
+      def compute_item(item)
+        currency = item.order.currency
+        if item && preferred_currency.casecmp(currency).zero?
           preferred_amount
         else
-          0
+          Spree::ZERO
         end
       end
+      alias_method :compute_line_item, :compute_item
+      alias_method :compute_shipment, :compute_item
+      alias_method :compute_shipping_rate, :compute_item
     end
   end
 end

--- a/promotions/spec/models/solidus_promotions/calculators/flat_rate_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/flat_rate_spec.rb
@@ -4,9 +4,8 @@ require "rails_helper"
 require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::FlatRate, type: :model do
-  subject { calculator.compute(line_item) }
+  subject { calculator.compute(discountable) }
 
-  let(:line_item) { mock_model(Spree::LineItem, order: order) }
   let(:order) { mock_model(Spree::Order, currency: order_currency) }
   let(:calculator) do
     described_class.new(
@@ -17,7 +16,9 @@ RSpec.describe SolidusPromotions::Calculators::FlatRate, type: :model do
 
   it_behaves_like "a calculator with a description"
 
-  context "compute" do
+  context "compute_line_item" do
+    let(:discountable) { mock_model(Spree::LineItem, order: order) }
+
     describe "when preferred currency matches order" do
       let(:preferred_currency) { "GBP" }
       let(:order_currency) { "GBP" }
@@ -44,6 +45,28 @@ RSpec.describe SolidusPromotions::Calculators::FlatRate, type: :model do
 
     describe "when preferred currency and order currency use different casing" do
       let(:preferred_currency) { "gbP" }
+      let(:order_currency) { "GBP" }
+      let(:preferred_amount) { 25 }
+
+      it { is_expected.to eq(25.0) }
+    end
+  end
+
+  context "compute_shipment" do
+    let(:discountable) { mock_model(Spree::Shipment, order: order) }
+    describe "when preferred currency matches order" do
+      let(:preferred_currency) { "GBP" }
+      let(:order_currency) { "GBP" }
+      let(:preferred_amount) { 25 }
+
+      it { is_expected.to eq(25.0) }
+    end
+  end
+
+  context "compute_shipping_rate" do
+    let(:discountable) { mock_model(Spree::ShippingRate, order: order) }
+    describe "when preferred currency matches order" do
+      let(:preferred_currency) { "GBP" }
       let(:order_currency) { "GBP" }
       let(:preferred_amount) { 25 }
 


### PR DESCRIPTION

## Summary

`Spree::Calculator#compute` dispatches to `compute_line_item`, `compute_shipment` or `compute_shipping_rate`, and we want to keep that behavior. This also documents what kind of objects this calculator knows how to reasonably work with.


Extracted from #6287 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
