### PR TITLE
Remove adjustments from cart orders when promotion is discarded

### DIFF
--- a/promotions/app/models/solidus_promotions/benefit.rb
+++ b/promotions/app/models/solidus_promotions/benefit.rb
@@ -40,7 +40,7 @@ module SolidusPromotions
     # @!attribute [rw] promotion
     #   The owning promotion.
     #   @return [SolidusPromotions::Promotion]
-    belongs_to :promotion, inverse_of: :benefits
+    belongs_to :promotion, -> { with_discarded }, inverse_of: :benefits
     # @!attribute [rw] original_promotion_action
     #   Back-reference to the original Solidus (Spree) promotion action, when migrated.
     #   @return [Spree::PromotionAction, nil]

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -174,6 +174,7 @@ module SolidusPromotions
 
     def delete_cart_connections
       order_promotions.where(order: Spree::Order.incomplete).destroy_all
+      benefits.each(&:remove_adjustments_from_incomplete_orders)
     end
   end
 end

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -12,7 +12,7 @@ module SolidusPromotions
       optional: true,
       inverse_of: :promotions
     belongs_to :original_promotion, class_name: "Spree::Promotion", optional: true
-    has_many :benefits, class_name: "SolidusPromotions::Benefit", dependent: :destroy
+    has_many :benefits, class_name: "SolidusPromotions::Benefit", dependent: :destroy, inverse_of: :promotion
     has_many :conditions, through: :benefits
     has_many :codes, class_name: "SolidusPromotions::PromotionCode", dependent: :destroy, inverse_of: :promotion
     has_many :code_batches, class_name: "SolidusPromotions::PromotionCodeBatch", dependent: :destroy

--- a/promotions/spec/models/solidus_promotions/benefit_spec.rb
+++ b/promotions/spec/models/solidus_promotions/benefit_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe SolidusPromotions::Benefit do
   it { is_expected.to respond_to :discount }
   it { is_expected.to respond_to :can_discount? }
 
+  describe "promotion association" do
+    let(:promotion) { create(:solidus_promotion, :with_adjustable_benefit) }
+    let(:benefit) { promotion.benefits.first }
+
+    it "loads discarded promotions" do
+      promotion.discard!
+      expect(benefit.reload.promotion).to eq(promotion)
+    end
+  end
+
   describe "#can_adjust?" do
     let(:adjustable) { Spree::LineItem.new }
     let(:benefit_class) do

--- a/promotions/spec/models/solidus_promotions/promotion_spec.rb
+++ b/promotions/spec/models/solidus_promotions/promotion_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe SolidusPromotions::Promotion, type: :model do
       it "destroys the connection" do
         expect { subject }.to change(SolidusPromotions::OrderPromotion, :count).by(-1)
       end
+
+      it "removes adjustments from incomplete orders" do
+        benefit = promotion.benefits.first
+        order.adjustments.create!(
+          source: benefit,
+          order: order,
+          amount: -10.0,
+          label: "Test Adjustment"
+        )
+        expect { subject }.to change { order.adjustments.reload.count }.from(1).to(0)
+      end
     end
 
     context "when the promotion has been added to a complete order" do

--- a/promotions/spec/models/spree/line_item_spec.rb
+++ b/promotions/spec/models/spree/line_item_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe Spree::LineItem do
 
       it { is_expected.to eq(26) }
     end
+
+    context "with an adjustment from a discarded promotion" do
+      before do
+        pre_lane_promotion.discard!
+      end
+
+      it "does not crash when accessing promotion.lane" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "still calculates the discounted amount correctly" do
+        is_expected.to eq(23)
+      end
+    end
   end
 
   describe "#current_lane_discounts" do


### PR DESCRIPTION
## Summary

Fix orphaned adjustments from discarded promotions.

## Problem

When a promotion is soft-deleted (discarded), it cleans up `order_promotions` associations for incomplete orders but leaves behind the adjustments that were created by the promotion's benefits. These orphaned adjustments cause crashes during order recalculation because the code tries to access `adjustment.source.promotion.lane`, but the promotion association returns `nil` for discarded promotions.

Error example:
```
undefined method 'lane' for nil
  adjustment.source.promotion.lane.in?(lanes)
                             ^^^^^
```

## Solution

1. **Association fix**: Add `with_discarded` scope to the benefit → promotion association so discarded promotions can be accessed (matches pattern in `OrderPromotion` and `PromotionCode`)
2. **Proactive cleanup**: When a promotion is discarded, call `remove_adjustments_from_incomplete_orders` on each benefit to immediately clean up orphaned adjustments

## Changes

- Added `with_discarded` to `Benefit#promotion` association
- Modified `Promotion#delete_cart_connections` to remove adjustments from incomplete orders when promotion is discarded
- Added test coverage for the discard behavior

## Checklist

- [x] Added test coverage
- [x] Ran specs locally and they pass
- [x] Followed Solidus coding standards
