### PR TITLE
Add frontend_viewable checkbox to admin new order form

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -61,14 +61,15 @@ module Spree
       end
 
       def new
-        user = Spree.user_class.find_by(id: params[:user_id]) if params[:user_id]
-        order_importer_params = order_params
-        order_importer_params[:bill_address] = user&.bill_address
-        order_importer_params[:ship_address] = user&.ship_address
+  if request.post?
+    user = Spree.user_class.find_by(id: params[:user_id]) if params[:user_id]
+    order_importer_params = order_params
+    order_importer_params[:bill_address] = user&.bill_address
+    order_importer_params[:ship_address] = user&.ship_address
+    @order = Spree::Core::Importer::Order.import(user, order_importer_params)
+    redirect_to cart_admin_order_url(@order)
+  end
 
-        @order = Spree::Core::Importer::Order.import(user, order_importer_params)
-        redirect_to cart_admin_order_url(@order)
-      end
 
       def edit
         require_ship_address
@@ -161,7 +162,7 @@ module Spree
       def order_params
         {
           created_by_id: spree_current_user.try(:id),
-          frontend_viewable: false,
+          frontend_viewable: params.dig(:order, :frontend_viewable) == "1",
           store_id: current_store.try(:id)
         }.with_indifferent_access
       end

--- a/backend/app/views/spree/admin/orders/new.html.erb
+++ b/backend/app/views/spree/admin/orders/new.html.erb
@@ -1,0 +1,23 @@
+<% admin_breadcrumb(plural_resource_name(Spree::Order), spree.admin_orders_path) %>
+<% admin_breadcrumb(t('spree.new_order')) %>
+
+<%= form_tag admin_orders_path, method: :post do %>
+  <div class="row">
+    <div class="col-12">
+      <fieldset class="no-border-top">
+        <legend><%= t('spree.new_order') %></legend>
+
+        <div class="field">
+          <label for="order_frontend_viewable">
+            <%= check_box_tag "order[frontend_viewable]", "1", false, id: "order_frontend_viewable" %>
+            <%= t('spree.frontend_viewable') %>
+          </label>
+        </div>
+
+        <div class="form-buttons actions" data-hook="buttons">
+          <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Replaced the hard-coded frontend_viewable value in the admin order creation flow with a dynamic implementation based on user input.

Updated the orders controller to read the frontend_viewable value from request parameters instead of always defaulting to false.

Introduced a new admin order creation view to allow input before order creation, including a checkbox that lets admins control whether an order is visible to the customer.

Modified the new action to handle both rendering the form and creating the order on submission, instead of immediately creating and redirecting.