### PR TITLE
add chekbox to make order visible by customer

### DIFF
--- a/admin/app/components/solidus_admin/orders/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/index/component.rb
@@ -97,7 +97,8 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
       total_column,
       items_column,
       payment_column,
-      shipment_column
+      shipment_column,
+      frontend_viewable_column 
     ]
   end
 
@@ -181,6 +182,29 @@ class SolidusAdmin::Orders::Index::Component < SolidusAdmin::UI::Pages::Index::C
       header: :shipment,
       data: ->(order) do
         component("ui/badge").new(name: order.shipment_state.humanize, color: order.shipped? ? :green : :yellow) if order.shipment_state?
+      end
+    }
+  end
+
+  def frontend_viewable_column
+    {
+      col: { class: "w-[100px]" },
+      header: :visible,
+      data: ->(order) do
+        content_tag :div, class: "flex justify-center items-center" do
+          content_tag :form, action: solidus_admin.order_path(order), method: :post do
+            content_tag(:input, nil, type: :hidden, name: "_method", value: "patch") +
+            content_tag(:input, nil, type: :hidden, name: "authenticity_token", value: form_authenticity_token) +
+            content_tag(:input, nil, type: :hidden, name: "order[frontend_viewable]", value: "0") +
+            render(component("ui/checkbox").new(
+              name: "order[frontend_viewable]",
+              value: "1",
+              checked: order.frontend_viewable?,
+              onchange: "this.form.submit()",
+              size: :s
+            ))
+          end
+        end
       end
     }
   end

--- a/admin/app/components/solidus_admin/orders/index/component.yml
+++ b/admin/app/components/solidus_admin/orders/index/component.yml
@@ -3,6 +3,9 @@ en:
     items:
       one: 1 Item
       other: '%{count} Items'
+    frontend_viewable:
+      yes: "Visible"
+      no: "Hidden"
   filters:
     status: Status
     store: Store

--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -28,7 +28,7 @@ module SolidusAdmin
     def new
       order = Spree::Order.create!(
         created_by: current_solidus_admin_user,
-        frontend_viewable: false,
+        frontend_viewable: true,
         store_id: current_store.try(:id)
       )
 
@@ -53,12 +53,6 @@ module SolidusAdmin
         flash[:notice] = t(".success")
       else
         flash[:error] = t(".error")
-      end
-
-      respond_to do |format|
-        format.html { redirect_to spree.edit_admin_order_path(@order) }
-
-        format.turbo_stream { render turbo_stream: '<turbo-stream action="refresh" />' }
       end
     end
 
@@ -117,7 +111,7 @@ module SolidusAdmin
     end
 
     def order_params
-      params.require(:order).permit(:user_id, permitted_order_attributes)
+      params.require(:order).permit(:user_id, :frontend_viewable, permitted_order_attributes)
     end
   end
 end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -25,6 +25,12 @@ SolidusAdmin::Engine.routes.draw do
 
   admin_resources :orders, only: [:index]
 
+  admin_resources :orders, only: [:index] do
+    member do
+      patch :update
+    end
+  end
+
   admin_resources :orders, except: [
     :destroy, :index
   ], constraints: -> { SolidusAdmin::Config.enable_alpha_features? } do


### PR DESCRIPTION
## Summary

Updated the admin orders list to include a checkbox that controls whether an order is visible to the customer. The frontend_viewable flag is now set to true by default when an order is created, and can be toggled between true and false by an admin.
 
<img width="1920" height="1080" alt="Screenshot 2026-04-27 at 17 14 08" src="https://github.com/user-attachments/assets/066377ac-ea28-479a-855b-5b494c6f636c" />

Fixes #6365

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
