### PR TITLE
Include refund logs in payment log listing

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -9,6 +9,7 @@ module Spree
       before_action :load_payment, except: [:create, :new, :index, :fire]
       before_action :load_payment_for_fire, only: :fire
       before_action :load_data
+      before_action :load_log_entries, only: [:show]
       before_action :require_bill_address, only: [:index]
 
       helper ::Spree::Admin::OrdersHelper
@@ -100,6 +101,13 @@ module Spree
 
       def load_payment
         @payment = Spree::Payment.find(params[:id])
+      end
+
+      def load_log_entries
+        @all_log_entries = Spree::LogEntry
+          .where(source: @payment)
+          .or(Spree::LogEntry.where(source: @payment.refunds))
+          .order(:created_at)
       end
 
       def load_payment_for_fire

--- a/backend/app/views/spree/admin/payments/_log_entries.html.erb
+++ b/backend/app/views/spree/admin/payments/_log_entries.html.erb
@@ -1,12 +1,14 @@
 <table class='index' id='listing_log_entries'>
   <colgroup>
-    <col style="width: 30%">
-    <col style="width: 60%">
+    <col style="width: 25%">
+    <col style="width: 15%">
+    <col style="width: 50%">
     <col style="width: 10%">
   </colgroup>
   <thead>
     <tr>
       <th><%= Spree::LogEntry.human_attribute_name(:created_at) %></th>
+      <th><%= Spree::LogEntry.human_attribute_name(:source) %></th>
       <th><%= Spree::LogEntry.human_attribute_name(:details) %></th>
       <th></th>
     </tr>
@@ -16,6 +18,9 @@
     <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
       <td>
         <%= pretty_time(entry.created_at) %>
+      </td>
+      <td>
+        <%= entry.source_type.constantize.model_name.human %>
       </td>
       <td>
         <pre><%= entry.parsed_details.message %></pre>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -21,9 +21,9 @@
   </fieldset>
 <% end %>
 
-<% if @payment.log_entries.any? %>
+<% if @all_log_entries.any? %>
   <fieldset class="no-border-bottom">
     <legend><%= plural_resource_name(Spree::LogEntry) %></legend>
-    <%= render 'spree/admin/payments/log_entries', log_entries: @payment.log_entries %>
+    <%= render 'spree/admin/payments/log_entries', log_entries: @all_log_entries %>
   </fieldset>
 <% end %>

--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -53,4 +53,29 @@ describe "Log entries", type: :feature do
       end
     end
   end
+
+  context "with a log entry belonging to a refund of the payment", :js do
+    let(:payment) { create(:payment, amount: 100) }
+    let(:refund) { create(:refund, payment:, amount: 10) }
+
+    before do
+      response = ActiveMerchant::Billing::Response.new(
+        true,
+        "Refund processed",
+        transid: "REFUND-1"
+      )
+
+      refund.log_entries.create!(details: response.to_yaml)
+    end
+
+    it "shows the refund entry on the payment page with 'Refund' as its source" do
+      visit spree.admin_order_payments_path(payment.order)
+      click_on payment.number
+
+      within("#listing_log_entries") do
+        expect(page).to have_content("Refund processed")
+        expect(page).to have_content("Refund")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Payment refunds were not previously shown in the admin's payment logs.

Resolves https://github.com/solidusio/solidus/issues/4866

<!--
  Please include a summary of your changes, along with any useful context.
  Your contribution will be merged under the terms of the license of the parent repository (usually a FreeBSD License).

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
