### PR TITLE
feat(backend): Use Remixicons when new navbar is used

### DIFF
--- a/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
+++ b/admin/app/components/solidus_admin/orders/show/adjustments/index/component.rb
@@ -13,8 +13,6 @@ class SolidusAdmin::Orders::Show::Adjustments::Index::Component < SolidusAdmin::
     t(".title", number: @order.number)
   end
 
-  NBSP = "&nbsp;".html_safe
-
   def initialize(order:, adjustments:)
     @order = order
     @adjustments = adjustments

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js.erb
@@ -24,3 +24,20 @@ Handlebars.registerHelper("concat", function() {
 Handlebars.registerHelper("format_money", function(amount, currency) {
   return Spree.formatMoney(amount, currency);
 });
+
+Handlebars.registerHelper("solidus_icon", function(name) {
+  var useRemix = <%= Spree::Backend::Config.admin_updated_navbar.to_json %>;
+  var spritePath = <%= image_path("spree/backend/themes/solidus_admin/remixicon.symbol.svg").to_json %>;
+  var remixNames = <%= Spree::Backend::REMIX_ICONS.to_json %>;
+  var symbol = remixNames[name];
+
+  if (useRemix && symbol) {
+    return new Handlebars.SafeString(
+      '<svg aria-hidden="true" style="fill: currentColor; width: 16px; height: 16px;"><use xlink:href="' +
+      spritePath + '#' + symbol + '"></use></svg>'
+    );
+  }
+  return new Handlebars.SafeString(
+    '<i class="fa fa-' + name + '" aria-hidden="true"></i>'
+  );
+});

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
@@ -33,12 +33,12 @@
 </td>
 <td class="cart-line-item-delete actions" data-hook="cart_line_item_delete">
   {{#if editing}}
-    <button class="save-line-item fa fa-ok no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
+    <button class="save-line-item icon_button no-text with-tip" data-action="save" title="{{ t "actions.save" }}">{{solidus_icon "ok"}}</button>
     {{#unless noCancel}}
-      <button class="cancel-line-item fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
+      <button class="cancel-line-item icon_button no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}">{{solidus_icon "cancel"}}</button>
     {{/unless}}
   {{else}}
-    <button class="edit-line-item fa fa-edit no-text with-tip" data-action="edit" title="{{ t "actions.edit" }}"></button>
-    <button class="delete-line-item fa fa-trash no-text with-tip" data-action="remove" title="{{ t "actions.delete" }}"></button>
+    <button class="edit-line-item icon_button no-text with-tip" data-action="edit" title="{{ t "actions.edit" }}">{{solidus_icon "edit"}}</button>
+    <button class="delete-line-item icon_button no-text with-tip" data-action="remove" title="{{ t "actions.delete" }}">{{solidus_icon "trash"}}</button>
   {{/if}}
 </td>

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipment_tracking.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipment_tracking.hbs
@@ -16,9 +16,9 @@
 </td>
 <td class="actions">
   {{#if editing}}
-    <button class="js-save fa fa-check no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
-    <button class="js-cancel fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
+    <button class="js-save icon_button no-text with-tip" data-action="save" title="{{ t "actions.save" }}">{{solidus_icon "check"}}</button>
+    <button class="js-cancel icon_button no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}">{{solidus_icon "cancel"}}</button>
   {{else}}
-    <button class="js-edit fa fa-edit no-text with-tip" data-action="edit" title=""{{ t "actions.edit" }}"></button>
+    <button class="js-edit icon_button no-text with-tip" data-action="edit" title="{{ t "actions.edit" }}">{{solidus_icon "edit"}}</button>
   {{/if}}
 </td>

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
@@ -25,10 +25,10 @@
 <td class="actions">
   {{#if editing}}
     {{#if shipping_rates}}
-    <button class="js-save fa fa-check no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
+    <button class="js-save icon_button no-text with-tip" data-action="save" title="{{ t "actions.save" }}">{{solidus_icon "check"}}</button>
     {{/if}}
-    <button class="js-cancel fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
+    <button class="js-cancel icon_button no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}">{{solidus_icon "cancel"}}</button>
   {{else}}
-    <button class="js-edit fa fa-edit no-text with-tip" data-action="edit" title=""{{ t "actions.edit" }}"></button>
+    <button class="js-edit icon_button no-text with-tip" data-action="edit" title="{{ t "actions.edit" }}">{{solidus_icon "edit"}}</button>
   {{/if}}
 </td>

--- a/backend/app/assets/javascripts/spree/backend/templates/products/sortable.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/sortable.hbs
@@ -1,5 +1,5 @@
 <a href="#" id="product_{{ id }}" data-product-id="{{ id }}" class="sort_item list-group-item">
-  <i class="fa fa-sort"></i>
+  {{solidus_icon "sort"}}
   <span class="product_name">{{ name }}</span>
   <span class="float-right">{{ display_price }}</span>
 </a>

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -34,6 +34,6 @@
   </form>
 </td>
 <td class="actions">
-  <a class="submit fa fa-check icon_link with-tip no-text" data-action="save" href="#"></a>
-  <a class="cancel fa fa-cancel icon_link with-tip no-text" data-action="cancel" href="#"></a>
+  <a class="submit icon_link with-tip no-text" data-action="save" href="#">{{solidus_icon "check"}}</a>
+  <a class="cancel icon_link with-tip no-text" data-action="cancel" href="#">{{solidus_icon "cancel"}}</a>
 </td>

--- a/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
@@ -4,13 +4,13 @@
     <div class="taxon">
     {{else}}
     <div class="taxon sortable">
-      <i class="fa fa-arrows"></i>
+      {{solidus_icon "arrows"}}
     {{/if}}
       {{name}}
       <div class="actions float-right">
-        <a href="#" class="js-taxon-add-child fa fa-plus icon_link no-text"></a>
-        <a href="{{admin_url}}/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="fa fa-edit icon_link no-text"></a>
-        <a href="#" class="js-taxon-delete fa fa-trash icon_link no-text"></a>
+        <a href="#" class="js-taxon-add-child icon_link no-text">{{solidus_icon "plus"}}</a>
+        <a href="{{admin_url}}/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="icon_link no-text">{{solidus_icon "edit"}}</a>
+        <a href="#" class="js-taxon-delete icon_link no-text">{{solidus_icon "trash"}}</a>
       </div>
     </div>
     {{#if taxons }}

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
@@ -22,6 +22,6 @@
   </form>
 </td>
 <td class='actions'>
-  <button class="save-split icon_link fa fa-ok no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
-  <button class="cancel-split icon_link fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
+  <button class="save-split icon_button no-text with-tip" data-action="save" title="{{ t "actions.save" }}">{{solidus_icon "ok"}}</button>
+  <button class="cancel-split icon_button no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}">{{solidus_icon "cancel"}}</button>
 </td>

--- a/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
@@ -1,10 +1,12 @@
 // Some fixes for fontwesome stylesheets
-[class^="icon-"], [class*=" icon-"] {
+[class^="icon-"],
+[class*=" icon-"] {
   &:before {
     padding-right: 5px;
   }
 
-  &.button, &.icon_link {
+  &.button,
+  &.icon_link {
     width: auto;
 
     &:before {
@@ -15,29 +17,53 @@
 }
 
 .btn.fa {
-  font: normal normal $btn-font-weight #{$font-size-base}/#{$btn-line-height} "FontAwesome";
+  font: normal normal $btn-font-weight #{$font-size-base}/#{$btn-line-height}
+    "FontAwesome";
 }
 
-.fa-email     { @extend .fa-envelope }
-.fa-resume    { @extend .fa-refresh  }
-.fa-approve   { @extend .fa-check    }
+.fa-email {
+  @extend .fa-envelope;
+}
+.fa-resume {
+  @extend .fa-refresh;
+}
+.fa-approve {
+  @extend .fa-check;
+}
 
 .fa-remove,
 .fa-cancel,
-.fa-void      { @extend .fa-times    }
+.fa-void {
+  @extend .fa-times;
+}
 
-.fa-failure   { @extend .fa-thumbs-down }
+.fa-failure {
+  @extend .fa-thumbs-down;
+}
 
-.fa-trash     { @extend .fa-trash-o  }
+.fa-trash {
+  @extend .fa-trash-o;
+}
 
-.fa-capture   { @extend .fa-thumbs-up }
-.fa-credit    { @extend .fa-check    }
-.fa-approve   { @extend .fa-check    }
-.fa-icon-cogs { @extend .fa-cogs     }
+.fa-capture {
+  @extend .fa-thumbs-up;
+}
+.fa-credit {
+  @extend .fa-check;
+}
+.fa-approve {
+  @extend .fa-check;
+}
+.fa-icon-cogs {
+  @extend .fa-cogs;
+}
 .fa-ok,
-.fa-icon-ok   { @extend .fa-check    }
+.fa-icon-ok {
+  @extend .fa-check;
+}
 
-button, a {
+button,
+a {
   &.fa:before {
     padding-right: 5px;
   }
@@ -49,11 +75,36 @@ button, a {
 .icon-external-link {
   @extend .fa;
 }
-.icon-user          { @extend .fa-user; }
-.icon-signout       { @extend .fa-sign-out; }
-.icon-external-link { @extend .fa-external-link; }
+.icon-user {
+  @extend .fa-user;
+}
+.icon-signout {
+  @extend .fa-sign-out;
+}
+.icon-external-link {
+  @extend .fa-external-link;
+}
 
 // Avoid ugly default browser font (usually a serif) when an element has an icon AND text
 .fa {
   font-family: "FontAwesome", $font-family-base !important;
+}
+
+.content-wrapper {
+  svg.icon {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+  }
+
+  .icon_link {
+    &:has(svg) {
+      display: inline-flex;
+      width: 20px;
+      height: 20px;
+      align-items: center;
+      gap: 0.25rem;
+      vertical-align: -0.3em;
+    }
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
@@ -97,6 +97,7 @@ a {
     fill: currentColor;
   }
 
+  .icon_button,
   .icon_link {
     &:has(svg) {
       display: inline-flex;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -92,20 +92,35 @@ table {
         }
       }
 
-      .fa-trash:hover, .fa-void:hover, .fa-failure:hover {
+      .fa-trash:hover,
+      .fa-void:hover,
+      .fa-failure:hover,
+      [data-action="remove"]:hover {
         color: theme-color("danger");
       }
 
-      .fa-cancel:hover {
+      .fa-cancel:hover,
+      [data-action="cancel"]:hover {
         color: theme-color("warning");
       }
 
-      .fa-edit:hover, .fa-capture:hover, .fa-ok:hover, .fa-plus:hover,
-      .fa-save:hover, .fa-arrows-h:hover, .fa-check:hover {
+      .fa-edit:hover,
+      .fa-capture:hover,
+      .fa-ok:hover,
+      .fa-plus:hover,
+      .fa-save:hover,
+      .fa-arrows-h:hover,
+      .fa-check:hover,
+      [data-action="save"]:hover,
+      [data-action="edit"]:hover,
+      [data-action="capture"]:hover,
+      [data-action="add"]:hover,
+      [data-action="new"]:hover {
         color: theme-color("success");
       }
 
-      .fa-copy:hover {
+      .fa-copy:hover,
+      [data-action="clone"]:hover {
         color: theme-color("warning");
       }
 
@@ -113,7 +128,8 @@ table {
         color: theme-color("success");
       }
 
-      .fa-thumbs-down:hover {
+      .fa-thumbs-down:hover,
+      [data-action="void"]:hover {
         color: theme-color("danger");
       }
     }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -23,6 +23,14 @@ table {
       padding: 3px 0;
     }
 
+    .icon_link:has(svg) {
+      color: $color-dark;
+
+      &:hover {
+        color: $color-dark-light;
+      }
+    }
+
     &.actions {
       text-align: right;
       padding-left: 1.25rem;
@@ -56,6 +64,14 @@ table {
 
         &:hover {
           background: transparent;
+        }
+      }
+
+      .icon_link:has(svg) {
+        padding: 2px;
+
+        + .icon_link:has(svg) {
+          margin-left: 2px;
         }
       }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -56,21 +56,29 @@ table {
         }
       }
 
-      button[class*='fa-'] {
-        color: $link-color;
+      button[class*="fa-"],
+      button.icon_button:has(.fa) {
+        padding: 0 !important;
+      }
+
+      button[class*="fa-"],
+      .icon_button {
+        color: $color-dark;
         background: transparent;
         border: 0 none;
-        padding: 0 !important;
 
         &:hover {
+          color: $color-dark-light;
           background: transparent;
         }
       }
 
-      .icon_link:has(svg) {
+      .icon_link:has(svg),
+      .icon_button:has(svg) {
         padding: 2px;
 
-        + .icon_link:has(svg) {
+        + .icon_link:has(svg),
+        + .icon_button:has(svg) {
           margin-left: 2px;
         }
       }

--- a/backend/app/helpers/spree/admin/adjustments_helper.rb
+++ b/backend/app/helpers/spree/admin/adjustments_helper.rb
@@ -5,7 +5,7 @@ module Spree
     module AdjustmentsHelper
       def adjustment_state(adjustment)
         icon = adjustment.finalized? ? "lock" : "unlock"
-        content_tag(:span, "", class: "fa fa-#{icon}")
+        solidus_icon(icon)
       end
 
       def display_adjustable(adjustable)

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -121,13 +121,9 @@ module Spree
       def link_to_with_icon(icon_name, text, url, options = {})
         options[:class] = "#{options[:class]} icon_link with-tip".strip
 
-        if icon_name.starts_with?("ri-")
-          svg_map = image_path("spree/backend/themes/solidus_admin/remixicon.symbol.svg")
-          icon_tag = tag.svg(
-            tag.use("xlink:href": "#{svg_map}##{icon_name}"),
-            "aria-hidden": true,
-            style: "fill: currentColor;"
-          )
+        icon = icon_for(icon_name)
+        if icon.starts_with?("ri-")
+          icon_tag = remix_icon(icon)
         else
           options[:class] << " fa fa-#{icon_name}"
           icon_tag = "".html_safe
@@ -141,7 +137,28 @@ module Spree
       end
 
       def solidus_icon(icon_name)
-        icon_name ? content_tag(:i, "", class: icon_name) : ""
+        if icon_name&.include?("fa-")
+          icon_name = icon_name.gsub(/(fa\s|fa-)/, "")
+          Spree.deprecator.warn "Using FontAwesome icon classes with solidus_icon is deprecated. Please use just `#{icon_name}` instead."
+        end
+        icon = icon_for(icon_name)
+        if icon&.starts_with?("ri-")
+          remix_icon(icon)
+        elsif icon_name
+          content_tag(:i, "", class: "fa fa-#{icon_name}")
+        else
+          ""
+        end
+      end
+
+      def remix_icon(icon_name)
+        svg_map = image_path("spree/backend/themes/solidus_admin/remixicon.symbol.svg")
+        tag.svg(
+          tag.use(href: "#{svg_map}##{icon_name}"),
+          "aria-hidden": true,
+          style: "fill: currentColor",
+          class: "icon"
+        )
       end
 
       def configurations_menu_item(link_text, url, description = "")
@@ -173,6 +190,12 @@ module Spree
         content_tag(:li, options) do
           link_to(link_text, url)
         end
+      end
+
+      private
+
+      def icon_for(icon_name)
+        Spree::Backend::Config.admin_updated_navbar ? Spree::Backend::REMIX_ICONS.fetch(icon_name, icon_name) : icon_name
       end
     end
   end

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -24,8 +24,8 @@
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
-        <%= button_tag '', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: { action: 'edit', 'variant-id' => item.variant.id }, title: t('spree.actions.split'), type: :button %>
-        <%= button_tag '', class: 'delete-item fa fa-trash no-text with-tip', data: { action: 'remove', 'variant-id' => item.variant.id }, title: t('spree.actions.delete'), type: :button %>
+        <%= button_tag class: 'split-item icon_button no-text with-tip', data: { action: 'edit', 'variant-id' => item.variant.id }, title: t('spree.actions.split'), type: :button do %><%= solidus_icon('arrows-h') %><% end %>
+        <%= button_tag class: 'delete-item icon_button no-text with-tip', data: { action: 'remove', 'variant-id' => item.variant.id }, title: t('spree.actions.delete'), type: :button do %><%= solidus_icon('trash') %><% end %>
       <% end %>
     </td>
   </tr>

--- a/backend/app/views/spree/admin/payments/_log_entries.html.erb
+++ b/backend/app/views/spree/admin/payments/_log_entries.html.erb
@@ -21,7 +21,7 @@
         <pre><%= entry.parsed_details.message %></pre>
       </td>
       <td class="text-right">
-        <i class='fa fa-<%= entry.parsed_details.success? ? 'check' : 'remove' %>'></i>
+        <%= solidus_icon(entry.parsed_details.success? ? 'check' : 'remove') %>
       </td>
     </tr>
   <% end %>

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -29,7 +29,6 @@
             <%= link_to_edit(price, no_text: true) unless price.discarded? %>
           <% end %>
           <% if can?(:destroy, price) %>
-            &nbsp;
             <%= link_to_delete(price, no_text: true) unless price.discarded? %>
           <% end %>
         </td>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -24,7 +24,6 @@
               <%= link_to_edit(price, no_text: true) unless price.discarded? %>
             <% end %>
             <% if can?(:destroy, price) %>
-              &nbsp;
               <%= link_to_delete(price, no_text: true) unless price.discarded? %>
             <% end %>
           </td>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -87,9 +87,7 @@
             <td class="align-right"><%= product.display_price&.to_html %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">
               <%= link_to_edit product, no_text: true, class: 'edit' if can?(:edit, product) && !product.deleted? %>
-              &nbsp;
               <%= link_to_clone product, no_text: true, class: 'clone' if can?(:clone, product) %>
-              &nbsp;
               <%= link_to_delete product, no_text: true if can?(:destroy, product) && !product.deleted? %>
             </td>
           </tr>

--- a/backend/app/views/spree/admin/shared/_datepicker.html.erb
+++ b/backend/app/views/spree/admin/shared/_datepicker.html.erb
@@ -1,7 +1,7 @@
 <div class="input-group">
   <div class="input-group-prepend">
     <span class="input-group-text">
-      <%= solidus_icon('fa fa-calendar') %>
+      <%= solidus_icon('calendar') %>
     </span>
   </div>
   <%= f.text_field date_attr, value: datepicker_field_value(f.object.public_send(date_attr)), class: 'form-control datepicker' %>

--- a/backend/app/views/spree/admin/variants/_table.html.erb
+++ b/backend/app/views/spree/admin/variants/_table.html.erb
@@ -33,7 +33,6 @@
           <%= link_to_edit(variant, no_text: true) unless variant.deleted? %>
         <% end %>
         <% if can?(:destroy, variant) %>
-          &nbsp;
           <%= link_to_delete(variant, no_text: true) unless variant.deleted? %>
         <% end %>
       </td>

--- a/backend/lib/spree/backend/engine.rb
+++ b/backend/lib/spree/backend/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spree/backend/config"
+require "spree/backend/remix_icons"
 
 module Spree
   module Backend

--- a/backend/lib/spree/backend/remix_icons.rb
+++ b/backend/lib/spree/backend/remix_icons.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Spree
+  module Backend
+    REMIX_ICONS = {
+      "arrows-h" => "ri-arrow-left-right-line",
+      "calendar" => "ri-calendar-line",
+      "cancel" => "ri-close-line",
+      "capture" => "ri-thumb-up-line",
+      "check" => "ri-check-line",
+      "copy" => "ri-file-copy-line",
+      "edit" => "ri-edit-line",
+      "email" => "ri-mail-line",
+      "file" => "ri-file-line",
+      "lock" => "ri-lock-line",
+      "ok" => "ri-check-line",
+      "plus" => "ri-add-line",
+      "refresh" => "ri-refresh-line",
+      "remove" => "ri-delete-bin-7-line",
+      "reply" => "ri-reply-line",
+      "send" => "ri-plane-plane-line",
+      "th-large" => "ri-function-line",
+      "trash" => "ri-delete-bin-7-line",
+      "unlock" => "ri-lock-unlock-line",
+      "void" => "ri-close-circle-line",
+    }.freeze
+  end
+end

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -152,9 +152,56 @@ describe Spree::Admin::NavigationHelper, type: :helper do
 
   describe "#solidus_icon" do
     context "if given an icon_name" do
-      subject(:solidus_icon) { helper.solidus_icon("example-icon-name") }
+      subject(:solidus_icon) { helper.solidus_icon(icon_name) }
 
-      it { is_expected.to eq "<i class=\"example-icon-name\"></i>" }
+      context "when the icon is a fontawesome icon" do
+        let(:icon_name) { "fa fa-example-icon-name" }
+
+        it "returns an fa icon tag" do
+          Spree.deprecator.silence do
+            is_expected.to eq '<i class="fa fa-example-icon-name"></i>'
+          end
+        end
+
+        it "is deprecated" do
+          expect(Spree.deprecator).to receive(:warn)
+          subject
+        end
+      end
+
+      context "when the icon is a remix icon" do
+        let(:icon_name) { "ri-example-icon-name" }
+
+        it "returns a svg icon" do
+          is_expected.to have_css 'svg.icon use[href*="#ri-example-icon-name"]'
+        end
+      end
+
+      context "when the icon is a generic icon name" do
+        context "when the icon name maps to a remix icon" do
+          let(:icon_name) { "copy" }
+
+          context "when updated navbar is disabled" do
+            before do
+              stub_spree_preferences(Spree::Backend::Config, admin_updated_navbar: false)
+            end
+
+            it "returns an fa icon tag" do
+              is_expected.to eq '<i class="fa fa-copy"></i>'
+            end
+          end
+
+          context "when updated navbar is enabled" do
+            before do
+              stub_spree_preferences(Spree::Backend::Config, admin_updated_navbar: true)
+            end
+
+            it "returns a svg icon" do
+              is_expected.to have_css 'svg.icon use[href*="#ri-file-copy-line"]'
+            end
+          end
+        end
+      end
     end
 
     context "if not given nil icon_name" do


### PR DESCRIPTION
## Summary

The updated admin navbar also toggles the icons to remixicon, leading to a ugly mismatch of old fontawesome icons and the shiny new remixicons in the navbar.

Since the new admin is still in heavy development and even when `solidus_admin` is used the backend is used as fallback. We should be nice to our users and give them the new icons in the body as well if this is the case.

Add a simple mapping to `link_to_with_icon` (the helper we end up using for all icon based links), to make the remix icons
automatically be used when the `Spree::Backend::Config.admin_updated_navbar` is enabled.

### Screenshots



#### Before

##### Orders

<img width="2880" height="1800" alt="Orders Before" src="https://github.com/user-attachments/assets/39b05f94-32e1-43fd-9c7b-a7f4aa1a6845" />

##### Products

<img width="2880" height="1800" alt="Products Before" src="https://github.com/user-attachments/assets/2c8dc66e-9317-4ec8-9008-e88788b699b6" />


#### After

##### Orders

<img width="2880" height="1800" alt="Orders After" src="https://github.com/user-attachments/assets/9bd92a60-a451-4765-9c07-e5805a3b8b67" />

##### Products

<img width="2880" height="1800" alt="Products After" src="https://github.com/user-attachments/assets/c03d494c-02de-4086-87d8-6a65224f66af" />

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have localized any and all user-facing strings that I added to the source code.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
