### PR TITLE
Don't "persist_amounts" in order recalculation

### DIFF
--- a/core/app/models/spree/in_memory_order_updater.rb
+++ b/core/app/models/spree/in_memory_order_updater.rb
@@ -236,7 +236,6 @@ module Spree
     end
 
     def persist_totals
-      shipments.each(&:persist_amounts)
       assign_item_totals
       log_state_change("payment")
       log_state_change("shipment")

--- a/core/app/models/spree/in_memory_order_updater.rb
+++ b/core/app/models/spree/in_memory_order_updater.rb
@@ -236,7 +236,6 @@ module Spree
     end
 
     def persist_totals
-      shipments.each(&:persist_amounts)
       log_state_change("payment")
       log_state_change("shipment")
       order.save!

--- a/core/spec/models/spree/in_memory_order_updater_spec.rb
+++ b/core/spec/models/spree/in_memory_order_updater_spec.rb
@@ -575,7 +575,6 @@ module Spree
 
         it "updates the shipment amount" do
           expect(shipment).to receive(:assign_amounts)
-          expect(shipment).to receive(:persist_amounts)
           updater.recalculate
         end
       end


### PR DESCRIPTION
This association is autosaved, and Rails knows not to retouch things when autosaving associated records. I did a test to confirm that removing this doesn't change whether the field is persisted.