### PR TITLE
Skip VAT price generation without a valid price

### DIFF
--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -25,6 +25,7 @@ module Spree
       def run
         # Early return if there is no VAT rates in the current store.
         return if !variant.tax_category || variant_vat_rates.empty?
+        return if variant.default_price&.amount.nil?
 
         country_isos_requiring_price.each do |country_iso|
           # Don't re-create the default price

--- a/core/spec/models/spree/variant/vat_price_generator_spec.rb
+++ b/core/spec/models/spree/variant/vat_price_generator_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe Spree::Variant::VatPriceGenerator do
       described_class.new(variant).run
       expect { subject }.not_to change { variant.prices.size }
     end
+
+    context "when the default price has no amount" do
+      let(:variant) { build(:variant, price: nil, tax_category:) }
+
+      it "builds no additional prices" do
+        expect { subject }.not_to change { variant.prices.length }
+      end
+    end
+
+    context "when the variant has no default price" do
+      before do
+        variant.prices.destroy_all
+        variant.reload
+      end
+
+      it "builds no additional prices" do
+        expect { subject }.not_to change { variant.prices.length }
+      end
+    end
   end
 
   context "with no default admin country" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -120,6 +120,19 @@ RSpec.describe Spree::Variant, type: :model do
 
         it { is_expected.to be_valid }
       end
+
+      context "when VAT rates exist for other countries" do
+        let(:product) { build(:base_product, price: nil, tax_category:) }
+        let(:tax_category) { create(:tax_category) }
+        let(:germany) { create(:country, iso: "DE") }
+        let(:germany_zone) { create(:zone, countries: [germany]) }
+        let!(:german_vat) { create(:tax_rate, included_in_price: true, amount: 0.19, zone: germany_zone, tax_categories: [tax_category]) }
+
+        it "is invalid without a price instead of raising" do
+          variant.valid?
+          expect(subject.errors.full_messages).to include("Price Must supply price for variant or master.price for product.")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Creating a product without a price in a store that has VAT rates configured raises `NoMethodError` instead of just showing a validation error. This makes the user sad because they don't know what's wrong. This extremely simple fix adds an early return so we don't divide by zero. Shout out to @firemind for the initial work on #5324, which this supersedes.