### PR TITLE
Fix docker run instructions and hardcode internal port

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ environment variable:
 ```bash
 SANDBOX_PORT=4000 docker-compose up -d
 docker-compose exec app bin/sandbox
-docker-compose exec app bin/rails server --binding 0.0.0.0 --port 4000
+SANDBOX_PORT=4000 docker-compose exec app bin/dev
 ```
 
 ### Sandbox
@@ -303,7 +303,7 @@ sandbox one by running the command:
 
 Please note: if you run `bin/rails server` or similar commands, only the Rails server will
 start. This might cause the error `couldn't find file 'solidus_admin/tailwind.css'` when you
-try to load admin pages.
+try to load all pages.
 
 ### Tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       ACTIVE_STORAGE_VARIANT_PROCESSOR: "vips"
       BINDING: "0.0.0.0"
     ports:
-      - "${SANDBOX_PORT:-3000}:${SANDBOX_PORT:-3000}"
+      - "${SANDBOX_PORT:-3000}:3000"
     volumes:
       - .:/home/solidus_user/app:delegated,z
       - bundle:/home/solidus_user/gems:cached


### PR DESCRIPTION


## Summary

There's no real reason to make the internal rails port used in a docker container configurable. All that matters is the host port.

The docker compose instructions also gave the wrong command for starting the app. Starting the rails server directly caused a tailwindcss error
on the frontend AND admin - we need to call bin/dev within Docker to start the tailwind watch process

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have localized any and all user-facing strings that I added to the source code.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
