### PR TITLE
Localization and missing strings

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -124,7 +124,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
           'canceled' => :blue,
           'cart' => :graphite_light,
         }[order.state] || :yellow
-        component('ui/badge').new(name: order.state.humanize, color:)
+        component('ui/badge').new(name: I18n.t("spree.order_state.#{order.state}"), color:)
       end
     }
   end
@@ -171,7 +171,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :payment,
       data: ->(order) do
-        component('ui/badge').new(name: order.payment_state.humanize, color: order.paid? ? :green : :yellow) if order.payment_state?
+        component('ui/badge').new(name: I18n.t("spree.payment_states.#{order.payment_state}"), color: order.paid? ? :green : :yellow) if order.payment_state?
       end
     }
   end
@@ -180,7 +180,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :shipment,
       data: ->(order) do
-        component('ui/badge').new(name: order.shipment_state.humanize, color: order.shipped? ? :green : :yellow) if order.shipment_state?
+        component('ui/badge').new(name: I18n.t("spree.shipment_states.#{order.shipment_state}"), color: order.shipped? ? :green : :yellow) if order.shipment_state?
       end
     }
   end

--- a/admin/app/components/solidus_admin/ui/pages/index/component.rb
+++ b/admin/app/components/solidus_admin/ui/pages/index/component.rb
@@ -35,7 +35,7 @@ class SolidusAdmin::UI::Pages::Index::Component < SolidusAdmin::BaseComponent
   end
 
   def title
-    model_class.model_name.human.pluralize
+    I18n.t("activerecord.models.#{model_class.model_name.i18n_key}", count: 2)
   end
 
   def search_params


### PR DESCRIPTION
## Summary

- Added missing new admin `menu_items`; (normalized with i18n-tasks`)
- Changed `orders/index` table to display localized strings for: `order_state`, `payment_state`, and `shipment_state`;
- Localized the new admin page title according to the existing active record strings

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
