### PR TITLE
Fix a few test environment issues

### DIFF
--- a/.github/workflows/test_solidus.yml
+++ b/.github/workflows/test_solidus.yml
@@ -16,7 +16,10 @@ on:
 jobs:
   RSpec:
     name: Rails ${{ matrix.rails }}, Ruby ${{ matrix.ruby }}, ${{ matrix.database }}, ${{ matrix.storage }}
-    runs-on: ubuntu-22.04
+    # NOTE: ubuntu-24.04 is required for libvips 8.13+. ActiveStorage 8.1 refuses to
+    # load with older libvips, because it cannot disable the unfuzzed operations that
+    # are unsafe on untrusted content. ubuntu-22.04 only ships libvips 8.12.1.
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_solidus.yml
+++ b/.github/workflows/test_solidus.yml
@@ -83,11 +83,17 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - uses: awalsh128/cache-apt-pkgs-action@v1
+      # NOTE: Install libvips with plain apt-get rather than a caching action. A
+      # cached install can report a cache hit while restoring zero packages, which
+      # leaves libvips missing and surfaces much later as an opaque
+      # "undefined method 'new' for nil" from ImageProcessing::Vips inside the
+      # specs. `vips --version` makes a bad install fail here instead.
+      - name: Install libvips
         if: ${{ matrix.storage == 'activestorage' }}
-        name: Install libvips
-        with:
-          packages: libvips-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq libvips-dev
+          vips --version
       - name: Setup coverage
         id: setup-coverage
         if: ${{ inputs.coverage && matrix.rails == '8.0' && matrix.ruby == '3.4' }}

--- a/.github/workflows/test_solidus.yml
+++ b/.github/workflows/test_solidus.yml
@@ -91,11 +91,15 @@ jobs:
       # leaves libvips missing and surfaces much later as an opaque
       # "undefined method 'new' for nil" from ImageProcessing::Vips inside the
       # specs. `vips --version` makes a bad install fail here instead.
