### PR TITLE
chore: Add breaking change category to release generator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -27,3 +27,6 @@ changelog:
     - title: Solidus Promotions
       labels:
         - "changelog:solidus_promotions"
+    - title: Breaking Changes
+      labels:
+        - "changelog:breaking-change"


### PR DESCRIPTION
## Summary

We want to mark some PRs as breaking change. For that we need a label and the category

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
