### PR TITLE
Adds 'Visible' (by customer) checkbox to Legacy UI admin orders

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/orders/index.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/index.js
@@ -1,2 +1,16 @@
 //= require spree/backend/orders/edit
 //= require spree/backend/orders/cart
+$(document).ready(function() {
+  $('.js-frontend-viewable-toggle').on('change', function() {
+    var $checkbox = $(this);
+    $.ajax({
+      url: $checkbox.data('url'),
+      type: 'PATCH',
+      data: { order: { frontend_viewable: $checkbox.is(':checked') } },
+      error: function() { 
+        show_flash('error', 'Failed');
+        $checkbox.prop('checked', !$checkbox.is(':checked'));
+      }
+    });
+  });
+});

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -105,6 +105,26 @@ module Spree
         end
       end
 
+      # PATCH
+      def update
+        @order = Spree::Order.find_by!(number: params[:id])
+
+        if @order.update(order_params)
+          respond_to do |format|
+            format.html do
+              flash[:success] = t('spree.admin.updated')
+              redirect_to edit_admin_order_path(@order), status: :see_other
+            end
+            format.json { head :no_content }
+          end
+        else
+          respond_to do |format|
+            format.html { render :edit }
+            format.json { render json: @order.errors, status: :unprocessable_entity }
+          end
+        end
+      end
+
       # PUT
       def complete
         @order.complete!
@@ -161,9 +181,8 @@ module Spree
       def order_params
         {
           created_by_id: spree_current_user.try(:id),
-          frontend_viewable: false,
           store_id: current_store.try(:id)
-        }.with_indifferent_access
+        }.merge(params[:order]&.permit(:frontend_viewable) || {}).with_indifferent_access
       end
 
       def load_order

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -39,6 +39,7 @@
 <% if @orders.any? %>
   <table class="index" id="listing_orders" data-hook>
     <colgroup>
+       <col style="width: 5%;">
        <col style="width: 13%;">
        <col style="width: 10%;">
        <col style="width: 10%;">
@@ -52,6 +53,7 @@
     </colgroup>
     <thead>
       <tr data-hook="admin_orders_index_headers">
+        <th><%= sort_link @search, :frontend_viewable, Spree::Order.human_attribute_name(:frontend_viewable) %></th>
         <% if @show_only_completed %>
           <th><%= sort_link @search, :completed_at %></th>
         <% else %>
@@ -71,6 +73,12 @@
     <tbody>
     <% @orders.each do |order| %>
       <tr data-hook="admin_orders_index_rows">
+        <td class="align-center">
+          <%= check_box_tag "frontend_viewable_#{order.id}", 1, order.frontend_viewable, 
+            class: 'js-frontend-viewable-toggle', 
+            data: { url: admin_order_path(order) } 
+          %>
+        </td>
         <td><%= l (@show_only_completed ? order.completed_at : order.created_at).to_date %></td>
         <td><%= link_to order.number, edit_admin_order_path(order) %></td>
         <td>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
         name: Name
         presentation: Presentation
       spree/order:
+        frontend_viewable: 'Visible'
         additional_tax_total: Tax
         approved_at: Approved at
         approver_id: Approver


### PR DESCRIPTION
## Summary

This change only addresses the Legacy UI.
This pull request adds a 'Visible' checkbox to the Legacy UI admin orders table.
<img width="1630" height="137" alt="solidus-admin_orders_visible_checkbox" src="https://github.com/user-attachments/assets/2059632d-f527-4034-ab8a-6103f6bcb408" />
The checked state will be the current frontend_viewable boolean value of that order.
When new orders are created, frontend_viewable is set to true by default.
Previously, order_params had been hardcoding it false.

Updates issue [#6365](https://github.com/solidusio/solidus/issues/6365)

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📸 I have attached screenshots to demo visual changes.