### PR TITLE
Delegate create_proposed_shipments to Spree::OrderShipping

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -307,6 +307,14 @@ module Spree
       inventory_units.reload.all?(&:returned?)
     end
 
+    # Since this method is called from within the order state machine, we cannot
+    # simply delegate this to :shipping. The state_machines gem uses the arity
+    # of the method to determine if it should pass in the transition as an
+    # argument. The arity of the method is masked when using delegates.
+    def create_proposed_shipments
+      shipping.create_proposed_shipments
+    end
+
     def contents
       @contents ||= Spree::Config.order_contents_class.new(self)
     end
@@ -499,17 +507,6 @@ module Spree
 
     def billing_address_required?
       Spree::Config.billing_address_required
-    end
-
-    def create_proposed_shipments
-      if completed?
-        raise CannotRebuildShipments.new(I18n.t("spree.cannot_rebuild_shipments_order_completed"))
-      elsif shipments.any? { |shipment| !shipment.pending? }
-        raise CannotRebuildShipments.new(I18n.t("spree.cannot_rebuild_shipments_shipments_not_pending"))
-      else
-        shipments.destroy_all
-        shipments.push(*Spree::Config.stock.coordinator_class.new(self).shipments)
-      end
     end
 
     def create_shipments_for_line_item(line_item)

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -8,6 +8,23 @@ class Spree::OrderShipping
     @order = order
   end
 
+  # A method that destroys the current shipments on an order, creates new
+  # shipments for the line items, and assigns them to the order.
+  #
+  # @return [Array<Spree::Shipment>] The created shipments
+  # @raise [Spree::Order::CannotRebuildShipments] raised if order is completed
+  #   or there are any non-pending shipments.
+  def create_proposed_shipments
+    if @order.completed?
+      raise Spree::Order::CannotRebuildShipments.new(I18n.t("spree.cannot_rebuild_shipments_order_completed"))
+    elsif @order.shipments.any? { |shipment| !shipment.pending? }
+      raise Spree::Order::CannotRebuildShipments.new(I18n.t("spree.cannot_rebuild_shipments_shipments_not_pending"))
+    else
+      @order.shipments.destroy_all
+      @order.shipments.push(*Spree::Config.stock.coordinator_class.new(@order).shipments)
+    end
+  end
+
   # A shortcut method that ships *all* inventory units in a shipment in a single
   # carton.  See also {#ship}.
   #

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -64,7 +64,7 @@ module Spree
             calculator.available?(package) &&
               (calculator.preferences[:currency].blank? ||
                calculator.preferences[:currency] == package.shipment.order.currency)
-        end
+          end
       end
     end
   end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -47,7 +47,7 @@ module Spree
       if locales.empty?
         super(nil)
       else
-        super(locales.map(&:to_s).join(","))
+        super(locales.join(","))
       end
     end
 

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -101,7 +101,7 @@ module Spree
       # @return [String] cache key to be used in views
       #
       def cache_key
-        desired_attributes.values.select(&:present?).map(&:to_s).join("/")
+        desired_attributes.values.select(&:present?).join("/")
       end
     end
   end

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -53,6 +53,50 @@ RSpec.describe Spree::OrderShipping do
     end
   end
 
+  describe "#create_proposed_shipments" do
+    subject(:order) { create(:order) }
+
+    it "assigns the coordinator returned shipments to its shipments" do
+      shipment = build(:shipment)
+      allow_any_instance_of(Spree::Stock::SimpleCoordinator).to receive(:shipments).and_return([shipment])
+      order.shipping.create_proposed_shipments
+      expect(order.shipments).to eq [shipment]
+    end
+
+    it "raises an error if any shipments are ready" do
+      shipment = create(:shipment, order:, state: "ready")
+
+      expect {
+        expect {
+          order.shipping.create_proposed_shipments
+        }.to raise_error(Spree::Order::CannotRebuildShipments)
+      }.not_to change { order.reload.shipments.pluck(:id) }
+
+      expect { shipment.reload }.not_to raise_error
+    end
+
+    it "raises an error if any shipments are shipped" do
+      shipment = create(:shipment, order:, state: "shipped")
+      expect {
+        expect {
+          order.shipping.create_proposed_shipments
+        }.to raise_error(Spree::Order::CannotRebuildShipments)
+      }.not_to change { order.reload.shipments.pluck(:id) }
+
+      expect { shipment.reload }.not_to raise_error
+    end
+
+    context "when the order is already completed" do
+      let(:order) { create(:completed_order_with_pending_payment) }
+
+      it "raises an error" do
+        expect {
+          order.shipping.create_proposed_shipments
+        }.to raise_error(Spree::Order::CannotRebuildShipments)
+      end
+    end
+  end
+
   describe "#ship" do
     subject do
       order.shipping.ship(

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1247,49 +1247,6 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
-  describe "#create_proposed_shipments" do
-    subject(:order) { create(:order) }
-    it "assigns the coordinator returned shipments to its shipments" do
-      shipment = build(:shipment)
-      allow_any_instance_of(Spree::Stock::SimpleCoordinator).to receive(:shipments).and_return([shipment])
-      subject.create_proposed_shipments
-      expect(subject.shipments).to eq [shipment]
-    end
-
-    it "raises an error if any shipments are ready" do
-      shipment = create(:shipment, order: subject, state: "ready")
-
-      expect {
-        expect {
-          subject.create_proposed_shipments
-        }.to raise_error(Spree::Order::CannotRebuildShipments)
-      }.not_to change { subject.reload.shipments.pluck(:id) }
-
-      expect { shipment.reload }.not_to raise_error
-    end
-
-    it "raises an error if any shipments are shipped" do
-      shipment = create(:shipment, order: subject, state: "shipped")
-      expect {
-        expect {
-          subject.create_proposed_shipments
-        }.to raise_error(Spree::Order::CannotRebuildShipments)
-      }.not_to change { subject.reload.shipments.pluck(:id) }
-
-      expect { shipment.reload }.not_to raise_error
-    end
-
-    context "when the order is already completed" do
-      let(:order) { create(:completed_order_with_pending_payment) }
-
-      it "raises an error" do
-        expect {
-          order.create_proposed_shipments
-        }.to raise_error(Spree::Order::CannotRebuildShipments)
-      end
-    end
-  end
-
   describe "#all_inventory_units_returned?" do
     let(:order) { create(:order_with_line_items, line_items_count: 3) }
 


### PR DESCRIPTION
## Summary
(From the first commit message)

Spree::OrderShipping is a configurable class, which increases the extensibility for this system behaviour. The Spree::Order model also shouldn't need to be responsible for the creation of its own shipments.

Separating this concern will allow us to refactor the underlying stock coordination implementation without introducing additional churn on the already heavy Spree::Order class.
<!--
  Please include a summary of your changes, along with any useful context.
  Your contribution will be merged under the terms of the license of the parent repository (usually a FreeBSD License).

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
