### PR TITLE
Skip undefined classes in Spree::LogEntry permitted_classes

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -59,7 +59,15 @@ module Spree
     end
 
     def self.permitted_classes
-      CORE_PERMITTED_CLASSES + Spree::Config.log_entry_permitted_classes.map(&:constantize)
+      # A missing configured class (e.g. a gateway gem dropped a serialized payload class)
+      # would otherwise crash every payment view that loads any log entry.
+      configured = Spree::Config.log_entry_permitted_classes.filter_map do |class_name|
+        class_name.constantize
+      rescue NameError
+        Rails.logger.warn("Spree::LogEntry: ignoring missing permitted class #{class_name.inspect}")
+        nil
+      end
+      CORE_PERMITTED_CLASSES + configured
     end
 
     belongs_to :source, polymorphic: true, optional: true

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -3,6 +3,20 @@
 require "rails_helper"
 
 RSpec.describe Spree::LogEntry, type: :model do
+  describe ".permitted_classes" do
+    it "skips configured classes that are no longer defined" do
+      stub_spree_preferences(
+        log_entry_permitted_classes: ["Date", "Spree::NoLongerDefinedExampleClass"]
+      )
+
+      expect { described_class.permitted_classes }.not_to raise_error
+      expect(described_class.permitted_classes).to include(Date)
+      expect(described_class.permitted_classes).to match_array(
+        described_class::CORE_PERMITTED_CLASSES + [Date]
+      )
+    end
+  end
+
   describe "#parsed_details" do
     it "allows aliases by default" do
       x = []
@@ -51,6 +65,16 @@ RSpec.describe Spree::LogEntry, type: :model do
       log_entry = described_class.new(details: Date.today)
 
       expect { log_entry.parsed_details }.to raise_error(described_class::DisallowedClass, /log_entry_permitted_classes/)
+    end
+
+    it "still parses known classes when the configured permitted list contains a missing class" do
+      stub_spree_preferences(
+        log_entry_permitted_classes: ["Spree::NoLongerDefinedExampleClass"]
+      )
+      response = ActiveMerchant::Billing::Response.new("success", "message")
+      log_entry = described_class.new(details: response.to_yaml)
+
+      expect { log_entry.parsed_details }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
When a payment gateway gem upgrade removes a class that's still listed in `Spree::Config.log_entry_permitted_classes` (e.g. Braintree v3 dropping `AndroidPayDetails`), `name.constantize` raised `NameError` and crashed every admin payment view that loaded any log entry.

Skip missing classes with a warning log instead. YAML payloads that actually reference the removed class still raise the existing `DisallowedClass` error via Psych — which callers already handle — rather than a hard crash at config-resolution time.

Closes #4934

## Summary

<!--
  Please include a summary of your changes, along with any useful context.
  Your contribution will be merged under the terms of the license of the parent repository (usually a FreeBSD License).

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
