### PR TITLE
fix(core): permit Symbol and HashWithIndifferentAccess in log entries

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -11,8 +11,10 @@ module Spree
     CORE_PERMITTED_CLASSES = [
       ActiveMerchant::Billing::Response,
       ActiveSupport::TimeWithZone,
+      ActiveSupport::HashWithIndifferentAccess,
       Time,
-      ActiveSupport::TimeZone
+      ActiveSupport::TimeZone,
+      Symbol
     ].freeze
 
     class SerializationError < RuntimeError

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details }.not_to raise_error
     end
 
+    it "can parse Symbol instances" do
+      log_entry = described_class.new(details: :foo.to_yaml)
+
+      expect { log_entry.parsed_details }.not_to raise_error
+    end
+
+    it "can parse ActiveSupport::HashWithIndifferentAccess instances" do
+      log_entry = described_class.new(details: {"foo" => "bar"}.with_indifferent_access.to_yaml)
+
+      expect { log_entry.parsed_details }.not_to raise_error
+    end
+
     it "can parse user specified class instances" do
       stub_spree_preferences(log_entry_permitted_classes: ["Date"])
 
@@ -97,6 +109,18 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details = time }.not_to raise_error
     end
 
+    it "can dump Symbol instances" do
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = :foo }.not_to raise_error
+    end
+
+    it "can dump ActiveSupport::HashWithIndifferentAccess instances" do
+      log_entry = described_class.new
+
+      expect { log_entry.parsed_details = {"foo" => "bar"}.with_indifferent_access }.not_to raise_error
+    end
+
     it "can dump user specified class instances" do
       stub_spree_preferences(log_entry_permitted_classes: ["Date"])
 
@@ -120,7 +144,7 @@ RSpec.describe Spree::LogEntry, type: :model do
       bad_response = ActiveMerchant::Billing::Response.new(
         true,
         "FooBar",
-        {foo: {bar: "Symbol keys are not allowed"}}
+        {"data" => {"date" => Date.today}}
       )
 
       log_entry.parsed_payment_response_details_with_fallback = bad_response
@@ -128,8 +152,8 @@ RSpec.describe Spree::LogEntry, type: :model do
 
       expect(details.success?).to eq(true)
       expect(details.message).to eq("[WARNING: An error occurred while trying to serialize the payment response] FooBar")
-      expect(details.params["data"]).to include('"Symbol keys are not allowed"')
-      expect(details.params["error"]).to include("Tried to dump unspecified class: Symbol")
+      expect(details.params["data"]).to include("FooBar")
+      expect(details.params["error"]).to include("Tried to dump unspecified class: Date")
     end
   end
 end


### PR DESCRIPTION
## Summary

Serialized log entry details frequently contain symbols and `HashWithIndifferentAccess` instances (e.g. from payment gateway responses and request params). Because neither class was permitted, serializing such details raised a DisallowedClass error while writing `parsed_details=` unless every integrator added them to `log_entry_permitted_classes` themselves. Since both are core Ruby and Rails value types with no safe-loading risk here, permit them by default.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
