### PR TITLE
Remove `inverse_of` from Spree::Adjustment#order

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -9,7 +9,7 @@ module Spree
   class Adjustment < Spree::Base
     belongs_to :adjustable, polymorphic: true, touch: true, optional: true
     belongs_to :source, polymorphic: true, optional: true
-    belongs_to :order, class_name: 'Spree::Order', inverse_of: :all_adjustments, optional: true
+    belongs_to :order, class_name: 'Spree::Order', inverse_of: false, optional: true
     belongs_to :adjustment_reason, class_name: 'Spree::AdjustmentReason', inverse_of: :adjustments, optional: true
 
     validates :adjustable, presence: true

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2241,4 +2241,26 @@ RSpec.describe Spree::Order, type: :model do
       expect(state_change.name).to eq('order')
     end
   end
+
+  describe "Adjustment resurrection bug" do
+    let(:order) { create(:order_ready_to_ship) }
+    let(:shipment) { order.shipments.first }
+
+    it "destroys a shipment adjustment properly when order is saved" do
+      adj = shipment.adjustments.build(
+        amount: -5,
+        order: order,
+        label: "Nefarious adjustment",
+        source: nil
+      )
+
+      expect(Spree::Adjustment.exists?(adj.id)).to eq(false)
+
+      shipment.adjustments.first.mark_for_destruction
+
+      order.save!
+
+      expect(Spree::Adjustment.exists?(adj.id)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION

## Summary

This `inverse_of` gives rise to spurious adjustments appearing in the database if there are newly built and directly marked for destruction.

Since we're never calling `adjustment.order` anywhere in production code, I am pretty sure we can remove this inverse_of safely.

I believe what happens is that the adjustment gets added to `order.all_adjustments` on initialization, and marking it for destruction on the shipment does not carry on to that association as it does not have the `autosave` property.

Alternatively, we could add `autosave` to `order.all_adjustments`, but that could surface even weirder bugs.

Found while building #6371 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
