### PR TITLE
Relax kt-paperclip dependency

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency "image_processing", "~> 1.10"
   s.add_dependency "mini_magick", "~> 4.10"
   s.add_dependency "monetize", "~> 1.8"
-  s.add_dependency "kt-paperclip", [">= 6.3", "< 8"]
+  s.add_dependency "kt-paperclip", [">= 6.3", "< 8.1"]
   s.add_dependency "psych", [">= 4.0.1", "< 6.0"]
   s.add_dependency "ransack", ["~> 4.0", "< 5"]
   s.add_dependency "state_machines", ["~> 0.6", "< 0.10.0"]


### PR DESCRIPTION
## Summary

We need to allow for kt-paperclip v8.0.0 which has some changes that allow us to support Rails 8.2

There are no deprecations in v8.0.0 that affect our code.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
