### PR TITLE
TaxonRevenue condition: Add "exclude" match policy

### DIFF
--- a/promotions/app/models/solidus_promotions/conditions/taxon_revenue.rb
+++ b/promotions/app/models/solidus_promotions/conditions/taxon_revenue.rb
@@ -9,8 +9,12 @@ module SolidusPromotions
       preference :operator, :string, default: "gte"
       preference :amount, :decimal, default: 0
       preference :currency, :string, default: -> { Spree::Config.currency }
+      preference :match_policy, :string, default: "include"
 
       OPERATORS = {"gte" => :>=, "gt" => :>, "lt" => :<, "lte" => :<=}.freeze
+      MATCH_POLICIES = ["include", "exclude"].freeze
+
+      validates :preferred_match_policy, inclusion: {in: MATCH_POLICIES}
 
       def self.operator_options
         OPERATORS.map do |name, _method|
@@ -18,13 +22,28 @@ module SolidusPromotions
         end
       end
 
-      def order_eligible?(order, _options = {})
-        matching = order.line_items.select do |line_item|
-          taxon_ids_with_children.any? do |taxon_and_descendant_ids|
-            (line_item.variant.product.classifications.map(&:taxon_id) & taxon_and_descendant_ids).any?
-          end
+      def self.match_policy_options
+        MATCH_POLICIES.map do |name|
+          [I18n.t(name, scope: %i[solidus_promotions conditions taxon_revenue match_policies]), name]
         end
+      end
+
+      def order_eligible?(order, _options = {})
+        matching = order.line_items.select { |line_item| taxon_match?(line_item) }
+
         matching.sum(&:discounted_amount).public_send(OPERATORS.fetch(preferred_operator), preferred_amount)
+      end
+
+      private
+
+      def taxon_match?(line_item)
+        line_item_taxon_ids = line_item.variant.product.classifications.map(&:taxon_id)
+
+        in_selected_taxons = taxon_ids_with_children.any? do |taxon_and_descendant_ids|
+          (line_item_taxon_ids & taxon_and_descendant_ids).any?
+        end
+
+        (preferred_match_policy == "exclude") ? !in_selected_taxons : in_selected_taxons
       end
     end
   end

--- a/promotions/config/locales/en.yml
+++ b/promotions/config/locales/en.yml
@@ -76,6 +76,10 @@ en:
         match_policies:
           include: Line item's product has one of the chosen taxons
           exclude: Line item's product does not have one of the chosen taxons
+      taxon_revenue:
+        match_policies:
+            include: Revenue from selected taxons
+            exclude: Revenue excluding selected taxons
     item_total_condition:
       operators:
         gt: greater than
@@ -331,9 +335,10 @@ en:
       solidus_promotions/conditions/user_role:
         description: Order includes User with specified Role(s)
       solidus_promotions/conditions/taxon_revenue:
-        description: Revenue from configured taxons is...
+        description: Controls eligibility by matching on revenue from or excluding selected taxons.
         preferred_operator: Operator
         preferred_amount: Amount
+        preferred_match_policy: Match Policy
       solidus_promotions/calculators/tiered_flat_rate:
         description: Flat Rate in tiers based on item amount
         preferred_base_amount: Base Amount

--- a/promotions/lib/views/backend/solidus_promotions/admin/condition_fields/_taxon_revenue.html.erb
+++ b/promotions/lib/views/backend/solidus_promotions/admin/condition_fields/_taxon_revenue.html.erb
@@ -2,6 +2,13 @@
   <%= condition.class.human_attribute_name(:description) %>
 </p>
 <%= fields_for param_prefix, condition do |form| %>
+  <div class="field">
+    <%= form.label :preferred_match_policy %>
+    <%= form.select :preferred_match_policy,
+      SolidusPromotions::Conditions::TaxonRevenue.match_policy_options,
+      {}, class: "custom-select fullwidth" %>
+  </div>
+
   <div class="row">
     <div class="col-6">
       <div class="field">

--- a/promotions/spec/models/solidus_promotions/conditions/taxon_revenue_spec.rb
+++ b/promotions/spec/models/solidus_promotions/conditions/taxon_revenue_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe SolidusPromotions::Conditions::TaxonRevenue do
       condition.preferred_operator = "gt"
       expect(condition.preferred_operator).to eq("gt")
     end
+
+    it "defaults preferred_match_policy to 'include'" do
+      expect(condition.preferred_match_policy).to eq("include")
+    end
+
+    it "accepts 'exclude' as a valid match policy" do
+      condition.preferred_match_policy = "exclude"
+      expect(condition.preferred_match_policy).to eq("exclude")
+    end
+
+    it "is invalid with an unrecognized match policy" do
+      condition.preferred_match_policy = "some_other_policy"
+      expect(condition).not_to be_valid
+      expect(condition.errors[:preferred_match_policy]).to be_present
+    end
   end
 
   describe "taxons association" do
