### PR TITLE
Handle state change of shipments without inventory units

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -224,7 +224,9 @@ module Spree
       self.state =
         if shipped?
           "shipped"
-        elsif order.canceled? || inventory_units.present? && inventory_units.all?(&:canceled?)
+        elsif inventory_units.none?
+          "pending"
+        elsif order.canceled? || inventory_units.all?(&:canceled?)
           "canceled"
         elsif !order.can_ship?
           "pending"

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -224,7 +224,7 @@ module Spree
       self.state =
         if shipped?
           "shipped"
-        elsif order.canceled? || inventory_units.all?(&:canceled?)
+        elsif order.canceled? || inventory_units.present? && inventory_units.all?(&:canceled?)
           "canceled"
         elsif !order.can_ship?
           "pending"

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -120,6 +120,15 @@ RSpec.describe Spree::Shipment, type: :model do
       }.to change { shipment.state }.from("pending").to("canceled")
     end
 
+    it "returns ready if the order's inventory units have been destroyed" do
+      expect {
+        shipment.inventory_units.each(&:destroy!)
+        shipment.reload
+
+        recalculate_state
+      }.to change { shipment.state }.from("pending").to("ready")
+    end
+
     it "returns pending unless order.can_ship?" do
       allow(order).to receive_messages can_ship?: false
       expect(recalculate_state).to eq "pending"
@@ -135,14 +144,28 @@ RSpec.describe Spree::Shipment, type: :model do
       expect(recalculate_state).to eq "shipped"
     end
 
-    it "returns pending when unpaid" do
-      allow(order).to receive_messages paid?: false
-      expect(recalculate_state).to eq "pending"
-    end
-
     it "returns ready when paid" do
       allow(order).to receive_messages paid?: true
       expect(recalculate_state).to eq "ready"
+    end
+
+    context "when the order hasn't been paid" do
+      let(:order) { create(:order_ready_to_complete, line_items_count: 1) }
+
+      it "returns pending" do
+        expect(recalculate_state).to eq "pending"
+      end
+
+      context "when the shipment's inventory units have been destroyed" do
+        it "returns pending" do
+          expect {
+            shipment.inventory_units.each(&:destroy!)
+            shipment.reload
+
+            recalculate_state
+          }.not_to change { shipment.state }.from("pending")
+        end
+      end
     end
   end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -120,13 +120,13 @@ RSpec.describe Spree::Shipment, type: :model do
       }.to change { shipment.state }.from("pending").to("canceled")
     end
 
-    it "returns ready if the order's inventory units have been destroyed" do
+    it "returns pending if the shipment doesn't have any inventory units" do
       expect {
         shipment.inventory_units.each(&:destroy!)
         shipment.reload
 
         recalculate_state
-      }.to change { shipment.state }.from("pending").to("ready")
+      }.not_to change { shipment.state }.from("pending")
     end
 
     it "returns pending unless order.can_ship?" do


### PR DESCRIPTION
## Summary

### Current Behaviour

If a shipment's inventory units have been destroyed, by some means, then the expression `inventory_units.all?(&:canceled?)` vacuously returns true, since there are no elements to call #canceled? on. This matters specifically when an order has not been `paid?`.

In the case that an order has not been fully paid, then the "cancelled" branch described below does not describe the behaviour of the `Spree::Shipment#recalculate_state` method accurately.

If an order is in the `paid` state, then this empty shipment would be marked as `ready`, which likely prompted the regression containing commit in the first place: b1471dacd44db1e6f1cd11ebac6bdb5c753ea408

### Existing comment at time of PR:

> Assigns the appropriate +state+ according to the following logic:
>
> canceled   if order is canceled
> pending    unless order is complete and +order.payment_state+ is +paid+
> shipped    if already shipped (ie. does not change the state)
> ready      all other cases

### What stores this will affect

For stores that support making adjustments to orders after taking a deposit/partial payment, when all line items or inventory units on a shipment have been destroyed, the current implementation of `Spree::Shipment#recalculate_state` will mark the shipment as cancelled, preventing it from being destroyed.

### Solution

To conform to the intended behaviour described in the comment at line 217, we can ensure shipments are not considered cancelled unless the order has been cancelled, or all the inventory units exist _and_ they have been explicitly cancelled.

Furthermore, if there are no inventory units associated to a shipment, setting the shipment into `ready` state is likely to cause all kinds of issues.

Since a shipment's state is initially set to `pending`, it makes sense to set the shipment state to `pending` when all inventory units have been removed. We do this instead of marking it as either `cancelled` or `ready`, because neither reflect the state or circumstances of the shipment. We also don't want to just destroy the shipment, because we want to keep the shipment-related information for record-keeping purposes.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
