### PR TITLE
feat(log_entry): write details unparsed and validate on read

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -67,37 +67,39 @@ module Spree
     belongs_to :source, polymorphic: true, optional: true
 
     def parsed_details
+      @details ||= deserialize_details
+    end
+
+    def parsed_details=(value)
+      self.details = YAML.dump(value)
+    end
+
+    def parsed_payment_response_details_with_fallback=(response)
+      self.parsed_details = response
+    end
+
+    private
+
+    def deserialize_details
       handle_psych_serialization_errors do
-        @details ||= YAML.safe_load(
+        YAML.safe_load(
           details,
           permitted_classes: self.class.permitted_classes,
           aliases: Spree::Config.log_entry_allow_aliases
         )
       end
-    end
-
-    def parsed_details=(value)
-      handle_psych_serialization_errors do
-        self.details = YAML.safe_dump(
-          value,
-          permitted_classes: self.class.permitted_classes,
-          aliases: Spree::Config.log_entry_allow_aliases
-        )
-      end
-    end
-
-    def parsed_payment_response_details_with_fallback=(response)
-      self.parsed_details = response
-    rescue SerializationError, YAML::Exception => e
-      # Fall back on wrapping the response and signaling the error to the end user.
-      self.parsed_details = ActiveMerchant::Billing::Response.new(
-        response.success?,
-        "[WARNING: An error occurred while trying to serialize the payment response] #{response.message}",
-        {"data" => response.inspect, "error" => e.message.to_s}
+    rescue SerializationError, Psych::Exception => e
+      # The stored response could not be deserialized (a class that isn't
+      # permitted, a disabled alias, or malformed YAML). Keep the record readable
+      # by wrapping the raw details and surfacing the reason instead of raising,
+      # while reporting the error so it stays visible to developers.
+      Rails.error.report(e, handled: true, severity: :warning, context: {spree_log_entry_id: id})
+      ActiveMerchant::Billing::Response.new(
+        false,
+        "[WARNING: An error occurred while trying to deserialize the stored payment response] #{e.message}",
+        {"data" => details, "error" => e.message}
       )
     end
-
-    private
 
     def handle_psych_serialization_errors
       yield

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -13,14 +13,16 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details }.not_to raise_error
     end
 
-    it "can disable aliases and raises a meaningful exception when used" do
+    it "can disable aliases and returns a wrapper referencing the meaningful message when used" do
       stub_spree_preferences(log_entry_allow_aliases: false)
       x = []
       x << x
 
       log_entry = described_class.new(details: x.to_yaml)
 
-      expect { log_entry.parsed_details }.to raise_error(described_class::BadAlias, /log_entry_allow_aliases/)
+      details = log_entry.parsed_details
+      expect(details.success?).to eq(false)
+      expect(details.params["error"]).to match(/log_entry_allow_aliases/)
     end
 
     it "can parse ActiveMerchant::Billing::Response instances" do
@@ -59,10 +61,51 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details }.not_to raise_error
     end
 
-    it "raises a meaningful exception when a disallowed class is found" do
-      log_entry = described_class.new(details: Date.today)
+    it "returns a wrapper referencing the meaningful message when a disallowed class is found" do
+      serialized_date = Date.today.to_yaml
+      log_entry = described_class.new(details: serialized_date)
 
