### PR TITLE
Enable admin alpha features by default during sandbox app generation

### DIFF
--- a/admin/lib/generators/solidus_admin/install/install_generator.rb
+++ b/admin/lib/generators/solidus_admin/install/install_generator.rb
@@ -3,6 +3,7 @@
 module SolidusAdmin
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      class_option :alpha_features, type: :boolean, default: !!ENV["SOLIDUS_ADMIN_ALPHA_FEATURES"], desc: "Enable unstable alpha features currently in development."
       class_option :lookbook, type: :boolean, default: !!ENV["SOLIDUS_ADMIN_LOOKBOOK"], desc: "Install Lookbook for component previews"
       class_option :tailwind, type: :boolean, default: false, desc: "Install TailwindCSS for custom components"
 
@@ -18,7 +19,9 @@ module SolidusAdmin
       end
 
       def copy_initializer
-        template "config/initializers/solidus_admin.rb.tt", "config/initializers/solidus_admin.rb"
+        template "config/initializers/solidus_admin.rb.tt",
+          "config/initializers/solidus_admin.rb",
+          enable_alpha_features: options[:alpha_features]
       end
 
       def ignore_tailwind_build_files

--- a/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
+++ b/admin/lib/generators/solidus_admin/install/templates/config/initializers/solidus_admin.rb.tt
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 SolidusAdmin::Config.configure do |config|
+  # Enable alpha features.
+  #
+  # Do this at your own risk. Alpha features are still in development. Enabling
+  # this option will likely break some admin pages and components.
+  config.enable_alpha_features = <%= config[:enable_alpha_features] %>
+
   # Path to the logo used in the admin interface.
   #
   # It needs to be a path to an image file accessible by Sprockets.

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -107,6 +107,7 @@ unbundled bin/rails db:drop db:create
 
 echo "~~~> Running the solidus:install generator"
 export SOLIDUS_ADMIN_LOOKBOOK=true
+export SOLIDUS_ADMIN_ALPHA_FEATURES=true
 export SOLIDUS_STOREFRONT_TEMPLATE="$PWD/../storefront/template.rb"
 unbundled bin/rails generate solidus:install --admin-preview --auto-accept $@
 


### PR DESCRIPTION
## Summary
`SolidusAdmin::Config.enable_alpha_features?` is called in the `solidus_admin` code, but the flag is not advertised in the configuration file template.

But as a developer who is generating lots of storefronts for Solidus framework development, I think it's valuable to expose this as an option. We can use the option defaults and documentation to discourage end users from enabling this in production stores.

I think it's reasonable for newly-generated sandboxes for Solidus framework development to enable alpha features by default. Many framework developers are currently working on alpha `solidus_admin` features.

### Testing

I have manually verified that sandbox apps continue to generate correctly and include the desired `SOLIDUS_ADMIN_ALPHA_FEATURES` setting.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
