### PR TITLE
Remove references to mb_chars

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -93,7 +93,7 @@ module Spree
         end
       end
 
-      content_tag(:nav, content_tag(:ol, raw(items.join), class: breadcrumb_class, itemscope: "", itemtype: "https://schema.org/BreadcrumbList"), id: "breadcrumbs", class: "sixteen columns")
+      content_tag(:nav, content_tag(:ol, safe_join(items), class: breadcrumb_class, itemscope: "", itemtype: "https://schema.org/BreadcrumbList"), id: "breadcrumbs", class: "sixteen columns")
     end
 
     def taxons_tree(root_taxon, current_taxon, max_level = 1)

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -93,7 +93,7 @@ module Spree
         end
       end
 
-      content_tag(:nav, content_tag(:ol, raw(items.map(&:mb_chars).join), class: breadcrumb_class, itemscope: "", itemtype: "https://schema.org/BreadcrumbList"), id: "breadcrumbs", class: "sixteen columns")
+      content_tag(:nav, content_tag(:ol, raw(items.join), class: breadcrumb_class, itemscope: "", itemtype: "https://schema.org/BreadcrumbList"), id: "breadcrumbs", class: "sixteen columns")
     end
 
     def taxons_tree(root_taxon, current_taxon, max_level = 1)

--- a/storefront/templates/app/components/breadcrumbs_component.rb
+++ b/storefront/templates/app/components/breadcrumbs_component.rb
@@ -27,7 +27,7 @@ class BreadcrumbsComponent < ViewComponent::Base
     content_tag(:div, class: wrapper_classes) do
       content_tag(:nav) do
         content_tag(:ol, class: container_classes, itemscope: "", itemtype: "https://schema.org/BreadcrumbList") do
-          raw(items.map(&:mb_chars).join)
+          raw(items.join)
         end
       end
     end

--- a/storefront/templates/app/components/breadcrumbs_component.rb
+++ b/storefront/templates/app/components/breadcrumbs_component.rb
@@ -27,7 +27,7 @@ class BreadcrumbsComponent < ViewComponent::Base
     content_tag(:div, class: wrapper_classes) do
       content_tag(:nav) do
         content_tag(:ol, class: container_classes, itemscope: "", itemtype: "https://schema.org/BreadcrumbList") do
-          raw(items.join)
+          safe_join(items)
         end
       end
     end


### PR DESCRIPTION

## Summary

Just fixing a deprecation. This method is a very old remnant of Ruby 1.8 and no longer serves a purpose. The content tags can be safely joined without this.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
