### PR TITLE
Don't Allow Refunding Non-Refundable Payments

### DIFF
--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -39,7 +39,7 @@ module Spree
       end
 
       def ensure_refundable_payment
-        return if Spree::Refund::REFUNDABLE_PAYMENT_STATES.include?(@payment.state)
+        return if Spree::Config.refundable_payment_states.include?(@payment.state)
 
         flash[:error] = t("spree.payment_is_not_refundable")
         redirect_to admin_order_payments_path(@order)

--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -5,6 +5,7 @@ module Spree
     class RefundsController < ResourceController
       belongs_to "spree/payment"
       before_action :load_order
+      before_action :ensure_refundable_payment, only: [:new, :create]
 
       helper_method :refund_reasons
 
@@ -35,6 +36,13 @@ module Spree
       def load_order
         # the spree/admin/shared/order_tabs partial expects the @order instance variable to be set
         @order = @payment.order if @payment
+      end
+
+      def ensure_refundable_payment
+        return if Spree::Refund::REFUNDABLE_PAYMENT_STATES.include?(@payment.state)
+
+        flash[:error] = t("spree.payment_is_not_refundable")
+        redirect_to admin_order_payments_path(@order)
       end
 
       def refund_reasons

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -29,6 +29,16 @@ describe Spree::Admin::RefundsController do
         expect(flash[:error]).to eq I18n.t("spree.payment_is_not_refundable")
       end
     end
+
+    context "with a customized refundable_payment_states list" do
+      before { stub_spree_preferences(refundable_payment_states: %w[completed pending void]) }
+
+      let(:payment) { create(:payment, state: "void", amount: payment_amount) }
+
+      it "renders the new template" do
+        is_expected.to render_template(:new)
+      end
+    end
   end
 
   describe "POST create" do

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -5,13 +5,33 @@ require "spec_helper"
 describe Spree::Admin::RefundsController do
   stub_authorization!
 
+  let(:refund_reason) { create(:refund_reason) }
+  let(:refund_amount) { 100.0 }
+
+  let(:payment) { create(:payment, state: "completed", amount: payment_amount) }
+  let(:payment_amount) { refund_amount * 2 }
+
+  describe "GET new" do
+    subject do
+      get(:new, params: {order_id: payment.order_id, payment_id: payment.id})
+    end
+
+    it "renders the new template" do
+      is_expected.to render_template(:new)
+    end
+
+    context "when the payment is not in a refundable state" do
+      let(:payment) { create(:payment, state: "checkout", amount: payment_amount) }
+
+      it "redirects to the payments page with an error" do
+        subject
+        expect(response).to redirect_to(spree.admin_order_payments_path(payment.order))
+        expect(flash[:error]).to eq I18n.t("spree.payment_is_not_refundable")
+      end
+    end
+  end
+
   describe "POST create" do
