### PR TITLE
Log refund gateway responses on payments

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -55,10 +55,13 @@ module Spree
       credit_cents = money.cents
 
       @perform_response = process!(credit_cents)
-      log_entries.build(parsed_payment_response_details_with_fallback: perform_response)
 
-      self.transaction_id = perform_response.authorization
-      save!
+      transaction do
+        self.transaction_id = perform_response.authorization
+        save!
+
+        payment.log_entries.create!(parsed_payment_response_details_with_fallback: perform_response)
+      end
 
       update_order
     end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe Spree::Refund, type: :model do
           expect(refund.reload.amount).to eq amount
         end
 
-        it "creates a log entry" do
+        it "creates a payment log entry" do
           subject
-          expect(refund.reload.log_entries).to be_present
+          expect(payment.reload.log_entries).to be_present
         end
 
         it "attempts to process a transaction" do


### PR DESCRIPTION
## Summary

- record successful refund gateway responses on the original payment instead of the refund record
- wrap the refund transaction id update and log entry creation in one database transaction
- update the refund spec to assert the payment receives the refund log entry

Closes #4866

## Notes

The admin payment page renders `@payment.log_entries`, so storing the refund response on `refund.log_entries` meant the gateway response was persisted but not visible from the payment admin view.

## Testing

- `ruby --disable=gems -c core/app/models/spree/refund.rb`
- `ruby --disable=gems -c core/spec/models/spree/refund_spec.rb`
- `git diff --check`

I attempted `bundle exec rspec core/spec/models/spree/refund_spec.rb`, but this Windows environment blocked Ruby's native `cgi/escape.so` via Application Control policy before the spec suite could boot.