### PR TITLE
fix: eliminate 250MB+ memory spike in User promotion rule eligibility check

### DIFF
--- a/legacy_promotions/app/models/spree/promotion/rules/user.rb
+++ b/legacy_promotions/app/models/spree/promotion/rules/user.rb
@@ -12,6 +12,14 @@ module Spree
         has_many :users, through: :promotion_rule_users, class_name: Spree::UserClassHandle.new
 
         def preload_relations
+          []
+        end
+
+        # Returns relations to copy during promotion migration.
+        # Separate from preload_relations because migration needs to copy
+        # user associations, but preloading all users for eligibility
+        # checks causes massive memory allocation with large user lists.
+        def migration_relations
           [:users]
         end
 
@@ -20,7 +28,7 @@ module Spree
         end
 
         def eligible?(order, _options = {})
-          users.include?(order.user)
+          users.where(id: order.user&.id).exists?
         end
 
         def user_ids_string

--- a/legacy_promotions/app/models/spree/promotion_rule.rb
+++ b/legacy_promotions/app/models/spree/promotion_rule.rb
@@ -16,6 +16,13 @@ module Spree
       []
     end
 
+    # Returns relations to copy during promotion system migration.
+    # Defaults to preload_relations for backward compatibility with
+    # custom rules that don't override this method.
+    def migration_relations
+      preload_relations
+    end
+
     def applicable?(_promotable)
       raise NotImplementedError, "applicable? should be implemented in a sub-class of Spree::PromotionRule"
     end

--- a/legacy_promotions/spec/models/spree/promotion/rules/user_spec.rb
+++ b/legacy_promotions/spec/models/spree/promotion/rules/user_spec.rb
@@ -5,6 +5,16 @@ require "rails_helper"
 RSpec.describe Spree::Promotion::Rules::User, type: :model do
   let(:rule) { Spree::Promotion::Rules::User.new }
 
+  describe "#preload_relations" do
+    subject { rule.preload_relations }
+    it { is_expected.to eq([]) }
+  end
+
+  describe "#migration_relations" do
+    subject { rule.migration_relations }
+    it { is_expected.to eq([:users]) }
+  end
+
   context "#eligible?(order)" do
     let(:order) { Spree::Order.new }
 
@@ -13,20 +23,37 @@ RSpec.describe Spree::Promotion::Rules::User, type: :model do
     end
 
     it "should be eligible if users include user placing the order" do
-      user = mock_model(Spree::LegacyUser)
-      users = [user, mock_model(Spree::LegacyUser)]
-      allow(rule).to receive_messages(users:)
+      user = Spree::LegacyUser.create!(email: "test1@example.com")
+      rule.users << user
       allow(order).to receive_messages(user:)
 
       expect(rule).to be_eligible(order)
     end
 
     it "should not be eligible if user placing the order is not listed" do
-      allow(order).to receive_messages(user: mock_model(Spree::LegacyUser))
-      users = [mock_model(Spree::LegacyUser), mock_model(Spree::LegacyUser)]
-      allow(rule).to receive_messages(users:)
+      order_user = Spree::LegacyUser.create!(email: "order_user@example.com")
+      other_user1 = Spree::LegacyUser.create!(email: "other1@example.com")
+      other_user2 = Spree::LegacyUser.create!(email: "other2@example.com")
+      rule.users << [other_user1, other_user2]
+      allow(order).to receive_messages(user: order_user)
 
       expect(rule).not_to be_eligible(order)
+    end
+
+    it "should not be eligible if order has no user" do
+      allow(order).to receive_messages(user: nil)
+
+      expect(rule).not_to be_eligible(order)
+    end
+
+    it "uses a database query instead of loading all users into memory" do
+      user = Spree::LegacyUser.create!(email: "test_query@example.com")
+      rule.users << user
+      allow(order).to receive_messages(user:)
+
+      # eligible? should use exists? which does not load user records
+      expect(rule.users).not_to receive(:load)
+      expect(rule).to be_eligible(order)
     end
 
     # Regression test for https://github.com/spree/spree/issues/3885

--- a/promotions/app/models/solidus_promotions/condition.rb
+++ b/promotions/app/models/solidus_promotions/condition.rb
@@ -90,6 +90,13 @@ module SolidusPromotions
       []
     end
 
+    # Returns relations to copy during promotion system migration.
+    # Defaults to preload_relations for backward compatibility with
+    # custom conditions that don't override this method.
+    def migration_relations
+      preload_relations
+    end
+
     # Determines if this condition can be applied to a given promotable object.
     #
     # @param _promotable [Object] The object to check (e.g., Spree::Order, Spree::LineItem)

--- a/promotions/app/models/solidus_promotions/conditions/user.rb
+++ b/promotions/app/models/solidus_promotions/conditions/user.rb
@@ -14,11 +14,19 @@ module SolidusPromotions
       has_many :users, through: :condition_users, class_name: Spree::UserClassHandle.new
 
       def preload_relations
+        []
+      end
+
+      # Returns relations to copy during promotion migration.
+      # Separate from preload_relations because migration needs to copy
+      # user associations, but preloading all users for eligibility
+      # checks causes massive memory allocation with large user lists.
+      def migration_relations
         [:users]
       end
 
       def order_eligible?(order, _options = {})
