### PR TITLE
Fix docker dev setup

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -54,6 +54,8 @@ RUN gem update --system \
 
 USER $APP_USER
 
+RUN git config --global --add safe.directory /home/$APP_USER/app
+
 RUN mkdir -p /home/$APP_USER/history
 
 WORKDIR /home/$APP_USER/app

--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -qq \
     libsqlite3-dev \
     chromium \
     chromium-driver \
+    libyaml-dev \
   && rm -rf /var/cache/apt/lists/*
 
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       CAPYBARA_DRIVER: selenium_chrome_headless_docker_friendly
       DB_USERNAME: root
       DB_PASSWORD: password
-      RAILS_VERSION: ${RAILS_VERSION:-~> 7.1.0}
+      RAILS_VERSION: ${RAILS_VERSION:-~> 8.0.0}
       DB_ALL: "1"
       DB_MYSQL_HOST: mysql
       DB_POSTGRES_HOST: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   mysql:
     image: docker.io/mysql:8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   mysql:
-    image: mysql:8.0
+    image: docker.io/mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: password
@@ -10,7 +10,7 @@ services:
       - mysql:/var/lib/mysql:cached
 
   postgres:
-    image: postgres:13.2
+    image: docker.io/postgres:13.2
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
This is a follow-up to #6510 and #6511, superseding #6513. I took the parts I wanted from #6513 and fixed the remaining issue that broke `docker compose up` for everyone, not just podman users.

Closes #6510.

## Checklist

- [x] I agree that my PR will be published under the same license as Solidus.
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] I have used clear, explanatory commit messages.