### PR TITLE
Reuse the order's line items when building a shipping manifest

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,6 +1,7 @@
 <%
   manifest_items = Spree::ShippingManifest.new(
     inventory_units: shipment.inventory_units.where(carton_id: nil),
+    order: order
   ).items.sort_by { |item| item.line_item.created_at }
 %>
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -178,7 +178,12 @@ module Spree
     end
 
     def manifest
-      @manifest ||= Spree::ShippingManifest.new(inventory_units:).items
+      @manifest ||= Spree::ShippingManifest.new(
+        inventory_units:,
+        # Only when it is already in memory — the manifest treats the order as an
+        # optimization and must not cause a query for it.
+        order: (order if association(:order).loaded?)
+      ).items
     end
 
     def selected_shipping_rate_id

--- a/core/app/models/spree/shipping_manifest.rb
+++ b/core/app/models/spree/shipping_manifest.rb
@@ -3,28 +3,63 @@
 class Spree::ShippingManifest
   ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)
 
-  def initialize(inventory_units:)
-    @inventory_units = inventory_units.to_a
+  attr_reader :inventory_units, :order
+
+  # @param inventory_units [Enumerable<Spree::InventoryUnit>]
+  # @param order [Spree::Order, nil] the order the units belong to. When
+  #   given and its line items are already loaded, the manifest reuses those
+  #   +Spree::LineItem+ instances rather than letting each inventory unit
+  #   load its own copy.
+  def initialize(inventory_units:, order: nil)
+    @inventory_units = inventory_units
+    @order = order
   end
 
   def for_order(order)
