### PR TITLE
Explicitly use exception for protect_from_forgery

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -7,7 +7,7 @@ module Spree
     class BaseController < ActionController::Base
       self.responder = Spree::Api::Responders::AppResponder
       respond_to :json
-      protect_from_forgery unless: -> { request.format.json? }
+      protect_from_forgery with: :exception, unless: -> { request.format.json? }
 
       include CanCan::ControllerAdditions
       include ActiveStorage::SetCurrent


### PR DESCRIPTION
## Summary

[In Rails 8.2, declaring this value without a strategy will be deprecated.](https://edgeguides.rubyonrails.org/8_2_release_notes.html#action-pack-deprecations) Because this is for our API which doesn't really use sessions, let's make sure we explicitly tell it we want to use the exception strategy.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