-        users.include?(order.user)
+        users.where(id: order.user&.id).exists?
       end
 
       def user_ids_string

--- a/promotions/lib/solidus_promotions/promotion_migrator.rb
+++ b/promotions/lib/solidus_promotions/promotion_migrator.rb
@@ -96,7 +96,7 @@ module SolidusPromotions
         new_promo_condition_class.call(old_promotion_rule)
       else
         new_condition = new_promo_condition_class.new(old_promotion_rule.attributes.except(*PROMOTION_IGNORED_ATTRIBUTES))
-        new_condition.preload_relations.each do |relation|
+        new_condition.migration_relations.each do |relation|
           new_condition.send(:"#{relation}=", old_promotion_rule.send(relation))
         end
         [new_condition]

--- a/promotions/spec/models/solidus_promotions/conditions/user_spec.rb
+++ b/promotions/spec/models/solidus_promotions/conditions/user_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe SolidusPromotions::Conditions::User, type: :model do
 
   describe "#preload_relations" do
     subject { condition.preload_relations }
+    it { is_expected.to eq([]) }
+  end
+
+  describe "#migration_relations" do
+    subject { condition.migration_relations }
     it { is_expected.to eq([:users]) }
   end
 
@@ -35,20 +40,37 @@ RSpec.describe SolidusPromotions::Conditions::User, type: :model do
     end
 
     it "is eligible if users include user placing the order" do
-      user = mock_model(Spree::LegacyUser)
-      users = [user, mock_model(Spree::LegacyUser)]
-      allow(condition).to receive_messages(users: users)
+      user = Spree::LegacyUser.create!(email: "test1@example.com")
+      condition.users << user
       allow(order).to receive_messages(user: user)
 
       expect(condition).to be_eligible(order)
     end
 
     it "is not eligible if user placing the order is not listed" do
-      allow(order).to receive_messages(user: mock_model(Spree::LegacyUser))
-      users = [mock_model(Spree::LegacyUser), mock_model(Spree::LegacyUser)]
-      allow(condition).to receive_messages(users: users)
+      order_user = Spree::LegacyUser.create!(email: "order_user@example.com")
+      other_user1 = Spree::LegacyUser.create!(email: "other1@example.com")
+      other_user2 = Spree::LegacyUser.create!(email: "other2@example.com")
+      condition.users << [other_user1, other_user2]
+      allow(order).to receive_messages(user: order_user)
 
       expect(condition).not_to be_eligible(order)
+    end
+
+    it "is not eligible if order has no user" do
+      allow(order).to receive_messages(user: nil)
+
+      expect(condition).not_to be_eligible(order)
+    end
+
+    it "uses a database query instead of loading all users into memory" do
+      user = Spree::LegacyUser.create!(email: "test_query@example.com")
+      condition.users << user
+      allow(order).to receive_messages(user: user)
+
+      # eligible? should use exists? which does not load user records
+      expect(condition.users).not_to receive(:load)
+      expect(condition).to be_eligible(order)
     end
 
     # Regression test for https://github.com/spree/spree/issues/3885


### PR DESCRIPTION
`PromotionHandler::Cart` (legacy) and `LoadPromotions` (new promotion system) preload all users associated with promotion rules. When a store has thousands of users in `promotion_rules_users`, this causes 250MB+ RAM spikes per cart update request.

**Root cause:**

Two things compound:
1. `preload_relations` declared `[:users]`, telling the preloader to load all user records
2. `eligible?` used `users.include?(order.user)`, which requires all users in memory for Ruby's `Enumerable#include?`

**What changed:**

1. **`eligible?` now uses `exists?` instead of `include?`** — generates `SELECT 1 ... LIMIT 1` instead of loading all records into an Array. Applied to both legacy (`Spree::Promotion::Rules::User`) and new (`SolidusPromotions::Conditions::User`) promotion systems.

2. **Separated `preload_relations` from `migration_relations`** — `preload_relations` now returns `[]` (no preloading during requests), while a new `migration_relations` method preserves `[:users]` for the promotion system migration path. The `PromotionMigrator` uses `migration_relations` instead of `preload_relations`. Base classes default `migration_relations` to `preload_relations` for backward compatibility with all existing custom rules.

**Why `migration_relations` instead of just removing preloading:**

The `preload_relations` mechanism is also used by `PromotionMigrator` to copy associations when migrating from the legacy to new promotion system. Simply removing `[:users]` from `preload_relations` would break migration. The separation keeps the migration path intact while eliminating the per-request memory spike.

**Files changed:**

| File | Change |
|------|--------|
| `Spree::Promotion::Rules::User` | `preload_relations` → `[]`, added `migration_relations`, `eligible?` uses `exists?` |
| `SolidusPromotions::Conditions::User` | Same changes for new promotion system |
| `Spree::PromotionRule` | Added `migration_relations` base method |
| `SolidusPromotions::Condition` | Added `migration_relations` base method |
| `PromotionMigrator` | Uses `migration_relations` instead of `preload_relations` |
| Both test files | Updated mocks to real DB records, added `exists?` and nil user tests |

Closes #4696