-    Spree::ShippingManifest.new(
-      inventory_units: @inventory_units.select { |iu| iu.order_id == order.id }
+    self.class.new(
+      inventory_units: inventory_units.select { |unit| unit.order_id == order.id },
+      order: order
     )
   end
 
   def items
     # Grouping by the ID means that we don't have to call out to the association accessor
     # This makes the grouping by faster because it results in less SQL cache hits.
-    @inventory_units.group_by(&:variant_id).flat_map do |_variant_id, variant_units|
-      variant_units.group_by(&:line_item_id).map do |_line_item_id, units|
+    inventory_units.group_by(&:variant_id).flat_map do |_variant_id, variant_units|
+      variant_units.group_by(&:line_item_id).map do |line_item_id, line_item_units|
         states = {}
-        units.group_by(&:state).each { |state, iu| states[state] = iu.count }
+        line_item_units.group_by(&:state).each { |state, iu| states[state] = iu.count }
 
-        first_unit = units.first
+        first_unit = line_item_units.first
 
-        ManifestItem.new(first_unit.line_item, first_unit.variant, units.length, states)
+        ManifestItem.new(
+          line_item_for(line_item_id, first_unit),
+          first_unit.variant,
+          line_item_units.length,
+          states
+        )
       end
     end
+  end
+
+  private
+
+  # Prefer the instance the order already holds in memory. Rails has no identity
+  # map, so +unit.line_item+ returns a second instance of the same row: it does
+  # not reflect adjustments that have been recalculated on the order's own line
+  # items but not yet persisted, and it costs a query per line item on top.
+  def line_item_for(line_item_id, unit)
+    order_line_items.fetch(line_item_id) { unit.line_item }
+  end
+
+  # Empty unless the order's line items are already loaded. This is an
+  # optimization for callers that have them, never a reason to run a query.
+  def order_line_items
+    @order_line_items ||=
+      if order&.association(:line_items)&.loaded?
+        order.line_items.index_by(&:id)
+      else
+        {}
+      end
   end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -263,6 +263,34 @@ RSpec.describe Spree::Shipment, type: :model do
         expect(shipment.manifest.first.variant).to eq variant
       end
     end
+
+    context "when the order and its line items are already loaded" do
+      before { order.line_items.load }
+
+      it "reuses the order's line item instance" do
+        expect(shipment.manifest.first.line_item).to equal(order.line_items.first)
+      end
+
+      it "reflects unsaved changes to the order's line items" do
+        order.line_items.first.adjustment_total = 5
+
+        expect(shipment.manifest.first.line_item.adjustment_total).to eq 5
+      end
+    end
+
+    context "when the order is not loaded" do
+      let(:reloaded_shipment) { Spree::Shipment.find(shipment.id) }
+
+      it "does not load the order" do
+        reloaded_shipment.manifest
+
+        expect(reloaded_shipment.association(:order)).not_to be_loaded
+      end
+
+      it "still returns the line item expected" do
+        expect(reloaded_shipment.manifest.first.line_item).to eq line_item
+      end
+    end
   end
 
   context "shipping_rates" do

--- a/core/spec/models/spree/shipping_manifest_spec.rb
+++ b/core/spec/models/spree/shipping_manifest_spec.rb
@@ -106,5 +106,33 @@ module Spree
         end
       end
     end
+
+    context "when an order with loaded line items is given" do
+      let(:order) { create(:order_with_line_items) }
+      it "reuses the order's line item instances" do
+        manifest = described_class.new(inventory_units: shipment.inventory_units, order: order)
+        expect(manifest.items.map { |item| item.line_item.object_id })
+          .to match_array(order.line_items.map(&:object_id))
+      end
+
+      it "reflects unsaved changes made to the order's line items" do
+        order.line_items.first.adjustment_total = 5
+        manifest = described_class.new(inventory_units: shipment.inventory_units, order: order)
+        expect(manifest.items.first.line_item.adjustment_total).to eq(5)
+      end
+
+      it "does not mark the inventory units as changed" do
+        manifest = described_class.new(inventory_units: shipment.inventory_units, order: order)
+        expect { manifest.items }.not_to change { shipment.inventory_units.map(&:changed?) }
+      end
+    end
+
+    context "when the order's line items are not loaded" do
+      it "does not load them" do
+        order.association(:line_items).reset
+        described_class.new(inventory_units: shipment.inventory_units, order: order).items
+        expect(order.association(:line_items)).not_to be_loaded
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Spree::ShippingManifest` builds its items from inventory units, and reaches the line
item through `unit.line_item`. Since Rails has no identity map, that returns a *second*
instance of a row the caller almost always already holds in memory as part of
`order.line_items`.

Two consequences:

1. **Stale data.** Adjustments recalculated on the order's line items but not yet
   persisted are invisible to the manifest, which reports the values as they were on
   disk. This is the bug that motivated the change.
2. **A query per line item**, on a path that is usually rendered once per shipment.

This adds an optional `order:` keyword to `ShippingManifest#initialize`. When given, and
when that order's line items are *already loaded*, the manifest resolves each item's line
item from the order instead of from the inventory unit. It falls back to `unit.line_item`
otherwise, so behaviour is unchanged for every existing caller.

## Implementation notes

- **Query-neutral by construction.** The reuse is skipped entirely unless
  `order.association(:line_items).loaded?`. It is an optimization for callers that already
  have the line items, never a reason to issue a query.
- For the same reason, `Shipment#manifest` passes `order: (order if
  association(:order).loaded?)` rather than `order: order` — it must not trigger a load of
  the order. In the common path (`order.shipments`) the association is already populated
  via `inverse_of`, so this costs nothing.
- Nothing is mutated: the lookup happens where the manifest item is constructed, so no
  association targets are reassigned and no inventory unit is touched.
- `for_order` propagates the order, which is how `Carton#manifest_for_order` picks this
  up. `Carton#manifest` is deliberately left alone — a carton can span multiple orders,
  so there is no single order to pass.
- `nil` `line_item_id` (the association is `optional: true`) and units belonging to a
  different order both fall through to the existing behaviour via `Hash#fetch` with a
  block.
- The `group_by(&:variant_id)` / `group_by(&:line_item_id)` optimization in `items` is
  preserved. This arguably extends it: the one remaining association call per group now
  resolves from memory too.

## Call sites updated

- `Spree::Shipment#manifest`
- `spree/admin/orders/_shipment` — this one builds the manifest from
  `shipment.inventory_units.where(carton_id: nil)`, and already has `order` in scope.

## Behaviour change to be aware of

A manifest built with `order:` now surfaces in-memory, unsaved changes to line items.
That is the intent, but it is observable: anything relying on the manifest's line item
being a clean read of the row will see the order's working copy instead.

## Why not `inverse_of`?

`InventoryUnit` and `LineItem` already declare it on both sides, but `inverse_of` only
links objects loaded *through* one another. The shipment → inventory units → line item
path never passes through `order.line_items`.

## Not addressed

`first_unit.variant` has the same shape and gets no equivalent treatment. Variants are
not mutated in memory during order recalculation the way adjustments are, so there is no
correctness bug there — only a preloading question, which callers can handle with
`includes`.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
