### PR TITLE
Test "DEPRECATION WARNING" text output

### DIFF
--- a/core/spec/lib/spree/deprecator_spec.rb
+++ b/core/spec/lib/spree/deprecator_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe "Spree.deprecator" do
       if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
         expect { Dummy.new.deprecated_method }.to raise_error(ActiveSupport::DeprecationException)
       else
-        expect { Dummy.new.deprecated_method }.not_to raise_error
+        expect { Dummy.new.deprecated_method }.to output(/DEPRECATION WARNING: deprecated_method/).to_stderr,
+          "If this test fails, it means an real error was raised or the " \
+          "STDERR output we're asserting on is stale."
       end
     end
   end

--- a/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb
+++ b/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Spree::OrderMailerSubscriber do
       if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
         expect { subject }.to raise_error(ActiveSupport::DeprecationException)
       else
+        expect { subject }
+          .to output(/DEPRECATION WARNING: send_confirmation_email/)
+          .to_stderr
         expect(subject).to eq nil
       end
     end
@@ -31,6 +34,9 @@ RSpec.describe Spree::OrderMailerSubscriber do
       if ENV["SOLIDUS_RAISE_DEPRECATIONS"]
         expect { subject }.to raise_error(ActiveSupport::DeprecationException)
       else
+        expect { subject }
+          .to output(/DEPRECATION WARNING: send_reimbursement_email/)
+          .to_stderr
         expect(subject).to eq nil
       end
     end


### PR DESCRIPTION
## Summary 
This change tests the deprecation warning output instead of emitting it in the test runner output. Before this change, for example, the literal warnings would be presented like so:

    bundle exec rspec spec/subscribers/spree/order_mailer_subscriber_spec.rb
    Run options: include {focus: true}

    All examples were filtered out; ignoring {focus: true}

    Randomized with seed 38622
    DEPRECATION WARNING: send_reimbursement_email is deprecated and will be removed from Solidus 5.0 (use Spree::ReimbursementMailerSubscriber#send_reimbursement_email instead) (called from block (3 levels) in <top (required)> at /home/bw/Dev/solidus/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb:28)
    .DEPRECATION WARNING: send_confirmation_email is deprecated and will be removed from Solidus 5.0 (Use Spree::OrderConfirmationMailerSubscriber#send_confirmation_email instead) (called from block (3 levels) in <top (required)> at /home/bw/Dev/solidus/core/spec/subscribers/spree/order_mailer_subscriber_spec.rb:16)
    .

    Finished in 0.02454 seconds (files took 1.23 seconds to load)
    2 examples, 0 failures

This is misleading at best and confusing at worst.

Now the output looks like:

    bundle exec rspec spec/subscribers/spree/order_mailer_subscriber_spec.rb
    Run options: include {focus: true}

    All examples were filtered out; ignoring {focus: true}

    Randomized with seed 21923
    ..

    Finished in 0.02454 seconds (files took 1.23 seconds to load)
    2 examples, 0 failures

<!--
  Please include a summary of your changes, along with any useful context.
  Your contribution will be merged under the terms of the license of the parent repository (usually a FreeBSD License).

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
