### PR TITLE
Move shared examples for promo calculators to lib/

### DIFF
--- a/promotions/lib/solidus_promotions/testing_support/shared_examples.rb
+++ b/promotions/lib/solidus_promotions/testing_support/shared_examples.rb
@@ -3,3 +3,4 @@
 require "solidus_promotions/testing_support/shared_examples/product_condition"
 require "solidus_promotions/testing_support/shared_examples/taxon_condition"
 require "solidus_promotions/testing_support/shared_examples/option_value_condition"
+require "solidus_promotions/testing_support/shared_examples/promotion_calculator"

--- a/promotions/lib/solidus_promotions/testing_support/shared_examples/promotion_calculator.rb
+++ b/promotions/lib/solidus_promotions/testing_support/shared_examples/promotion_calculator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for "a calculator with a description" do
+RSpec.shared_examples_for "a promotion calculator" do
   describe ".description" do
     subject { described_class.description }
 

--- a/promotions/spec/models/solidus_promotions/calculators/distributed_amount_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/distributed_amount_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::DistributedAmount, type: :model do
   let(:calculator) { described_class.new(preferred_amount: 15, preferred_currency: currency) }
@@ -12,6 +11,8 @@ RSpec.describe SolidusPromotions::Calculators::DistributedAmount, type: :model d
   let(:benefit) { SolidusPromotions::Benefits::AdjustLineItem.create(calculator: calculator, conditions: conditions) }
   let(:order) { create(:order_with_line_items, line_items_attributes: line_items_attributes) }
   let(:currency) { "USD" }
+
+  it_behaves_like "a promotion calculator"
 
   context "applied to an order" do
     let(:line_items_attributes) { [{ price: 20 }, { price: 30 }, { price: 100 }] }

--- a/promotions/spec/models/solidus_promotions/calculators/flat_rate_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/flat_rate_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::FlatRate, type: :model do
   subject { calculator.compute(discountable) }
@@ -14,7 +13,7 @@ RSpec.describe SolidusPromotions::Calculators::FlatRate, type: :model do
     )
   end
 
-  it_behaves_like "a calculator with a description"
+  it_behaves_like "a promotion calculator"
 
   context "compute_line_item" do
     let(:discountable) { mock_model(Spree::LineItem, order: order) }

--- a/promotions/spec/models/solidus_promotions/calculators/flexi_rate_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/flexi_rate_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::FlexiRate, type: :model do
   let(:calculator) do
@@ -26,7 +25,7 @@ RSpec.describe SolidusPromotions::Calculators::FlexiRate, type: :model do
     )
   end
 
-  it_behaves_like "a calculator with a description"
+  it_behaves_like "a promotion calculator"
 
   context "compute" do
     subject { calculator.compute(line_item) }

--- a/promotions/spec/models/solidus_promotions/calculators/percent_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/percent_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::Percent, type: :model do
   context "compute" do
@@ -29,5 +28,5 @@ RSpec.describe SolidusPromotions::Calculators::Percent, type: :model do
     end
   end
 
-  it_behaves_like "a calculator with a description"
+  it_behaves_like "a promotion calculator"
 end

--- a/promotions/spec/models/solidus_promotions/calculators/percent_with_cap_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/percent_with_cap_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe SolidusPromotions::Calculators::PercentWithCap, type: :model do
+  it_behaves_like "a promotion calculator"
+
   context "applied to an order" do
     let(:calculator) { described_class.new(preferred_percent: 15, preferred_max_amount: 50) }
     let(:promotion) do

--- a/promotions/spec/models/solidus_promotions/calculators/tiered_flat_rate_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/tiered_flat_rate_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::TieredFlatRate, type: :model do
   let(:calculator) { described_class.new }
 
-  it_behaves_like "a calculator with a description"
+  it_behaves_like "a promotion calculator"
 
   describe "#valid?" do
     subject { calculator.valid? }

--- a/promotions/spec/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/tiered_percent_on_eligible_item_quantity_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe SolidusPromotions::Calculators::TieredPercentOnEligibleItemQuanti
 
     subject { promotion.benefits.first.calculator.compute(item) }
 
+    it_behaves_like "a promotion calculator"
+
     # 2 Shirts at 50, 100 USD. 10 % == 10
     it { is_expected.to eq(10) }
 

--- a/promotions/spec/models/solidus_promotions/calculators/tiered_percent_spec.rb
+++ b/promotions/spec/models/solidus_promotions/calculators/tiered_percent_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "shared_examples/calculator_shared_examples"
 
 RSpec.describe SolidusPromotions::Calculators::TieredPercent, type: :model do
   let(:calculator) { described_class.new }
 
-  it_behaves_like "a calculator with a description"
+  it_behaves_like "a promotion calculator"
 
   describe "#valid?" do
     subject { calculator.valid? }


### PR DESCRIPTION
## Summary

This way, the shared examples can be extended and used in consuming apps.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
