### PR TITLE
Update stale CI/CD info in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,13 +310,14 @@ try to load all pages.
 Solidus uses [RSpec](http://rspec.info) for tests. Refer to its documentation for
 more information about the testing library.
 
-#### CircleCI
+#### CI/CD
 
-We use CircleCI to run the tests for Solidus as well as all incoming pull
-requests. All pull requests must pass to be merged.
+We use GitHub Actions to run Solidus' test suites against all supported versions
+of Ruby and Rails. Before a pull request can be merged, all of the tests must
+pass.
 
-You can see the build statuses at
-[https://circleci.com/gh/solidusio/solidus](https://circleci.com/gh/solidusio/solidus).
+You can see the build statuses on the repository's [GitHub Actions
+page](https://github.com/solidusio/solidus/actions).
 
 #### Run all tests
 


### PR DESCRIPTION
## Summary

While setting up a fresh framework development environment, I noticed that the **CircleCI** section was stale.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
