### PR TITLE
Skip redundant preference re-serialization on load

### DIFF
--- a/core/app/models/concerns/spree/preferences/persistable.rb
+++ b/core/app/models/concerns/spree/preferences/persistable.rb
@@ -20,9 +20,10 @@ module Spree
       private
 
       def initialize_preference_defaults
-        if has_attribute?(:preferences)
-          self.preferences = default_preferences.merge(preferences)
-        end
+        return unless has_attribute?(:preferences)
+
+        merged = default_preferences.merge(preferences)
+        self.preferences = merged unless merged == preferences
       end
     end
   end

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -387,6 +387,17 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
       end
     end
 
+    it "does not re-serialize unchanged preferences when read after load" do
+      loaded = PrefTest.find(@pt.id)
+
+      # NOTE: assigning preferences in after_initialize (even an identical value) flips
+      # the attribute to "from user" state, so every later read re-dumps YAML. Skipping
+      # the redundant assignment keeps reads on the cheaper "from database" path.
+      expect(Psych).not_to receive(:safe_dump)
+
+      loaded.preferences
+    end
+
     it "clear preferences when record is deleted" do
       @pt.save!
       @pt.preferred_pref_test_pref = "lmn"


### PR DESCRIPTION
Solidus stores Preferable preferences in a YAML-serialized column. The `initialize_preference_defaults` callback runs on every load and reassigns the preferences attribute even when the merged defaults already equal the stored value.

That assignment flips the attribute to ActiveModel's "from user" state, whose reads round-trip the hash through YAML on every access. "from database" reads only load it, so any code that reads a freshly loaded record's preferences pays for the extra serialization.

Shipping-rate estimation is one hot path that hits this. It reads each shipping method's calculator preferences to filter by currency, so it re-serializes YAML once per shipping method, on every estimation.

This guards the assignment so it only runs when the merge actually changes the stored preferences:

- unchanged records stay on the cheaper read path
- defaults are still backfilled when they are missing
- behaviour is otherwise the same