### PR TITLE
Admin Orders spec: Do not restrict Line Item loading from setup

### DIFF
--- a/admin/spec/requests/solidus_admin/orders_spec.rb
+++ b/admin/spec/requests/solidus_admin/orders_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "SolidusAdmin::OrdersController", type: :request do
     end
 
     it "loads line item variants in a single query" do
+      order
       expect { get solidus_admin.order_path(order) }
         .to make_database_queries(matching: /from .spree_variants..*\bid. IN \(/im, count: 1)
     end


### PR DESCRIPTION


## Summary

We want to make sure the admin only loads line items once, but we do not need to include the test setup for that loading in the spec.

By creating the order once before testing the absence of n+1 queries, we fix the specs.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
