### PR TITLE
Fix: {LineItem;Shipment}#total_before_tax: Ignore stale adjustments

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -62,7 +62,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
-      amount + adjustments.reject(&:tax?).sum(&:amount)
+      amount + adjustments.reject { |adjustment| adjustment.tax? || adjustment.marked_for_destruction? }.sum(&:amount)
     end
 
     # @return [BigDecimal] the amount of this line item before VAT tax

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -95,7 +95,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
-      amount + adjustments.reject(&:tax?).sum(&:amount)
+      amount + adjustments.reject { |adjustment| adjustment.tax? || adjustment.marked_for_destruction? }.sum(&:amount)
     end
 
     # @return [BigDecimal] the amount of this shipment before VAT tax

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -65,11 +65,21 @@ RSpec.describe Spree::LineItem, type: :model do
     before do
       line_item.update!(price: 10, quantity: 2)
     end
-    let!(:admin_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -1, source: nil) }
-    let!(:other_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -2, source: nil) }
+    let!(:admin_adjustment) { build(:adjustment, adjustable: line_item, order: line_item.order, amount: -1, source: nil) }
+    let!(:other_adjustment) { build(:adjustment, adjustable: line_item, order: line_item.order, amount: -2, source: nil) }
 
     it "returns the amount minus any adjustments" do
       expect(line_item.total_before_tax).to eq(20 - 1 - 2)
+    end
+
+    context "with adjustments that are marked for destruction" do
+      before do
+        other_adjustment.mark_for_destruction
+      end
+
+      it "ignores adjustments that are marked for destruction" do
+        expect(line_item.total_before_tax).to eq(20 - 1)
+      end
     end
   end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -222,6 +222,16 @@ RSpec.describe Spree::Shipment, type: :model do
     it "returns the amount minus any adjustments" do
       expect(shipment.total_before_tax).to eq(10 - 1 - 2)
     end
+
+    context "with adjustments that are marked for destruction" do
+      before do
+        shipment.adjustments.select { |adjustment| adjustment.amount == -2 }.each(&:mark_for_destruction)
+      end
+
+      it "ignores adjustments that are marked for destruction" do
+        expect(shipment.total_before_tax).to eq(10 - 1)
+      end
+    end
   end
 
   it "#tax_total with included taxes" do


### PR DESCRIPTION

## Summary

SolidusPromotions will mark adjustments for destruction if they no longer apply (especially if there are two adjustments from promotions from the same lane). With unpersisted orders, this can lead to `#total_before_tax` on line items and shipments to count those stale adjustments.

The fix is to always exclude adjustments that are marked for destruction.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
