### PR TITLE
Remove references to undefined attachment styles

### DIFF
--- a/storefront/templates/app/views/home/_collections_with_call_to_action.html.erb
+++ b/storefront/templates/app/views/home/_collections_with_call_to_action.html.erb
@@ -12,11 +12,12 @@
     <%= cache [I18n.locale, current_pricing_options, @taxon, product] do %>
       <%= link_to product_path(product) do %>
         <div class="relative bg-gray-50 overflow-hidden rounded-lg h-full md:rounded-xl lg:rounded-2xl">
-          <%= render(ImageComponent.new(
+          <%= render ImageComponent.new(
             image: product_image,
             class: 'w-full h-full object-cover',
-            size: :full,
-          )) %>
+            size: :large,
+          ) %>
+
           <div class="absolute bottom-0 left-0 right-0 flex flex-col items-start w-full gap-y-1 p-3 !pt-0 md:p-6 md:flex-row md:justify-between md:items-center md:gap-y-0 md:gap-x-2">
             <span class="w-full text-body-sm md:text-body">
               <%= product.name %>

--- a/storefront/templates/app/views/home/_featured_product_banner.html.erb
+++ b/storefront/templates/app/views/home/_featured_product_banner.html.erb
@@ -1,10 +1,11 @@
 <section class="relative my-4 w-full lg:my-12 bg-red-500">
   <div class="wrapper-mobile-fullwidth">
-    <%= render(ImageComponent.new(
+    <%= render ImageComponent.new(
       image: product.gallery.images.last,
-      size: :full,
+      size: :large,
       class: 'w-full object-cover aspect-square md:aspect-auto'
-    )) %>
+    ) %>
+
     <div class="absolute bottom-0 left-0 right-0 text-center pb-14">
       <span class="rounded-full px-3 py-1 bg-white text-sm text-black mb-2">New</span>
       <div class="text-h3 font-serif-md mb-6 text-white md:mb-9 md:text-h2.5"><%= product.name %></div>

--- a/storefront/templates/app/views/home/_featured_products.html.erb
+++ b/storefront/templates/app/views/home/_featured_products.html.erb
@@ -1,7 +1,7 @@
 <section class="wrapper pt-3 pb-14 md:pb-24">
   <div class="grid-container">
     <div class="col-span-full md:col-span-8 md:max">
-      <%= render 'products/featured_product_card', { product: products[0], size: :big } %>
+      <%= render 'products/featured_product_card', { product: products[0], size: :large } %>
     </div>
     <div class="col-span-full flex flex-col gap-y-6 md:col-span-4">
       <% products.each_with_index do |product, index| %>


### PR DESCRIPTION
## Summary

`Spree::AppConfiguration` defines the built-in product image styles as

    class_name_attribute :product_image_styles,
      default: {mini: "48x48>",
                small: "400x400>",
                product: "680x680>",
                large: "1200x1200>"}

There are no `:full` or `:big` styles configured, causing the storefront template code to error out when trying to render any of the views that use the partials changes as part of this commit.

Here's an example of the error:

    ImageProcessing::Error - either width or height must be specified:
      app/components/image_component.rb:15:in `call'
      app/views/home/_collections_with_call_to_action.html.erb:15
      app/views/home/_collections_with_call_to_action.html.erb:13
      app/views/home/_collections_with_call_to_action.html.erb:12
      app/views/home/_collections_with_call_to_action.html.erb:7
      app/views/home/index.html.erb:3

We have seen users report this issue in support channels (In the Slack community and in #5649 and #5858.)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
