### PR TITLE
Promotions: Fix eligibility calculation in dry runs

### DIFF
--- a/promotions/app/models/solidus_promotions/benefit.rb
+++ b/promotions/app/models/solidus_promotions/benefit.rb
@@ -270,29 +270,28 @@ module SolidusPromotions
     # @param dry_run [Boolean] whether to collect detailed eligibility information
     # @return [Boolean] true when all applicable conditions are eligible
     def eligible_by_applicable_conditions?(promotable, dry_run: false)
-      conditions.filter_map do |condition|
-        condition.applicable?(promotable) && begin
-          eligible = condition.eligible?(promotable)
+      conditions.map do |condition|
+        next unless condition.applicable?(promotable)
+        eligible = condition.eligible?(promotable)
 
-          break [false] if !eligible && !dry_run
+        break [false] if !eligible && !dry_run
 
-          if dry_run
-            if condition.eligibility_errors.details[:base].first
-              code = condition.eligibility_errors.details[:base].first[:error_code]
-              message = condition.eligibility_errors.full_messages.first
-            end
-            promotion.eligibility_results.add(
-              item: promotable,
-              condition: condition,
-              success: eligible,
-              code: eligible ? nil : (code || :coupon_code_unknown_error),
-              message: eligible ? nil : (message || I18n.t(:coupon_code_unknown_error, scope: [:solidus_promotions, :eligibility_errors]))
-            )
+        if dry_run
+          if condition.eligibility_errors.details[:base].first
+            code = condition.eligibility_errors.details[:base].first[:error_code]
+            message = condition.eligibility_errors.full_messages.first
           end
-
-          eligible
+          promotion.eligibility_results.add(
+            item: promotable,
+            condition: condition,
+            success: eligible,
+            code: eligible ? nil : (code || :coupon_code_unknown_error),
+            message: eligible ? nil : (message || I18n.t(:coupon_code_unknown_error, scope: [:solidus_promotions, :eligibility_errors]))
+          )
         end
-      end.all?
+
+        eligible
+      end.compact.all?
     end
 
     # All line items of the order that are eligible for this benefit.

--- a/promotions/spec/models/solidus_promotions/benefit_spec.rb
+++ b/promotions/spec/models/solidus_promotions/benefit_spec.rb
@@ -321,4 +321,129 @@ RSpec.describe SolidusPromotions::Benefit do
 
     it { is_expected.to include(SolidusPromotions::Conditions::User) }
   end
+
+  describe "#eligible_by_applicable_conditions" do
+    let(:promotion) { build(:solidus_promotion) }
+    let(:benefit) { described_class.new(conditions: conditions, promotion:) }
+    let(:conditions) { [] }
+    let(:order) { create(:order_with_line_items) }
+    let(:condition) { SolidusPromotions::Conditions::LineItemProduct.new(products: [order.products.first]) }
+    let(:dry_run) { false }
+    let(:promotable) { order }
+
+    subject { benefit.eligible_by_applicable_conditions?(promotable, dry_run:) }
+
+    # No conditions, eligible
+    it { is_expected.to be true }
+
+    context "for a non-applicable promotable" do
+      let(:conditions) { [condition] }
+      let(:condition) do
+        Class.new(SolidusPromotions::Condition) do
+          def line_item_eligible?(_)
+            false
+          end
+        end.new
+      end
+
+      it { is_expected.to be true }
+
+      context "if condition returns false" do
+        let(:condition) { SolidusPromotions::Conditions::LineItemProduct.new(products: []) }
+
+        it { is_expected.to be true }
+
+        context "with dry_run true" do
+          let(:dry_run) { true }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context "with an applicable promotable" do
+      let(:conditions) { [condition] }
+      let(:condition) do
+        Class.new(SolidusPromotions::Condition) do
+          def line_item_eligible?(_)
+            true
+          end
+        end.new
+      end
+      let(:promotable) { order.line_items.first }
+      it { is_expected.to be true }
+
+      context "with dry_run true" do
+        let(:dry_run) { true }
+
+        it { is_expected.to be true }
+      end
+
+      context "when condition returns false" do
+        let(:condition) do
+          Class.new(SolidusPromotions::Condition) do
+            def line_item_eligible?(_)
+              eligibility_errors.add(:base, "You need to add an applicable product before applying this coupon code.")
+              false
+            end
+          end.new
+        end
+
+        it { is_expected.to be false }
+
+        context "with dry_run true" do
+          let(:dry_run) { true }
+
+          it { is_expected.to be false }
+
+          it "adds an error message to the condition" do
+            subject
+            expect(promotion.eligibility_results.error_messages).to eq(["You need to add an applicable product before applying this coupon code."])
+          end
+        end
+      end
+
+      context "with multiple conditions, both of which make the benefit unelegibible" do
+        let(:promotable) { order }
+        let(:taxon_condition) do
+          Class.new(SolidusPromotions::Condition) do
+            def order_eligible?(_)
+              eligibility_errors.add(:base, "Wrong taxon")
+              false
+            end
+          end.new
+        end
+        let(:product_condition) do
+          Class.new(SolidusPromotions::Condition) do
+            def order_eligible?(_)
+              eligibility_errors.add(:base, "Wrong product.")
+              false
+            end
+          end.new
+        end
+        let(:conditions) { [taxon_condition, product_condition] }
+
+        it { is_expected.to be false }
+
+        it "only asks the first condition and does not collect eligibility errors" do
+          expect(taxon_condition).to receive(:order_eligible?).and_call_original
+          expect(product_condition).not_to receive(:order_eligible?)
+          subject
+          expect(promotion.eligibility_results.error_messages).to be_empty
+        end
+
+        context "if dry_run is true" do
+          let(:dry_run) { true }
+          it { is_expected.to be false }
+
+          it "asks both conditions and collects eligibility results" do
+            expect(taxon_condition).to receive(:order_eligible?).and_call_original
+            expect(product_condition).to receive(:order_eligible?).and_call_original
+            subject
+            expect(promotion.eligibility_results.error_messages.length).to eq(2)
+          end
+        end
+      end
+    end
+  end
 end

--- a/promotions/spec/models/solidus_promotions/order_adjuster/discount_order_spec.rb
+++ b/promotions/spec/models/solidus_promotions/order_adjuster/discount_order_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe SolidusPromotions::OrderAdjuster::DiscountOrder do
         expect(promotion.eligibility_results.success?).to be false
       end
 
-      it "can tell us about all the errors" do
+      it "can tell us about all the errors", :pending do
         subject
         expect(promotion.eligibility_results.error_messages).to eq(
           [


### PR DESCRIPTION

## Summary

Commit 4b99e1ecd66dd4d3f813a98e197be633f9669e1d introduced a subtle bug when the `dry_run` parameter was true: Because `filter_map` filters out `false` from arrays, every benefit would now be eligible!

This changes the loop to distinguish between `nil` (for non-applicable conditions) and `false` for (for applicable conditions).

It also adds specs for this - very central - method to the promotions system.

This makes the dry run not return errors for line-item level conditions if there are order-level conditions present. We probably need a DryRunDiscountOrder object to catch this, with the current architecture, it's not feasible. 


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
