### PR TITLE
fix(locale selection): Use international language icon

### DIFF
--- a/admin/app/components/solidus_admin/layout/navigation/account/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/account/component.html.erb
@@ -32,7 +32,7 @@
         <%= autosubmit_select_tag(
           "switch_to_locale",
           options_for_select(locale_options_for_select(available_locales), selected: I18n.locale),
-          icon: 'global-line',
+          icon: 'translate-2',
         ) %>
       </li>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_locale_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection.html.erb
@@ -5,7 +5,7 @@
 <% if available_locale_options_for_select.size > 1 %>
   <%= form_tag(spree.admin_set_locale_path(format: :html), method: :put, style: "width: 100%;") do %>
     <label class="admin-navbar-selection admin-locale-selection">
-      <i class="fa fa-globe fa-fw" title="<%= I18n.t('spree.choose_dashboard_locale') %>"></i>
+      <i class="fa fa-language fa-fw" title="<%= I18n.t('spree.choose_dashboard_locale') %>"></i>
       <select class="custom-select fullwidth" onchange="this.form.requestSubmit()">
         <%= options_for_select(available_locale_options_for_select, I18n.locale) %>
       </select>

--- a/backend/app/views/spree/admin/shared/_locale_selection_solidus_admin.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection_solidus_admin.html.erb
@@ -6,7 +6,7 @@
   <li>
     <%= form_tag(spree.admin_set_locale_path(format: :html), method: :put, style: "width: 100%;") do %>
       <label>
-        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-global-line"></use></svg>
+        <svg aria-hidden="true"><use xlink:href="<%= image_path('spree/backend/themes/solidus_admin/remixicon.symbol.svg') %>#ri-translate-2"></use></svg>
         <select name="switch_to_locale" onchange="this.form.requestSubmit()">
           <%= options_for_select(available_locale_options_for_select, selected: I18n.locale) %>
         </select>


### PR DESCRIPTION
## Summary

The icon for language is not a globe and not flags, because countries are not synomous to spoken languages. Using the language symbol instead.

This allows us to use the globe icon for a timezone select later.

Ref: https://languageicon.org


<img width="478" height="618" alt="CleanShot 2026-04-15 at 19 23 19@2x" src="https://github.com/user-attachments/assets/77dda31c-d7c5-40ce-a0e6-37ab62239afe" />


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
