### PR TITLE
Make PayPal optional to fix solidus_stripe specs

### DIFF
--- a/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
+++ b/core/lib/generators/solidus/install/app_templates/payment_method/paypal.rb
@@ -1,5 +1,6 @@
 unless Bundler.locked_gems.dependencies["solidus_paypal_commerce_platform"]
-  bundle_command "add solidus_paypal_commerce_platform --version='~> 1.0'"
+  # The released gem uses the old enum syntax and breaks on recent Ruby/Rails, so install from GitHub.
+  bundle_command "add solidus_paypal_commerce_platform --github solidusio/solidus_paypal_commerce_platform"
 end
 
 generate "solidus_paypal_commerce_platform:install --migrate=#{options[:migrate]}"

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -178,8 +178,8 @@ module Solidus
 
     def install_subcomponents
       apply_template_for :authentication, @selected_authentication
-      apply_template_for :frontend, @selected_frontend
       apply_template_for :payment_method, @selected_payment_method
+      apply_template_for :frontend, @selected_frontend
     end
 
     def install_solidus_admin

--- a/storefront/template.rb
+++ b/storefront/template.rb
@@ -104,15 +104,26 @@ with_log["installing gems"] do
     gem "rubocop-performance", "~> 1.5"
     gem "rubocop-rails", "~> 2.3"
     gem "rubocop-rspec", "~> 3.0"
-    gem "solidus_paypal_commerce_platform", github: "solidusio/solidus_paypal_commerce_platform"
   end
 
   run_bundle
 end
 
 with_log["installing files"] do
+  # Check the Gemfile directly; Bundler.locked_gems is memoized earlier in the run and would be stale here.
+  gemfile = Pathname(app_path).join("Gemfile")
+  paypal_present = gemfile.exist? && gemfile.read.include?("solidus_paypal_commerce_platform")
+
   directory "app", "app", verbose: auto_accept, force: auto_accept
   directory "public", "public"
+
+  unless paypal_present
+    remove_file "app/controllers/solidus_paypal_commerce_platform", verbose: false
+    remove_file "app/views/solidus_paypal_commerce_platform", verbose: false
+    remove_file "app/views/checkouts/payment/_paypal_commerce_platform.html.erb", verbose: false
+    remove_file "app/views/orders/payment/_paypal_commerce_platform.html.erb", verbose: false
+    remove_file "app/views/products/payment/_paypal_commerce_platform.html.erb", verbose: false
+  end
 
   copy_file "config/importmap.rb"
   copy_file "config/initializers/solidus_auth_devise_unauthorized_redirect.rb"
@@ -159,6 +170,11 @@ with_log["installing files"] do
   # Allows to skip frontend specs generation from extensions CI pipelines
   if ENV.fetch("FRONTEND_SPECS", "all") == "all"
     directory "spec", verbose: false
+
+    unless paypal_present
+      remove_file "spec/requests/solidus_paypal_commerce_platform", verbose: false
+      remove_file "spec/system/paypal_spec.rb", verbose: false
+    end
   else
     # This file is always necessary in order to run frontend specs from extensions
     copy_file "spec/solidus_storefront_spec_helper.rb", verbose: auto_accept, force: auto_accept

--- a/storefront/templates/spec/solidus_storefront_spec_helper.rb
+++ b/storefront/templates/spec/solidus_storefront_spec_helper.rb
@@ -18,7 +18,11 @@ require "spree/testing_support/caching"
 require "spree/testing_support/order_walkthrough"
 require "spree/testing_support/translations"
 
-require "solidus_paypal_commerce_platform/testing_support/factories"
+begin
+  require "solidus_paypal_commerce_platform/testing_support/factories"
+rescue LoadError
+  # solidus_paypal_commerce_platform is optional
+end
 
 # Define the namespace for the helpers.
 module SolidusStorefront; end


### PR DESCRIPTION
## Summary

We're working on some updates to solidus_stripe. The tests related to PayPal are failing on that project. In order to get it green we need these changes to make PayPal optional. The admin test failures are on main and not related to this change. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
