### PR TITLE
Preload adjustments in promotion recalculation to avoid an N+1

### DIFF
--- a/legacy_promotions/app/models/spree/promotion/order_adjustments_recalculator.rb
+++ b/legacy_promotions/app/models/spree/promotion/order_adjustments_recalculator.rb
@@ -15,6 +15,7 @@ module Spree
 
       def call(persist: true)
         all_items = line_items + shipments
+        ActiveRecord::Associations::Preloader.new(records: all_items, associations: :adjustments).call
         all_items.each do |item|
           promotion_adjustments = item.adjustments.select(&:promotion?)
 

--- a/legacy_promotions/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
+++ b/legacy_promotions/spec/models/spree/promotion/order_adjustments_recalculator_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Spree::Promotion::OrderAdjustmentsRecalculator do
       let(:order) { create(:order_with_line_items, line_items_count: 1, line_items_price: 10) }
       let(:line_item) { order.line_items[0] }
 
+      context "with multiple line items" do
+        let(:order) { create(:order_with_line_items, line_items_count: 3) }
+
+        before { order.reload }
+
+        it "loads line item adjustments in a single query" do
+          expect { subject }.to make_database_queries(matching: /from .spree_adjustments..*adjustable_id. IN \(/im, count: 1)
+        end
+      end
+
       context "when the quantity changes with a CreateQuantityAdjustments promotion" do
         let(:promotion) { create(:promotion, promotion_actions: [promotion_action]) }
         let(:promotion_action) { Spree::Promotion::Actions::CreateQuantityAdjustments.new(calculator:, preferred_group_size: 2) }

--- a/promotions/app/models/solidus_promotions/order_adjuster.rb
+++ b/promotions/app/models/solidus_promotions/order_adjuster.rb
@@ -22,6 +22,8 @@ module SolidusPromotions
     def call(persist: true) # rubocop:disable Lint/UnusedMethodArgument
       return order unless SolidusPromotions::Promotion.order_activatable?(order)
 
+      ActiveRecord::Associations::Preloader.new(records: order.line_items + order.shipments, associations: :adjustments).call
+
       SetDiscountsToZero.call(order)
 
       DiscountOrder.new(order, promotions, dry_run: dry_run).call

--- a/promotions/spec/models/solidus_promotions/order_adjuster_spec.rb
+++ b/promotions/spec/models/solidus_promotions/order_adjuster_spec.rb
@@ -237,4 +237,21 @@ RSpec.describe SolidusPromotions::OrderAdjuster, type: :model do
       end
     end
   end
+
+  context "with multiple line items" do
+    let(:order) { create(:order_with_line_items, line_items_count: 3) }
+    let!(:benefit) do
+      SolidusPromotions::Benefits::AdjustLineItem.create(promotion: promotion, calculator: calculator)
+    end
+
+    before do
+      order_adjuster.call
+      order.save!
+      order.reload
+    end
+
+    it "loads line item adjustments in a single query" do
+      expect { order_adjuster.call }.to make_database_queries(matching: /from .spree_adjustments..*adjustable_id. IN \(/im, count: 1)
+    end
+  end
 end


### PR DESCRIPTION
Recalculating promotions loaded each line item's and shipment's adjustments with its own query, so the adjustment query count grew with the number of items in the order. This runs on every order recalculation.

- preloads adjustments for all line items and shipments in one batch before the recalculation loop
- applies the same fix to both the legacy and the new promotion adjusters
- adjustment queries stay constant regardless of order size
- adds a spec to each engine asserting line item adjustments load in a single query
