### PR TITLE
Avoid redundant queries when recalculating payment totals

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -148,7 +148,7 @@ module Spree
     end
 
     def recalculate_payment_total
-      order.payment_total = payments.completed.includes(:refunds).sum { |payment| payment.amount - payment.refunds.sum(:amount) }
+      order.payment_total = payments.completed.includes(:refunds).sum { |payment| payment.amount - payment.refunds.sum(&:amount) }
     end
     alias_method :update_payment_total, :recalculate_payment_total
     deprecate update_payment_total: :recalculate_payment_total, deprecator: Spree.deprecator

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -23,6 +23,17 @@ module Spree
         end
       end
 
+      context "recalculating payment totals" do
+        before { create(:payment_with_refund, order:, amount: 33.25, refund_amount: 3) }
+
+        it "sums refunds from a single preload, not once per payment" do
+          create(:payment_with_refund, order:, amount: 20, refund_amount: 2)
+          order.payments.reset
+
+          expect { updater.recalculate }.to make_database_queries(matching: /from .spree_refunds./i, count: 1)
+        end
+      end
+
       it "update item total" do
         expect {
           updater.recalculate


### PR DESCRIPTION
Recalculating the payment total preloaded each payment's refunds with `includes(:refunds)` but then summed them with `refunds.sum(:amount)`, which issues a separate query per payment instead of using the records already loaded.

- sums the preloaded refunds in memory
- refund queries stay at the single preload regardless of how many payments the order has