-    let(:refund_reason) { create(:refund_reason) }
-    let(:refund_amount) { 100.0 }
-
-    let(:payment) { create(:payment, amount: payment_amount) }
-    let(:payment_amount) { refund_amount * 2 }
-
     subject do
       post(
         :create,
@@ -56,6 +76,24 @@ describe Spree::Admin::RefundsController do
       end
 
       it { is_expected.to render_template(:new) }
+    end
+
+    context "when the payment is not in a refundable state" do
+      %w[checkout invalid].each do |state|
+        context "with a #{state} payment" do
+          let(:payment) { create(:payment, state:, amount: payment_amount) }
+
+          it "does not create a refund record" do
+            expect { subject }.to_not change { Spree::Refund.count }
+          end
+
+          it "redirects to the payments page with an error" do
+            subject
+            expect(response).to redirect_to(spree.admin_order_payments_path(payment.order))
+            expect(flash[:error]).to eq I18n.t("spree.payment_is_not_refundable")
+          end
+        end
+      end
     end
   end
 end

--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -55,7 +55,7 @@ describe "Log entries", type: :feature do
   end
 
   context "with a log entry belonging to a refund of the payment", :js do
-    let(:payment) { create(:payment, amount: 100) }
+    let(:payment) { create(:payment, state: "completed", amount: 100) }
     let(:refund) { create(:refund, payment:, amount: 10) }
 
     before do

--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -83,6 +83,10 @@ module Spree
       %w[capture void credit]
     end
 
+    def can_credit?(payment)
+      payment.completed? && payment.credit_allowed > 0
+    end
+
     private
 
     def generate_profile_id(success)

--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -6,14 +6,16 @@ module Spree
       %w[capture void credit]
     end
 
-    # Indicates whether its possible to capture the payment
     def can_capture?(payment)
       ["checkout", "pending"].include?(payment.state)
     end
 
-    # Indicates whether its possible to void the payment.
     def can_void?(payment)
       payment.state != "void"
+    end
+
+    def can_credit?(payment)
+      payment.completed? && payment.credit_allowed > 0
     end
 
     def capture(*)

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -4,8 +4,6 @@ module Spree
   class Refund < Spree::Base
     include Metadata
 
-    REFUNDABLE_PAYMENT_STATES = %w[completed pending].freeze
-
     belongs_to :payment, inverse_of: :refunds, optional: true
     belongs_to :reason, class_name: "Spree::RefundReason", foreign_key: :refund_reason_id, optional: true
     belongs_to :reimbursement, inverse_of: :refunds, optional: true
@@ -95,7 +93,7 @@ module Spree
     end
 
     def payment_is_in_refundable_state
-      return if payment.nil? || REFUNDABLE_PAYMENT_STATES.include?(payment.state)
+      return if payment.nil? || Spree::Config.refundable_payment_states.include?(payment.state)
 
       if Spree::Config.require_refundable_payment_state
         errors.add(:payment, :not_refundable)
@@ -103,7 +101,7 @@ module Spree
         Spree.deprecator.warn(
           "Creating a refund for a payment in the '#{payment.state}' state is deprecated " \
           "and will become a validation error in Solidus 5.0. Refunds should only be created " \
-          "for payments in one of these states: #{REFUNDABLE_PAYMENT_STATES.join(", ")}. " \
+          "for payments in one of these states: #{Spree::Config.refundable_payment_states.join(", ")}. " \
           "Set `Spree::Config.require_refundable_payment_state = true` to adopt the new " \
           "behavior early."
         )

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -4,6 +4,8 @@ module Spree
   class Refund < Spree::Base
     include Metadata
 
+    REFUNDABLE_PAYMENT_STATES = %w[completed pending].freeze
+
     belongs_to :payment, inverse_of: :refunds, optional: true
     belongs_to :reason, class_name: "Spree::RefundReason", foreign_key: :refund_reason_id, optional: true
     belongs_to :reimbursement, inverse_of: :refunds, optional: true
@@ -15,6 +17,7 @@ module Spree
     validates :amount, presence: true, numericality: {greater_than: 0}
 
     validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create
+    validate :payment_is_in_refundable_state, on: :create
 
     attr_reader :perform_response
 
@@ -88,6 +91,22 @@ module Spree
     def amount_is_less_than_or_equal_to_allowed_amount
       if payment && amount > payment.credit_allowed
         errors.add(:amount, :greater_than_allowed)
+      end
+    end
+
+    def payment_is_in_refundable_state
+      return if payment.nil? || REFUNDABLE_PAYMENT_STATES.include?(payment.state)
+
+      if Spree::Config.require_refundable_payment_state
+        errors.add(:payment, :not_refundable)
+      else
+        Spree.deprecator.warn(
+          "Creating a refund for a payment in the '#{payment.state}' state is deprecated " \
+          "and will become a validation error in Solidus 5.0. Refunds should only be created " \
+          "for payments in one of these states: #{REFUNDABLE_PAYMENT_STATES.join(", ")}. " \
+          "Set `Spree::Config.require_refundable_payment_state = true` to adopt the new " \
+          "behavior early."
+        )
       end
     end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1945,6 +1945,7 @@ en:
     payment_could_not_be_created: Payment could not be created.
     payment_identifier: Payment Identifier
     payment_information: Payment Information
+    payment_is_not_refundable: This payment cannot be refunded in its current state.
     payment_method: Payment Method
     payment_method_not_supported: That payment method is unsupported. Please choose another one.
     payment_method_settings_warning: If you are changing the payment method type, you must save first before you can edit the payment method settings

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -495,6 +495,8 @@ en:
           attributes:
             amount:
               greater_than_allowed: is greater than the allowed amount.
+            payment:
+              not_refundable: cannot be refunded in its current state.
         spree/reimbursement:
           attributes:
             base:

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -254,6 +254,10 @@ module Spree
     #   @return [Boolean] Require a price on the master variant of a product (default: +true+)
     preference :require_master_price, :boolean, default: true
 
+    # @!attribute [rw] require_refundable_payment_state
+    #   @return [Boolean] Whether creating a refund for a payment outside Spree::Refund::REFUNDABLE_PAYMENT_STATES is a validation error rather than a deprecation warning (default: +false+)
+    versioned_preference :require_refundable_payment_state, :boolean, initial_value: false, boundaries: {"5.0.0.alpha" => true}
+
     # @!attribute [rw] require_payment_to_ship
     #   @return [Boolean] Allows shipments to be ready to ship regardless of the order being paid if false (default: +true+)
     preference :require_payment_to_ship, :boolean, default: true # Allows shipments to be ready to ship regardless of the order being paid if false

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -250,12 +250,16 @@ module Spree
     #   @return [Boolean] Whether to recalculate cart prices when recalculating (default: +false+)
     versioned_preference :recalculate_cart_prices, :boolean, initial_value: false, boundaries: {"5.0.0.alpha" => true}
 
+    # @!attribute [rw] refundable_payment_states
+    #   @return [Array<String>] Payment states in which refunds may be created (default: +["completed", "pending"]+)
+    preference :refundable_payment_states, :array, default: %w[completed pending]
+
     # @!attribute [rw] require_master_price
     #   @return [Boolean] Require a price on the master variant of a product (default: +true+)
     preference :require_master_price, :boolean, default: true
 
     # @!attribute [rw] require_refundable_payment_state
-    #   @return [Boolean] Whether creating a refund for a payment outside Spree::Refund::REFUNDABLE_PAYMENT_STATES is a validation error rather than a deprecation warning (default: +false+)
+    #   @return [Boolean] Whether creating a refund for a payment outside Spree::Config.refundable_payment_states is a validation error rather than a deprecation warning (default: +false+)
     versioned_preference :require_refundable_payment_state, :boolean, initial_value: false, boundaries: {"5.0.0.alpha" => true}
 
     # @!attribute [rw] require_payment_to_ship

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -264,4 +264,18 @@ RSpec.describe Spree::AppConfiguration do
       it { is_expected.to be true }
     end
   end
+
+  describe "#require_refundable_payment_state" do
+    subject { prefs[:require_refundable_payment_state] }
+
+    it { is_expected.to be false }
+
+    context "if solidus version is 5.0" do
+      before do
+        prefs.load_defaults "5.0"
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -265,6 +265,12 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  describe "#refundable_payment_states" do
+    subject { prefs[:refundable_payment_states] }
+
+    it { is_expected.to eq %w[completed pending] }
+  end
+
   describe "#require_refundable_payment_state" do
     subject { prefs[:require_refundable_payment_state] }
 

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Spree::Payment::Cancellation do
     subject { described_class.new.cancel(payment) }
 
     let(:payment_method) { create(:payment_method) }
-    let(:payment) { create(:payment, payment_method:, amount: 10) }
+    let(:payment) { create(:payment, state: "pending", payment_method:, amount: 10) }
 
     context "if payment method returns void response" do
       before do

--- a/core/spec/models/spree/payment_method/check_spec.rb
+++ b/core/spec/models/spree/payment_method/check_spec.rb
@@ -54,6 +54,44 @@ RSpec.describe Spree::PaymentMethod::Check do
     end
   end
 
+  context "#can_credit?" do
+    let(:payment) { create(:payment, order:, state:, amount: 10) }
+
+    context "with payment in state completed" do
+      let(:state) { "completed" }
+
+      it "returns true" do
+        expect(subject.can_credit?(payment)).to be_truthy
+      end
+
+      context "when the payment is fully refunded" do
+        before do
+          create(:refund, payment:, amount: payment.amount)
+        end
+
+        it "returns false" do
+          expect(subject.can_credit?(payment)).to be_falsy
+        end
+      end
+    end
+
+    context "with payment in state checkout" do
+      let(:state) { "checkout" }
+
+      it "returns false" do
+        expect(subject.can_credit?(payment)).to be_falsy
+      end
+    end
+
+    context "with payment in state invalid" do
+      let(:state) { "invalid" }
+
+      it "returns false" do
+        expect(subject.can_credit?(payment)).to be_falsy
+      end
+    end
+  end
+
   context "#capture" do
     it "succeeds" do
       expect(subject.capture).to be_success

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -284,7 +284,8 @@ RSpec.describe Spree::PaymentMethod::StoreCredit do
             payment_method:,
             source: store_credit,
             amount: captured_amount,
-            response_code: auth_code)
+            response_code: auth_code,
+            state: "completed")
         end
 
         it "refunds the capture amount" do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -674,6 +674,8 @@ RSpec.describe Spree::Payment, type: :model do
   end
 
   describe "#credit_allowed" do
