### PR TITLE
Configurable Order Mergeable Scope

### DIFF
--- a/core/app/helpers/spree/core/controller_helpers/order.rb
+++ b/core/app/helpers/spree/core/controller_helpers/order.rb
@@ -42,10 +42,8 @@ module Spree
         end
 
         def set_current_order
-          if spree_current_user && current_order
-            spree_current_user.orders.by_store(current_store).incomplete.where(frontend_viewable: true).where('id != ?', current_order.id).find_each do |order|
-              current_order.merge!(order, spree_current_user)
-            end
+          Spree::Config.mergeable_orders_finder_class.new(context: self).call.find_each do |order|
+            current_order.merge!(order, spree_current_user)
           end
         end
 

--- a/core/app/models/spree/mergeable_orders_finder.rb
+++ b/core/app/models/spree/mergeable_orders_finder.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Spree
+  # Finds orders to merge when a user logs in.
+  #
+  # Configurable via {Spree::Config#mergeable_orders_finder_class}.
+  # Default behavior finds all incomplete orders from the same store.
+  #
+  # @example Custom finder for recent orders only
+  #   class RecentOrdersFinder
+  #     def initialize(context:)
+  #       @user = context.spree_current_user
+  #       @store = context.current_store
+  #       @current_order = context.current_order
+  #     end
+  #
+  #     def call
+  #       @user.orders.by_store(@store).incomplete
+  #            .where.not(id: @current_order.id)
+  #            .where('created_at > ?', 7.days.ago)
+  #     end
+  #   end
+  #
+  #   Spree::Config.mergeable_orders_finder_class = RecentOrdersFinder
+  class MergeableOrdersFinder
+    # @param context [Object] an object that responds to spree_current_user,
+    #   current_store, and current_order (typically a controller)
+    def initialize(context:)
+      @user = context.spree_current_user
+      @store = context.current_store
+      @current_order = context.current_order
+    end
+
+    # Returns orders that should be merged into the current order
+    #
+    # @return [ActiveRecord::Relation<Spree::Order>] incomplete orders from the
+    # same store
+    def call
+      return Spree::Order.none unless @user && @current_order
+
+      @user.orders.by_store(@store).incomplete.where(frontend_viewable: true).where.not(id: @current_order.id)
+    end
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -409,6 +409,13 @@ module Spree
     #   as Spree::OrderMerger.
     class_name_attribute :order_merger_class, default: 'Spree::OrderMerger'
 
+    # Allows providing your own class for selecting which orders to merge.
+    #
+    # @!attribute [rw] mergeable_orders_finder_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::MergeableOrdersFinder.
+    class_name_attribute :mergeable_orders_finder_class, default: 'Spree::MergeableOrdersFinder'
+
     # Allows providing your own class for adding default payments to a user's
     # order from their "wallet".
     #

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.promotions).to be_a Spree::Core::NullPromotionConfiguration
   end
 
+  it 'uses mergeable orders finder class by default' do
+    expect(prefs.mergeable_orders_finder_class).to eq Spree::MergeableOrdersFinder
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do

--- a/core/spec/models/spree/mergeable_orders_finder_spec.rb
+++ b/core/spec/models/spree/mergeable_orders_finder_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Spree
+  RSpec.describe MergeableOrdersFinder do
+    let(:user) { create(:user) }
+    let(:store) { create(:store) }
+    let(:current_order) { create(:order, user: user, store: store) }
+    let(:context) { double('context', spree_current_user: user, current_store: store, current_order: current_order) }
+    let(:subject) { Spree::MergeableOrdersFinder.new(context: context) }
+
+    describe '#call' do
+      let!(:incomplete_order1) { create(:order, user: user, store: store, state: 'cart') }
+      let!(:incomplete_order2) { create(:order, user: user, store: store, state: 'address') }
+      let!(:complete_order) { create(:order, user: user, store: store, state: 'complete').touch(:completed_at) }
+      let!(:other_store_order) { create(:order, user: user, state: 'cart') }
+
+      it 'returns incomplete orders from the same store' do
+        orders = subject.call
+        expect(orders).to include(incomplete_order1, incomplete_order2)
+        expect(orders).not_to include(current_order, complete_order, other_store_order)
+      end
+
+      context 'when user is nil' do
+        let(:context) { double('context', spree_current_user: nil, current_store: store, current_order: current_order) }
+
+        it 'returns empty relation' do
+          orders = subject.call
+          expect(orders).to be_empty
+          expect(orders).to eq(Spree::Order.none)
+        end
+      end
+
+      context 'when current_order is nil' do
+        let(:context) { double('context', spree_current_user: user, current_store: store, current_order: nil) }
+
+        it 'returns empty relation' do
+          orders = subject.call
+          expect(orders).to be_empty
+          expect(orders).to eq(Spree::Order.none)
+        end
+      end
+
+      context 'when both user and current_order are nil' do
+        let(:context) { double('context', spree_current_user: nil, current_store: store, current_order: nil) }
+
+        it 'returns empty relation' do
+          orders = subject.call
+          expect(orders).to be_empty
+          expect(orders).to eq(Spree::Order.none)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -422,6 +422,41 @@ RSpec.describe Spree::Order, type: :model do
         expect(order1.merge!(order2, user)).to eq([order1, order2, user])
       end
     end
+
+    describe 'mergeable_orders_finder_class customization' do
+      let(:user) { create(:user) }
+      let(:store) { create(:store) }
+      let(:current_order) { create(:order, user: user, store: store) }
+      let(:context) { double('context', spree_current_user: user, current_store: store, current_order: current_order) }
+      let(:test_mergeable_orders_finder_class) do
+        Class.new do
+          def initialize(context:)
+            @user = context.spree_current_user
+            @store = context.current_store
+            @current_order = context.current_order
+          end
+
+          def call
+            @user.orders.by_store(@store).where.not(id: @current_order.id).where('created_at > ?', 7.days.ago)
+          end
+        end
+      end
+
+      before do
+        stub_spree_preferences(mergeable_orders_finder_class: test_mergeable_orders_finder_class)
+      end
+
+      subject(:finder) { Spree::Config.mergeable_orders_finder_class.new(context: context) }
+
+      it 'uses the configured mergeable orders finder' do
+        old_order = create(:order, user: user, store: store, created_at: 8.days.ago)
+        recent_order = create(:order, user: user, store: store, created_at: 3.days.ago)
+
+        orders = finder.call
+        expect(orders).to include(recent_order)
+        expect(orders).not_to include(old_order, current_order)
+      end
+    end
   end
 
   describe "#ensure_updated_shipments" do


### PR DESCRIPTION
## Summary

This PR makes the mergeable order finding logic in `set_current_order` configurable by introducing a new `mergeable_orders_finder_class` configuration option and `Spree::MergeableOrdersFinder` class. 

Fixes #6366 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- ✅ I have added automated tests to cover my changes.
