### PR TITLE
Avoid an N+1 loading stock on the admin products index

### DIFF
--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -16,7 +16,8 @@ module SolidusAdmin
         Spree::Product.includes(
           :variant_images,
           master: :prices,
-          variants: :prices
+          variants: :prices,
+          variants_including_master: {stock_items: :stock_location}
         ),
         param: :q,
         distinct: false

--- a/admin/spec/requests/solidus_admin/products_spec.rb
+++ b/admin/spec/requests/solidus_admin/products_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe "SolidusAdmin::ProductsController", type: :request do
     allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
   end
 
+  describe "GET #index" do
+    before { create_list(:product, 3) }
+
+    it "renders successfully" do
+      get solidus_admin.products_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "loads stock for every product without an N+1" do
+      expect { get solidus_admin.products_path }
+        .to make_database_queries(matching: /from .spree_stock_items./i, count: 1)
+    end
+  end
+
   describe "PATCH #update" do
     let(:product) { create(:product) }
     let(:params) do


### PR DESCRIPTION
The solidus_admin products index renders each product's stock via `total_on_hand`, which loaded `stock_items` for every variant because `variants_including_master` and their stock items weren't eager-loaded. The page's query count grew with the number of products and variants.

- eager-loads `variants_including_master` with their stock items and stock locations
- the index issues a single `stock_items` query regardless of page size
- adds a request spec asserting the index renders and has no stock N+1
