### PR TITLE
Preload line item variants and products in the promotions order adjuster

### DIFF
--- a/promotions/app/models/solidus_promotions/order_adjuster.rb
+++ b/promotions/app/models/solidus_promotions/order_adjuster.rb
@@ -23,6 +23,8 @@ module SolidusPromotions
       return order unless SolidusPromotions::Promotion.order_activatable?(order)
 
       ActiveRecord::Associations::Preloader.new(records: order.line_items + order.shipments, associations: :adjustments).call
+      # DiscountOrder dereferences `line_item.variant.product` for every line item.
+      ActiveRecord::Associations::Preloader.new(records: order.line_items, associations: {variant: :product}).call
 
       SetDiscountsToZero.call(order)
 

--- a/promotions/spec/models/solidus_promotions/order_adjuster_spec.rb
+++ b/promotions/spec/models/solidus_promotions/order_adjuster_spec.rb
@@ -253,5 +253,13 @@ RSpec.describe SolidusPromotions::OrderAdjuster, type: :model do
     it "loads line item adjustments in a single query" do
       expect { order_adjuster.call }.to make_database_queries(matching: /from .spree_adjustments..*adjustable_id. IN \(/im, count: 1)
     end
+
+    it "loads line item variants in a single query" do
+      expect { order_adjuster.call }.to make_database_queries(matching: /from .spree_variants./im, count: 1)
+    end
+
+    it "loads variant products in a single query" do
+      expect { order_adjuster.call }.to make_database_queries(matching: /from .spree_products./im, count: 1)
+    end
   end
 end


### PR DESCRIPTION
`SolidusPromotions::OrderAdjuster` preloads each line item's adjustments, but `DiscountOrder#adjust_line_items` then reads `line_item.variant.product` for every line item and nothing preloaded that chain. Line items hold distinct variants, so the query cache cannot collapse the lookups.

`adjust_line_items` runs for every lane before its benefits are consulted, so a store that installs SolidusPromotions and configures no promotions at all still pays one variant and one product lookup per line item on every recalculation.

- preloads `{variant: :product}` over the line items, as its own pass since shipments have no variant
- variant and product loads stay constant regardless of cart size
- adds two specs asserting each table is loaded in a single query

Recalculating a five line item order drops from 31 to 25 queries, and a ten line item order from 38 to 25. The saving appears when the order is loaded fresh from the database, which is the ordinary storefront path of loading a cart and recalculating it.

Both specs were confirmed to fail without the fix, reporting "expected 1 query, but 3 were made" on a three line item order.
