### PR TITLE
[solidus_admin] Add configurable pagination resource ratios for admin index pages

### DIFF
--- a/admin/app/controllers/solidus_admin/orders_controller.rb
+++ b/admin/app/controllers/solidus_admin/orders_controller.rb
@@ -18,7 +18,7 @@ module SolidusAdmin
         distinct: false
       )
 
-      set_page_and_extract_portion_from(orders)
+      set_page_and_extract_portion_from(orders, per_page: SolidusAdmin::Config[:pagination_ratios_per_page])
 
       respond_to do |format|
         format.html { render component("orders/index").new(page: @page) }

--- a/admin/app/controllers/solidus_admin/products_controller.rb
+++ b/admin/app/controllers/solidus_admin/products_controller.rb
@@ -25,7 +25,8 @@ module SolidusAdmin
 
       set_page_and_extract_portion_from(
         products,
-        ordered_by: {name: :asc}
+        ordered_by: {name: :asc},
+        per_page: SolidusAdmin::Config[:pagination_ratios_per_page]
       )
 
       respond_to do |format|

--- a/admin/lib/solidus_admin/configuration.rb
+++ b/admin/lib/solidus_admin/configuration.rb
@@ -191,6 +191,13 @@ module SolidusAdmin
     # The HTTP method used to logout the user in the admin interface.
     preference :logout_link_method, :string, default: :delete
 
+    # @!attribute [rw] pagination_ratios_per_page
+    #   @return [Array] An array of four integers representing the number of
+    #   items to display per page in the admin interface. The values in this
+    #   array represent the number of resources displayed on the first, second,
+    #   third and every subsequent page after.
+    preference :pagination_ratios_per_page, :array, default: [15, 30, 50, 100]
+
     # @!attribute [rw] themes
     #   @return [Hash] A hash containing the themes that are available for the admin panel
     preference :themes, :hash, default: {

--- a/admin/spec/requests/solidus_admin/orders_spec.rb
+++ b/admin/spec/requests/solidus_admin/orders_spec.rb
@@ -10,6 +10,41 @@ RSpec.describe "SolidusAdmin::OrdersController", type: :request do
     allow_any_instance_of(SolidusAdmin::BaseController).to receive(:spree_current_user).and_return(admin_user)
   end
 
+  describe "GET #index" do
+    around do |example|
+      original_per_page = SolidusAdmin::Config[:pagination_ratios_per_page]
+      SolidusAdmin::Config[:pagination_ratios_per_page] = [1, 2, 3, 4]
+      example.run
+      SolidusAdmin::Config[:pagination_ratios_per_page] = original_per_page
+    end
+
+    it "paginates resources on first page based on pagination config" do
+      orders = create_list(:completed_order_with_totals, 4)
+      orders.sort_by!(&:completed_at).reverse!
+
+      get solidus_admin.orders_path
+      expect(response).to have_http_status(:ok)
+
+      expect(response.body).to include(orders[0].number)
+      expect(response.body).to_not include(orders[1].number)
+      expect(response.body).to_not include(orders[2].number)
+      expect(response.body).to_not include(orders[3].number)
+    end
+
+    it "paginates resources on second page based on pagination config" do
+      orders = create_list(:completed_order_with_totals, 4)
+      orders.sort_by!(&:completed_at).reverse!
+
+      get solidus_admin.orders_path(params: {page: 2})
+      expect(response).to have_http_status(:ok)
+
+      expect(response.body).to_not include(orders[0].number)
+      expect(response.body).to include(orders[1].number)
+      expect(response.body).to include(orders[2].number)
+      expect(response.body).to_not include(orders[3].number)
+    end
+  end
+
   describe "GET #show" do
     let(:order) { create(:completed_order_with_totals, line_items_count: 3) }
 

--- a/admin/spec/requests/solidus_admin/products_spec.rb
+++ b/admin/spec/requests/solidus_admin/products_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "SolidusAdmin::ProductsController", type: :request do
   end
 
   describe "GET #index" do
-    before { create_list(:product, 3) }
+    let!(:products) { create_list(:product, 3) }
 
     it "renders successfully" do
       get solidus_admin.products_path
@@ -20,6 +20,35 @@ RSpec.describe "SolidusAdmin::ProductsController", type: :request do
     it "loads stock for every product without an N+1" do
       expect { get solidus_admin.products_path }
         .to make_database_queries(matching: /from .spree_stock_items./i, count: 1)
+    end
+
+    context "with pagination config" do
+      around do |example|
+        original_per_page = SolidusAdmin::Config[:pagination_ratios_per_page]
+        SolidusAdmin::Config[:pagination_ratios_per_page] = [1, 2, 3, 4]
+        example.run
+        SolidusAdmin::Config[:pagination_ratios_per_page] = original_per_page
+      end
+
+      it "paginates resources on first and second page based on pagination config" do
+        get solidus_admin.products_path
+        expect(response).to have_http_status(:ok)
+
+        products.sort_by!(&:name)
+
+        expect(response.body).to include(products[0].name)
+        expect(response.body).to_not include(products[1].name)
+        expect(response.body).to_not include(products[2].name)
+
+        # Extract next page query param for cursored pagination.
+        next_href = Nokogiri::HTML(response.body).at_css('a[rel="next"]')["href"]
+        next_page = Rack::Utils.parse_nested_query(URI(next_href).query)["page"]
+
+        get solidus_admin.products_path(params: {page: next_page})
+
+        expect(response.body).to_not include(products[0].name)
+        expect(response.body).to include(products[1].name)
+      end
     end
   end
 

--- a/admin/spec/solidus_admin/configuration_spec.rb
+++ b/admin/spec/solidus_admin/configuration_spec.rb
@@ -130,4 +130,19 @@ RSpec.describe SolidusAdmin::Configuration do
       ])
     end
   end
+
+  describe "#pagination_ratios_per_page" do
+    subject { described_class.new.pagination_ratios_per_page }
+
+    it "returns the number of resources to display on the first, second, third and remaining pages" do
+      expect(subject).to eq([15, 30, 50, 100])
+    end
+
+    it "allows an array of integers to be set as the pagination ratios" do
+      config = described_class.new
+      config.pagination_ratios_per_page = [1, 2, 3, 4]
+
+      expect(config.pagination_ratios_per_page).to eq([1, 2, 3, 4])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This change aims to introduce a new config that can be used in the admin to customize the resource count ratios for geared pagination, without having to override the global configuration that gem provides.

In the future we can extend this to a per-model config, by switching the static configuration to a hash keyed by the resource name, but for now a single config for all resource types is used.

This is still a rough draft, but since there is another PR attempting to do a similar thing, we thought it may be good to open it up for early feedback. The next step is to specify this in the base resources controller and also extract a shared partial that can be used throughout all other index views.

This PR addresses issue https://github.com/solidusio/solidus/issues/6520

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
