### PR TITLE
Persist line item action quantity when updated

### DIFF
--- a/legacy_promotions/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/legacy_promotions/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -111,6 +111,13 @@ module Spree
           line_item_action = line_item_actions.where(
             line_item_id: line_item.id
           ).first_or_initialize
+
+          if line_item_action.persisted?
+            line_item.line_item_actions
+              .find { |action| action.id == line_item_action.id }
+              .quantity = quantity
+          end
+
           line_item_action.quantity = quantity
         end
 

--- a/legacy_promotions/app/models/spree/promotion/order_adjustments_recalculator.rb
+++ b/legacy_promotions/app/models/spree/promotion/order_adjustments_recalculator.rb
@@ -70,7 +70,10 @@ module Spree
 
           adjustment.eligible = calculate_eligibility(adjustment)
 
-          adjustment.save!(validate: false) if persist
+          if persist
+            adjustment.save!(validate: false)
+            adjustment.adjustable.line_item_actions.find_all(&:changed?).each(&:save!) if adjustment.adjustable.respond_to?(:line_item_actions)
+          end
         end
         adjustment.amount
       end

--- a/legacy_promotions/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
+++ b/legacy_promotions/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
@@ -18,6 +18,35 @@ RSpec.describe Spree::Promotion::OrderAdjustmentsRecalculator do
       let(:order) { create(:order_with_line_items, line_items_count: 1, line_items_price: 10) }
       let(:line_item) { order.line_items[0] }
 
+      context "when the quantity changes with a CreateQuantityAdjustments promotion" do
+        let(:promotion) { create(:promotion, promotion_actions: [promotion_action]) }
+        let(:promotion_action) { Spree::Promotion::Actions::CreateQuantityAdjustments.new(calculator:, preferred_group_size: 2) }
+        let(:calculator) { create :calculator, preferred_amount: 5 }
+        let(:order) { create(:order_with_line_items, line_items_attributes: [{quantity: 2, price: 10}]) }
+
+        before do
+          promotion.activate(order:)
+          order.recalculate
+          line_item.update!(quantity: 5)
+        end
+
+        it "updates the promotion adjustments amount" do
+          expect {
+            subject
+          }.to change {
+            line_item.adjustments.first.amount
+          }.from(-10).to(-20)
+        end
+
+        it "updates the quantity on the line item action" do
+          expect {
+            subject
+          }.to change {
+            promotion_action.line_item_actions.reload.first.quantity
+          }.from(2).to(4)
+        end
+      end
+
       context "when the item quantity has changed" do
         let(:promotion) { create(:promotion, promotion_actions: [promotion_action]) }
         let(:promotion_action) { Spree::Promotion::Actions::CreateItemAdjustments.new(calculator:) }


### PR DESCRIPTION
## Summary

There's a test failure in Solidus Starter Frontend that pointed toward an actual issue in the legacy promotion system. We are not persisting quantity changes in some cases. It seems that if the order is recalculated then the issue is resolved but  when the quantity is adjusted or when new items are added to the cart then the quantity on the line_item_action is not persisted which further causes issues in figuring out the used quantity in the CreateQuantityAdjustments action. 

The fix requires us to find the line item action based off of the line item in memory so that it can be properly referenced later and to add a line to persist the line item actions when that is the adjustable. 

The failing test in Solidus Starter Frontend is spec/system/quantity_promotions_spec.rb:68 which can be seen failing in recent actions runs such as https://github.com/solidusio/solidus_starter_frontend/actions/runs/24611089582/job/71965516590?pr=438

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
