### PR TITLE
Allow opting countries out of states_required at seed time

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -7,13 +7,17 @@ require "carmen"
 
 connection = Spree::Base.connection
 
+countries_not_requiring_states = Spree::Config[:countries_not_requiring_states]
+
 country_mapper = ->(country) do
   name = connection.quote country.name
   iso3 = connection.quote country.alpha_3_code
   iso = connection.quote country.alpha_2_code
   iso_name = connection.quote country.name.upcase
   numcode = connection.quote country.numeric_code
-  states_required = connection.quote country.subregions?
+  states_required = connection.quote(
+    country.subregions? && countries_not_requiring_states.exclude?(country.alpha_2_code)
+  )
 
   [name, iso3, iso, iso_name, numcode, states_required].join(", ")
 end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -276,6 +276,15 @@ module Spree
     #   (default: +['IT']+)
     preference :countries_that_use_nested_subregions, :array, default: ["IT"]
 
+    # @!attribute [rw] countries_not_requiring_states
+    #   @return [Array] An array of ISO alpha-2 country codes whose addresses do not
+    #   require a state, even though Carmen exposes subregions for them. Used at
+    #   country-seeding time to override `Spree::Country#states_required`. Germany is
+    #   the canonical case: PayPal/Braintree return no state for German addresses,
+    #   which would otherwise fail address validation at checkout.
+    #   (default: +['DE']+)
+    preference :countries_not_requiring_states, :array, default: ["DE"]
+
     # @!attribute [rw] send_core_emails
     #   @return [Boolean] Whether to send transactional emails (default: true)
     preference :send_core_emails, :boolean, default: true

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -15,6 +15,9 @@ FactoryBot.define do
     iso3 { carmen_country.alpha_3_code }
     numcode { carmen_country.numeric_code }
 
-    states_required { carmen_country.subregions? }
+    states_required do
+      carmen_country.subregions? &&
+        Spree::Config[:countries_not_requiring_states].exclude?(carmen_country.alpha_2_code)
+    end
   end
 end

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -103,6 +103,24 @@ RSpec.describe Spree::Country, type: :model do
     end
   end
 
+  describe "factory states_required default" do
+    it "is false for countries listed in countries_not_requiring_states (Germany by default)" do
+      germany = build(:country, iso: "DE")
+      expect(germany.states_required).to be(false)
+    end
+
+    it "is true for countries with subregions that aren't excluded" do
+      united_states = build(:country, iso: "US")
+      expect(united_states.states_required).to be(true)
+    end
+
+    it "honors a custom countries_not_requiring_states configuration" do
+      stub_spree_preferences(countries_not_requiring_states: ["IT"])
+      italy = build(:country, iso: "IT")
+      expect(italy.states_required).to be(false)
+    end
+  end
+
   describe "#prices" do
     let(:country) { create(:country, iso: "BR") }
     subject { country.prices }


### PR DESCRIPTION
Carmen exposes German Bundesländer as subregions, so the default seeder marks Germany's `Spree::Country#states_required` as `true`. PayPal and Braintree do not return state data for German addresses, which then fails Solidus's address validation at checkout.

Introduce a `countries_not_requiring_states` preference (default `["DE"]`) and consult it from both the country seeder and the country factory. The `Spree::Country.iso == "DE"` row will be seeded with `states_required = false` going forward, and host applications can extend the list (e.g. `["DE", "ES"]`) without monkey-patching the seeder.

Existing seeded databases keep their current values; this only affects new installs and freshly created `Spree::Country` records.

Closes #3803

## Summary

<!--
  Please include a summary of your changes, along with any useful context.
  Your contribution will be merged under the terms of the license of the parent repository (usually a FreeBSD License).

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
