### PR TITLE
Prevent merging of non-frontend-viewable orders

### DIFF
--- a/core/app/helpers/spree/core/controller_helpers/order.rb
+++ b/core/app/helpers/spree/core/controller_helpers/order.rb
@@ -43,7 +43,7 @@ module Spree
 
         def set_current_order
           if spree_current_user && current_order
-            spree_current_user.orders.by_store(current_store).incomplete.where('id != ?', current_order.id).find_each do |order|
+            spree_current_user.orders.by_store(current_store).incomplete.where(frontend_viewable: true).where('id != ?', current_order.id).find_each do |order|
               current_order.merge!(order, spree_current_user)
             end
           end

--- a/core/spec/helpers/controller_helpers/order_spec.rb
+++ b/core/spec/helpers/controller_helpers/order_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe Spree::Core::ControllerHelpers::Order, type: :controller do
           controller.set_current_order
         end
       end
+
+      context 'an order from the same store but not frontend viewable' do
+        let(:incomplete_order_store) { store }
+        let(:incomplete_order) { create(:order, store: incomplete_order_store, user:, frontend_viewable: false) }
+
+        it 'does not call Spree::Order#merge! method' do
+          expect(order).not_to receive(:merge!)
+          controller.set_current_order
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Non-frontend viewable orders are created by Solidus admins, and these can be unintentionally merged into a user's existing orders when they login.

We want to exclude them from the list of order merge candidates

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