+      #
+      # ruby-vips binds libvips.so through FFI at runtime, so the docs and the GUI
+      # tools apt recommends are dead weight; libvips-tools is requested explicitly
+      # because it provides the `vips` binary used by the check below.
       - name: Install libvips
         if: ${{ matrix.storage == 'activestorage' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -yq libvips-dev
+          sudo apt-get install -yq --no-install-recommends libvips-dev libvips-tools
           vips --version
       - name: Setup coverage
         id: setup-coverage

--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -53,6 +53,7 @@ Capybara.exact = true
 Capybara.disable_animation = true
 Capybara.default_max_wait_time = ENV["DEFAULT_MAX_WAIT_TIME"].to_f if ENV["DEFAULT_MAX_WAIT_TIME"].present?
 Capybara.enable_aria_label = true
+Capybara.server = :puma, {Silent: true} # A workaround for https://github.com/rspec/rspec-rails/issues/1897
 
 # DATABASE CLEANER
 require "database_cleaner"

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -4,7 +4,15 @@ module Spree
   module TestingSupport
     module CapybaraExt
       def click_icon(type)
-        find(".fa-#{type}").click
+        el = find(".fa-#{type}", visible: :all)
+        begin
+          el.click
+        rescue Selenium::WebDriver::Error::ElementClickInterceptedError
+          # When a floating element (eg. tooltips/overlays) intercepts the click,
+          # scroll the target into view and dispatch a click via JS to keep tests stable.
+          page.execute_script('arguments[0].scrollIntoView({block: "center"});', el.native)
+          page.execute_script("arguments[0].click();", el.native)
+        end
       end
 
       def eventually_fill_in(field, options = {})

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -3,6 +3,18 @@
 ENV["RAILS_ENV"] = "test"
 ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"] = "1"
 
+# Speed up the sqlite runs: `fast_sqlite` patches SQLite3::Database#initialize to
+# set `PRAGMA synchronous = OFF` and `journal_mode = MEMORY`, trading durability we
+# don't need for a database the suite recreates anyway.
+#
+# NOTE: The gem is declared `require: false`, and only when DB is sqlite, so it is
+# genuinely absent for the mysql and postgres runs.
+begin
+  require "fast_sqlite"
+rescue LoadError
+  # Not running against sqlite, nothing to speed up.
+end
+
 require "rails"
 require "active_record/railtie"
 require "action_controller/railtie"
@@ -106,7 +118,10 @@ module DummyApp
 
     # Set the preview path within the dummy app:
     if ActionMailer::Base.respond_to? :preview_paths # Rails 7.1+
-      config.action_mailer.preview_paths << File.expand_path("dummy_app/mailer_previews", __dir__)
+      # Some Rails versions return a frozen array here; assign a new array
+      # to avoid FrozenError when augmenting the paths.
+      existing = Array(config.action_mailer.preview_paths)
+      config.action_mailer.preview_paths = existing + [File.expand_path("dummy_app/mailer_previews", __dir__)]
     else
       config.action_mailer.preview_path = File.expand_path("dummy_app/mailer_previews", __dir__)
     end

--- a/core/spec/lib/spree/testing_support/capybara_ext_spec.rb
+++ b/core/spec/lib/spree/testing_support/capybara_ext_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "selenium-webdriver"
+require "spree/testing_support/capybara_ext"
+
+RSpec.describe Spree::TestingSupport::CapybaraExt do
+  subject(:page_object) do
+    Class.new do
+      include Spree::TestingSupport::CapybaraExt
+
+      attr_reader :page
+
+      def initialize(element:, page:)
+        @element = element
+        @page = page
+      end
+
+      def find(*) = @element
+    end.new(element: element, page: page)
+  end
+
+  let(:element) { instance_double(Capybara::Node::Element, native: :native_element) }
+  let(:page) { instance_double(Capybara::Session, execute_script: nil) }
+
+  describe "#click_icon" do
+    it "clicks the icon it finds" do
+      allow(element).to receive(:click)
+
+      page_object.click_icon(:edit)
+
+      expect(element).to have_received(:click)
+    end
+
+    context "when a floating element intercepts the click" do
+      before do
+        allow(element).to receive(:click)
+          .and_raise(Selenium::WebDriver::Error::ElementClickInterceptedError)
+      end
+
+      it "scrolls the element into view and clicks it via JavaScript" do
+        page_object.click_icon(:edit)
+
+        expect(page).to have_received(:execute_script)
+          .with('arguments[0].scrollIntoView({block: "center"});', :native_element).ordered
+        expect(page).to have_received(:execute_script)
+          .with("arguments[0].click();", :native_element).ordered
+      end
+    end
+
+    context "when finding the icon is itself intercepted" do
+      subject(:page_object) do
+        Class.new do
+          include Spree::TestingSupport::CapybaraExt
+
+          attr_reader :page
+
+          def initialize(page:)
+            @page = page
+          end
+
+          def find(*)
+            raise Selenium::WebDriver::Error::ElementClickInterceptedError
+          end
+        end.new(page: page)
+      end
+
+      # The fallback needs an element to scroll to, so a failure to find one has to
+      # surface as itself rather than as a NoMethodError on nil.
+      it "lets the error through instead of retrying without an element" do
+        expect { page_object.click_icon(:edit) }
+          .to raise_error(Selenium::WebDriver::Error::ElementClickInterceptedError)
+      end
+    end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   mysql:
@@ -18,12 +18,12 @@ services:
       - postgres:/var/lib/postgresql/data:cached
 
   app:
-    shm_size: '512mb'
+    shm_size: "512mb"
     build:
       context: .dockerdev
       dockerfile: Dockerfile
       args:
-        RUBY_VERSION: "3.1"
+        RUBY_VERSION: "3.4.6"
         PG_VERSION: 13
         NODE_VERSION: 20
         MYSQL_VERSION: "8.0"


### PR DESCRIPTION
## Summary

Test-environment and CI fixes, extracted from #6329 so that PR can stay focused on
`Spree.admin_user_class`. No production code is touched — everything here is
testing support, CI configuration, or local tooling.

The two CI commits fix the currently-red `activestorage` matrix. They turned out to
be a chain: the first failure was masking the second, so both are needed to get
green.

## What's in here

### CI: libvips

**Install libvips with apt-get instead of a cached action** — every `activestorage`
job was failing with an opaque `undefined method 'new' for nil`, raised where
ActiveStorage resolves
`ImageProcessing.const_get(ActiveStorage.variant_processor.to_s.camelize)`. The
constant was `nil` because libvips was never installed:
`awalsh128/cache-apt-pkgs-action@v1` reported a cache hit and then restored nothing.

```
Cache hit for: cache-apt-pkgs_c6a33a4bc2050d519bb8c70e7705bd4e
Restoring 0 packages from cache...
```

The same key had restored 79 packages on previously green runs, so the entry had
gone bad. The action still exits `0`, which makes a poisoned cache indistinguishable
from a working one until the specs fail for a seemingly unrelated reason. Bumping the
action's `version` input would mint a fresh key and restore green, but it re-arms the
same trap — so this installs the package directly, matching what
`solidus_installer.yml` already does, and runs `vips --version` so a bad install
fails loudly at that step.

**Run the RSpec matrix on ubuntu-24.04** — with libvips actually installing again,
every Rails 8.0 and 8.1 job failed at load time, before a single example ran:

```
libvips's unfuzzed operations are not safe to use with untrusted content, and Active
Storage cannot disable them. Disabling them requires libvips 8.13 or later and
ruby-vips 2.2.1 or later.
```

ActiveStorage 8.1 raises this from `active_storage/vips.rb` while its engine is being
required, so the whole suite dies in `rake test_app` regardless of which specs would
have run. Rails 7.2 has no such check, which is why only the 8.x rows were affected.
ubuntu-22.04 ships libvips 8.12.1 — one version below the floor. ubuntu-24.04 ships
8.15.1, and is already what `install_dummy_app.yml` and `solidus_installer.yml` use.

The poisoned cache had been hiding this: with no libvips present, `ruby-vips` never
loaded and the version check never ran.

**Skip packages the suite does not need** — `--no-install-recommends` drops
`libvips-doc` and `nip2` (a GUI image editor), taking the download from 67.4MB to
47.0MB. `libvips-tools` is then requested explicitly, since it is only a
recommendation of `libvips-dev` but provides the `vips` binary the check runs.

### On the cost of dropping the cache

Being upfront, since it is a real regression and you have to live with the choice.
Timing the install step across six jobs each:

| | download | mean | range |
|---|---|---|---|
| cached action (when the cache worked) | — | ~6.5s | single sample |
| plain apt-get | 67.4MB | 33.6s | 20.9–47.5s |
| plain apt-get, no recommends | 47.0MB | 29.0s | 21.5–38.1s |

So this trades roughly 22s per job for an install that cannot silently no-op. Those
jobs run in parallel and each takes ~7 minutes, so pipeline latency grows by about
22s once, not 28×. Mirror throughput dominates the variance, which is why trimming
20MB only buys ~5s.

If you would rather have the time back, caching is reasonable — the request is that
any cache layer be guarded by something like `vips --version || <install>`, so a
stale entry degrades loudly at that step instead of resurfacing as
`undefined method 'new' for nil` deep in the specs.

### Test environment

**Silence the puma server for admin specs** — sets `Capybara.server = :puma,
{Silent: true}` in `admin/spec/spec_helper.rb`, matching what
`core/lib/spree/testing_support/capybara_ext.rb` already does. Works around
[rspec-rails#1897](https://github.com/rspec/rspec-rails/issues/1897), which
otherwise floods admin spec output with server logs.

**Fix the ActionMailer `preview_paths` FrozenError, speed up sqlite, fix the dev
container** — on Rails versions where `config.action_mailer.preview_paths` returns a
frozen array, `<<` raises `FrozenError`, so the dummy app assigns a new array
instead.

`fast_sqlite` is required for its side effect: it patches
`SQLite3::Database#initialize` to set `PRAGMA synchronous = OFF` and
`journal_mode = MEMORY`, dropping fsync for a database the suite recreates anyway
(locally, 500 inserts went from ~105ms to ~7ms). It is declared `require: false` and
only when `DB` is sqlite, hence the `rescue LoadError`.

And `docker-compose.yml` was still building the dev container on Ruby 3.1, below the
`>= 3.2.0` in `solidus_core.gemspec`, so `bundle install` could not resolve inside
it; it now matches the version the suite is developed against.

**Make `click_icon` resilient to intercepted clicks** — when a floating element
(tooltip/overlay) sits over the target, Selenium raises
`ElementClickInterceptedError`. The helper now rescues it, scrolls the target
into view, and dispatches the click via JS. The rescue is scoped to the click
itself: covering the `find` as well meant that when *finding* the icon raised, the
fallback ran with a nil element and died with `undefined method 'native' for nil`,
hiding the real error. Comes with a unit spec covering both branches.

## How to test

CI is the test for the libvips commits: the `activestorage` RSpec jobs pass on this
branch, and the `Install libvips` step logs `vips-8.15.1`. Before these commits, 12
of them failed with `undefined method 'new' for nil`.

`bin/rake lint:rb` is clean. The test-environment changes are exercised implicitly —
`dummy_app.rb` and `capybara_ext.rb` are loaded by every gem's specs, and
`spec_helper.rb` by the admin specs:

```
cd core && bundle exec rake test_app && bundle exec rspec
cd admin && bundle exec rake test_app && bundle exec rspec
```

## On the red `codecov/project` check

It reports `92.14% (-2.94%)`, but nothing here reduced coverage — Codecov's own
file-level comparison lists zero files with a coverage change, and `codecov/patch`
is at 100%. The totals it is comparing are not the same shape:

- base (`72f9fcd`): 7,534 / 7,924 lines across **460 files**
- head: 19,488 / 21,149 lines across **1,035 files**

`72f9fcd` is the merge commit for #6509 and never ran the Test workflow, so it has no
coverage report of its own and the baseline falls back to older, partial data
covering about a third of the codebase. This branch uploads the full set because all
seven coverage jobs pass, which tripled the denominator and dropped the percentage.

Worth a maintainer's glance, since it will keep flagging on PRs until a full report
lands on main.

## For maintainers to decide

`mini_magick` is still a declared dependency in `core/solidus_core.gemspec`, while
the test environment is effectively vips-only (`dummy_app.rb` defaults
`variant_processor` to `:vips`). Whether Solidus wants to stay vips-only in test, or
grow a graceful fallback when neither binary is present, seemed like a maintainer
call rather than something to decide inside a CI fix. Worth noting that the failure
mode when the processor is missing is the unhelpful `undefined method 'new' for nil`
shown above.

Also note `test_solidus_rubocops.yml` still runs on ubuntu-22.04. It does not touch
libvips, so it is unaffected and left alone.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code. No user-facing strings are added.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- [x] I have added tests: `core/spec/lib/spree/testing_support/capybara_ext_spec.rb` covers both `click_icon` branches. The remaining changes are CI configuration and test-harness plumbing exercised by the existing suites.
