### PR TITLE
Preserve Tailwind's default blue color scale

### DIFF
--- a/admin/config/tailwind.config.js
+++ b/admin/config/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
         // Secondary palette
         yellow: "#fdc071",
         orange: "#f68050",
-        blue: "#2554b1",
+        "solidus-blue": "#2554b1",
         moss: "#2d3925",
         forest: "#096756",
         midnight: "#163449",
@@ -112,7 +112,7 @@ module.exports = {
       // Add a text style for links
       addComponents({
         ".body-link": {
-          color: theme("colors.blue"),
+          color: theme("colors.solidus-blue"),
           "&:hover": {
             textDecoration: "underline",
           },


### PR DESCRIPTION
## Summary

- rename Solidus Admin's custom `blue` palette entry to `solidus-blue`
- keep `.body-link` using the Solidus brand color through the new namespaced token
- stop shadowing Tailwind's default `blue-*` color scale in host apps using the Solidus Admin preset

Closes #6405

## Notes

Tailwind presets merge theme extensions into the host app. Defining `colors.blue` as a single hex value removes the default `blue-50` through `blue-950` scale, so standard utilities such as `bg-blue-600` are unavailable. A namespaced token keeps Solidus Admin's brand color without taking over Tailwind's blue scale.

## Testing

- `node -c admin/config/tailwind.config.js`
- `git diff --check`