### PR TITLE
DistributedAmount Calculator: Add YARD docs

### DIFF
--- a/promotions/app/models/solidus_promotions/calculators/distributed_amount.rb
+++ b/promotions/app/models/solidus_promotions/calculators/distributed_amount.rb
@@ -2,24 +2,50 @@
 
 require_dependency "spree/calculator"
 
-# This is a calculator for line item adjustment benefits. It accepts a line item
-# and calculates its weighted adjustment amount based on the value of the
-# preferred amount and the price of the other line items. More expensive line
-# items will receive a greater share of the preferred amount.
 module SolidusPromotions
   module Calculators
+    # A calculator that distributes a fixed discount amount across line items based on their value.
+    #
+    # This calculator takes a preferred total discount amount and distributes it proportionally
+    # across applicable line items based on their prices. More expensive line items receive
+    # a greater share of the discount.
+    #
+    # @example
+    #   # Given a $30 discount and line items worth $100, $50, and $50:
+    #   # - $100 line item receives $15 discount (50% of total value)
+    #   # - $50 line item receives $7.50 discount (25% of total value)
+    #   # - $50 line item receives $7.50 discount (25% of total value)
     class DistributedAmount < Spree::Calculator
       include PromotionCalculator
 
-      preference :amount, :decimal, default: 0
+      preference :amount, :decimal, default: Spree::ZERO
       preference :currency, :string, default: -> { Spree::Config[:currency] }
 
+      # Computes the weighted discount amount for a specific line item.
+      #
+      # The discount is calculated by distributing the preferred amount across all
+      # applicable line items, weighted by their prices. Returns 0 if:
+      # - The line item is nil
+      # - The currency doesn't match the preferred currency
+      # - The line item is not in the list of applicable line items
+      #
+      # @param line_item [Spree::LineItem] The line item to calculate the discount for
+      #
+      # @return [BigDecimal] The weighted discount amount for this line item
+      #
+      # @example Computing discount for a line item
+      #   calculator = DistributedAmount.new(preferred_amount: 20, preferred_currency: 'USD')
+      #   # Assuming there are 2 line items: one at $80, one at $20
+      #   calculator.compute_line_item(expensive_line_item) # => 16.0 (80% of 20)
+      #   calculator.compute_line_item(cheaper_line_item)   # => 4.0 (20% of 20)
+      #
+      # @see DistributedAmountsHandler
       def compute_line_item(line_item)
-        return 0 unless line_item
-        return 0 unless preferred_currency.casecmp(line_item.currency).zero?
+        return Spree::ZERO unless line_item
+        return Spree::ZERO unless preferred_currency.casecmp(line_item.currency).zero?
 
         distributable_line_items = calculable.applicable_line_items(line_item.order)
-        return 0 unless line_item.in?(distributable_line_items)
+        return Spree::ZERO unless line_item.in?(distributable_line_items)
 
         DistributedAmountsHandler.new(
           distributable_line_items,


### PR DESCRIPTION

## Summary

This just adds some documentation, and changes the use of Numeric 0 to BigDecimal 0 such that the documentation matches the behavior exactly.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