+    before { payment.update!(state: "completed") }
+
     it "is the difference between refunds total and payment amount" do
       payment.amount = 100
 
@@ -698,7 +700,10 @@ RSpec.describe Spree::Payment, type: :model do
   describe "#fully_refunded?" do
     subject { payment.fully_refunded? }
 
-    before { payment.amount = 100 }
+    before do
+      payment.update!(state: "completed")
+      payment.amount = 100
+    end
 
     context "before refund" do
       it { is_expected.to be false }

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -76,6 +76,27 @@ RSpec.describe Spree::Refund, type: :model do
       end
     end
 
+    context "with a customized refundable_payment_states list" do
+      before { stub_spree_preferences(refundable_payment_states: %w[completed pending void]) }
+
+      context "with a void payment" do
+        let(:payment) { create(:payment, state: "void", amount: payment_amount, payment_method:) }
+
+        it "does not emit a deprecation warning" do
+          expect(Spree.deprecator).not_to receive(:warn)
+          subject
+        end
+
+        context "with require_refundable_payment_state enabled" do
+          before { stub_spree_preferences(require_refundable_payment_state: true) }
+
+          it "creates a refund record" do
+            expect { subject }.to change { Spree::Refund.count }.by(1)
+          end
+        end
+      end
+    end
+
     context "when the payment is not in a refundable state" do
       %w[checkout invalid failed void processing].each do |state|
         context "with a #{state} payment" do

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Refund, type: :model do
   let(:amount) { 100.0 }
   let(:amount_in_cents) { amount * 100 }
 
