### PR TITLE
Handle missing master price when adding a variant

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -16,7 +16,9 @@ module Spree
         @object.attributes = @object.product.master.attributes.except("id", "created_at", "deleted_at",
           "sku", "is_master")
         # Shallow Clone of the default price to populate the price field.
-        @object.prices.build(@object.product.master.default_price.attributes.except("id", "created_at", "updated_at", "deleted_at"))
+        if (default_price = @object.product.master.default_price)
+          @object.prices.build(default_price.attributes.except("id", "created_at", "updated_at", "deleted_at"))
+        end
       end
 
       def collection

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -7,6 +7,42 @@ module Spree
     describe VariantsController, type: :controller do
       stub_authorization!
 
+      describe "#new" do
+        render_views
+
+        let(:product) { create(:product_with_option_types) }
+
+        before do
+          create(:option_value, option_type: product.option_types.first)
+        end
+
+        subject { get :new, params: {product_id: product.slug} }
+
+        it "builds a variant with the master default price" do
+          subject
+
+          expect(response).to be_successful
+          expect(assigns(:variant).default_price.amount).to eq(product.master.default_price.amount)
+        end
+
+        context "when the product has no master default price" do
+          before do
+            product.master.prices.delete_all
+          end
+
+          it "builds a variant with a new default price" do
+            subject
+
+            default_price = assigns(:variant).default_price
+
+            expect(response).to be_successful
+            expect(default_price).to be_new_record
+            expect(default_price.amount).to be_nil
+            expect(default_price.currency).to eq(Spree::Config[:currency])
+          end
+        end
+      end
+
       describe "#index" do
         let(:product) { create(:product) }
         let(:params) { {product_id: product.slug} }


### PR DESCRIPTION
## Summary

Fixes #4831.

This prevents the admin variant form from raising when a product's master variant has no default price. The new variant action still copies the master default price when it exists, but skips that clone when it is missing so the rendered form can build a blank default-currency price field.

## Testing

- `bundle exec rspec spec/controllers/spree/admin/variants_controller_spec.rb`
- `bundle exec standardrb backend/app/controllers/spree/admin/variants_controller.rb backend/spec/controllers/spree/admin/variants_controller_spec.rb`

I ran these in the `backend` gem context with Ruby 4.0.1 via mise. Full `bin/build` was not run locally.