### PR TITLE
Fix docker development build (closes #6361)

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -qq \
     libvips \
     libffi-dev \
     libmariadb-dev \
+    libyaml-dev \
     sqlite3 \
     libsqlite3-dev \
     chromium \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: .dockerdev
       dockerfile: Dockerfile
       args:
-        RUBY_VERSION: "3.1"
+        RUBY_VERSION: "3.4"
         PG_VERSION: 13
         NODE_VERSION: 20
         MYSQL_VERSION: "8.0"
@@ -34,7 +34,7 @@ services:
       CAPYBARA_DRIVER: selenium_chrome_headless_docker_friendly
       DB_USERNAME: root
       DB_PASSWORD: password
-      RAILS_VERSION: ${RAILS_VERSION:-~> 7.1.0}
+      RAILS_VERSION: ${RAILS_VERSION:-~> 8.0.0}
       DB_ALL: "1"
       DB_MYSQL_HOST: mysql
       DB_POSTGRES_HOST: postgres


### PR DESCRIPTION
## Summary

The development docker image (`docker compose build app`) currently fails on a fresh checkout because three defaults in `.dockerdev/Dockerfile` and `docker-compose.yml` have drifted from the rest of the project:

1. `psych` gem cannot compile its native extension because **`libyaml-dev`** (which provides `yaml.h`) is not installed in the base image — this is the failure surfaced in #6361.
2. `RUBY_VERSION` defaulted to **`"3.1"`**, but `solidus.gemspec` requires `>= 3.2`.
3. `RAILS_VERSION` defaulted to **`"~> 7.1.0"`**, but the Gemfile requires `> 7.2`.

The Ruby/Rails defaults are bumped to **3.4 / 8.0**, which match the combination already exercised by `.github/workflows/test_solidus.yml` and used for the JS test job.

## Changes

- `.dockerdev/Dockerfile`: add `libyaml-dev` to the apt install list (grouped with the other `lib*-dev` packages).
- `docker-compose.yml`: bump `RUBY_VERSION` build arg from `"3.1"` → `"3.4"`, bump `RAILS_VERSION` default from `~> 7.1.0` → `~> 8.0.0`.

## Verification

`docker compose build app` was run on a clean checkout (Docker Desktop 29.1.3) and completes successfully:

```
#5 [ 1/10] FROM docker.io/library/ruby:3.4-slim-bookworm
...
#15 naming to docker.io/library/solidus-4.8.0.dev:latest done
```

## Out of scope

This addresses the build break but does not attempt a broader refresh of the docker dev environment — the `version: '3.7'` compose attribute is now obsolete and emits a warning, postgres is still pinned to `13.2`, and `Dockerfile` ARGs have no defaults so the image cannot be built without compose. Those feel like a separate cleanup pass.

Closes #6361.
