### PR TITLE
Passing a hash to resources is deprecated

### DIFF
--- a/admin/lib/solidus_admin/admin_resources.rb
+++ b/admin/lib/solidus_admin/admin_resources.rb
@@ -6,7 +6,7 @@ module SolidusAdmin::AdminResources
     batch_actions &= options[:only] if options[:only]
     batch_actions -= options[:except] if options[:except]
 
-    resources(resource, options) do
+    resources(resource, **options) do
       yield if block_given?
 
       collection do


### PR DESCRIPTION
## Summary

As of Rails 8.2 it is deprecated and we should pass keyword arguements instead.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
