### PR TITLE
Remove redundant item total setting

### DIFF
--- a/core/app/models/spree/in_memory_order_updater.rb
+++ b/core/app/models/spree/in_memory_order_updater.rb
@@ -237,7 +237,6 @@ module Spree
 
     def persist_totals
       shipments.each(&:persist_amounts)
-      assign_item_totals
       log_state_change("payment")
       log_state_change("shipment")
       order.save!


### PR DESCRIPTION
It was an error in refactoring that led to it being called twice. The old updater is unaffected.