### PR TITLE
feat: Make state change tracker a configurable class

### DIFF
--- a/core/app/models/concerns/spree/state_change_tracking.rb
+++ b/core/app/models/concerns/spree/state_change_tracking.rb
@@ -19,11 +19,11 @@ module Spree
       previous_state, current_state = saved_changes['state']
 
       # Enqueue the job to track this state change
-      StateChangeTrackingJob.perform_later(
-        self,
-        previous_state,
-        current_state,
-        Time.current
+      Spree::Config.state_change_tracking_class.call(
+        stateful: self,
+        previous_state:,
+        current_state:,
+        transition_timestamp: Time.current
       )
     end
   end

--- a/core/app/models/spree/state_change_tracker.rb
+++ b/core/app/models/spree/state_change_tracker.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Spree
+  # Configurable class to enqueue state change tracking jobs
+  # Configure your custom logic by setting Spree::Config.state_change_tracking_class
+  # @example Spree::Config.state_change_tracking_class = MyCustomTracker
+  class StateChangeTracker
+    # @param stateful [Object] The stateful object to track changes for
+    # @param previous_state [String] The previous state of the order
+    # @param current_state [String] The current state of the order
+    # @param transition_timestamp [Time] When the state transition occurred
+    # @param stateful_name [String] The element name of the state transition being
+    #   tracked. It defaults to the `stateful` model element name.
+    def self.call(
+      stateful:,
+      previous_state:,
+      current_state:,
+      transition_timestamp:,
+      stateful_name: stateful.class.model_name.element
+    )
+      # Enqueue a background job to track this state change
+      StateChangeTrackingJob.perform_later(
+        stateful,
+        previous_state,
+        current_state,
+        transition_timestamp,
+        stateful_name
+      )
+    end
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -549,6 +549,13 @@ module Spree
                                                           product: '680x680>',
                                                           large: '1200x1200>' }
 
+    # Allows to provide your own class for tracking state changes of stateful models
+    #
+    # @!attribute [rw] state_change_tracking_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::StateChangeTracker.
+    class_name_attribute :state_change_tracking_class, default: "Spree::StateChangeTracker"
+
     # Allows providing your own class for prioritizing store credit application
     # to an order.
     #

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.variant_price_selector_class).to eq Spree::Variant::PriceSelector
   end
 
+  it "uses state change tracker class by default" do
+    expect(prefs.state_change_tracking_class).to eq Spree::StateChangeTracker
+  end
+
   it "uses core's promotion configuration class by default" do
     expect(prefs.promotions).to be_a Spree::Core::NullPromotionConfiguration
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2181,7 +2181,8 @@ RSpec.describe Spree::Order, type: :model do
         order,
         'cart',
         'address',
-        kind_of(Time)
+        kind_of(Time),
+        'order'
       )
     end
 
@@ -2201,7 +2202,8 @@ RSpec.describe Spree::Order, type: :model do
           order,
           'cart',
           'address',
-          kind_of(Time)
+          kind_of(Time),
+        'order'
         )
       end
     end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -1350,7 +1350,8 @@ RSpec.describe Spree::Payment, type: :model do
         payment,
         'checkout',
         'completed',
-        kind_of(Time)
+        kind_of(Time),
+        'payment'
       )
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -974,7 +974,8 @@ RSpec.describe Spree::Shipment, type: :model do
         shipment,
         'pending',
         'shipped',
-        kind_of(Time)
+        kind_of(Time),
+        'shipment'
       )
     end
 

--- a/core/spec/models/spree/state_change_tracker_spec.rb
+++ b/core/spec/models/spree/state_change_tracker_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::StateChangeTracker, type: :model do
+  let(:order) { create(:order) }
+  let(:transition_timestamp) { Time.current }
+
+  describe "#call" do
+    it "enqueues a StateChangeTrackingJob with correct arguments" do
+      expect {
+        described_class.call(
+          stateful: order,
+          previous_state: "cart",
+          current_state: "address",
+          transition_timestamp: transition_timestamp,
+          stateful_name: "order"
+        )
+      }.to have_enqueued_job(Spree::StateChangeTrackingJob).with(
+        order,
+        "cart",
+        "address",
+        transition_timestamp,
+        "order"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Currently we always enqueues a ActiveJob, but some stores maybe want to inline the state changes or add more information to the state change record. This allows to set your own state change tracker class. It defaults to the current behavior.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
