### PR TITLE
Allow temporary_address via the checkout API (#2845)

### DIFF
--- a/api/spec/requests/spree/api/checkouts_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_spec.rb
@@ -109,6 +109,20 @@ module Spree::Api
           expect(response.status).to eq(200)
         end
 
+        # Regression test for https://github.com/solidusio/solidus/issues/2845
+        it "does not persist the address to the user's address book when temporary_address is set" do
+          expect_any_instance_of(Spree.user_class).not_to receive(:persist_order_address)
+
+          put spree.api_checkout_path(order),
+            params: {order_token: order.guest_token, order: {
+              temporary_address: true,
+              bill_address_attributes: address,
+              ship_address_attributes: address
+            }}
+
+          expect(response.status).to eq(200)
+        end
+
         # Regression Spec for https://github.com/spree/spree/issues/5389 and https://github.com/spree/spree/issues/5880
         it "can update addresses but not transition to delivery w/o shipping setup" do
           Spree::ShippingMethod.all.find_each(&:destroy)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -153,6 +153,7 @@ module Spree
     @@checkout_address_attributes = [
       :use_billing,
       :use_shipping,
+      :temporary_address,
       :email,
       bill_address_attributes: address_attributes,
       ship_address_attributes: address_attributes


### PR DESCRIPTION
## Summary

Closes #2845.

`Spree::Order` has long had a transient `temporary_address` attribute that, when truthy, suppresses persisting the order's address to the user's address book on transition out of the `address` step. The model behavior is exercised by `core/spec/models/spree/order/checkout_spec.rb` ("does not call persist_order_address on the order's user for a temporary address").

The checkout API never permitted that attribute, so an API consumer had no way to opt out of address-book persistence — exactly the problem the reporter describes in #2845.

## Change

Add `:temporary_address` to `Spree::PermittedAttributes.checkout_address_attributes`. That's the single permitted-params list used by `Spree::Api::CheckoutsController#update_params` when the order is in the `:address` step.

Default behavior is unchanged: the attribute defaults to `nil`/falsey, and `persist_user_address!` continues to call `persist_order_address` whenever the param isn't explicitly set to a truthy value. This is strictly additive — no existing API contract changes.

## Test

Added a regression spec under `api/spec/requests/spree/api/checkouts_spec.rb`:

```
Checkouts
  PUT 'update'
    transitioning to delivery
      does not persist the address to the user's address book when temporary_address is set
```

Confirmed the spec **fails on `main`** (the param is silently dropped by strong-params, so persistence still fires) and **passes** with the change applied.

## Notes

- The attribute is intentionally placed in `checkout_address_attributes` rather than a more general `order_attributes` list, since persistence only happens during the address-step transition and that's the only step where opting out is meaningful.
- Reporter mentioned a related concern about going-back-and-editing addresses also persisting — that's a different code path (the second persistence is happening because the *new* address has `bill_address_id` set the second time too). Worth a separate look but out of scope here.
