### PR TITLE
Preload variants when checking order promotionability to avoid an N+1

### DIFF
--- a/legacy_promotions/app/models/spree/promotion.rb
+++ b/legacy_promotions/app/models/spree/promotion.rb
@@ -240,6 +240,7 @@ module Spree
       when Spree::LineItem
         !promotable.variant.product.promotionable?
       when Spree::Order
+        ActiveRecord::Associations::Preloader.new(records: promotable.line_items, associations: {variant: :product}).call
         promotable.line_items.any? { |line_item| !line_item.variant.product.promotionable? }
       end
     end

--- a/legacy_promotions/spec/models/spree/promotion_spec.rb
+++ b/legacy_promotions/spec/models/spree/promotion_spec.rb
@@ -714,6 +714,17 @@ RSpec.describe Spree::Promotion, type: :model do
           it { is_expected.to be true }
         end
       end
+
+      context "with several line items" do
+        let(:promotion) { create(:promotion, :with_line_item_adjustment, apply_automatically: true) }
+        let(:promotable) { create(:order_with_line_items, line_items_count: 3) }
+
+        before { promotable.reload }
+
+        it "loads line item variants in a single query" do
+          expect { subject }.to make_database_queries(matching: /from .spree_variants..*\bid. IN \(/im, count: 1)
+        end
+      end
     end
 
     context "when promotable is a Spree::LineItem" do


### PR DESCRIPTION
Evaluating a promotion's eligibility checks whether the order contains a non-promotionable product, reading each line item's variant and product with a separate query per line item. This runs every time a promotion is evaluated, including on order recalculation when promotions are present.

- preloads each line item's variant and product before the promotionable check
- variant and product loads stay constant regardless of order size
- adds a spec asserting line item variants load in a single query
