### PR TITLE
Fix admin payment logs to include refund entries

### DIFF
--- a/backend/app/views/spree/admin/payments/_log_entries.html.erb
+++ b/backend/app/views/spree/admin/payments/_log_entries.html.erb
@@ -1,12 +1,14 @@
 <table class='index' id='listing_log_entries'>
   <colgroup>
-    <col style="width: 30%">
-    <col style="width: 60%">
+    <col style="width: 25%">
+    <col style="width: 15%">
+    <col style="width: 50%">
     <col style="width: 10%">
   </colgroup>
   <thead>
     <tr>
       <th><%= Spree::LogEntry.human_attribute_name(:created_at) %></th>
+      <th><%= Spree::LogEntry.human_attribute_name(:source) %></th>
       <th><%= Spree::LogEntry.human_attribute_name(:details) %></th>
       <th></th>
     </tr>
@@ -16,6 +18,9 @@
     <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
       <td>
         <%= pretty_time(entry.created_at) %>
+      </td>
+      <td>
+        <%= entry.source_type.to_s.demodulize %>
       </td>
       <td>
         <pre><%= entry.parsed_details.message %></pre>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -21,9 +21,10 @@
   </fieldset>
 <% end %>
 
-<% if @payment.log_entries.any? %>
+<% log_entries = @payment.all_log_entries %>
+<% if log_entries.any? %>
   <fieldset class="no-border-bottom">
     <legend><%= plural_resource_name(Spree::LogEntry) %></legend>
-    <%= render 'spree/admin/payments/log_entries', log_entries: @payment.log_entries %>
+    <%= render 'spree/admin/payments/log_entries', log_entries: log_entries %>
   </fieldset>
 <% end %>

--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -53,4 +53,29 @@ describe "Log entries", type: :feature do
       end
     end
   end
+
+  context "with a log entry belonging to a refund of the payment" do
+    let!(:payment) { create(:payment, amount: 100) }
+    let!(:refund) { create(:refund, payment: payment, amount: 10) }
+
+    before do
+      response = ActiveMerchant::Billing::Response.new(
+        true,
+        "Refund processed",
+        transid: "REFUND-1"
+      )
+
+      refund.log_entries.create!(details: response.to_yaml)
+    end
+
+    it "shows the refund entry on the payment page with 'Refund' as its source" do
+      visit spree.admin_order_payments_path(payment.order)
+      click_on payment.number
+
+      within("#listing_log_entries") do
+        expect(page).to have_content("Refund processed")
+        expect(page).to have_content("Refund")
+      end
+    end
+  end
 end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -94,6 +94,15 @@ module Spree
       amount - refunds.sum(:amount)
     end
 
+    # @return [ActiveRecord::Relation<Spree::LogEntry>] log entries for this
+    #   payment and its refunds, ordered by creation time
+    def all_log_entries
+      Spree::LogEntry
+        .where(source: self)
+        .or(Spree::LogEntry.where(source: refunds))
+        .order(:created_at)
+    end
+
     # @return [Boolean] true when this payment can be credited
     def can_credit?
       credit_allowed > 0

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -108,6 +108,39 @@ RSpec.describe Spree::Payment, type: :model do
     end
   end
 
+  describe "#all_log_entries" do
+    let(:payment) { create(:payment, amount: 100) }
+
+    it "is empty when neither the payment nor any refund has log entries" do
+      expect(payment.all_log_entries).to be_empty
+    end
+
+    it "includes log entries whose source is the payment itself" do
+      entry = payment.log_entries.create!(details: "a".to_yaml)
+
+      expect(payment.all_log_entries).to contain_exactly(entry)
+    end
+
+    it "includes log entries from every refund on the payment" do
+      refund_a = create(:refund, payment: payment, reason: refund_reason, amount: 10)
+      refund_b = create(:refund, payment: payment, reason: refund_reason, amount: 20)
+      refund_a_entry = refund_a.log_entries.create!(details: "a".to_yaml)
+      refund_b_entry = refund_b.log_entries.create!(details: "b".to_yaml)
+
+      expect(payment.all_log_entries).to contain_exactly(refund_a_entry, refund_b_entry)
+    end
+
+    it "merges payment and refund entries and orders them chronologically" do
+      refund = create(:refund, payment: payment, reason: refund_reason, amount: 10)
+
+      first = payment.log_entries.create!(details: "first".to_yaml, created_at: 2.minutes.ago)
+      second = refund.log_entries.create!(details: "second".to_yaml, created_at: 1.minute.ago)
+      third = payment.log_entries.create!(details: "third".to_yaml, created_at: Time.current)
+
+      expect(payment.all_log_entries.to_a).to eq([first, second, third])
+    end
+  end
+
   context "validations" do
     it "returns useful error messages when source is invalid" do
       payment.source = Spree::CreditCard.new


### PR DESCRIPTION

## Summary

Fixes [solidusio/solidus#4866](https://github.com/solidusio/solidus/issues/4866):
refund log entries not appearing on the admin payment page.

## Changes

1. **Add `Spree::Payment#all_log_entries`**
   Returns `Spree::LogEntry` records whose `source` is the payment itself or any of its refunds, ordered by `created_at`. Uses a polymorphic `where(source: ...).or(where(source: refunds))` relation — chainable, paginatable, no N+1.

2. **Update the admin payment view**
   - `backend/app/views/spree/admin/payments/show.html.erb`: renders `@payment.all_log_entries` instead of `@payment.log_entries`.
   - `backend/app/views/spree/admin/payments/_log_entries.html.erb`: new `Source` column showing `Payment` or `Refund` (via `entry.source_type.to_s.demodulize`). Column widths rebalanced from `30/60/10` to `25/15/50/10`.
