### PR TITLE
Link main README installation to storefront docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,37 +84,9 @@ Begin by making sure you have
 required for Paperclip. (You can install it using [Homebrew](https://brew.sh) if
 you're on a Mac.)
 
-To add Solidus, begin with a newly created Rails application with its database.
+To install Solidus with the current storefront, follow the instructions in
+[storefront/README.md](storefront/README.md).
 
-```bash
-rails new my_store
-```
-
-> [!CAUTION]
-> Due to [a bug in `sprockets-rails`](https://github.com/rails/sprockets-rails/pull/546) we need to manually add the sprockets manifest into the generated rails app **before** running any rails commands inside the rails app folder.
-
-```bash
-mkdir -p my_store/app/assets/config
-cat <<MANIFEST > my_store/app/assets/config/manifest.js
-//= link_tree ../images
-//= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
-MANIFEST
-```
-
-### Installing Solidus
-
-In your application's root folder run:
-
-```bash
-bundle add solidus
-bin/rails g solidus:install
-```
-
-> [!NOTE]
-> Please make sure to generate the sprockets manifest before running the `solidus:install` generator.
-
-And follow the prompt's instructions.
 ### Accessing Solidus Store
 
 Start the Rails server with the command:


### PR DESCRIPTION
Fixes #6516

## Summary

The root README duplicated an outdated Solidus installation flow (`solidus:install` without `--frontend=starter`) and a sprockets manifest workaround. The storefront README is the canonical install path.

This PR removes the duplicated steps from the root README and links to [`storefront/README.md`](storefront/README.md) instead. Post-install info (Imagemagick prerequisite, server URLs, default admin credentials, and support links) stays in the root README.

## Test plan

- [x] Verified the link to `storefront/README.md` renders correctly
- [x] Confirmed storefront README contains the current install flow with `--frontend=starter`

## Checklist

The following are mandatory for all PRs:

- [x] I agree that my PR will be published under the same license as Solidus.
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code. *(N/A — no user-facing strings added)*
- [x] I have used clear, explanatory commit messages.

The following are not always needed:

- [x] 📖 I have updated the README to account for my changes.
- [ ] 📑 I have documented new code with YARD. *(N/A — docs-only change)*
- [ ] 🛣️ I have opened a PR to update the guides. *(N/A — no guide changes needed)*
- [ ] ✅ I have added automated tests to cover my changes. *(N/A — documentation-only change)*
- [ ] 📸 I have attached screenshots to demo visual changes. *(N/A — no visual changes)*