### PR TITLE
Eager load variant stock on the products API index to avoid an N+1

### DIFF
--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -9,10 +9,12 @@ module Spree
           @products = product_scope.where(id: ids)
         else
           products_includes = [
-            :variants,
             :option_types,
             :product_properties,
-            {classifications: :taxon}
+            {classifications: :taxon},
+            {master: {stock_items: :stock_location}},
+            {variants: {stock_items: :stock_location}},
+            {variants_including_master: {stock_items: :stock_location}}
           ]
           @products = product_scope
             .ransack(params[:q])

--- a/api/spec/requests/spree/api/products_spec.rb
+++ b/api/spec/requests/spree/api/products_spec.rb
@@ -58,6 +58,13 @@ module Spree::Api
         expect(json_response["per_page"]).to eq(Kaminari.config.default_per_page)
       end
 
+      it "loads stock for every product variant without an N+1" do
+        2.times { create(:variant, product: create(:product)) }
+
+        expect { get spree.api_products_path }
+          .to make_database_queries(matching: /from .spree_stock_items./i, count: 3)
+      end
+
       it "retrieves a list of products by id" do
         get spree.api_products_path, params: {ids: [product.id]}
         expect(json_response["products"].first).to have_attributes(show_attributes)


### PR DESCRIPTION
The products API index renders each variant's stock on hand, but did not eager load stock items, so the stock queries grew with the number of variants across the listed products. The page also loaded the master and the variants-including-master per product.

- eager loads stock items and stock locations for the master, the variants, and the variants including master
- stock queries stay constant regardless of how many products and variants are listed
- adds a spec asserting the index loads variant stock without an N+1
