### PR TITLE
Deprecate Orphaned Preferences

### DIFF
--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -12,7 +12,7 @@ module Spree
     #   * Combine allocated and on hand inventory into a single shipment per-location
     #
     # Allocation logic can be changed using a custom class (as
-    # configured in Spree::Config::stock_allocator_class )
+    # configured in Spree::Config.stock.allocator_class)
     #
     # After allocation, splitters are run on each Package (as configured in
     # Spree::Config.environment.stock_splitters)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -163,7 +163,14 @@ module Spree
 
     # @!attribute [rw] customer_returns_per_page
     #   @return [Integer] Customer returns to show per-page in the admin (default: +15+)
+    #   @deprecated Unused since 834a24a695; remove it from your initializer.
     preference :customer_returns_per_page, :integer, default: 15
+    msg = "`Spree::Config.customer_returns_per_page` has had no effect since commit 834a24a695; remove it from your initializer."
+    deprecate(
+      customer_returns_per_page: msg,
+      "customer_returns_per_page=": msg,
+      deprecator: Spree.deprecator
+    )
 
     # @!attribute [rw] default_country_iso
     #   Default customer country ISO code

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -397,7 +397,15 @@ module Spree
     #   Spree::Variant::VatPriceGenerator.
     class_name_attribute :variant_vat_prices_generator_class, default: "Spree::Variant::VatPriceGenerator"
 
+    # @!attribute [rw] allocator_class
+    #   @deprecated Never read; use Spree::Config.stock.allocator_class instead.
     class_name_attribute :allocator_class, default: "Spree::Stock::Allocator::OnHandFirst"
+    msg = "`Spree::Config.allocator_class` has never been read; the stock allocator is configured with `Spree::Config.stock.allocator_class`."
+    deprecate(
+      allocator_class: msg,
+      "allocator_class=": msg,
+      deprecator: Spree.deprecator
+    )
 
     class_name_attribute :shipping_rate_sorter_class, default: "Spree::Stock::ShippingRateSorter"
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -81,7 +81,14 @@ module Spree
 
     # @!attribute [rw] alternative_billing_phone
     #   @return [Boolean] Request an extra phone number for bill address (default: +false+)
+    #   @deprecated Unused since c40d4cbeef; remove it from your initializer.
     preference :alternative_billing_phone, :boolean, default: false
+    msg = "`Spree::Config.alternative_billing_phone` has had no effect since commit c40d4cbeef; remove it from your initializer."
+    deprecate(
+      alternative_billing_phone: msg,
+      "alternative_billing_phone=": msg,
+      deprecator: Spree.deprecator
+    )
 
     # @!attribute [rw] alternative_shipping_phone
     #   @return [Boolean] Request an extra phone number for shipping address (default: +false+)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -70,7 +70,14 @@ module Spree
 
     # @!attribute [rw] allow_return_item_amount_editing
     #   @return [Boolean] Determines whether an admin is allowed to change a return item's pre-calculated amount (default: +false+)
+    #   @deprecated Unused since a6755a7f0f; remove it from your initializer.
     preference :allow_return_item_amount_editing, :boolean, default: false
+    msg = "`Spree::Config.allow_return_item_amount_editing` has had no effect since commit a6755a7f0f; remove it from your initializer."
+    deprecate(
+      allow_return_item_amount_editing: msg,
+      "allow_return_item_amount_editing=": msg,
+      deprecator: Spree.deprecator
+    )
 
     # @!attribute [rw] alternative_billing_phone
     #   @return [Boolean] Request an extra phone number for bill address (default: +false+)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -235,7 +235,14 @@ module Spree
 
     # @!attribute [rw] order_capturing_time_window
     #   @return [Integer] the number of days to look back for fully-shipped/cancelled orders in order to charge for them
+    #   @deprecated Unused since 9c5107fcae; remove it from your initializer.
     preference :order_capturing_time_window, :integer, default: 14
+    msg = "`Spree::Config.order_capturing_time_window` has had no effect since commit 9c5107fcae; remove it from your initializer."
+    deprecate(
+      order_capturing_time_window: msg,
+      "order_capturing_time_window=": msg,
+      deprecator: Spree.deprecator
+    )
 
     # @!attribute [rw] order_mutex_max_age
     #   @return [Integer] Max age of {Spree::OrderMutex} in seconds (default: 2 minutes)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -108,7 +108,14 @@ module Spree
 
     # @!attribute [rw] auto_capture_exchanges
     #   @return [Boolean] Automatically capture the credit card (as opposed to just authorize and capture later) (default: +false+)
