### PR TITLE
Preload variant and product when calculating taxes to avoid an N+1

### DIFF
--- a/core/app/models/spree/tax_calculator/default.rb
+++ b/core/app/models/spree/tax_calculator/default.rb
@@ -23,6 +23,8 @@ module Spree
       #
       # @return [Spree::Tax::OrderTax] the calculated taxes for the order
       def calculate
+        ActiveRecord::Associations::Preloader.new(records: order.line_items, associations: {variant: :product}).call
+
         Spree::Tax::OrderTax.new(
           order_id: order.id,
           order_taxes: order_rates,

--- a/core/spec/models/spree/tax_calculator/default_spec.rb
+++ b/core/spec/models/spree/tax_calculator/default_spec.rb
@@ -76,5 +76,18 @@ RSpec.describe Spree::TaxCalculator::Default do
         expect(order_tax.label).to eq "Flat Book Fee"
       end
     end
+
+    context "with multiple line items" do
+      before do
+        2.times do
+          order.contents.add(FactoryBot.create(:product, tax_category: books_category).master)
+        end
+        order.reload
+      end
+
+      it "loads line item variants in a single query" do
+        expect { calculator.calculate }.to make_database_queries(matching: /from .spree_variants..*\bid. IN \(/im, count: 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Calculating order taxes resolves each line item's tax category through its variant, falling back to the product when the variant has none. With those associations unloaded, that was two queries per line item, and taxes are recalculated on every order recalculation.

- preloads each line item's variant and product before calculating taxes
- variant and product loads stay constant regardless of order size
- adds a spec asserting line item variants load in a single query
