### PR TITLE
Improve Solidus Admin Orders Loading Performance

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -162,7 +162,7 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :items,
       data: ->(order) do
-        content_tag :div, t(".columns.items", count: order.line_items.sum(:quantity))
+        content_tag :div, t(".columns.items", count: order.line_items.sum(&:quantity))
       end
     }
   end

--- a/admin/app/controllers/solidus_admin/controller_helpers/search.rb
+++ b/admin/app/controllers/solidus_admin/controller_helpers/search.rb
@@ -19,15 +19,15 @@ module SolidusAdmin::ControllerHelpers::Search
 
   private
 
-  def apply_search_to(relation, param:)
+  def apply_search_to(relation, param:, distinct: true)
     relation = apply_scopes_to(relation, param:)
-    apply_ransack_search_to(relation, param:)
+    apply_ransack_search_to(relation, param:, distinct:)
   end
 
-  def apply_ransack_search_to(relation, param:)
+  def apply_ransack_search_to(relation, param:, distinct: true)
     relation
       .ransack(params[param]&.except(:scope))
-      .result(distinct: true)
+      .result(distinct:)
   end
 
   def apply_scopes_to(relation, param:)

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -5,15 +5,15 @@ module SolidusAdmin
     include Spree::Core::ControllerHelpers::StrongParameters
     include SolidusAdmin::ControllerHelpers::Search
 
-    search_scope(:completed, default: true) { _1.complete }
-    search_scope(:canceled) { _1.canceled }
-    search_scope(:returned) { _1.with_state(:returned) }
-    search_scope(:in_progress) { _1.with_state([:cart] + _1.checkout_step_names) }
-    search_scope(:all) { _1 }
+    search_scope(:completed, default: true) { _1.complete.order(completed_at: :desc) }
+    search_scope(:canceled) { _1.canceled.order(completed_at: :desc) }
+    search_scope(:returned) { _1.with_state(:returned).order(completed_at: :desc) }
+    search_scope(:in_progress) { _1.with_state([:cart] + _1.checkout_step_names).order(id: :desc) }
+    search_scope(:all) { _1.order(id: :desc) }
 
     def index
       orders = apply_search_to(
-        Spree::Order.order(created_at: :desc, id: :desc),
+        Spree::Order,
         param: :q,
         distinct: false
       )

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -14,7 +14,8 @@ module SolidusAdmin
     def index
       orders = apply_search_to(
         Spree::Order.order(created_at: :desc, id: :desc),
-        param: :q
+        param: :q,
+        distinct: false
       )
 
       set_page_and_extract_portion_from(orders)

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -13,7 +13,7 @@ module SolidusAdmin
 
     def index
       orders = apply_search_to(
-        Spree::Order,
+        Spree::Order.includes(:line_items),
         param: :q,
         distinct: false
       )


### PR DESCRIPTION
## Summary

On data sets with a few million rows the orders view is becoming very slow. It takes around 72 seconds to load the completed scope with 8 million orders in the database.
This change is improving the loading performance slightly to around 500ms*. It also removes one N+1s in the order index view. 

*the [geared_pagination](https://github.com/basecamp/geared_pagination) gem is causing some delays because they are not unscoping the order on the count queries and that is increasing the loading time. We have to consider to move to [kaminari](https://github.com/kaminari/kaminari) instead. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [ ] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
