### PR TITLE
Recalculate the order once per cart change

### DIFF
--- a/legacy_promotions/app/models/spree/order_contents.rb
+++ b/legacy_promotions/app/models/spree/order_contents.rb
@@ -8,14 +8,15 @@ module Spree
       if order.update(params)
         unless order.completed?
           order.line_items = order.line_items.select { |li| li.quantity > 0 }
+          order.check_shipments_and_restart_checkout
           # Update totals, then check if the order is eligible for any cart promotions.
           # If we do not update first, then the item total will be wrong and ItemTotal
           # promotion rules would not be triggered.
           reload_totals
-          order.check_shipments_and_restart_checkout
-          ::Spree::PromotionHandler::Cart.new(order).activate
+          apply_cart_promotions
         end
-        reload_totals
+        # Incomplete orders were already recalculated above, only when something changed.
+        reload_totals if order.completed?
         true
       else
         false
@@ -25,12 +26,17 @@ module Spree
     private
 
     def after_add_or_remove(line_item, options = {})
-      reload_totals
       shipment = options[:shipment]
       shipment.present? ? shipment.update_amounts : order.check_shipments_and_restart_checkout
-      ::Spree::PromotionHandler::Cart.new(order, line_item).activate
       reload_totals
+      apply_cart_promotions(line_item)
       line_item
+    end
+
+    def apply_cart_promotions(line_item = nil)
+      # Only the promotions that actually changed an adjustment invalidate the totals above.
+      promotion_applied = ::Spree::PromotionHandler::Cart.new(order, line_item).activate
+      reload_totals if promotion_applied
     end
   end
 end

--- a/legacy_promotions/app/models/spree/promotion_handler/cart.rb
+++ b/legacy_promotions/app/models/spree/promotion_handler/cart.rb
@@ -23,14 +23,18 @@ module Spree
       end
 
       def activate
-        promotions.each do |promotion|
-          if (line_item && promotion.eligible?(line_item, promotion_code: promotion_code(promotion))) || promotion.eligible?(order, promotion_code: promotion_code(promotion))
-            promotion.activate(line_item:, order:, promotion_code: promotion_code(promotion))
-          end
-        end
+        promotions.map { |promotion| activate_if_eligible(promotion) }.any?
       end
 
       private
+
+      def activate_if_eligible(promotion)
+        promotion_code = promotion_code(promotion)
+        eligible = (line_item && promotion.eligible?(line_item, promotion_code:)) ||
+          promotion.eligible?(order, promotion_code:)
+
+        eligible && promotion.activate(line_item:, order:, promotion_code:)
+      end
 
       def promotions
         promos = connected_order_promotions | sale_promotions

--- a/legacy_promotions/spec/models/spree/order_contents_spec.rb
+++ b/legacy_promotions/spec/models/spree/order_contents_spec.rb
@@ -11,6 +11,46 @@ RSpec.describe Spree::OrderContents, type: :model do
 
   subject(:order_contents) { described_class.new(order) }
 
+  describe "recalculation count when no promotion applies" do
+    shared_examples "a single recalculation" do
+      it "recalculates the order once" do
+        allow(order).to receive(:recalculate).and_call_original
+
+        change_cart
+
+        expect(order).to have_received(:recalculate).once
+      end
+    end
+
+    context "when an item is added" do
+      def change_cart
+        order_contents.add(variant, 1)
+      end
+
+      it_behaves_like "a single recalculation"
+    end
+
+    context "when a quantity is updated" do
+      before { order_contents.add(variant, 1) }
+
+      def change_cart
+        order_contents.update_cart(line_items_attributes: {"0" => {id: order.line_items.first.id, quantity: 3}})
+      end
+
+      it_behaves_like "a single recalculation"
+    end
+
+    context "when an item is removed" do
+      before { order_contents.add(variant, 1) }
+
+      def change_cart
+        order_contents.remove_line_item(order.line_items.first)
+      end
+
+      it_behaves_like "a single recalculation"
+    end
+  end
+
   context "#add" do
     context "running promotions" do
       let(:promotion) { create(:promotion, apply_automatically: true) }
@@ -65,6 +105,29 @@ RSpec.describe Spree::OrderContents, type: :model do
       }.to change { subject.order.total }
     end
 
