### PR TITLE
fix(refunds): persist log entries when processing refunds

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -55,7 +55,7 @@ module Spree
       credit_cents = money.cents
 
       @perform_response = process!(credit_cents)
-      log_entries.build(parsed_payment_response_details_with_fallback: perform_response)
+      log_entries.create!(parsed_payment_response_details_with_fallback: perform_response)
 
       self.transaction_id = perform_response.authorization
       save!

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe Spree::Refund, type: :model do
           expect(refund.reload.log_entries).to be_present
         end
 
+        it "persists the log entry with correct source" do
+          subject
+          entry = Spree::LogEntry.find_by(source: refund)
+          expect(entry).not_to be_nil
+          expect(entry.source_type).to eq("Spree::Refund")
+          expect(entry.parsed_details).to be_present
+        end
+
         it "attempts to process a transaction" do
           expect(payment.payment_method).to receive(:credit).once.and_call_original
           subject


### PR DESCRIPTION
## Summary

When processing a refund via `Refund#perform!`, the log entry recording the gateway response is built in memory but may not be persisted to the database. This means the admin payment page shows no log entry for the refund operation.

**Root cause**: `log_entries.build` creates an in-memory association that relies on Rails' save cascade behavior. The Payment model uses `log_entries.create!` for the same purpose, which guarantees immediate persistence.

**Fix**: Change `log_entries.build` to `log_entries.create!` in `Refund#perform!`, matching the established pattern in `Payment#record_response`.

Closes #4866

## How to reproduce

1. Complete a payment on the storefront
2. Go to admin, capture the payment
3. Refund the payment
4. Check for log entries on the payment page
5. **Before fix**: no log entry for the refund operation
6. **After fix**: log entry is persisted and queryable

## What changed

- `core/app/models/spree/refund.rb` — Changed `log_entries.build` to `log_entries.create!`
- `core/spec/models/spree/refund_spec.rb` — Added regression test verifying log entry persistence with correct source type

## Trade-offs

`create!` persists the log entry immediately, before the refund itself is saved. If the refund save fails after the gateway credit succeeds, the log entry remains in the DB. This is the same behavior as `Payment#record_response` and is acceptable because the gateway operation is already irreversible at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)