### PR TITLE
fix(admin): Guard timezone select to support older solidus versions

### DIFF
--- a/admin/app/components/solidus_admin/layout/navigation/account/component.html.erb
+++ b/admin/app/components/solidus_admin/layout/navigation/account/component.html.erb
@@ -27,14 +27,16 @@
       shadow-base
     ">
 
-    <% available_timezones_for_select = ActiveSupport::TimeZone.all.map(&:name) %>
-    <li class="h-8 flex items-center hover:bg-gray-25 rounded">
-      <%= autosubmit_select_tag(
-        "solidus_timezone",
-        options_for_select(available_timezones_for_select, selected: Time.zone.name),
-        icon: 'time-zone-line',
-      ) %>
-    </li>
+    <% if defined?(Spree::Core::ControllerHelpers::Timezone) %>
+      <% available_timezones_for_select = ActiveSupport::TimeZone.all.map(&:name) %>
+      <li class="h-8 flex items-center hover:bg-gray-25 rounded">
+        <%= autosubmit_select_tag(
+          "solidus_timezone",
+          options_for_select(available_timezones_for_select, selected: Time.zone.name),
+          icon: 'time-zone-line',
+        ) %>
+      </li>
+    <% end %>
 
     <% if (available_locales = Spree.i18n_available_locales).any? %>
       <li class="h-8 flex items-center hover:bg-gray-25 rounded">

--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -14,7 +14,8 @@ module SolidusAdmin
     include SolidusAdmin::ControllerHelpers::Theme
     include SolidusAdmin::ComponentsHelper
     include SolidusAdmin::AuthenticationAdapters::Backend if defined?(Spree::Backend)
-    include Spree::Core::ControllerHelpers::Timezone
+    # Guarded so that solidus_admin can be released ahead of solidus_core
+    include Spree::Core::ControllerHelpers::Timezone if defined?(Spree::Core::ControllerHelpers::Timezone)
 
     layout :set_layout
 

--- a/admin/spec/components/solidus_admin/layout/navigation/account/component_spec.rb
+++ b/admin/spec/components/solidus_admin/layout/navigation/account/component_spec.rb
@@ -3,14 +3,16 @@
 require "spec_helper"
 
 RSpec.describe SolidusAdmin::Layout::Navigation::Account::Component, type: :component do
-  it "renders correctly" do
-    component = described_class.new(
+  let(:component) do
+    described_class.new(
       user_label: "Alice",
       account_path: "/admin/account",
       logout_path: "/admin/logout",
       logout_method: :delete
     )
+  end
 
+  it "renders correctly" do
     render_inline(component)
 
     aggregate_failures do
@@ -22,6 +24,22 @@ RSpec.describe SolidusAdmin::Layout::Navigation::Account::Component, type: :comp
         expect(page).to have_button("Logout", visible: :any)
         expect(page).to have_css('input[type="hidden"][name="_method"][value="delete"]')
       end
+    end
+  end
+
+  describe "the timezone select" do
+    it "is rendered when solidus_core provides the Timezone helper" do
+      render_inline(component)
+
+      expect(page).to have_css('select[name="solidus_timezone"]', visible: :any)
+    end
+
+    it "is omitted when solidus_core does not provide the Timezone helper" do
+      hide_const("Spree::Core::ControllerHelpers::Timezone")
+
+      render_inline(component)
+
+      expect(page).to have_no_css('select[name="solidus_timezone"]', visible: :any)
     end
   end
 end

--- a/admin/spec/solidus_admin/core_compatibility_spec.rb
+++ b/admin/spec/solidus_admin/core_compatibility_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Some code paths are guarded with `defined?` so that solidus_admin can be
+# released ahead of solidus_core. These specs fail once the gemspec stops
+# supporting the versions that made a guard necessary, so that the guard is
+# removed together with the version bump instead of lingering as dead code.
+RSpec.describe "solidus_core compatibility guards" do
+  let(:solidus_core_requirement) do
+    gemspec = Gem::Specification.load(
+      SolidusAdmin::Engine.root.join("solidus_admin.gemspec").to_s
+    )
+    gemspec.dependencies.find { _1.name == "solidus_core" }.requirement
+  end
+
+  describe "Spree::Core::ControllerHelpers::Timezone" do
+    it "is still guarded, because solidus_core 4.7 does not provide it" do
+      expect(solidus_core_requirement).to be_satisfied_by(Gem::Version.new("4.7.0")),
+        "solidus_core 4.7 is no longer supported, so the Timezone helper is always " \
+        "available. Remove the `defined?(Spree::Core::ControllerHelpers::Timezone)` " \
+        "guards from app/controllers/solidus_admin/base_controller.rb and " \
+        "app/components/solidus_admin/layout/navigation/account/component.html.erb, " \
+        "along with the specs covering the unguarded path."
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The Spree::Core::ControllerHelpers::Timezone is only available for a not released version of solidus_core. This breaks solidus_admin on all solidus versions <= 4.7. Add a small guard which will show the timezone select if the helper class is available. Also provide a small spec that breaks, if the gemspec requires solidus_core > 4.7.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [ ] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
