### PR TITLE
Refactor tiered calculators

### DIFF
--- a/promotions/app/models/solidus_promotions/calculators/tiered_flat_rate.rb
+++ b/promotions/app/models/solidus_promotions/calculators/tiered_flat_rate.rb
@@ -101,8 +101,6 @@ module SolidusPromotions
       # Converts all tier threshold keys and percentage values from strings or other numeric
       # types to BigDecimal to ensure precision in monetary calculations.
       def transform_preferred_tiers
-        return unless preferred_tiers.is_a?(Hash)
-
         preferred_tiers.transform_keys! { |key| key.to_s.to_d }
         preferred_tiers.transform_values! { |value| value.to_s.to_d }
       end
@@ -111,12 +109,8 @@ module SolidusPromotions
       #
       # Ensures the tiers preference is properly formatted for tier-based calculations.
       def preferred_tiers_content
-        if preferred_tiers.is_a? Hash
-          unless preferred_tiers.keys.all? { |key| key.is_a?(Numeric) && key > 0 }
-            errors.add(:base, :keys_should_be_positive_number)
-          end
-        else
-          errors.add(:preferred_tiers, :should_be_hash)
+        unless preferred_tiers.keys.all? { |key| key.is_a?(Numeric) && key > 0 }
+          errors.add(:base, :keys_should_be_positive_number)
         end
       end
     end

--- a/promotions/app/models/solidus_promotions/calculators/tiered_percent.rb
+++ b/promotions/app/models/solidus_promotions/calculators/tiered_percent.rb
@@ -114,8 +114,6 @@ module SolidusPromotions
       # Converts all tier threshold keys and percentage values from strings or other numeric
       # types to BigDecimal to ensure precision in monetary calculations.
       def transform_preferred_tiers
-        return unless preferred_tiers.is_a?(Hash)
-
         preferred_tiers.transform_keys! { |key| key.to_s.to_d }
         preferred_tiers.transform_values! { |value| value.to_s.to_d }
       end
@@ -127,15 +125,11 @@ module SolidusPromotions
       # - All keys (thresholds) are positive numbers
       # - All values (percentages) are between 0 and 100
       def preferred_tiers_content
-        if preferred_tiers.is_a? Hash
-          unless preferred_tiers.keys.all? { |key| key.is_a?(Numeric) && key > 0 }
-            errors.add(:base, :keys_should_be_positive_number)
-          end
-          unless preferred_tiers.values.all? { |key| key.is_a?(Numeric) && key >= 0 && key <= 100 }
-            errors.add(:base, :values_should_be_percent)
-          end
-        else
-          errors.add(:preferred_tiers, :should_be_hash)
+        unless preferred_tiers.keys.all? { |key| key.is_a?(Numeric) && key > 0 }
+          errors.add(:base, :keys_should_be_positive_number)
+        end
+        unless preferred_tiers.values.all? { |key| key.is_a?(Numeric) && key >= 0 && key <= 100 }
+          errors.add(:base, :values_should_be_percent)
         end
       end
     end

--- a/promotions/app/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity.rb
+++ b/promotions/app/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity.rb
@@ -109,8 +109,6 @@ module SolidusPromotions
       # Converts tier threshold keys (item quantities) to integers and percentage values
       # to BigDecimal for consistent calculations.
       def transform_preferred_tiers
-        return unless preferred_tiers.is_a?(Hash)
-
         preferred_tiers.transform_keys!(&:to_i)
         preferred_tiers.transform_values! { |value| value.to_s.to_d }
       end

--- a/promotions/spec/models/solidus_promotions/calculators/tiered_flat_rate_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/tiered_flat_rate_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe SolidusPromotions::Calculators::TieredFlatRate, type: :model do
         end
       end
     end
+
+    context "setting tiers to anything but a Hash" do
+      it "raises TypeError" do
+        expect {
+          calculator.preferred_tiers = :no_hash
+        }.to raise_exception(TypeError)
+      end
+    end
   end
 
   describe "#compute" do

--- a/promotions/spec/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
@@ -3,59 +3,71 @@
 require "rails_helper"
 
 RSpec.describe SolidusPromotions::Calculators::TieredPercentOnEligibleItemQuantity do
