### PR TITLE
Fix changelog labels for storefront, i18n and legacy promotions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,6 +28,16 @@
   - changed-files:
     - any-glob-to-any-file:
       - "legacy_promotions/**/*"
+"changelog:solidus_storefront":
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "storefront/**/*"
+"changelog:solidus_i18n":
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "i18n/**/*"
 "changelog:solidus_sample":
 - any:
   - changed-files:
@@ -53,6 +63,8 @@
       - "!promotions/**/*"
       - "!legacy_promotions/**/*"
       - "!sample/**/*"
+      - "!storefront/**/*"
+      - "!i18n/**/*"
       - "!lib/**/*"
       - "!README.md"
       - "!solidus.gemspec"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -27,6 +27,15 @@ changelog:
     - title: Solidus Promotions
       labels:
         - "changelog:solidus_promotions"
+    - title: Solidus Legacy Promotions
+      labels:
+        - "changelog:solidus_legacy_promotions"
+    - title: Solidus Storefront
+      labels:
+        - "changelog:solidus_storefront"
+    - title: Solidus I18n
+      labels:
+        - "changelog:solidus_i18n"
     - title: Breaking Changes
       labels:
         - "changelog:breaking-change"


### PR DESCRIPTION
## Summary

When `solidus_storefront` (#6468) and `solidus_i18n` (#6537) were merged into the monorepo, we forgot to update the PR labeler. PRs touching `storefront/` or `i18n/` have been falling through to the `changelog:repository` catch-all, which is why both merge PRs have that label.

While fixing that, I noticed that `bin/release/update-release-draft` only emits PRs whose label has a category
in `.github/release.yml` and silently drops the rest. `changelog:solidus_legacy_promotions` has never had a category, so legacy promotions PRs have been missing from generated release notes since that gem was split out. Between v4.6.2 and v4.7.0 alone, 8 PRs were dropped this way. It's a sad fate to be forgotten.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
