### PR TITLE
Make resources per page configurable on admin index pages (#6520)

### DIFF
--- a/admin/app/controllers/solidus_admin/base_controller.rb
+++ b/admin/app/controllers/solidus_admin/base_controller.rb
@@ -25,6 +25,14 @@ module SolidusAdmin
 
     private
 
+    def set_page_and_extract_portion_from(records, per_page: self.per_page, **options)
+      super(records, per_page:, **options)
+    end
+
+    def per_page
+      SolidusAdmin::Config.per_page
+    end
+
     def set_layout
       if turbo_frame_request?
         "turbo_rails/frame"

--- a/admin/app/controllers/solidus_admin/resources_controller.rb
+++ b/admin/app/controllers/solidus_admin/resources_controller.rb
@@ -2,7 +2,6 @@
 
 module SolidusAdmin
   class ResourcesController < SolidusAdmin::BaseController
-    DEFAULT_PER_PAGE = 20
 
     include SolidusAdmin::ControllerHelpers::Search
 
@@ -86,10 +85,6 @@ module SolidusAdmin
 
     def resources_sorting_options
       {id: :desc}
-    end
-
-    def per_page
-      DEFAULT_PER_PAGE
     end
 
     def resources_collection

--- a/admin/docs/index_pages.md
+++ b/admin/docs/index_pages.md
@@ -29,6 +29,25 @@ def index
   # ...
 ```
 
+By default, `set_page_and_extract_portion_from` uses the global `SolidusAdmin::Config.per_page` setting (default: 20).
+
+You can configure the global per page count in an initializer:
+
+```ruby
+SolidusAdmin::Config.per_page = 50
+```
+
+Alternatively, you can customize the per page count for a specific controller by overriding the `per_page` method or passing `per_page:` explicitly:
+
+```ruby
+class SolidusAdmin::UsersController < SolidusAdmin::BaseController
+  # ...
+  def per_page
+    10
+  end
+end
+```
+
 Finally, the index action should render the `index` component passing the `@page` instance variable as the `collection` prop.
 
 ```ruby

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -46,6 +46,11 @@ module SolidusAdmin
     #                     Default: false
     preference :enable_alpha_features, :boolean, default: false
 
+    # @!attribute [rw] per_page
+    #   @return [Integer] Default number of resources shown per page on admin index pages.
+    #                     Default: 20
+    preference :per_page, :integer, default: 20
+
     alias_method :enable_alpha_features?, :enable_alpha_features
 
     preference :storefront_product_path_proc, :proc, default: ->(_version) {

--- a/admin/spec/controllers/solidus_admin/base_controller_spec.rb
+++ b/admin/spec/controllers/solidus_admin/base_controller_spec.rb
@@ -74,4 +74,20 @@ describe SolidusAdmin::BaseController, type: :controller do
       end
     end
   end
+
+  describe "#per_page" do
+    it "returns SolidusAdmin::Config.per_page" do
+      allow(SolidusAdmin::Config).to receive(:per_page).and_return(35)
+      expect(controller.send(:per_page)).to eq(35)
+    end
+  end
+
+  describe "#set_page_and_extract_portion_from" do
+    it "passes per_page to geared_pagination" do
+      records = Spree::Order.all
+      allow(SolidusAdmin::Config).to receive(:per_page).and_return(15)
+      controller.send(:set_page_and_extract_portion_from, records)
+      expect(controller.instance_variable_get(:@page).recordset.ratios.fixed).to eq(15)
+    end
+  end
 end

--- a/admin/spec/solidus_admin/configuration_spec.rb
+++ b/admin/spec/solidus_admin/configuration_spec.rb
@@ -40,6 +40,19 @@ RSpec.describe SolidusAdmin::Configuration do
     end
   end
 
+  describe "#per_page" do
+    it "defaults to 20" do
+      config = described_class.new
+      expect(config.per_page).to eq(20)
+    end
+
+    it "can be configured" do
+      config = described_class.new
+      config.per_page = 50
+      expect(config.per_page).to eq(50)
+    end
+  end
+
   describe "#import_menu_items_from_backend!" do
     it "imports the menu items from the backend" do
       allow(Spree::Backend::Config).to receive(:menu_items).and_return([


### PR DESCRIPTION
## Summary

Closes #6520.

Makes the number of resources per page on admin index pages globally and locally configurable:
- Adds `SolidusAdmin::Config.per_page` preference (defaults to `20`).
- Updates `SolidusAdmin::BaseController#set_page_and_extract_portion_from` to pass `per_page: self.per_page` by default.
- Allows per-controller overrides by overriding `def per_page` or passing `per_page:`.
- Removes hardcoded `DEFAULT_PER_PAGE` from `SolidusAdmin::ResourcesController`.

## Checklist

- [x] I agree that my PR will be published under the same license as Solidus.
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] I have used clear, explanatory commit messages.
- [x] I have updated documentation (`admin/docs/index_pages.md`).
- [x] I have added automated tests to cover my changes.
