### PR TITLE
Add SELinux labels to docker-compose bind mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,10 @@ services:
     ports:
       - "${SANDBOX_PORT:-3000}:${SANDBOX_PORT:-3000}"
     volumes:
-      - .:/home/solidus_user/app:delegated
+      - .:/home/solidus_user/app:delegated,z
       - bundle:/home/solidus_user/gems:cached
       - history:/home/solidus_user/history:cached
-      - .dockerdev/.psqlrc:/home/solidus_user/.psqlrc:cached
+      - .dockerdev/.psqlrc:/home/solidus_user/.psqlrc:cached,z
     tty: true
     stdin_open: true
     tmpfs:


### PR DESCRIPTION
On SELinux-enforcing hosts (e.g. Fedora, RHEL) running podman, bind mounts without the "z" label are blocked by SELinux, so the project directory appears empty inside the container and bundler exits with "Could not locate Gemfile". The label is a no-op where SELinux is not enforcing, so this is safe for Docker users.

I've not actually tested this because I'm not running Podman on a Linux system that enforces SELinux.
