### PR TITLE
Exclude canceled inventory units from Shipment#to_package

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -262,7 +262,9 @@ module Spree
     def to_package
       package = Stock::Package.new(stock_location)
       package.shipment = self
-      inventory_units.includes(variant: :product).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
+      # Canceled units must not contribute to shipping rate calculation: every
+      # caller of this method feeds the result to the shipping estimator/calculators.
+      inventory_units.not_canceled.includes(variant: :product).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
         package.add_multiple state_inventory_units, state.to_sym
       end
       package

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Spree::Shipment, type: :model do
         before do
           allow(line_item).to receive(:order) { order }
           shipment.inventory_units = inventory_units
-          allow(shipment.inventory_units).to receive_message_chain(:includes, :joins).and_return inventory_units
+          allow(shipment.inventory_units).to receive_message_chain(:not_canceled, :includes, :joins).and_return inventory_units
         end
 
         it "should use symbols for states when adding contents to package" do
@@ -315,6 +315,20 @@ RSpec.describe Spree::Shipment, type: :model do
 
         it "should set the shipment to itself" do
           expect(shipment.to_package.shipment).to eq(shipment)
+        end
+
+        context "with a canceled inventory unit on the shipment" do
+          let(:order_with_units) { create(:order_ready_to_ship, line_items_count: 2) }
+          let(:real_shipment) { order_with_units.shipments.first }
+
+          it "excludes canceled inventory units from the package" do
+            kept_unit, canceled_unit = real_shipment.inventory_units.to_a
+            canceled_unit.update_columns(state: "canceled")
+
+            package = real_shipment.to_package
+
+            expect(package.contents.map(&:inventory_unit)).to contain_exactly(kept_unit)
+          end
         end
       end
     end


### PR DESCRIPTION
`Shipment#to_package` is the single source of input for shipping rate calculation: `Shipment#refresh_rates`, `Shipment#select_shipping_method`, and `Spree::Api::ShipmentsController#estimate_rates` all feed its output into the configured shipping estimator and calculators.

Cancelled inventory units (`InventoryUnit#state == "canceled"`) were still being grouped into the package's contents, which caused per-item and percent-of-total shipping calculators to bill for goods that will never ship. Filtering with the existing `InventoryUnit.not_canceled` scope keeps remaining units on the shipment available for rate calculation while ensuring cancelled units no longer contribute.

Closes #1837

## Summary

<!--
  Please include a summary of your changes, along with any useful context.
  Your contribution will be merged under the terms of the license of the parent repository (usually a FreeBSD License).

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
