### PR TITLE
Eager load line item details on the admin order page to avoid N+1s

### DIFF
--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -36,7 +36,7 @@ module SolidusAdmin
     end
 
     def show
-      load_order
+      load_order(Spree::Order.includes(line_items: {variant: [:images, {product: :variant_images, option_values: :option_type}]}))
 
       respond_to do |format|
         format.html { render component("orders/show").new(order: @order) }
@@ -111,8 +111,8 @@ module SolidusAdmin
 
     private
 
-    def load_order
-      @order = Spree::Order.find_by!(number: params[:id])
+    def load_order(scope = Spree::Order)
+      @order = scope.find_by!(number: params[:id])
       authorize! action_name, @order
     end
 

--- a/admin/spec/requests/solidus_admin/orders_spec.rb
+++ b/admin/spec/requests/solidus_admin/orders_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidusAdmin::OrdersController", type: :request do
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    allow(SolidusAdmin::Config).to receive(:enable_alpha_features?).and_return(true)
+    allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
+  end
+
+  describe "GET #show" do
+    let(:order) { create(:completed_order_with_totals, line_items_count: 3) }
+
+    it "renders successfully" do
+      get solidus_admin.order_path(order)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "loads line item variants in a single query" do
+      expect { get solidus_admin.order_path(order) }
+        .to make_database_queries(matching: /from .spree_variants..*\bid. IN \(/im, count: 1)
+    end
+  end
+end


### PR DESCRIPTION
The admin order page loaded each line item's variant, product, images and option values lazily while rendering the cart, so the page's query count grew with the number of line items on the order.

- eager loads each line item's variant, product, variant images and option values
- the page's query count stays constant regardless of order size
- adds a request spec asserting the page renders and loads line item variants in a single query
