### PR TITLE
Return BigDecimal from FlatRate zero branches

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -21,7 +21,7 @@ module Spree
     #                            Spree::ShippingRate)
     # @param ... [args, kwargs] Additional arguments passed to the specific compute method
     #
-    # @return [BigDecimal, Numeric] The computed amount
+    # @return [BigDecimal] The computed amount
     #
     # @raise [NotImplementedError] If the calculator doesn't implement the required compute method
     #

--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -11,7 +11,7 @@ module Spree
       if object && preferred_currency.casecmp(object.currency).zero?
         preferred_amount
       else
-        0
+        Spree::ZERO
       end
     end
   end

--- a/core/spec/models/spree/calculator/flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flat_rate_spec.rb
@@ -26,14 +26,18 @@ RSpec.describe Spree::Calculator::FlatRate, type: :model do
       calculator.preferred_amount = 100.0
       calculator.preferred_currency = "GBP"
       allow(order).to receive_messages currency: "USD"
-      expect(calculator.compute(order).round(2)).to eq(0.0)
+      result = calculator.compute(order)
+      expect(result).to be_a(BigDecimal)
+      expect(result.round(2)).to eq(0.0)
     end
 
     it "should compute the amount as 0 when currency is blank" do
       calculator.preferred_amount = 100.0
       calculator.preferred_currency = ""
       allow(order).to receive_messages currency: "GBP"
-      expect(calculator.compute(order).round(2)).to eq(0.0)
+      result = calculator.compute(order)
+      expect(result).to be_a(BigDecimal)
+      expect(result.round(2)).to eq(0.0)
     end
 
     it "should compute the amount as the rate when the currencies use different casing" do
@@ -46,7 +50,9 @@ RSpec.describe Spree::Calculator::FlatRate, type: :model do
     it "should compute the amount as 0 when there is no object" do
       calculator.preferred_amount = 100.0
       calculator.preferred_currency = "GBP"
-      expect(calculator.compute.round(2)).to eq(0.0)
+      result = calculator.compute
+      expect(result).to be_a(BigDecimal)
+      expect(result.round(2)).to eq(0.0)
     end
   end
 end


### PR DESCRIPTION
**Description**

Fixes #3756.

`Spree::Calculator::FlatRate#compute` returned an integer `0` when called without an object, with a blank preferred currency, or with a currency mismatch. Calculator results are expected to be `BigDecimal` monetary amounts, so this changes those zero branches to return `Spree::ZERO`.

This also updates the Calculator YARD return type and adds specs covering the FlatRate zero branches.

**Testing**

- `bundle exec rspec spec/models/spree/calculator/flat_rate_spec.rb`
- `bundle exec rspec spec/models/spree/calculator_spec.rb spec/models/spree/calculator`
- `git diff --check`

**Checklist:**
- [x] I have followed the Pull Request guidelines.
- [x] I have added a detailed description into the commit message.
- [x] Guides and README updates are not needed for this bug fix.
- [x] I have added tests to cover this change.
- [x] Screenshots are not applicable.