+    context "with an automatic ItemTotal promotion the update makes eligible" do
+      let!(:promotion) { create(:promotion, apply_automatically: true) }
+      let!(:action) do
+        Spree::Promotion::Actions::CreateAdjustment.create(
+          promotion:, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 5)
+        )
+      end
+      let!(:rule) do
+        Spree::Promotion::Rules::ItemTotal.create(
+          preferred_operator: "gt", preferred_amount: variant.price * 2, promotion:
+        )
+      end
+
+      it "does not apply while the item total is below the threshold" do
+        expect(order.adjustments).to be_empty
+      end
+
+      it "applies once the raised quantity crosses the threshold" do
+        order_contents.update_cart(params)
+        expect(order.adjustments.reload.map(&:source)).to include(action)
+      end
+    end
+
     context "submits item quantity 0" do
       let(:params) do
         {line_items_attributes: {
@@ -82,6 +145,65 @@ RSpec.describe Spree::OrderContents, type: :model do
     it "ensures updated shipments" do
       expect(subject.order).to receive(:check_shipments_and_restart_checkout)
       subject.update_cart params
+    end
+  end
+
+  describe "persisted totals after a cart change" do
+    let(:order) { create(:order_with_line_items, line_items_count: 1, state: "delivery") }
+    let(:total_columns) do
+      %w[item_total adjustment_total included_tax_total additional_tax_total
+        promo_total shipment_total payment_total total item_count]
+    end
+
+    shared_examples "totals a further recalculation would not change" do
+      it "persists the same totals a full recalculation would" do
+        change_cart
+
+        expect { order.recalculate }
+          .not_to change { order.reload.attributes.slice(*total_columns) }
+      end
+    end
+
+    context "when an item is added" do
+      def change_cart
+        order_contents.add(create(:variant), 1)
+      end
+
+      it_behaves_like "totals a further recalculation would not change"
+    end
+
+    context "when a quantity is updated" do
+      def change_cart
+        order_contents.update_cart(line_items_attributes: {"0" => {id: order.line_items.first.id, quantity: 3}})
+      end
+
+      it_behaves_like "totals a further recalculation would not change"
+    end
+
+    context "when an item is removed" do
+      def change_cart
+        order_contents.remove_line_item(order.line_items.first)
+      end
+
+      it_behaves_like "totals a further recalculation would not change"
+    end
+
+    # A cart change on an order past the cart step destroys its pending shipments and
+    # zeroes shipment_total with update_column, which does not touch total. The order
+    # is only recalculated once, so that recalculation has to happen after the
+    # shipments are gone or the destroyed shipment's cost stays stranded in total.
+    context "when the change destroys the order's pending shipments" do
+      it "leaves the destroyed shipment's cost out of the persisted total" do
+        expect(order.shipments).to be_present
+        expect(order.shipment_total).to be > 0
+
+        order_contents.update_cart(line_items_attributes: {"0" => {id: order.line_items.first.id, quantity: 3}})
+        order.reload
+
+        expect(order.shipments).to be_empty
+        expect(order.shipment_total).to eq(0)
+        expect(order.total).to eq(order.item_total + order.adjustment_total)
+      end
     end
   end
 

--- a/legacy_promotions/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/legacy_promotions/spec/models/spree/promotion_handler/cart_spec.rb
@@ -10,12 +10,12 @@ module Spree
       let(:promotion) { create(:promotion, apply_automatically: true) }
       let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }
 
-      subject { Cart.new(order, line_item) }
+      subject(:handler) { described_class.new(order, line_item) }
 
       shared_context "creates the adjustment" do
         it "creates the adjustment" do
           expect {
-            subject.activate
+            handler.activate
           }.to change { adjustable.adjustments.count }.by(1)
         end
       end
@@ -23,7 +23,7 @@ module Spree
       shared_context "creates an order promotion" do
         it "connects the promotion to the order" do
           expect {
-            subject.activate
+            handler.activate
           }.to change { order.promotions.reload.to_a }.from([]).to([promotion])
         end
       end
@@ -36,19 +36,27 @@ module Spree
           include_context "creates the adjustment"
           include_context "creates an order promotion"
 
+          it "returns true when an adjustment is created" do
+            expect(handler.activate).to be(true)
+          end
+
           context "for a non-sale promotion" do
             let(:promotion) { create(:promotion, apply_automatically: false) }
 
             it "doesn't connect the promotion to the order" do
               expect {
-                subject.activate
+                handler.activate
               }.to change { order.promotions.count }.by(0)
             end
 
             it "doesn't create an adjustment" do
               expect {
-                subject.activate
+                handler.activate
               }.to change { adjustable.adjustments.count }.by(0)
+            end
+
+            it "returns false when nothing is activated" do
+              expect(handler.activate).to be(false)
             end
           end
         end
@@ -118,13 +126,13 @@ module Spree
         include_context "creates the adjustment"
 
         it "records the promotion code in the adjustment" do
-          subject.activate
+          handler.activate
           expect(adjustable.adjustments.map(&:promotion_code)).to eq [promotion_code]
         end
 
         it "checks if the promotion code is eligible" do
           expect_any_instance_of(Spree::Promotion).to receive(:eligible?).at_least(2).times.with(anything, promotion_code:).and_return(false)
-          subject.activate
+          handler.activate
         end
       end
     end


### PR DESCRIPTION
Adding, removing or updating a cart item recalculated the order twice: once so promotion rules see correct totals, and once to fold in any adjustment the promotion handler created. The second pass is only needed when the handler actually changed an adjustment, and it already computes that signal and discards it.

- `PromotionHandler::Cart#activate` now returns whether any promotion created or changed an adjustment
- the second recalculation only runs when it did

Three things in the diff are worth calling out.

`check_shipments_and_restart_checkout` now runs before the recalculation rather than after. A cart change on an order past the cart step destroys its pending shipments and zeroes `shipment_total` with `update_column`, which does not touch `total`. With a single recalculation it has to happen after the shipments are gone, or the destroyed shipment's cost stays stranded in the total. A spec covers this. The promotion handler still runs after the shipment check, so the behaviour 0a9149b19a added for stores that removed the `address` state is unchanged, and the recalculation still precedes the handler so `ItemTotal` rules see correct totals.

This makes `PromotionAction#perform`'s return contract load-bearing for order totals. The contract is already documented in `Spree::Promotion#activate` and all three core actions honour it, but a custom action that creates an adjustment and returns something other than `true` was previously rescued by the unconditional second recalculation and no longer is.

`PromotionHandler::Cart#activate` changes return type, from the promotions array to a boolean. `Spree::OrderContents` is its only caller in the codebase.

Adding one item to a cart that already holds ten drops recalculations from 2 to 1, uncached queries from 8 to 7, and allocations from 9,987 to 6,305. On a five item cart it is 8,593 to 5,608. Measured on seeded variants with GC disabled, best of nine; the allocation counts reproduce exactly across runs. A cart build performs one recalculation per item added, so every one of them pays the saving.

Specs cover the recalculation count for add, update and remove, that the persisted totals match what a further full recalculation would write, that an automatic `ItemTotal` promotion still applies once a quantity change crosses its threshold, and that a cart change past the cart step keeps the destroyed shipment's cost out of the persisted total. All were confirmed to fail without the fix.
