### PR TITLE
Fix admin user edit link for custom user classes

### DIFF
--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -87,7 +87,7 @@
         <td class="align-center"><%= l user.created_at.to_date %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">
           <% if can?(:edit, user) %>
-            <%= link_to_edit user, no_text: true, url: spree.admin_user_path(user) %>
+            <%= link_to_edit user, no_text: true, url: spree.edit_admin_user_path(user) %>
           <% end %>
           <% if can?(:destroy, user) && user.can_be_deleted? %>
             <%= link_to_delete user, no_text: true, url: spree.admin_user_path(user) %>

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -72,7 +72,7 @@ describe Spree::Admin::UsersController, type: :controller do
         end)
         @actual_user_class_name = Spree.user_class.name
         Spree.user_class = "UserModel"
-        UserModel.create(email: "a@solidus.io")
+        @custom_user = UserModel.create(email: "a@solidus.io")
         allow(Spree.user_class).to receive(:find_by)
           .with(hash_including(:spree_api_key))
           .and_return(Spree.user_class.new)
@@ -88,6 +88,9 @@ describe Spree::Admin::UsersController, type: :controller do
         get :index
 
         expect(response).to be_successful
+
+        edit_link = Nokogiri::HTML(response.body).at_css("a.icon_link[data-action='edit']")
+        expect(edit_link["href"]).to eq spree.edit_admin_user_path(@custom_user)
       end
     end
   end


### PR DESCRIPTION
Fixes #4010.

This updates the legacy admin users index edit action to link directly to `edit_admin_user_path` instead of the admin user show path. That keeps the edit URL independent of the configured `Spree.user_class` name and avoids relying on the show action redirect.

The existing custom user class render spec now also asserts that the edit icon points to the admin user edit route.

Tests:

* From `backend/`: `bundle exec rspec spec/controllers/spree/admin/users_controller_spec.rb`
* `bundle exec standardrb backend/spec/controllers/spree/admin/users_controller_spec.rb`
* `bundle exec rake lint:erb`