@@ -50,6 +65,17 @@ RSpec.describe SolidusPromotions::Conditions::TaxonRevenue do
         ["greater than", "gt"],
         ["less than", "lt"],
         ["less than or equal to", "lte"]
+      )
+    }
+  end
+
+  describe ".match_policy_options" do
+    subject(:match_policy_options) { described_class.match_policy_options }
+
+    it {
+      is_expected.to contain_exactly(
+        ["Revenue from selected taxons", "include"],
+        ["Revenue excluding selected taxons", "exclude"]
       )
     }
   end
@@ -177,6 +203,99 @@ RSpec.describe SolidusPromotions::Conditions::TaxonRevenue do
 
       it "does not count any line items and is not eligible above zero" do
         expect(condition).not_to be_order_eligible(order)
+      end
+    end
+
+    context "when preferred_match_policy is 'exclude'" do
+      before { condition.preferred_match_policy = "exclude" }
+
+      context "when the non-excluded-taxon revenue equals the threshold" do
+        let(:preferred_amount) { 50 }
+
+        it "is eligible" do
+          # matching_item (in matching_taxon) is excluded from the sum;
+          # only non_matching_item (50) counts, and 50 >= 50
+          expect(condition).to be_order_eligible(order)
+        end
+      end
+
+      context "when the non-excluded-taxon revenue exceeds the threshold" do
+        let(:preferred_amount) { 40 }
+
+        it "is eligible" do
+          expect(condition).to be_order_eligible(order)
+        end
+      end
+
+      context "when the non-excluded-taxon revenue is below the threshold" do
+        let(:preferred_amount) { 60 }
+
+        it "is not eligible" do
+          # only non_matching_item (50) counts, 50 < 60
+          expect(condition).not_to be_order_eligible(order)
+        end
+      end
+
+      it "does not count revenue from line items in the excluded taxon" do
+        # If the excluded item were counted, total would be 80 (30 + 50).
+        # With it excluded, only 50 counts, so a threshold of 51 is not met.
+        condition.preferred_amount = 51
+        expect(condition).not_to be_order_eligible(order)
+      end
+
+      context "when all line items belong to the excluded taxon" do
+        let(:order) { build_stubbed(:order, line_items: [matching_item]) }
+        let(:preferred_amount) { 1 }
+
+        it "is not eligible because the non-excluded revenue is zero" do
+          expect(condition).not_to be_order_eligible(order)
+        end
+
+        context "when the preferred amount is zero" do
+          let(:preferred_amount) { 0 }
+
+          it { is_expected.to be_order_eligible(order) }
+        end
+      end
+
+      context "when multiple taxons are excluded" do
+        let(:other_excluded_item) { build(:line_item, price: 25, product: non_matching_product) }
+        let(:third_taxon) { create(:taxon) }
+        let(:third_product) { build(:product, taxons: [third_taxon]) }
+        let(:remaining_item) { build(:line_item, price: 15, product: third_product) }
+        let(:order) { build_stubbed(:order, line_items: [matching_item, other_excluded_item, remaining_item]) }
+        let(:preferred_amount) { 15 }
+
+        before do
+          condition.taxons << other_taxon
+        end
+
+        it "only counts revenue from line items outside every excluded taxon" do
+          # matching_item (matching_taxon) and other_excluded_item (other_taxon) are excluded;
+          # only remaining_item (15) counts, and 15 >= 15
+          expect(condition).to be_order_eligible(order)
+        end
+      end
+
+      context "when a line item belongs to both an excluded and a non-excluded taxon" do
+        let(:multi_taxon_item) { build(:line_item, price: 30, product: multi_taxon_product) }
+        let(:multi_taxon_product) { build(:product, taxons: [matching_taxon, other_taxon]) }
+        let(:order) { build_stubbed(:order, line_items: [multi_taxon_item]) }
+        let(:preferred_amount) { 1 }
+
+        it "is excluded, since it belongs to the excluded taxon" do
+          expect(condition).not_to be_order_eligible(order)
+        end
+      end
+
+      context "when no taxons are configured on the condition" do
+        subject(:condition) { described_class.new(preferred_amount:, preferred_match_policy: "exclude") }
+        let(:preferred_amount) { 79 }
+
+        it "counts all line items, since none belong to an excluded taxon" do
+          # 30 + 50 = 80 >= 79
+          expect(condition).to be_order_eligible(order)
+        end
       end
     end
   end


### PR DESCRIPTION

## Summary

It's useful to only count revenue from certain taxons, but some promotions require counting all revenue except that from the selected taxons. This commit extends the `TaxonRevenue` condition such that one can exclude taxons from revenue.

An example promotions that can be done with this condition that can be done with this condition would be: A free shirt for all non-belt purchases.

<img width="1465" height="1202" alt="image" src="https://github.com/user-attachments/assets/6299cdf7-7cfa-48d2-b1f3-de0a4ef04e64" />


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
