### PR TITLE
Avoid ActiveStorage n+1s

### DIFF
--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -69,13 +69,6 @@ module SolidusAdmin
     def variants_for
       load_order
 
-      # We need to eager load active storage attachments when using it
-      if Spree::Image.include?(Spree::Image::ActiveStorageAttachment)
-        image_includes = {
-          attachment_attachment: {blob: {variant_records: {image_attachment: :blob}}}
-        }
-      end
-
       @variants = Spree::Variant
         .where.not(id: @order.line_items.select(:variant_id))
         .order(created_at: :desc, id: :desc)
@@ -83,9 +76,9 @@ module SolidusAdmin
         .limit(10)
         .eager_load(
           :prices,
-          images: image_includes || {},
-          option_values: :option_type,
-          stock_items: :stock_location
+          {images: Spree::Image.attachment_preloads},
+          {option_values: :option_type},
+          {stock_items: :stock_location}
         )
 
       respond_to do |format|

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -14,7 +14,7 @@ module SolidusAdmin
     def index
       products = apply_search_to(
         Spree::Product.includes(
-          :variant_images,
+          {variant_images: Spree::Image.attachment_preloads},
           master: :prices,
           variants: :prices
         ),

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -170,7 +170,7 @@ module Spree
 
       def find_order(_lock = false)
         @order = Spree::Order
-          .includes(line_items: [:adjustments, {variant: :images}],
+          .includes(line_items: [:adjustments, {variant: {images: Spree::Image.attachment_preloads}}],
             payments: :payment_method,
             shipments: {
               shipping_rates: {shipping_method: :zones, taxes: :tax_rate}

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -104,7 +104,14 @@ module Spree
       end
 
       def product_includes
-        [:variant_images, {variants: [:images], master: [:images, :prices]}]
+        image_preloads = Spree::Image.attachment_preloads
+        [
+          {variant_images: image_preloads},
+          {
+            variants: [{images: image_preloads}],
+            master: [{images: image_preloads}, :prices]
+          }
+        ]
       end
 
       def clone_object_url(resource)

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -54,14 +54,15 @@ module Spree
       end
 
       def variant_scope
+        image_preloads = Spree::Image.attachment_preloads
         scope = Spree::Variant
           .accessible_by(current_ability)
           .distinct
           .includes(
-            :images,
-            stock_items: :stock_location,
-            product: :variant_images,
-            option_values: :option_type
+            {images: image_preloads},
+            {stock_items: :stock_location},
+            {product: {variant_images: image_preloads}},
+            {option_values: :option_type}
           )
 
         scope = scope.where(product: @product, is_master: !@product.has_variants?) if @product

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -4,5 +4,19 @@ module Spree
   class Asset < Spree::Base
     belongs_to :viewable, polymorphic: true, touch: true, optional: true
     acts_as_list scope: [:viewable_id, :viewable_type]
+
+    # Preload args to nest under asset-bearing associations, e.g.
+    #   includes(variant_images: Spree::Image.attachment_preloads)
+    #   includes(variants: { images: Spree::Image.attachment_preloads })
+    #
+    # Returns the ActiveStorage attachment + blob + variant preloads when the
+    # asset class is in ActiveStorage mode, or an empty array (no-op nested
+    # preload) when in Paperclip mode. Lets callers preload uniformly without
+    # branching on the configured attachment backend.
+    def self.attachment_preloads
+      return [] unless reflect_on_association(:attachment_attachment)
+
+      [{attachment_attachment: {blob: {variant_records: {image_attachment: :blob}}}}]
+    end
   end
 end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -59,7 +59,7 @@ module Spree
           # `where` constraints affecting joined tables are added to the search;
           # which is the case as soon as a taxon is added to the base scope.
           scope = scope.preload(master: :prices)
-          scope = scope.preload(master: :images) if @properties[:include_images]
+          scope = scope.preload(master: {images: Spree::Image.attachment_preloads}) if @properties[:include_images]
           scope
         end
 

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe Spree::Core::Search::Base do
       expect(subject.first).to eq @product1
       expect(subject.first.images).to eq @product1.master.images
     end
+
+    it "preloads images so accessing them does not trigger additional queries" do
+      results = subject.to_a
+
+      expect {
+        results.first.images.to_a
+      }.not_to make_database_queries
+    end
   end
 
   context "when ascend_by_master_price scope is included in the initialization params" do

--- a/core/spec/models/spree/asset_spec.rb
+++ b/core/spec/models/spree/asset_spec.rb
@@ -22,4 +22,38 @@ RSpec.describe Spree::Asset, type: :model do
       expect(asset2.position).to eq 1
     end
   end
+
+  describe ".attachment_preloads" do
+    context "when the class uses ActiveStorage" do
+      let(:asset_class) do
+        Class.new(Spree::Asset) do
+          include Spree::Image::ActiveStorageAttachment
+        end
+      end
+
+      it "returns the nested attachment + blob + variant preloads" do
+        expect(asset_class.attachment_preloads).to eq(
+          [{attachment_attachment: {blob: {variant_records: {image_attachment: :blob}}}}]
+        )
+      end
+    end
+
+    context "when the class uses Paperclip" do
+      let(:asset_class) do
+        Class.new(Spree::Asset) do
+          include Spree::Image::PaperclipAttachment
+        end
+      end
+
+      it "returns an empty array (no-op nested preload)" do
+        expect(asset_class.attachment_preloads).to eq([])
+      end
+    end
+
+    context "when called on Spree::Asset itself" do
+      it "returns an empty array since no attachment is configured" do
+        expect(Spree::Asset.attachment_preloads).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Spree::Asset (and therefore Image) can be setup for ActiveStorage or paperclip. When its ActiveStorage, there are extra classes involved- attachment, blob, and in some cases, variant. None of those are preloaded currently in most places.

As things would break if preload were attempted and kt-paperclip was being used, a helper method has been added that checks config, and defines the appropriate includes. This helper is referenced in a variety of controllers, addressing some n+1s.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
