### PR TITLE
Make OrderRecalculatorPatch prepend explicit

### DIFF
--- a/promotions/app/patches/models/solidus_promotions/order_recalculator_patch.rb
+++ b/promotions/app/patches/models/solidus_promotions/order_recalculator_patch.rb
@@ -10,6 +10,7 @@ module SolidusPromotions
       end
       super
     end
-    Spree::Config.order_recalculator_class.prepend self
+
+    Spree::OrderUpdater.prepend self
   end
 end


### PR DESCRIPTION
## Summary

Prepending a configurable class runs into all kinds of trouble with load order. If the patch is loaded before the configuration changes, the newly configured class won't have the patch applied.

This shows up fairly often in tests, but could also be an issue in other environments if the config is not set to run before all of the code is eager loaded.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
