### PR TITLE
feat: Allow to overwrite track_state_change?

### DIFF
--- a/core/app/models/concerns/spree/state_change_tracking.rb
+++ b/core/app/models/concerns/spree/state_change_tracking.rb
@@ -5,10 +5,14 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      after_update :enqueue_state_change_tracking, if: :saved_change_to_state?
+      after_update :enqueue_state_change_tracking, if: :track_state_change?
     end
 
     private
+
+    def track_state_change?
+      saved_change_to_state?
+    end
 
     # Enqueue background job to track state changes asynchronously
     def enqueue_state_change_tracking

--- a/core/lib/spree/testing_support/shared_examples/state_change_tracking.rb
+++ b/core/lib/spree/testing_support/shared_examples/state_change_tracking.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "tracking state changes" do
+  context "with track_state_change? true" do
+    before do
+      expect(stateful).to receive(:track_state_change?).and_return(true)
+    end
+
+    it "enqueues state change tracking job" do
+      expect { stateful.update!(state:) }
+        .to enqueue_job(Spree::StateChangeTrackingJob)
+    end
+  end
+
+  context "with track_state_change? false" do
+    before do
+      expect(stateful).to receive(:track_state_change?).and_return(false)
+    end
+
+    it "does not enqueue state change tracking job" do
+      expect { stateful.update!(state:) }
+        .not_to enqueue_job(Spree::StateChangeTrackingJob)
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'spree/testing_support/shared_examples/state_change_tracking'
 
 RSpec.describe Spree::Order, type: :model do
   let(:store) { create(:store) }
   let(:user) { create(:user, email: "solidus@example.com") }
   let(:order) { create(:order, user:, store:) }
+
+  it_behaves_like "tracking state changes" do
+    let(:stateful) { order }
+    let(:state) { "complete" }
+  end
 
   describe ".ransackable_associations" do
     subject { described_class.ransackable_associations }

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'spree/testing_support/shared_examples/state_change_tracking'
 
 RSpec.describe Spree::Payment, type: :model do
   let(:store) { create :store }
@@ -44,6 +45,11 @@ RSpec.describe Spree::Payment, type: :model do
       { transaction: {} },
       {}
     )
+  end
+
+  it_behaves_like "tracking state changes" do
+    let(:stateful) { payment }
+    let(:state) { "pending" }
   end
 
   context 'risk analysis' do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'benchmark'
+require 'spree/testing_support/shared_examples/state_change_tracking'
 
 RSpec.describe Spree::Shipment, type: :model do
   let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
@@ -42,6 +43,11 @@ RSpec.describe Spree::Shipment, type: :model do
       build(:inventory_unit, state: 'shipped', shipment: nil)
     ]
     expect(shipment).to be_backordered
+  end
+
+  it_behaves_like "tracking state changes" do
+    let(:stateful) { shipment }
+    let(:state) { "shipped" }
   end
 
   context "#determine_state" do


### PR DESCRIPTION
## Summary

Some stores might have their own logi of tracking state changes. Let's give them a way to disable the built in state change tracking by overwriting the `track_state_change?` per model instance. It defaults to the current behavior of tracking a state change if there is `saved_change_to_state?` from `ActiveRecord::Dirty`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