-  let(:payment) { create(:payment, amount: payment_amount, payment_method:) }
+  let(:payment) { create(:payment, state: "completed", amount: payment_amount, payment_method:) }
   let(:payment_amount) { amount * 2 }
   let(:payment_method) { create(:credit_card_payment_method) }
 
@@ -52,6 +52,57 @@ RSpec.describe Spree::Refund, type: :model do
 
       it "creates a refund record" do
         expect { subject }.to change { Spree::Refund.count }.by(1)
+      end
+    end
+
+    context "when the payment is in a refundable state" do
+      %w[completed pending].each do |state|
+        context "with a #{state} payment" do
+          let(:payment) { create(:payment, state:, amount: payment_amount, payment_method:) }
+
+          it "does not emit a deprecation warning" do
+            expect(Spree.deprecator).not_to receive(:warn)
+            subject
+          end
+
+          context "with require_refundable_payment_state enabled" do
+            before { stub_spree_preferences(require_refundable_payment_state: true) }
+
+            it "creates a refund record" do
+              expect { subject }.to change { Spree::Refund.count }.by(1)
+            end
+          end
+        end
+      end
+    end
+
+    context "when the payment is not in a refundable state" do
+      %w[checkout invalid failed void processing].each do |state|
+        context "with a #{state} payment" do
+          let(:payment) { create(:payment, state:, amount: payment_amount, payment_method:) }
+
+          context "with require_refundable_payment_state disabled" do
+            before { stub_spree_preferences(require_refundable_payment_state: false) }
+
+            it "emits a deprecation warning" do
+              expect(Spree.deprecator).to receive(:warn)
+                .with(/Creating a refund for a payment in the '#{state}' state is deprecated/, any_args)
+              subject
+            end
+          end
+
+          context "with require_refundable_payment_state enabled" do
+            before { stub_spree_preferences(require_refundable_payment_state: true) }
+
+            it "is invalid without emitting a deprecation warning" do
+              expect(Spree.deprecator).not_to receive(:warn)
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid) { |error|
+                expect(error.record.errors.full_messages)
+                  .to eq ["Payment cannot be refunded in its current state."]
+              }
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #2926.

This PR has layers, like an ogre:

1. Model-level validation controlled by a preference, so it's not a breaking change. I ❤️ deprecations.
2. An Admin controller check, which actually completes the work #6094 started.
3. Updates to the Check and BogusCreditCard methods for good measure.