### PR TITLE
Preload variants when building inventory units to avoid an N+1

### DIFF
--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -8,6 +8,7 @@ module Spree
       end
 
       def units
+        ActiveRecord::Associations::Preloader.new(records: @order.line_items, associations: {variant: :product}).call
         @order.line_items.flat_map do |line_item|
           build_units(line_item, line_item.quantity)
         end

--- a/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -28,6 +28,16 @@ module Spree
         it "builds the inventory units as pending" do
           expect(subject.units.map(&:pending).uniq).to eq [true]
         end
+
+        context "with multiple line items" do
+          let(:order) { create(:order_with_line_items, line_items_count: 3) }
+
+          before { order.reload }
+
+          it "loads line item variants in a single query" do
+            expect { described_class.new(order).units }.to make_database_queries(matching: /from .spree_variants..*\bid. IN \(/im, count: 1)
+          end
+        end
       end
 
       describe "#missing_units_for_line_item" do


### PR DESCRIPTION
Building inventory units for an order's proposed shipments reads each line item's variant, and the variant's product when resolving its shipping category, with a separate query per line item. This runs whenever shipments are rebuilt, such as the delivery step of checkout.

- preloads each line item's variant and product before building the units
- variant and product loads stay constant regardless of order size
- adds a spec asserting line item variants load in a single query
