### PR TITLE
Fix SolidusPromotion OrderRecalculator patch

### DIFF
--- a/promotions/app/patches/models/solidus_promotions/in_memory_order_updater_patch.rb
+++ b/promotions/app/patches/models/solidus_promotions/in_memory_order_updater_patch.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module SolidusPromotions
-  module OrderRecalculatorPatch
+  module InMemoryOrderUpdaterPatch
     # This is only needed for stores upgrading from the legacy promotion system.
     # Once we've removed support for the legacy promotion system, we can remove this.
-    def recalculate
+    def recalculate(persist: true)
       if SolidusPromotions.config.sync_order_promotions
         MigrationSupport::OrderPromotionSyncer.new(order: order).call
       end
       super
     end
 
-    Spree::OrderUpdater.prepend self
     Spree::InMemoryOrderUpdater.prepend self
   end
 end

--- a/promotions/app/patches/models/solidus_promotions/order_updater_patch.rb
+++ b/promotions/app/patches/models/solidus_promotions/order_updater_patch.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SolidusPromotions
+  module OrderUpdaterPatch
+    # This is only needed for stores upgrading from the legacy promotion system.
+    # Once we've removed support for the legacy promotion system, we can remove this.
+    def recalculate
+      if SolidusPromotions.config.sync_order_promotions
+        MigrationSupport::OrderPromotionSyncer.new(order: order).call
+      end
+      super
+    end
+
+    Spree::OrderUpdater.prepend self
+  end
+end

--- a/promotions/spec/models/promotion/in_memory_integration_spec.rb
+++ b/promotions/spec/models/promotion/in_memory_integration_spec.rb
@@ -16,5 +16,10 @@ RSpec.describe "Promotion System" do
     end
 
     it_behaves_like "a successfully integrated promotion system"
+
+    it "allows in memory order recalculates without persistence" do
+      order = create(:order_with_line_items)
+      expect { Spree::InMemoryOrderUpdater.new(order).recalculate(persist: false) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
## Summary

The method signature of the InMemoryOrderUpdater changed to include the `persist` flag. This would previously raise an ArgumentError after configuring the app to use the InMemoryOrderUpdater, and passing an explicit argument for persist.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
