### PR TITLE
Add uniqueness validation to StockLocation name

### DIFF
--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -23,7 +23,7 @@ module Spree
     has_many :shipping_method_stock_locations, dependent: :destroy
     has_many :shipping_methods, through: :shipping_method_stock_locations
 
-    validates :name, presence: true
+    validates :name, presence: true, uniqueness: { case_sensitive: false}
     validates :code, uniqueness: {allow_blank: true, case_sensitive: false}
 
     scope :active, -> { where(active: true) }

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :stock_location, class: "Spree::StockLocation" do
-    name { "NY Warehouse" }
+    sequence(:name) { |n| "NY Warehouse #{n}" }
     address1 { "1600 Pennsylvania Ave NW" }
     city { "Washington" }
     zipcode { "20500" }

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -5,6 +5,32 @@ require "rails_helper"
 module Spree
   RSpec.describe StockLocation, type: :model do
     subject(:stock_location) { create(:stock_location_with_items, backorderable_default: true) }
+      describe "validations" do
+      it "is invalid without a name" do
+        stock_location = build(:stock_location, name: nil)
+        expect(stock_location).not_to be_valid
+        expect(stock_location.errors[:name]).to include("can't be blank")
+      end
+
+      it "is invalid with a duplicate name" do
+        create(:stock_location, name: "Warehouse A")
+        duplicate = build(:stock_location, name: "Warehouse A")
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:name]).to include("has already been taken")
+      end
+
+      it "is case-insensitively unique" do
+        create(:stock_location, name: "warehouse a")
+        duplicate = build(:stock_location, name: "WAREHOUSE A")
+        expect(duplicate).not_to be_valid
+      end
+
+      it "allows different names" do
+        create(:stock_location, name: "Warehouse A")
+        different = build(:stock_location, name: "Warehouse B")
+        expect(different).to be_valid
+      end
+    end
     let(:stock_item) { subject.stock_items.order(:id).first }
     let(:variant) { stock_item.variant }
 


### PR DESCRIPTION
StockLocation names were validated for presence but not uniqueness, allowing duplicate names to be created programmatically or via the API.

Changes:
- Added case-insensitive uniqueness validation on name
- Updated factory to use sequence for unique names in tests
- Added test coverage for duplicate, case-insensitive, and valid cases

Fixes a data integrity gap where two stock locations could share the same name, causing confusion in fulfillment workflows.

## Summary

## What does this PR do?
Adds uniqueness validation to StockLocation name.

## Why is this needed?
StockLocation names were validated for presence but not uniqueness,
allowing duplicate names to be created via the API or programmatically.

## How was this tested?
Added 4 RSpec tests covering duplicate, case-insensitive, and valid cases.
Updated factory to use sequences to prevent test collisions.

## Checklist
- [x] Tests added
- [x] Follows Rails conventions
- [x] Commit message is clear