-  let(:order) do
-    create(:order_with_line_items, line_items_attributes: [first_item_attrs, second_item_attrs, third_item_attrs])
-  end
-
-  let(:first_item_attrs) { { variant: shirt, quantity: 2, price: 50 } }
-  let(:second_item_attrs) { { variant: pants, quantity: 3 } }
-  let(:third_item_attrs) { { variant: mug, quantity: 1 } }
-
-  let(:shirt) { create(:variant) }
-  let(:pants) { create(:variant) }
-  let(:mug) { create(:variant) }
-
-  let(:clothes) { create(:taxon, products: [shirt.product, pants.product]) }
-
-  let(:promotion) { create(:solidus_promotion, name: "10 Percent on 5 apparel, 15 percent on 10", benefits: [benefit]) }
-  let(:clothes_only) { SolidusPromotions::Conditions::Taxon.new(taxons: [clothes]) }
-  let(:benefit) { SolidusPromotions::Benefits::AdjustLineItem.new(calculator: calculator, conditions: [clothes_only]) }
-  let(:calculator) { described_class.new(preferred_base_percent: 10, preferred_tiers: { 10 => 15.0 }) }
-
-  let(:item) { order.line_items.detect { _1.variant == shirt } }
-
-  subject { promotion.benefits.first.calculator.compute(item) }
-
-  # 2 Shirts at 50, 100 USD. 10 % == 10
-  it { is_expected.to eq(10) }
-
-  context "if we have 12" do
-    let(:first_item_attrs) { { variant: shirt, quantity: 7, price: 50 } }
-    let(:second_item_attrs) { { variant: pants, quantity: 5 } }
-
-    # 7 Shirts at 50, 350 USD, 15 % == 52.5
-    it { is_expected.to eq(52.5) }
-  end
-
-  context "if the order's currency is different" do
-    before do
-      order.currency = "GBP"
-      order.save!
+  describe "#compute" do
+    let(:order) do
+      create(:order_with_line_items, line_items_attributes: [first_item_attrs, second_item_attrs, third_item_attrs])
     end
 
-    it { is_expected.to eq(0) }
+    let(:first_item_attrs) { { variant: shirt, quantity: 2, price: 50 } }
+    let(:second_item_attrs) { { variant: pants, quantity: 3 } }
+    let(:third_item_attrs) { { variant: mug, quantity: 1 } }
+
+    let(:shirt) { create(:variant) }
+    let(:pants) { create(:variant) }
+    let(:mug) { create(:variant) }
+
+    let(:clothes) { create(:taxon, products: [shirt.product, pants.product]) }
+
+    let(:promotion) { create(:solidus_promotion, name: "10 Percent on 5 apparel, 15 percent on 10", benefits: [benefit]) }
+    let(:clothes_only) { SolidusPromotions::Conditions::Taxon.new(taxons: [clothes]) }
+    let(:benefit) { SolidusPromotions::Benefits::AdjustLineItem.new(calculator: calculator, conditions: [clothes_only]) }
+    let(:calculator) { described_class.new(preferred_base_percent: 10, preferred_tiers: { 10 => 15.0 }) }
+
+    let(:item) { order.line_items.detect { _1.variant == shirt } }
+
+    subject { promotion.benefits.first.calculator.compute(item) }
+
+    # 2 Shirts at 50, 100 USD. 10 % == 10
+    it { is_expected.to eq(10) }
+
+    context "if we have 12" do
+      let(:first_item_attrs) { { variant: shirt, quantity: 7, price: 50 } }
+      let(:second_item_attrs) { { variant: pants, quantity: 5 } }
+
+      # 7 Shirts at 50, 350 USD, 15 % == 52.5
+      it { is_expected.to eq(52.5) }
+    end
+
+    context "if the order's currency is different" do
+      before do
+        order.currency = "GBP"
+        order.save!
+      end
+
+      it { is_expected.to eq(0) }
+    end
+
+    context "discounting a shipment" do
+      let(:item) { build(:shipment, order:, cost: 29) }
+
+      it { is_expected.to eq(2.9) }
+    end
+
+    context "discounting a shipping rate" do
+      let(:shipment) { build(:shipment, order:) }
+      let(:item) { build(:shipping_rate, shipment:, cost: 38) }
+
+      it { is_expected.to eq(3.8) }
+    end
   end
 
-  context "discounting a shipment" do
-    let(:item) { build(:shipment, order:, cost: 29) }
+  describe "setting tiers to anything but a Hash" do
+    let(:calculator) { described_class.new }
 
-    it { is_expected.to eq(2.9) }
-  end
-
-  context "discounting a shipping rate" do
-    let(:shipment) { build(:shipment, order:) }
-    let(:item) { build(:shipping_rate, shipment:, cost: 38) }
-
-    it { is_expected.to eq(3.8) }
+    it "raises TypeError" do
+      expect {
+        calculator.preferred_tiers = :no_hash
+      }.to raise_exception(TypeError)
+    end
   end
 end

--- a/promotions/spec/models/solidus_promotions/calculators/tiered_percent_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/tiered_percent_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe SolidusPromotions::Calculators::TieredPercent, type: :model do
         end
       end
     end
+
+    context "setting tiers to anything but a Hash" do
+      it "raises TypeError" do
+        expect {
+          calculator.preferred_tiers = :no_hash
+        }.to raise_exception(TypeError)
+      end
+    end
   end
 
   describe "#compute" do


### PR DESCRIPTION
## Summary

We have three "tiered" promotion benefit calculators in the codebase, and they are a bit enigmatic. This refactors them so some of the source is easier to parse, but most importantly this adds a bunch of (AI-generated, but vetted) YARD documentation that tells people what they're looking at. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
