### PR TITLE
Hide fully-cartoned shipments on the admin order page (#3357)

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -4,6 +4,7 @@
   ).items.sort_by { |item| item.line_item.created_at }
 %>
 
+<% if manifest_items.any? %>
 <div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">
   <fieldset class="no-border-bottom">
     <legend align="center" class="stock-location" data-hook="stock-location">
@@ -66,3 +67,4 @@
     </tbody>
   </table>
 </div>
+<% end %>

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -23,6 +23,18 @@ describe "Shipments", type: :feature do
     end
   end
 
+  # Regression test for https://github.com/solidusio/solidus/issues/3357
+  context "an order whose units have all been moved into a carton" do
+    let!(:order) { create(:shipped_order, number: "R200") }
+
+    it "does not render the now-empty shipment alongside the carton" do
+      visit spree.edit_admin_order_path(order)
+
+      expect(page).to have_selector("[data-hook='admin_carton_form']")
+      expect(page).not_to have_selector("[data-hook='admin_shipment_form']")
+    end
+  end
+
   context "shipping an order", js: true do
     before(:each) do
       visit spree.admin_path


### PR DESCRIPTION
## Summary

Closes #3357.

The admin order edit page renders a "Shipped package from 'X'" legend twice for fully-shipped orders: once from the `Carton` partial and once from the `Shipment` partial that the carton was created from. The reporter's screenshot shows the visual confusion this causes — admins see two rows that look like distinct packages but represent the same items.

## Approach

The `Shipment` partial already filters its manifest to inventory units with `carton_id IS NULL`. When that filter returns an empty list (i.e., every inventory unit has been moved into a Carton), the partial has nothing meaningful left to show:

- no items to display in the manifest table,
- no "Ship" action to expose (the shipment is already shipped),
- no tracking — that authoritatively lives on the Carton.

So this PR skips rendering the `Shipment` partial entirely in that case. The `Carton` partial remains the single source of truth for fully-shipped packages, and in-progress shipments (with any non-cartoned units) render unchanged.

## Test

Added a non-JS feature spec:

```
Shipments
  an order whose units have all been moved into a carton
    does not render the now-empty shipment alongside the carton
```

Verified the spec **fails on `main`** with the exact symptom reported in #3357 ("`H... - Shipped package from 'NY Warehouse'`" matching `[data-hook='admin_shipment_form']`) and **passes** with the fix applied. Existing shipment specs continue to pass.

## Trade-offs / alternatives considered

- **Filter at the call site (`_form.html.erb`)** instead of inside the partial — rejected because it would either trigger N+1 (`shipments.select { |s| s.inventory_units.where(carton_id: nil).any? }`) or push a more complex SQL filter into the view. Skipping render at the partial boundary keeps the change local and avoids any query restructuring.
- **A larger refactor** along the lines of #4319 (RFC: nest cartons under shipments, possibly extract cartons into their own admin tab) — out of scope for a bug fix; this PR is intentionally minimal so the visible duplication can ship without waiting on a product decision about cartons.

## Out of scope

- The Carton partial still has its own quirks (e.g., it doesn't show special-instructions like the Shipment partial does) — left untouched.
- No i18n changes.
