### PR TITLE
Pin state_machines to 0.6.0

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -45,7 +45,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'psych', ['>= 4.0.1', '< 6.0']
   s.add_dependency 'ransack', ['~> 4.0', '< 5']
   s.add_dependency 'sprockets-rails', '!= 3.5.0'
-  s.add_dependency 'state_machines-activerecord', '~> 0.6'
+  s.add_dependency 'state_machines', ['~> 0.6', '< 0.10.0']
+  s.add_dependency 'state_machines-activerecord', ['~> 0.6', '< 0.10.0']
   s.add_dependency 'omnes', '~> 0.2.2'
 
   s.post_install_message = <<-MSG


### PR DESCRIPTION
## Summary

The recently released state_machines gem 0.10.0 causes infinite recursions (StackLevelTooDeep). This is a backport of https://github.com/solidusio/solidus/pull/6286.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
