### PR TITLE
Fix order walkthrough for iso uniqueness

### DIFF
--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -10,7 +10,7 @@ module Spree
       def up_to(state, user: nil)
         # Need to create a valid zone too...
         @zone = ::FactoryBot.create(:zone)
-        @country = ::FactoryBot.create(:country)
+        @country = Spree::Country.find_by(iso: "US") || ::FactoryBot.create(:country)
         @state = ::FactoryBot.create(:state, country: @country)
 
         @zone.members << Spree::ZoneMember.create(zoneable: @country)


### PR DESCRIPTION
## Summary

Alternatively I also considered adding `initialize_with { Spree::Country.find_or_initialize_by(iso:) }` to the factory which seems like a broader solution to making sure iso uniqueness doesn't break tests but I find `initialize_with` results in some very unintuitive behaviour so I opted to avoid it. 

If anyone wants to see the test failures, they can see [this run](https://github.com/solidusio/solidus_starter_frontend/actions/runs/24043394371/job/70120585415). Not all of the failures are from the iso issue but a bunch of them are.  

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
