### PR TITLE
fix(CI): Use github format for standardrb output

### DIFF
--- a/.github/actions/install_solidus/action.yml
+++ b/.github/actions/install_solidus/action.yml
@@ -1,5 +1,7 @@
 name: "Install Solidus"
 
+description: "Test Solidus installer with different versions of Rails and Ruby."
+
 inputs:
   flags:
     type: string

--- a/.github/actions/install_solidus/action.yml
+++ b/.github/actions/install_solidus/action.yml
@@ -36,7 +36,7 @@ runs:
 
         cat $RUNNER_TEMP/.ruby-versions
         cat $RUNNER_TEMP/.gems-versions
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           /home/runner/.rubygems

--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -12,7 +12,7 @@ jobs:
   ensure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Check for the presence of a changelog label"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/install_dummy_app.yml
+++ b/.github/workflows/install_dummy_app.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       RUBY_VERSION: "3.2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -27,7 +27,7 @@ jobs:
       - name: Lint Ruby files
         run: bin/rake lint:rb
       - name: Store test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: standardrb-results
           path: test-results
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -52,7 +52,7 @@ jobs:
     env:
       ESLINT_USE_FLAT_CONFIG: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/prepare_post_release.yml
+++ b/.github/workflows/prepare_post_release.yml
@@ -21,7 +21,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'release:generate')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -15,7 +15,7 @@ jobs:
       BUNDLE_ONLY: "release"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/.github/workflows/solidus_installer.yml
+++ b/.github/workflows/solidus_installer.yml
@@ -20,7 +20,7 @@ jobs:
       DB: sqlite
       RUBY_VERSION: "3.2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install libvips
         run: |
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       LIB_NAME: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test_solidus.yml
+++ b/.github/workflows/test_solidus.yml
@@ -77,7 +77,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test_solidus_rubocops.yml
+++ b/.github/workflows/test_solidus_rubocops.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/triage_for_changelog.yml
+++ b/.github/workflows/triage_for_changelog.yml
@@ -9,8 +9,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # Uploads repository content to the runner
-      - uses: actions/labeler@v5
+      - uses: actions/checkout@v6 # Uploads repository content to the runner
+      - uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/update_release_draft.yml
+++ b/.github/workflows/update_release_draft.yml
@@ -21,7 +21,7 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'changelog:skip')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/tasks/linting.rake
+++ b/tasks/linting.rake
@@ -4,12 +4,12 @@ namespace :lint do
   task :rb do
     if ENV["CI"]
       results_dir = "#{__dir__}/../test-results"
-      sh "mkdir -p '#{results_dir}'"
-      ci_options = "--format junit "
-      ci_redirect = " > '#{results_dir}/rubocop-results.xml'"
+      system "mkdir -p '#{results_dir}'"
+      ci_options = "--format 'Standard::Formatter' --format github --format junit --out '#{results_dir}/rubocop-results.xml' "
     end
 
-    sh %{bundle exec standardrb #{ci_options}$(git ls-files -co --exclude-standard | grep -E "\\.rb$" | grep -v "/templates/")#{ci_redirect}}
+    cmd = %{bundle exec standardrb #{ci_options}$(git ls-files -co --exclude-standard | grep -E "\\.rb$" | grep -v "/templates/")}
+    system(cmd) || exit($?.exitstatus)
   end
 
   task :erb do


### PR DESCRIPTION
Currently we just [see a Ruby stacktrace](https://github.com/solidusio/solidus/actions/runs/24669841819/job/72137262697) and not any useful hint on what linting error happened in a PR.

This adds GitHub comments and only redirects the XML to the file while still printing the error and hiding the Rake stack trace. Much cleaner and more human friendly.

<img width="1714" height="570" alt="CleanShot 2026-04-22 at 18 49 02@2x" src="https://github.com/user-attachments/assets/4ea7968c-b198-4026-886c-e80deff60e31" />

<img width="2240" height="454" alt="CleanShot 2026-04-22 at 18 41 06@2x" src="https://github.com/user-attachments/assets/be37c8c9-d147-4535-805a-8dcaca899dd1" />

<img width="2290" height="448" alt="CleanShot 2026-04-22 at 18 39 02@2x" src="https://github.com/user-attachments/assets/3484e4f1-fee5-479f-9631-8277acbf98f2" />