### PR TITLE
Fix new-variant admin form when master variant has no default price

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -15,8 +15,14 @@ module Spree
       def new_before
         @object.attributes = @object.product.master.attributes.except("id", "created_at", "deleted_at",
           "sku", "is_master")
-        # Shallow Clone of the default price to populate the price field.
-        @object.prices.build(@object.product.master.default_price.attributes.except("id", "created_at", "updated_at", "deleted_at"))
+        # Shallow Clone of the default price to populate the price field, or
+        # build a blank one in the store's default currency when the master
+        # variant has no default price (e.g. it was removed).
+        if (master_default_price = @object.product.master.default_price)
+          @object.prices.build(master_default_price.attributes.except("id", "created_at", "updated_at", "deleted_at"))
+        else
+          @object.prices.build(Spree::Variant.default_price_attributes)
+        end
       end
 
       def collection

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -15,9 +15,6 @@ module Spree
       def new_before
         @object.attributes = @object.product.master.attributes.except("id", "created_at", "deleted_at",
           "sku", "is_master")
-        # Shallow Clone of the default price to populate the price field, or
-        # build a blank one in the store's default currency when the master
-        # variant has no default price (e.g. it was removed).
         if (master_default_price = @object.product.master.default_price)
           @object.prices.build(master_default_price.attributes.except("id", "created_at", "updated_at", "deleted_at"))
         else

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -7,6 +7,28 @@ module Spree
     describe VariantsController, type: :controller do
       stub_authorization!
 
+      describe "#new" do
+        let(:product) { create(:product_with_option_types) }
+
+        before do
+          create(:option_value, option_type: product.option_types.first)
+          product.master.prices.delete_all
+        end
+
+        subject { get :new, params: {product_id: product.slug} }
+
+        it "does not raise when the master variant has no default price" do
+          subject
+
+          default_price = assigns(:variant).default_price
+
+          expect(response).to be_successful
+          expect(default_price).to be_new_record
+          expect(default_price.amount).to be_nil
+          expect(default_price.currency).to eq(Spree::Config[:currency])
+        end
+      end
+
       describe "#index" do
         let(:product) { create(:product) }
         let(:params) { {product_id: product.slug} }


### PR DESCRIPTION
Fixes #4831.

`Spree::Admin::VariantsController#new_before` unconditionally clones the master variant's `default_price` onto the new variant. When the master variant has no default price (for example it was deleted), `default_price` is `nil` and calling `.attributes` on it raises, so opening the new-variant admin page for that product crashes.

This builds a blank price in the store's default currency instead when the master has none, the same way `Spree::Variant#default_price_or_build` already handles the same situation elsewhere in the codebase.

## Testing

- `bundle exec rspec spec/controllers/spree/admin/variants_controller_spec.rb` — 7 examples, 0 failures
- `bundle exec standardrb backend/app/controllers/spree/admin/variants_controller.rb backend/spec/controllers/spree/admin/variants_controller_spec.rb` — no offenses

Ran both in a plain `ruby:3.4-slim-bookworm` container against the `backend` gem, sqlite test DB.