### PR TITLE
Fix FlatRate calculator to always return BigDecimal

### DIFF
--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -9,9 +9,9 @@ module Spree
 
     def compute(object = nil)
       if object && preferred_currency.casecmp(object.currency).zero?
-        preferred_amount
+        BigDecimal(preferred_amount.to_s)
       else
-        0
+        BigDecimal("0")
       end
     end
   end

--- a/core/spec/models/spree/calculator/flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flat_rate_spec.rb
@@ -48,5 +48,32 @@ RSpec.describe Spree::Calculator::FlatRate, type: :model do
       calculator.preferred_currency = "GBP"
       expect(calculator.compute.round(2)).to eq(0.0)
     end
+    context "return type" do
+    it "always returns a BigDecimal when currency matches" do
+      calculator.preferred_amount = 25.0
+      calculator.preferred_currency = "USD"
+      allow(order).to receive_messages currency: "USD"
+      expect(calculator.compute(order)).to be_a(BigDecimal)
+    end
+
+    it "always returns a BigDecimal when currency does not match" do
+      calculator.preferred_amount = 100.0
+      calculator.preferred_currency = "GBP"
+      allow(order).to receive_messages currency: "USD"
+      expect(calculator.compute(order)).to be_a(BigDecimal)
+    end
+
+    it "always returns a BigDecimal when there is no object" do
+      calculator.preferred_amount = 100.0
+      expect(calculator.compute).to be_a(BigDecimal)
+    end
+
+    it "always returns a BigDecimal when amount is zero" do
+      calculator.preferred_amount = 0
+      calculator.preferred_currency = "USD"
+      allow(order).to receive_messages currency: "USD"
+      expect(calculator.compute(order)).to be_a(BigDecimal)
+    end
+  end
   end
 end


### PR DESCRIPTION
The compute method was returning Integer 0 instead of BigDecimal when the currency didn't match or when no object was passed. This caused warnings like 'FlatRate#compute returned 0, it should return a BigDecimal'.

Changes:
- Wrap both return values in BigDecimal() explicitly
- Added 4 tests asserting BigDecimal return type in all code paths

Fixes #3756

## Summary

## What does this PR do?
Fixes the FlatRate calculator to always return a BigDecimal.

## Why is this needed?
Fixes #3756

The compute method returned Integer 0 instead of BigDecimal when
the currency didn't match or no object was passed, causing warnings:
"Spree::Calculator::FlatRate#compute returned 0, it should return a BigDecimal"

## How was this tested?
Added 4 RSpec tests asserting BigDecimal return type across all code paths.

## Checklist
- [x] Tests added
- [x] Follows Rails conventions
- [x] Commit message is clear