### PR TITLE
Add privilege and category to legacy_promotions and promotion permission sets

### DIFF
--- a/legacy_promotions/app/models/spree/permission_sets/promotion_display.rb
+++ b/legacy_promotions/app/models/spree/permission_sets/promotion_display.rb
@@ -13,6 +13,16 @@ module Spree
     # - Promotion categories
     # - Promotion codes
     class PromotionDisplay < PermissionSets::Base
+      class << self
+        def privilege
+          :display
+        end
+
+        def category
+          :promotion
+        end
+      end
+
       def activate!
         can [:read, :admin, :edit], Spree::Promotion
         can [:read, :admin], Spree::PromotionRule

--- a/legacy_promotions/app/models/spree/permission_sets/promotion_management.rb
+++ b/legacy_promotions/app/models/spree/permission_sets/promotion_management.rb
@@ -13,6 +13,16 @@ module Spree
     # - Promotion categories
     # - Promotion codes
     class PromotionManagement < PermissionSets::Base
+      class << self
+        def privilege
+          :management
+        end
+
+        def category
+          :promotion
+        end
+      end
+
       def activate!
         can :manage, Spree::Promotion
         can :manage, Spree::PromotionRule

--- a/legacy_promotions/spec/models/spree/permission_sets/promotion_display_spec.rb
+++ b/legacy_promotions/spec/models/spree/permission_sets/promotion_display_spec.rb
@@ -39,4 +39,16 @@ RSpec.describe Spree::PermissionSets::PromotionDisplay do
     it { is_expected.not_to be_able_to(:admin, Spree::PromotionCode) }
     it { is_expected.not_to be_able_to(:edit, Spree::Promotion) }
   end
+
+  describe ".privilege" do
+    it "returns the correct privilege symbol" do
+      expect(described_class.privilege).to eq(:display)
+    end
+  end
+
+  describe ".category" do
+    it "returns the correct category symbol" do
+      expect(described_class.category).to eq(:promotion)
+    end
+  end
 end

--- a/legacy_promotions/spec/models/spree/permission_sets/promotion_management_spec.rb
+++ b/legacy_promotions/spec/models/spree/permission_sets/promotion_management_spec.rb
@@ -27,4 +27,16 @@ RSpec.describe Spree::PermissionSets::PromotionManagement do
     it { is_expected.not_to be_able_to(:manage, Spree::PromotionCategory) }
     it { is_expected.not_to be_able_to(:manage, Spree::PromotionCode) }
   end
+
+  describe ".privilege" do
+    it "returns the correct privilege symbol" do
+      expect(described_class.privilege).to eq(:management)
+    end
+  end
+
+  describe ".category" do
+    it "returns the correct category symbol" do
+      expect(described_class.category).to eq(:promotion)
+    end
+  end
 end

--- a/promotions/app/models/solidus_promotions/permission_sets/solidus_promotion_management.rb
+++ b/promotions/app/models/solidus_promotions/permission_sets/solidus_promotion_management.rb
@@ -3,6 +3,16 @@
 module SolidusPromotions
   module PermissionSets
     class SolidusPromotionManagement < Spree::PermissionSets::Base
+      class << self
+        def privilege
+          :management
+        end
+
+        def category
+          :solidus_promotion
+        end
+      end
+
       def activate!
         can :manage, SolidusPromotions::Promotion
         can :manage, SolidusPromotions::Condition

--- a/promotions/spec/models/solidus_promotions/permission_sets/solidus_promotion_management_spec.rb
+++ b/promotions/spec/models/solidus_promotions/permission_sets/solidus_promotion_management_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe SolidusPromotions::PermissionSets::SolidusPromotionManagement do
     it { is_expected.not_to be_able_to(:manage, SolidusPromotions::PromotionCategory) }
     it { is_expected.not_to be_able_to(:manage, SolidusPromotions::PromotionCode) }
   end
+
+  describe ".privilege" do
+    it "returns the correct privilege symbol" do
+      expect(described_class.privilege).to eq(:management)
+    end
+  end
+
+  describe ".category" do
+    it "returns the correct category symbol" do
+      expect(described_class.category).to eq(:solidus_promotion)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The permission_sets seed was failing with a NotImplementedError, because the privilege and category method was missing for the promotions and legacy_promotions permission sets.

With this fix in place the seeder is running again and is include all permission sets. This is only working, if you are eager load the application, because otherwise `Spree::PermissionSets::Base.subclasses` is returning a reduced set of permission sets.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [ ] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