-      expect { log_entry.parsed_details }.to raise_error(described_class::DisallowedClass, /log_entry_permitted_classes/)
+      details = log_entry.parsed_details
+      expect(details.success?).to eq(false)
+      expect(details.message).to include("[WARNING: An error occurred while trying to deserialize the stored payment response]")
+      expect(details.params["data"]).to eq(serialized_date)
+      expect(details.params["error"]).to match(/log_entry_permitted_classes/)
+    end
+
+    it "returns a wrapper when the stored details are malformed YAML" do
+      malformed = "{ this: is: not: valid"
+      log_entry = described_class.new(details: malformed)
+
+      details = log_entry.parsed_details
+      expect(details.success?).to eq(false)
+      expect(details.message).to include("[WARNING: An error occurred while trying to deserialize the stored payment response]")
+      expect(details.params["data"]).to eq(malformed)
+      expect(details.params["error"]).to be_present
+    end
+
+    it "reports the deserialization error so it is visible to developers" do
+      subscriber = Class.new do
+        attr_reader :reported
+
+        def initialize
+          @reported = []
+        end
+
+        def report(error, handled:, severity:, context:, source: nil)
+          @reported << {error: error, handled: handled, severity: severity, context: context}
+        end
+      end.new
+      Rails.error.subscribe(subscriber)
+
+      described_class.new(details: "{ this: is: not: valid").parsed_details
+
+      expect(subscriber.reported.size).to eq(1)
+      report = subscriber.reported.first
+      expect(report[:error]).to be_a(Psych::Exception)
+      expect(report[:handled]).to eq(true)
+      expect(report[:severity]).to eq(:warning)
+    ensure
+      Rails.error.unsubscribe(subscriber) if Rails.error.respond_to?(:unsubscribe)
     end
   end
 
@@ -83,14 +126,14 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details = x }.not_to raise_error
     end
 
-    it "can disable aliases and raises a meaningful exception when used" do
+    it "dumps self-referential structures without restricting aliases" do
       stub_spree_preferences(log_entry_allow_aliases: false)
       x = []
       x << x
 
       log_entry = described_class.new
 
-      expect { log_entry.parsed_details = x }.to raise_error(described_class::BadAlias, /log_entry_allow_aliases/)
+      expect { log_entry.parsed_details = x }.not_to raise_error
     end
 
     it "can dump ActiveMerchant::Billing::Response instances" do
@@ -121,25 +164,15 @@ RSpec.describe Spree::LogEntry, type: :model do
       expect { log_entry.parsed_details = {"foo" => "bar"}.with_indifferent_access }.not_to raise_error
     end
 
-    it "can dump user specified class instances" do
-      stub_spree_preferences(log_entry_permitted_classes: ["Date"])
-
+    it "dumps arbitrary class instances without restriction" do
       log_entry = described_class.new
 
       expect { log_entry.parsed_details = Date.new }.not_to raise_error
     end
-
-    it "raises a meaningful exception when a disallowed class is found" do
-      log_entry = described_class.new
-
-      expect { log_entry.parsed_details = Date.new }.to raise_error(
-        described_class::DisallowedClass, /log_entry_permitted_classes/
-      )
-    end
   end
 
   describe "#parsed_payment_response_details_with_fallback=" do
-    it "wraps non serializable responses" do
+    it "stores the full response and wraps it when it cannot be safely deserialized" do
       log_entry = described_class.new
       bad_response = ActiveMerchant::Billing::Response.new(
         true,
@@ -150,10 +183,10 @@ RSpec.describe Spree::LogEntry, type: :model do
       log_entry.parsed_payment_response_details_with_fallback = bad_response
       details = log_entry.parsed_details
 
-      expect(details.success?).to eq(true)
-      expect(details.message).to eq("[WARNING: An error occurred while trying to serialize the payment response] FooBar")
+      expect(details.success?).to eq(false)
+      expect(details.message).to include("[WARNING: An error occurred while trying to deserialize the stored payment response]")
       expect(details.params["data"]).to include("FooBar")
-      expect(details.params["error"]).to include("Tried to dump unspecified class: Date")
+      expect(details.params["error"]).to include("Tried to load unspecified class: Date")
     end
   end
 end


### PR DESCRIPTION
## Summary

Recording a payment response creates a `Spree::LogEntry`, and the log entry serialized the response through `YAML.safe_dump`. That validated permitted classes at write time and degraded any response it could not serialize, losing the real gateway data. The untrusted boundary is the database read, not the write of our own response, so the log entry now stores the response with a plain `YAML.dump` and defers the `safe_load` validation to when `parsed_details` is read.

The exception behind such a fallback is now reported via `Rails.error` so it stays visible to developers instead of being silently swallowed.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
