### PR TITLE
Eager load associations in admin and API collection endpoints

### DIFF
--- a/admin/app/controllers/solidus_admin/stock_items_controller.rb
+++ b/admin/app/controllers/solidus_admin/stock_items_controller.rb
@@ -33,7 +33,12 @@ module SolidusAdmin
 
     def resource_class = Spree::StockItem
 
-    def resources_collection = Spree::StockItem.reorder(nil)
+    def resources_collection
+      Spree::StockItem.reorder(nil).includes(
+        :stock_location,
+        variant: [:product, :images, {option_values: :option_type}]
+      )
+    end
 
     def resources_sorting_options
       {

--- a/admin/spec/requests/solidus_admin/stock_items_spec.rb
+++ b/admin/spec/requests/solidus_admin/stock_items_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidusAdmin::StockItemsController", type: :request do
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
+  end
+
+  describe "GET #index" do
+    it "loads stock item stock locations in a single query" do
+      3.times do
+        location = create(:stock_location, propagate_all_variants: false)
+        create(:stock_item, stock_location: location, variant: create(:variant))
+      end
+
+      expect { get solidus_admin.stock_items_path }.to make_database_queries(matching: /from .spree_stock_locations./i, count: 2)
+    end
+  end
+end

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -34,6 +34,7 @@ module Spree
 
       def scope
         @stock_location.stock_movements.accessible_by(current_ability)
+          .includes(stock_item: {variant: [:product, :prices, :stock_items, :images, {option_values: :option_type}]})
       end
 
       def stock_movement_params

--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -5,6 +5,7 @@ class Spree::Api::UsersController < Spree::Api::BaseController
 
   def index
     user_scope = user_class.accessible_by(current_ability, :show)
+      .includes(bill_address: [:state, :country], ship_address: [:state, :country])
     if params[:ids]
       ids = params[:ids].split(",").flatten
       @users = user_scope.where(id: ids)

--- a/api/spec/requests/spree/api/stock_movements_spec.rb
+++ b/api/spec/requests/spree/api/stock_movements_spec.rb
@@ -76,6 +76,18 @@ module Spree::Api
         expect(response.status).to eq(201)
         expect(json_response).to have_attributes(attributes)
       end
+
+      it "loads stock movement variant prices in a single query" do
+        3.times do
+          variant = create(:variant)
+          item = Spree::StockItem.where(stock_location:, variant:).first_or_create!
+          create(:stock_movement, stock_item: item)
+        end
+
+        expect {
+          get spree.api_stock_location_stock_movements_path(stock_location)
+        }.to make_database_queries(matching: /from .spree_prices./i, count: 1)
+      end
     end
   end
 end

--- a/api/spec/requests/spree/api/users_spec.rb
+++ b/api/spec/requests/spree/api/users_spec.rb
@@ -173,6 +173,14 @@ module Spree::Api
         expect(json_response["users"].size).to eq 2
       end
 
+      it "loads user addresses without an N+1" do
+        allow(Spree::LegacyUser).to receive(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
+
+        3.times { create(:user_with_addresses) }
+
+        expect { get spree.api_users_path }.to make_database_queries(matching: /from .spree_addresses./i, count: 1)
+      end
+
       it "can control the page size through a parameter" do
         2.times { create(:user) }
         get spree.api_users_path, params: {per_page: 1}

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -17,7 +17,7 @@ module Spree
       respond_to :html
 
       def index
-        @payments = @order.payments.includes(refunds: :reason)
+        @payments = @order.payments.includes(:payment_method, refunds: :reason)
         @refunds = @payments.flat_map(&:refunds)
         redirect_to new_admin_order_payment_url(@order) if @payments.empty?
       end

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -12,6 +12,18 @@ module Spree
       let(:user) { create(:admin_user) }
       let(:order) { create(:order) }
 
+      describe "#index" do
+        let(:order) { create(:order, bill_address: create(:address)) }
+
+        it "loads the listed payments' methods without an N+1" do
+          3.times { create(:payment, order:, payment_method: create(:check_payment_method)) }
+
+          expect {
+            get :index, params: {order_id: order.number}
+          }.to make_database_queries(matching: /from .spree_payment_methods./i, count: 2)
+        end
+      end
+
       describe "#create" do
         context "with a valid credit card" do
           let(:order) { create(:order_with_line_items, state: "payment") }


### PR DESCRIPTION
A few admin and API list endpoints render per-row associations that were not eager loaded, so the query count grew with the number of rows. This eager loads what each view already renders.

- solidus_admin stock items index: each row loaded its variant, the variant's product, images, option values, and the stock location
- API stock movements index: each movement loaded its stock item and the variant data the listing renders (product, prices, stock, images, option values)
- API users index: each user loaded its billing and shipping address
- admin order payments list: each payment loaded its payment method

Each fix is a controller-level includes. The specs assert the relevant table is loaded in a single batched query as the number of rows grows.

The solidus_admin products index fix that was originally in here landed separately in 937943f4e8, so it is no longer part of this branch.
