### PR TITLE
Abort solidus:install on migration/seed rake failures

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -126,7 +126,7 @@ module Solidus
     def install_file_attachment
       if options[:active_storage]
         say_status :assets, "Active Storage", :green
-        rake "active_storage:install"
+        rake "active_storage:install", abort_on_failure: true
       else
         say_status :assets, "Paperclip", :green
         gsub_file "config/initializers/spree.rb", "::ActiveStorageAttachment", "::PaperclipAttachment"
@@ -158,19 +158,19 @@ module Solidus
 
     def install_migrations
       say_status :copying, "migrations"
-      rake "railties:install:migrations"
+      rake "railties:install:migrations", abort_on_failure: true
     end
 
     def create_database
       say_status :creating, "database"
-      rake "db:create"
+      rake "db:create", abort_on_failure: true
     end
 
     def run_migrations
       if @run_migrations
         say_status :running, "migrations"
 
-        rake "db:migrate"
+        rake "db:migrate", abort_on_failure: true
       else
         say_status :skipping, "migrations (don't forget to run rake db:migrate)"
       end
@@ -200,7 +200,7 @@ module Solidus
         rake_options << "ADMIN_EMAIL=#{options[:admin_email]}" if options[:admin_email]
         rake_options << "ADMIN_PASSWORD=#{options[:admin_password]}" if options[:admin_password]
 
-        rake("db:seed #{rake_options.join(" ")}")
+        rake("db:seed #{rake_options.join(" ")}", abort_on_failure: true)
       else
         say_status :skipping, "seed data (you can always run rake db:seed)"
       end
@@ -209,7 +209,7 @@ module Solidus
     def load_sample_data
       if @load_sample_data
         say_status :loading, "sample data"
-        rake "spree_sample:load"
+        rake "spree_sample:load", abort_on_failure: true
       else
         say_status :skipping, "sample data (you can always run rake spree_sample:load)"
       end

--- a/core/spec/lib/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/lib/generators/solidus/install/install_generator_spec.rb
@@ -94,7 +94,9 @@ RSpec.describe Solidus::InstallGenerator do
       generator.prepare_options
       allow(generator).to receive(:say_status)
 
-      expect(generator).to receive(:rake).with("db:seed ", abort_on_failure: true)
+      # --auto-accept sets options[:auto_accept], which populate_seed_data
+      # folds into rake_options as "AUTO_ACCEPT=1".
+      expect(generator).to receive(:rake).with("db:seed AUTO_ACCEPT=1", abort_on_failure: true)
 
       generator.populate_seed_data
     end

--- a/core/spec/lib/generators/solidus/install/install_generator_spec.rb
+++ b/core/spec/lib/generators/solidus/install/install_generator_spec.rb
@@ -79,6 +79,52 @@ RSpec.describe Solidus::InstallGenerator do
     end
   end
 
+  describe "failure handling" do
+    it "aborts instead of continuing when migrations fail" do
+      generator = described_class.new([], ["--auto-accept"])
+      generator.prepare_options
+      allow(generator).to receive(:say_status)
+      allow(generator).to receive(:rake).with("db:migrate", abort_on_failure: true).and_raise(Thor::Error, "migration failed")
+
+      expect { generator.run_migrations }.to raise_error(Thor::Error, "migration failed")
+    end
+
+    it "passes abort_on_failure to the seed data rake task" do
+      generator = described_class.new([], ["--auto-accept"])
+      generator.prepare_options
+      allow(generator).to receive(:say_status)
+
+      expect(generator).to receive(:rake).with("db:seed ", abort_on_failure: true)
+
+      generator.populate_seed_data
+    end
+
+    it "passes abort_on_failure to the sample data rake task" do
+      generator = described_class.new([], ["--auto-accept"])
+      generator.prepare_options
+      allow(generator).to receive(:say_status)
+
+      expect(generator).to receive(:rake).with("spree_sample:load", abort_on_failure: true)
+
+      generator.load_sample_data
+    end
+
+    it "passes abort_on_failure to the migrations copy, database creation, and active storage rake tasks" do
+      generator = described_class.new([], ["--auto-accept"])
+      generator.prepare_options
+      allow(generator).to receive(:say_status)
+
+      expect(generator).to receive(:rake).with("railties:install:migrations", abort_on_failure: true)
+      generator.install_migrations
+
+      expect(generator).to receive(:rake).with("db:create", abort_on_failure: true)
+      generator.create_database
+
+      expect(generator).to receive(:rake).with("active_storage:install", abort_on_failure: true)
+      generator.install_file_attachment
+    end
+  end
+
   private
 
   def strip_ansi(string)


### PR DESCRIPTION
Fixes #6035

## Problem

`solidus:install` runs several rake tasks (`railties:install:migrations`, `db:create`, `db:migrate`, `active_storage:install`, `db:seed`, `spree_sample:load`) via the generator's `rake` helper without passing `abort_on_failure: true`.

Even though `Solidus::InstallGenerator.exit_on_failure?` returns `true`, Thor's `run` only falls back to that class-level default when the `:abort_on_failure` key is *absent* from the options hash (`config.fetch(:abort_on_failure, self.class.exit_on_failure?)`). Rails' `execute_command` always includes the key explicitly (as `nil` when not set), so the fallback never kicks in and a failing rake task is silently ignored. The generator then proceeds through the rest of its steps and prints `Solidus has been installed successfully. Enjoy!` even though migrations or seeding actually failed - exactly what was reported in #6035 (a `db:migrate` failure due to a pre-existing table went unnoticed, seeding then failed too, and the install was reported as successful).

## Fix

Pass `abort_on_failure: true` explicitly on each of these rake calls in `core/lib/generators/solidus/install/install_generator.rb`, so a real failure aborts the generator (a clean `Thor::Error`, since `exit_on_failure?` is already `true`) instead of continuing silently.

## Test plan

- Added specs in `core/spec/lib/generators/solidus/install/install_generator_spec.rb` asserting `abort_on_failure: true` is passed for the migrations, database creation, active storage, seed, and sample-data rake calls, and that a raised failure from `db:migrate` propagates out of `run_migrations` instead of being swallowed.
- Could not execute the suite locally (no Ruby/Bundler available in this environment) - verified the fix against Rails' `Rails::Generators::Actions#rake`/`#execute_command` and Thor's `Actions#run` source to confirm the exact fallback behavior described above.