### PR TITLE
Make SimpleCoordinator inventory_units keyword arg

### DIFF
--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -22,7 +22,10 @@ module Spree
 
     def perform!
       begin
-        shipments = Spree::Config.stock.coordinator_class.new(@order, @reimbursement_objects.map(&:build_exchange_inventory_unit)).shipments
+        shipments = Spree::Config.stock.coordinator_class.new(
+          @order,
+          inventory_units: @reimbursement_objects.map(&:build_exchange_inventory_unit)
+        ).shipments
       rescue Spree::Order::InsufficientStock
         raise UnableToCreateShipments.new("Could not generate shipments for all items. Out of stock?")
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -513,9 +513,9 @@ module Spree
     end
 
     def create_shipments_for_line_item(line_item)
-      units = Spree::Config.stock.inventory_unit_builder_class.new(self).missing_units_for_line_item(line_item)
+      inventory_units = Spree::Config.stock.inventory_unit_builder_class.new(self).missing_units_for_line_item(line_item)
 
-      Spree::Config.stock.coordinator_class.new(self, units).shipments.each do |shipment|
+      Spree::Config.stock.coordinator_class.new(self, inventory_units:).shipments.each do |shipment|
         shipments << shipment
       end
     end

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -27,7 +27,14 @@ module Spree
         :filtered_stock_locations, :inventory_units_by_variant, :desired,
         :availability, :allocator, :packages
 
-      def initialize(order, inventory_units = nil)
+      def initialize(order, inventory_units_deprecated = nil, inventory_units: nil)
+        if inventory_units_deprecated
+          Spree.deprecator.warn "Using the `inventory_units` positional " \
+            "argument is deprecated in favor of using the keyword argument. "
+
+          inventory_units ||= inventory_units_deprecated
+        end
+
         @order = order
         @inventory_units =
           inventory_units || Spree::Config.stock.inventory_unit_builder_class.new(order).units


### PR DESCRIPTION
## Summary

For future improvements, we need to support additional keyword arguments to this class. The current `inventory_units` positional argument interferes with this.

In this commit we preserve the existing positional argument behaviour, while allowing keyword arguments to be passed in instead. This makes upgrades easier for existing projects since it does not break the existing behaviour.

## Next Steps

[We are working to provide a configurable replacement for the Spree::Stock::SimpleCoordinator](https://github.com/solidusio/solidus/pull/6484), utilizing the middleware design pattern for increased configurability and extensibility.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
