### PR TITLE
Only fire order recalculated events after save

### DIFF
--- a/core/app/models/spree/in_memory_order_updater.rb
+++ b/core/app/models/spree/in_memory_order_updater.rb
@@ -53,10 +53,10 @@ module Spree
           end
         end
 
-        Spree::Bus.publish(:order_recalculated, order:)
-
         persist_totals if persist
       end
+
+      Spree::Bus.publish(:order_recalculated, order:) if persist
     end
     alias_method :update, :recalculate
     deprecate update: :recalculate, deprecator: Spree.deprecator

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -27,9 +27,9 @@ module Spree
           update_shipments
           recalculate_shipment_state
         end
-        Spree::Bus.publish(:order_recalculated, order:)
         persist_totals
       end
+      Spree::Bus.publish(:order_recalculated, order:)
     end
     alias_method :update, :recalculate
     deprecate update: :recalculate, deprecator: Spree.deprecator

--- a/core/spec/models/spree/in_memory_order_updater_spec.rb
+++ b/core/spec/models/spree/in_memory_order_updater_spec.rb
@@ -632,6 +632,12 @@ module Spree
 
         expect(item).to have_received(:do_something)
       end
+
+      it "does not fire the event when persist: false" do
+        updater.recalculate(persist: false)
+
+        expect(item).not_to have_received(:do_something)
+      end
     end
 
     context "with invalid associated objects" do


### PR DESCRIPTION
## Summary

The events should be published only once the transaction has completed, so any jobs fired from subscribers see the new version of the order. Also, the event bus has a job-backed backend (that I'm not sure anyone uses) so this should also fix race conditions with that.

Besides fixing race conditions with subscribers, this also ensure we don't fire the event when the order is *not* being persisted.