+    #   @deprecated Unused since ca63667027; remove it from your initializer.
     preference :auto_capture_exchanges, :boolean, default: false
+    msg = "`Spree::Config.auto_capture_exchanges` has had no effect since commit ca63667027; remove it from your initializer."
+    deprecate(
+      auto_capture_exchanges: msg,
+      "auto_capture_exchanges=": msg,
+      deprecator: Spree.deprecator
+    )
 
     # @!attribute [rw] automatic_default_address
     #   The default value of true preserves existing backwards compatible feature of

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.mergeable_orders_finder_class).to eq Spree::MergeableOrdersFinder
   end
 
+  context "deprecated allow_return_item_amount_editing" do
+    it "warns on assignment" do
+      expect(Spree.deprecator).to receive(:warn).with(/allow_return_item_amount_editing/, any_args)
+
+      prefs.allow_return_item_amount_editing = true
+    end
+
+    it "still stores the value" do
+      Spree.deprecator.silence do
+        prefs.allow_return_item_amount_editing = true
+        expect(prefs.allow_return_item_amount_editing).to eq true
+      end
+    end
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  context "deprecated auto_capture_exchanges" do
+    it "warns on assignment" do
+      expect(Spree.deprecator).to receive(:warn).with(/auto_capture_exchanges/, any_args)
+
+      prefs.auto_capture_exchanges = true
+    end
+
+    it "still stores the value" do
+      Spree.deprecator.silence do
+        prefs.auto_capture_exchanges = true
+        expect(prefs.auto_capture_exchanges).to eq true
+      end
+    end
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  context "deprecated order_capturing_time_window" do
+    it "warns on assignment" do
+      expect(Spree.deprecator).to receive(:warn).with(/order_capturing_time_window/, any_args)
+
+      prefs.order_capturing_time_window = 30
+    end
+
+    it "still stores the value" do
+      Spree.deprecator.silence do
+        prefs.order_capturing_time_window = 30
+        expect(prefs.order_capturing_time_window).to eq 30
+      end
+    end
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -75,6 +75,21 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  context "deprecated alternative_billing_phone" do
+    it "warns on assignment" do
+      expect(Spree.deprecator).to receive(:warn).with(/alternative_billing_phone/, any_args)
+
+      prefs.alternative_billing_phone = true
+    end
+
+    it "still stores the value" do
+      Spree.deprecator.silence do
+        prefs.alternative_billing_phone = true
+        expect(prefs.alternative_billing_phone).to eq true
+      end
+    end
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -105,6 +105,21 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  context "deprecated customer_returns_per_page" do
+    it "warns on assignment" do
+      expect(Spree.deprecator).to receive(:warn).with(/customer_returns_per_page/, any_args)
+
+      prefs.customer_returns_per_page = 20
+    end
+
+    it "still stores the value" do
+      Spree.deprecator.silence do
+        prefs.customer_returns_per_page = 20
+        expect(prefs.customer_returns_per_page).to eq 20
+      end
+    end
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -135,6 +135,21 @@ RSpec.describe Spree::AppConfiguration do
     end
   end
 
+  context "deprecated allocator_class" do
+    it "warns on assignment" do
+      expect(Spree.deprecator).to receive(:warn).with(/allocator_class/, any_args)
+
+      prefs.allocator_class = "DummyClass"
+    end
+
+    it "still stores the value" do
+      Spree.deprecator.silence do
+        prefs.allocator_class = "DummyClass"
+        expect(prefs.allocator_class).to eq DummyClass
+      end
+    end
+  end
+
   context "deprecated preferences" do
     around do |example|
       Spree.deprecator.silence do


### PR DESCRIPTION
## Summary

In a Super Good ensemble session today, we (@sofiabesenski4, @AlistairNorman, and myself) realized that the stock allocator preference was duplicated. This led to a quick audit of the preferences to see whether there were any other orphaned preferences out there.

<details>
  <summary>Spoilers</summary>
  There were.
</details>

Each commit provides the commit where the given preference became orphaned.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
