### PR TITLE
FlexiRate calculator: Add YARD docs

### DIFF
--- a/promotions/app/models/solidus_promotions/calculators/flexi_rate.rb
+++ b/promotions/app/models/solidus_promotions/calculators/flexi_rate.rb
@@ -4,19 +4,57 @@ require_dependency "spree/calculator"
 
 module SolidusPromotions
   module Calculators
+    # A calculator that applies different discount amounts for the first item and additional items.
+    #
+    # This calculator allows setting a discount for the first item in a line item and a
+    # different discount for each additional item. Optionally, a maximum number of items
+    # can be specified to limit the discount calculation.
+    #
+    # @example
+    #   # $5 off first item, $2 off each additional item, max 5 items
+    #   calculator = FlexiRate.new(
+    #     preferred_first_item: 5,
+    #     preferred_additional_item: 2,
+    #     preferred_max_items: 5
+    #   )
+    #   # Line item with quantity 3: $5 + ($2 × 2) = $9 discount
+    #   # Line item with quantity 10: $5 + ($2 × 4) = $13 discount (limited to 5 items)
     class FlexiRate < Spree::Calculator
       include PromotionCalculator
 
-      preference :first_item, :decimal, default: 0
-      preference :additional_item, :decimal, default: 0
+      preference :first_item, :decimal, default: Spree::ZERO
+      preference :additional_item, :decimal, default: Spree::ZERO
       preference :max_items, :integer, default: 0
       preference :currency, :string, default: -> { Spree::Config[:currency] }
 
-      def compute(object)
-        items_count = object.quantity
+      # Computes the discount amount for a line item based on its quantity.
+      #
+      # Calculates the total discount by applying the first_item rate to the first unit
+      # and the additional_item rate to remaining units. If max_items is set (non-zero),
+      # the calculation is limited to that number of items.
+      #
+      # @param line_item [Spree::LineItem] The line item to calculate the discount for
+      #
+      # @return [BigDecimal] The total discount amount based on quantity and preferences
+      #
+      # @example Computing discount for a line item with 3 items
+      #   calculator = FlexiRate.new(preferred_first_item: 10, preferred_additional_item: 5)
+      #   line_item.quantity # => 3
+      #   calculator.compute_line_item(line_item) # => 20.0 (10 + 5 + 5)
+      #
+      # @example Computing discount with max_items limit
+      #   calculator = FlexiRate.new(
+      #     preferred_first_item: 10,
+      #     preferred_additional_item: 5,
+      #     preferred_max_items: 2
+      #   )
+      #   line_item.quantity # => 5
+      #   calculator.compute_line_item(line_item) # => 15.0 (10 + 5, limited to 2 items)
+      def compute_line_item(line_item)
+        items_count = line_item.quantity
         items_count = [items_count, preferred_max_items].min unless preferred_max_items.zero?
 
-        return Spree::ZERO if items_count == 0
+        return Spree::ZERO if items_count.zero?
 
         additional_items_count = items_count - 1
         preferred_first_item + preferred_additional_item * additional_items_count

--- a/promotions/lib/solidus_promotions/configuration.rb
+++ b/promotions/lib/solidus_promotions/configuration.rb
@@ -59,7 +59,6 @@ module SolidusPromotions
     add_nested_class_set :promotion_calculators, default: {
       "SolidusPromotions::Benefits::AdjustShipment" => [
         "SolidusPromotions::Calculators::FlatRate",
-        "SolidusPromotions::Calculators::FlexiRate",
         "SolidusPromotions::Calculators::Percent",
         "SolidusPromotions::Calculators::TieredFlatRate",
         "SolidusPromotions::Calculators::TieredPercent",


### PR DESCRIPTION

## Summary

This also removes the FlexiRate calculator from the `AdjustShipment` Benefit, as `Spree::Shipment` does not respond to `quantity` and would therefore raise an error if used with this calculator.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
