### PR TITLE
Install libyaml headers in Docker dev image

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -qq \
     imagemagick \
     libvips \
     libffi-dev \
+    libyaml-dev \
     libmariadb-dev \
     sqlite3 \
     libsqlite3-dev \


### PR DESCRIPTION
## Summary

- install `libyaml-dev` in the Docker development image
- provide the `yaml.h` header needed when `psych` builds native extensions during bundle install

Closes #6361

## Notes

The reported Docker build failure happens while installing `psych`:

```text
checking for yaml.h... no
yaml.h not found
```

The image already installs native build dependencies for other gems, but it does not include libyaml headers. Adding `libyaml-dev` supplies the missing header while keeping the change scoped to the development Docker image.

## Testing

- `git diff --check`

I could not run a local Docker build because Docker is not installed in this environment.