### PR TITLE
Prevent JSON 3.0 from breaking solidus_admin when using Rails 8.0

### DIFF
--- a/admin/solidus_admin.gemspec
+++ b/admin/solidus_admin.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "blueprinter"
   s.add_dependency "geared_pagination", "~> 1.1"
+  # Rails < 8.1 isn't compatible with json 3.x
+  s.add_dependency "json", "< 3"
   s.add_dependency "importmap-rails", [">= 2.0", "< 3"]
   s.add_dependency "solidus_backend"
   s.add_dependency "solidus_core", "> 4.2"

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "discard", "~> 2.0"
   s.add_dependency "friendly_id", "~> 5.0"
   s.add_dependency "image_processing", "~> 1.10"
+  s.add_dependency "json", "< 3"
   s.add_dependency "mini_magick", "~> 4.10"
   s.add_dependency "monetize", "~> 1.8"
   s.add_dependency "kt-paperclip", [">= 6.3", "< 8.1"]


### PR DESCRIPTION
## Summary

In JSON 3.0.0, passing the `quirks_mode` keyword to methods was changed from a silent failure to a loud failure -
https://github.com/ruby/json/commit/ebf0f2901c162eb0b3008001a50ba378199a0a2f

The use of the JSON `quirks_mode` was removed from rails in v8.1.0

https://github.com/rails/rails/commit/646f1745e6e9a47c8c70728da68d30825b2d51c6#diff-c202bc84686ddd83549f9603008d8fb9f394a05e76393ff160b7c9494165fc4a

JSON 3.0.0 was released on September 7th.

A few solidus dependencies require json, and none limit major version upgrades, so new bundle operations (such as recreating the sandbox in docker) would resolve to a JSON version  >3

However, our rails version is pinned to 8.0.0 in the docker compose, and attempting to upgrade to 8.1+ in the docker compose results in a failed sandbox creation. 

This means we resolve to a active support version < 8.1 that still uses `quirks_mode`, but a JSON version > 3 which makes using `quirks_mode` an error that fails loudly.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have localized any and all user-facing strings that I added to the source code.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
