### PR TITLE
End sandbox generation if an `unbundled` command fails

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -27,8 +27,9 @@ sqlite|'')
   ;;
 esac
 
-# Stay away from the bundler env of the containing extension.
-# # The unbundled helper requires Bundler 2.1 or above
+# Wraps any given shell command to use an environment without the user's
+# current Bundler environment settings. The intent is to isolate the Solidus
+# development gem set from the Solidus sandbox gem set.
 function unbundled {
   ruby -rbundler -e'
     Gem::Version.new(Bundler::VERSION) < Gem::Version.new("2.1") ?

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -33,7 +33,7 @@ function unbundled {
   ruby -rbundler -e'
     Gem::Version.new(Bundler::VERSION) < Gem::Version.new("2.1") ?
       abort("The sandbox requires at least Bundler 2.1, please run bin/setup to update it.") :
-      Bundler.with_unbundled_env {system *ARGV}' -- \
+      Bundler.with_unbundled_env {system(*ARGV) || raise($?.to_s)}' -- \
         env BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES=true $@
 }
 


### PR DESCRIPTION
## Summary
   
Before this change, the command wrapped with `unbundled` would fail and subsequent commands would continue (despite the fact that, because the first command fails, the following commands would also likely fail).
    
In my case, even though the first `unbundled bin/rails` command aborted, all of the further commands would run and I would be presented with a success message on exit:
    
    🚀 This app is intended for test purposes.
    
This was misleading because I had no test app available to me.
    
Below, I'll paste examples of the script outputs before and after I made this change.
    
---
    
Here's an example of a failed `bin/sandbox` attempt before I made this change:
    
        bin/rails aborted!
        TZInfo::DataSourceNotFound: tzinfo-data is not present. Please add gem "tzinfo-data" to your Gemfile and run bundle install (TZInfo::DataSourceNotFound)
        /home/bw/Dev/solidus/sandbox/config/environment.rb:5:in '<top (required)>'
    
        Caused by:
        TZInfo::DataSources::ZoneinfoDirectoryNotFound: None of the paths included in TZInfo::DataSources::ZoneinfoDataSource.search_path are valid zoneinfo directories. (TZInfo::DataSources::ZoneinfoDirectoryNotFound)
        /home/bw/Dev/solidus/sandbox/config/environment.rb:5:in '<top (required)>'
        Tasks: TOP => db:drop => db:load_config => environment
        (See full trace by running task with --trace)
        ~~~> Running the solidus:install generator
        /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:159:in 'TZInfo::DataSource.create_default_data_source': tzinfo-data is not present. Please add gem "tzinfo-data" to your Gemfile and run bundle install (TZInfo::DataSourceNotFound)
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:55:in 'block in TZInfo::DataSource.get'
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:54:in 'Thread::Mutex#synchronize'
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:54:in 'TZInfo::DataSource.get'
                from /home/bw/Dev/solidus/.gem_path/gems/activesupport-8.1.3.1/lib/active_support/railtie.rb:113:in 'block in <class:Railtie>'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:24:in 'BasicObject#instance_exec'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:103:in 'block in Rails::Initializable#run_initializers'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:231:in 'block in TSort.tsort_each'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:353:in 'block (2 levels) in TSort.each_strongly_connected_component'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:434:in 'TSort.each_strongly_connected_component_from'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:352:in 'block in TSort.each_strongly_connected_component'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:59:in 'Array#each'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:59:in 'Rails::Initializable::Collection#each'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:350:in 'Method#call'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:350:in 'TSort.each_strongly_connected_component'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:229:in 'TSort.tsort_each'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:208:in 'TSort#tsort_each'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:102:in 'Rails::Initializable#run_initializers'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
                from /home/bw/Dev/solidus/sandbox/config/environment.rb:5:in '<top (required)>'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
                from /home/bw/Dev/solidus/.gem_path/gems/zeitwerk-2.8.3/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/application.rb:418:in 'Rails::Application#require_environment!'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command/actions.rb:20:in 'Rails::Command::Actions#boot_application!'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/commands/generate/generate_command.rb:21:in 'Rails::Command::GenerateCommand#perform'
                from /home/bw/Dev/solidus/.gem_path/gems/thor-1.5.0/lib/thor/command.rb:28:in 'Thor::Command#run'
                from /home/bw/Dev/solidus/.gem_path/gems/thor-1.5.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command/base.rb:176:in 'Rails::Command::Base#invoke_command'
                from /home/bw/Dev/solidus/.gem_path/gems/thor-1.5.0/lib/thor.rb:538:in 'Thor.dispatch'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command/base.rb:71:in 'Rails::Command::Base.perform'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command.rb:63:in 'Rails::Command.invoke'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/commands.rb:18:in '<top (required)>'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
                from bin/rails:4:in '<main>'
        /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_sources/zoneinfo_data_source.rb:252:in 'TZInfo::DataSources::ZoneinfoDataSource#initialize': None of the paths included in TZInfo::DataSources::ZoneinfoDataSource.search_path are valid zoneinfo directories. (TZInfo::DataSources::ZoneinfoDirectoryNotFound)
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:157:in 'TZInfo::DataSource.create_default_data_source'
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:55:in 'block in TZInfo::DataSource.get'
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:54:in 'Thread::Mutex#synchronize'
                from /home/bw/Dev/solidus/.gem_path/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:54:in 'TZInfo::DataSource.get'
                from /home/bw/Dev/solidus/.gem_path/gems/activesupport-8.1.3.1/lib/active_support/railtie.rb:113:in 'block in <class:Railtie>'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:24:in 'BasicObject#instance_exec'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:103:in 'block in Rails::Initializable#run_initializers'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:231:in 'block in TSort.tsort_each'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:353:in 'block (2 levels) in TSort.each_strongly_connected_component'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:434:in 'TSort.each_strongly_connected_component_from'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:352:in 'block in TSort.each_strongly_connected_component'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:59:in 'Array#each'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:59:in 'Rails::Initializable::Collection#each'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:350:in 'Method#call'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:350:in 'TSort.each_strongly_connected_component'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:229:in 'TSort.tsort_each'
                from /home/bw/Dev/solidus/.gem_path/gems/tsort-0.2.0/lib/tsort.rb:208:in 'TSort#tsort_each'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/initializable.rb:102:in 'Rails::Initializable#run_initializers'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
                from /home/bw/Dev/solidus/sandbox/config/environment.rb:5:in '<top (required)>'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
                from /home/bw/Dev/solidus/.gem_path/gems/zeitwerk-2.8.3/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/application.rb:418:in 'Rails::Application#require_environment!'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command/actions.rb:20:in 'Rails::Command::Actions#boot_application!'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/commands/generate/generate_command.rb:21:in 'Rails::Command::GenerateCommand#perform'
                from /home/bw/Dev/solidus/.gem_path/gems/thor-1.5.0/lib/thor/command.rb:28:in 'Thor::Command#run'
                from /home/bw/Dev/solidus/.gem_path/gems/thor-1.5.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command/base.rb:176:in 'Rails::Command::Base#invoke_command'
                from /home/bw/Dev/solidus/.gem_path/gems/thor-1.5.0/lib/thor.rb:538:in 'Thor.dispatch'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command/base.rb:71:in 'Rails::Command::Base.perform'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/command.rb:63:in 'Rails::Command.invoke'
                from /home/bw/Dev/solidus/.gem_path/gems/railties-8.1.3.1/lib/rails/commands.rb:18:in '<top (required)>'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
                from bin/rails:4:in '<main>'
    
        🚀 This app is intended for test purposes. If you're interested in running
        🚀 Solidus in production, visit:
        🚀 https://guides.solidus.io/getting-started/installing-solidus
    
---
    
After this change, the failing command wrapped with `unbundled` actually raises and forces the script to error out instead of continuing. This provides the user a more focused error message to start debugging with rather than a string of error messages that may not be relevant. (In my case, the subsequent errors only occur because the first error did not raise.)
    
Because `unbundled` raises properly, we also no longer end up with a "🚀 This app is intended for test purposes" message:
    
        bin/rails aborted!
        TZInfo::DataSourceNotFound: tzinfo-data is not present. Please add gem "tzinfo-data" to your Gemfile and run bundle install (TZInfo::DataSourceNotFound)
        /home/bw/Dev/solidus/sandbox/config/environment.rb:5:in '<top (required)>'
    
        Caused by:
        TZInfo::DataSources::ZoneinfoDirectoryNotFound: None of the paths included in TZInfo::DataSources::ZoneinfoDataSource.search_path are valid zoneinfo directories. (TZInfo::DataSources::ZoneinfoDirectoryNotFound)
        /home/bw/Dev/solidus/sandbox/config/environment.rb:5:in '<top (required)>'
        Tasks: TOP => db:drop => db:load_config => environment
        (See full trace by running task with --trace)
        -e:4:in 'block in <main>': pid 4005 exit 1 (RuntimeError)
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundler.rb:397:in 'block in Bundler.with_unbundled_env'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundler.rb:676:in 'Bundler.with_env'
                from /gnu/store/82d9szlzz47xj8wqc33gr8vrd69kcs39-ruby-4.0.5/lib/ruby/4.0.0/bundler.rb:397:in 'Bundler.with_unbundled_env'
                from -e:4:in '<main>'

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
