### PR TITLE
[v4.5] Remove adjustments from cart orders when promotion is discarded

### DIFF
--- a/promotions/app/models/solidus_promotions/benefit.rb
+++ b/promotions/app/models/solidus_promotions/benefit.rb
@@ -14,7 +14,13 @@ module SolidusPromotions
     before_destroy :remove_adjustments_from_incomplete_orders
     before_destroy :raise_for_adjustments_for_completed_orders
 
-    belongs_to :promotion, inverse_of: :benefits
+    # @!attribute [rw] promotion
+    #   The owning promotion.
+    #   @return [SolidusPromotions::Promotion]
+    belongs_to :promotion, -> { with_discarded }, inverse_of: :benefits
+    # @!attribute [rw] original_promotion_action
+    #   Back-reference to the original Solidus (Spree) promotion action, when migrated.
+    #   @return [Spree::PromotionAction, nil]
     belongs_to :original_promotion_action, class_name: "Spree::PromotionAction", optional: true
     has_many :adjustments, class_name: "Spree::Adjustment", as: :source
     has_many :shipping_rate_discounts, class_name: "SolidusPromotions::ShippingRateDiscount", inverse_of: :benefit

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -9,7 +9,7 @@ module SolidusPromotions
     belongs_to :category, class_name: "SolidusPromotions::PromotionCategory",
       foreign_key: :promotion_category_id, optional: true
     belongs_to :original_promotion, class_name: "Spree::Promotion", optional: true
-    has_many :benefits, class_name: "SolidusPromotions::Benefit", dependent: :destroy
+    has_many :benefits, class_name: "SolidusPromotions::Benefit", dependent: :destroy, inverse_of: :promotion
     has_many :conditions, through: :benefits
     has_many :codes, class_name: "SolidusPromotions::PromotionCode", dependent: :destroy, inverse_of: :promotion
     has_many :code_batches, class_name: "SolidusPromotions::PromotionCodeBatch", dependent: :destroy

--- a/promotions/app/models/solidus_promotions/promotion.rb
+++ b/promotions/app/models/solidus_promotions/promotion.rb
@@ -168,6 +168,7 @@ module SolidusPromotions
 
     def delete_cart_connections
       order_promotions.where(order: Spree::Order.incomplete).destroy_all
+      benefits.each(&:remove_adjustments_from_incomplete_orders)
     end
   end
 end

--- a/promotions/spec/models/solidus_promotions/benefit_spec.rb
+++ b/promotions/spec/models/solidus_promotions/benefit_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe SolidusPromotions::Benefit do
   it { is_expected.to respond_to :discount }
   it { is_expected.to respond_to :can_discount? }
 
+  describe "promotion association" do
+    let(:promotion) { create(:solidus_promotion, :with_adjustable_benefit) }
+    let(:benefit) { promotion.benefits.first }
+
+    it "loads discarded promotions" do
+      promotion.discard!
+      expect(benefit.reload.promotion).to eq(promotion)
+    end
+  end
+
   describe "#can_adjust?" do
     subject { described_class.new.can_discount?(double) }
 

--- a/promotions/spec/models/solidus_promotions/promotion_spec.rb
+++ b/promotions/spec/models/solidus_promotions/promotion_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe SolidusPromotions::Promotion, type: :model do
       it "destroys the connection" do
         expect { subject }.to change(SolidusPromotions::OrderPromotion, :count).by(-1)
       end
+
+      it "removes adjustments from incomplete orders" do
+        benefit = promotion.benefits.first
+        order.adjustments.create!(
+          source: benefit,
+          order: order,
+          amount: -10.0,
+          label: "Test Adjustment"
+        )
+        expect { subject }.to change { order.adjustments.reload.count }.from(1).to(0)
+      end
     end
 
     context "when the promotion has been added to a complete order" do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v4.5`:
 - [Merge pull request #6557 from mamhoff/fix-promotion-discard-adjustments](https://github.com/solidusio/solidus/pull/6557)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)