### PR TITLE
[solidus_admin] Add stores editor

### DIFF
--- a/admin/app/components/solidus_admin/stores/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/edit/component.html.erb
@@ -12,7 +12,18 @@
     <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
 
     <%= page_footer do %>
-      <%= render component("ui/button").save(form: form_id) %>
+      <div class="flex justify-between w-full">
+        <% unless @store.default %>
+          <%= form_for @store, url: solidus_admin.store_path(@store), method: :delete do %>
+            <%= render component("ui/button").delete(
+              "data-controller": "confirm",
+              "data-confirm-text-value": t("spree.are_you_sure")
+            ) %>
+          <% end %>
+        <% end %>
+
+        <%= render component("ui/button").save(form: form_id) %>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/edit/component.html.erb
@@ -1,29 +1,27 @@
-<%= turbo_frame_tag :resource_form, target: "_top" do %>
-  <%= page do %>
-    <%= page_header do %>
-      <%= page_header_back(back_url) %>
-      <%= page_header_title(@store.name) %>
-      <%= page_header_actions do %>
-        <%= render component("ui/button").discard(path: back_url) %>
-        <%= render component("ui/button").save(form: form_id) %>
-      <% end %>
+<%= page id: :resource_form do %>
+  <%= page_header do %>
+    <%= page_header_back(back_url) %>
+    <%= page_header_title(@store.name) %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").discard(path: back_url) %>
+      <%= render component("ui/button").save(form: form_id) %>
     <% end %>
+  <% end %>
 
-    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+  <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
 
-    <%= page_footer do %>
-      <div class="flex justify-between w-full">
-        <% unless @store.default %>
-          <%= form_for @store, url: solidus_admin.store_path(@store), method: :delete do %>
-            <%= render component("ui/button").delete(
-              "data-controller": "confirm",
-              "data-confirm-text-value": t("spree.are_you_sure")
-            ) %>
-          <% end %>
+  <%= page_footer do %>
+    <div class="flex justify-between w-full">
+      <% unless @store.default %>
+        <%= form_for @store, url: solidus_admin.store_path(@store), method: :delete do %>
+          <%= render component("ui/button").delete(
+            "data-controller": "confirm",
+            "data-confirm-text-value": t("spree.are_you_sure")
+          ) %>
         <% end %>
+      <% end %>
 
-        <%= render component("ui/button").save(form: form_id) %>
-      </div>
-    <% end %>
+      <%= render component("ui/button").save(form: form_id) %>
+    </div>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/edit/component.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
+  <%= page do %>
+    <%= page_header do %>
+      <%= page_header_back(back_url) %>
+      <%= page_header_title(@store.name) %>
+      <%= page_header_actions do %>
+        <%= render component("ui/button").discard(path: back_url) %>
+        <%= render component("ui/button").save(form: form_id) %>
+      <% end %>
+    <% end %>
+
+    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+
+    <%= page_footer do %>
+      <%= render component("ui/button").save(form: form_id) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/stores/edit/component.rb
+++ b/admin/app/components/solidus_admin/stores/edit/component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Stores::Edit::Component < SolidusAdmin::Resources::Edit::Component
+  include SolidusAdmin::Layout::PageHelpers
+end

--- a/admin/app/components/solidus_admin/stores/form/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/form/component.html.erb
@@ -1,0 +1,9 @@
+<%= form_for @store, url: @url, html: { id: @id } do |f| %>
+  <%= page_with_sidebar do %>
+    <%= page_with_sidebar_main do %>
+    <% end %>
+
+    <%= page_with_sidebar_aside do %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/stores/form/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/form/component.html.erb
@@ -1,9 +1,90 @@
 <%= form_for @store, url: @url, html: { id: @id } do |f| %>
   <%= page_with_sidebar do %>
     <%= page_with_sidebar_main do %>
+      <%= render component('ui/panel').new do |panel| %>
+        <% panel.with_section(class: "flex flex-col gap-4") do %>
+          <div class="flex flex-col gap-4 w-full">
+            <%= render component("ui/forms/field").text_field(f, :name) %>
+            <%= render component("ui/forms/field").text_field(f, :code) %>
+            <%= render component("ui/forms/field").text_field(f, :url) %>
+            <%= render component("ui/forms/field").text_field(f, :mail_from_address) %>
+          </div>
+        <% end %>
+      <% end %>
+      <%= render component('ui/panel').new(title: t('.localization')) do |panel| %>
+        <% panel.with_section(class: "flex flex-col gap-4") do %>
+          <div class="flex flex-col gap-4 w-full">
+            <%= render component("ui/forms/field").select(f, :default_currency, Spree::Config.available_currencies.map(&:iso_code)) %>
+            <%= render component("ui/forms/field").select(f, :cart_tax_country_iso, Spree::Country.order(:name).map { |c| [c.name, c.iso] },
+              include_blank: t(".tax_country.no_taxes_without_address")
+            ) %>
+            <%= render component("ui/forms/field").select(f, :available_locales, available_locales, multiple: true) %>
+          </div>
+          <%= render component('ui/panel').new do |inner_panel| %>
+            <% inner_panel.with_section(class: "flex justify-between") do %>
+              <div class="flex gap-2 items-center">
+                <div class="p-1 border border-gray-100 rounded-sm">
+                  <%= render component("ui/icon").new(name: "github-fill", class: "w-9 h-9 fill-gray-500") %>
+                </div>
+                <div class="flex flex-col">
+                  <div class="flex gap-1">
+                    <div class="font-semibold"><%= t(".plugins.solidus_i18n.title") %></div>
+                    <%= render component("ui/badge").new(name: t(".plugins.plugin"), color: :blue, size: :s) %>
+                  </div>
+                  <div class="text-sm text-gray-500"><%= t(".plugins.solidus_i18n.desc") %></div>
+                </div>
+              </div>
+              <div class="flex items-center">
+                <%= render component("ui/button").new(
+                  tag: :a,
+                  text: t(".plugins.install"),
+                  scheme: :secondary,
+                  href: t(".plugins.solidus_i18n.href"),
+                  target: "_blank"
+                ) %>
+              </div>
+            <% end %>
+          <% end %>
+
+          <%= render component('ui/panel').new do |inner_panel| %>
+            <% inner_panel.with_section(class: "flex justify-between") do %>
+              <div class="flex gap-2 items-center">
+                <div class="p-1 border border-gray-100 rounded-sm">
+                  <%= render component("ui/icon").new(name: "github-fill", class: "w-9 h-9 fill-gray-500") %>
+                </div>
+                <div class="flex flex-col">
+                  <div class="flex gap-1">
+                    <div class="font-semibold"><%= t(".plugins.solidus_globalize.title") %></div>
+                    <%= render component("ui/badge").new(name: t(".plugins.plugin"), color: :blue, size: :s) %>
+                  </div>
+                  <div class="text-sm text-gray-500"><%= t(".plugins.solidus_globalize.desc") %></div>
+                </div>
+              </div>
+              <div class="flex items-center">
+                <%= render component("ui/button").new(
+                  tag: :a,
+                  text: t(".plugins.install"),
+                  scheme: :secondary,
+                  href: t(".plugins.solidus_globalize.href"),
+                  target: "_blank"
+                ) %>
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
 
     <%= page_with_sidebar_aside do %>
+      <%= render component('ui/panel').new(title: t('.seo')) do |panel| %>
+        <% panel.with_section(class: "flex flex-col gap-4") do %>
+          <div class="flex flex-col gap-4 w-full">
+            <%= render component("ui/forms/field").text_field(f, :seo_title) %>
+            <%= render component("ui/forms/field").text_field(f, :meta_keywords) %>
+            <%= render component("ui/forms/field").text_field(f, :meta_description) %>
+          </div>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/form/component.rb
+++ b/admin/app/components/solidus_admin/stores/form/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Stores::Form::Component < SolidusAdmin::BaseComponent
+  include SolidusAdmin::Layout::PageHelpers
+
+  def initialize(store:, id:, url:)
+    @store = store
+    @id = id
+    @url = url
+  end
+end

--- a/admin/app/components/solidus_admin/stores/form/component.rb
+++ b/admin/app/components/solidus_admin/stores/form/component.rb
@@ -8,4 +8,10 @@ class SolidusAdmin::Stores::Form::Component < SolidusAdmin::BaseComponent
     @id = id
     @url = url
   end
+
+  def available_locales
+    Spree.i18n_available_locales.map do |locale|
+      [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+    end.sort
+  end
 end

--- a/admin/app/components/solidus_admin/stores/form/component.rb
+++ b/admin/app/components/solidus_admin/stores/form/component.rb
@@ -11,7 +11,7 @@ class SolidusAdmin::Stores::Form::Component < SolidusAdmin::BaseComponent
 
   def available_locales
     Spree.i18n_available_locales.map do |locale|
-      [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+      [I18n.t("spree.i18n.this_file_language", locale: locale, default: locale.to_s, fallback: false), locale]
     end.sort
   end
 end

--- a/admin/app/components/solidus_admin/stores/form/component.yml
+++ b/admin/app/components/solidus_admin/stores/form/component.yml
@@ -1,0 +1,16 @@
+en:
+  localization: Localization
+  plugins:
+    install: Install
+    plugin: Plugin
+    solidus_i18n:
+      href: https://github.com/solidusio/solidus_i18n
+      desc: Translate Solidus Admin in every language
+      title: Solidus i18n
+    solidus_globalize:
+      href: https://github.com/solidusio-contrib/solidus_globalize
+      desc: Translate your store content in every language
+      title: Solidus Globalize
+  seo: SEO
+  tax_country:
+    no_taxes_without_address: No taxes on carts without address

--- a/admin/app/components/solidus_admin/stores/index/component.rb
+++ b/admin/app/components/solidus_admin/stores/index/component.rb
@@ -32,9 +32,9 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
         label: t(".batch_actions.delete"),
         action: solidus_admin.stores_path,
         method: :delete,
-        icon: 'delete-bin-7-line',
-        require_confirmation: true,
-      },
+        icon: "delete-bin-7-line",
+        require_confirmation: true
+      }
     ]
   end
 
@@ -43,7 +43,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
       name_column,
       url_column,
       slug_column,
-      default_column,
+      default_column
     ]
   end
 
@@ -53,7 +53,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :name,
       data: ->(store) do
-        link_to store.name, edit_path(store), class: 'body-link'
+        link_to store.name, edit_path(store), class: "body-link"
       end
     }
   end
@@ -62,7 +62,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :url,
       data: ->(store) do
-        link_to store.url, edit_path(store), class: 'body-link'
+        link_to store.url, edit_path(store), class: "body-link"
       end
     }
   end
@@ -71,7 +71,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :slug,
       data: ->(store) do
-        link_to store.code, edit_path(store), class: 'body-link'
+        link_to store.code, edit_path(store), class: "body-link"
       end
     }
   end
@@ -80,7 +80,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
     {
       header: :default,
       data: ->(store) do
-        store.default? ? component('ui/badge').yes : component('ui/badge').no
+        store.default? ? component("ui/badge").yes : component("ui/badge").no
       end
     }
   end

--- a/admin/app/components/solidus_admin/stores/index/component.rb
+++ b/admin/app/components/solidus_admin/stores/index/component.rb
@@ -14,14 +14,14 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
   end
 
   def edit_path(store)
-    spree.edit_admin_store_path(store)
+    solidus_admin.edit_store_path(store)
   end
 
   def page_actions
     render component("ui/button").new(
       tag: :a,
       text: t(".add"),
-      href: spree.new_admin_store_path,
+      href: solidus_admin.new_store_path,
       icon: "add-line"
     )
   end

--- a/admin/app/components/solidus_admin/stores/index/component.rb
+++ b/admin/app/components/solidus_admin/stores/index/component.rb
@@ -13,7 +13,7 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
     solidus_admin.stores_path
   end
 
-  def row_url(store)
+  def edit_path(store)
     spree.edit_admin_store_path(store)
   end
 
@@ -32,27 +32,56 @@ class SolidusAdmin::Stores::Index::Component < SolidusAdmin::UI::Pages::Index::C
         label: t(".batch_actions.delete"),
         action: solidus_admin.stores_path,
         method: :delete,
-        icon: "delete-bin-7-line"
-      }
+        icon: 'delete-bin-7-line',
+        require_confirmation: true,
+      },
     ]
   end
 
   def columns
     [
-      :name,
-      :url,
-      {
-        header: :slug,
-        data: ->(store) do
-          content_tag :div, store.code
-        end
-      },
-      {
-        header: :default,
-        data: ->(store) do
-          store.default? ? component("ui/badge").yes : component("ui/badge").no
-        end
-      }
+      name_column,
+      url_column,
+      slug_column,
+      default_column,
     ]
+  end
+
+  private
+
+  def name_column
+    {
+      header: :name,
+      data: ->(store) do
+        link_to store.name, edit_path(store), class: 'body-link'
+      end
+    }
+  end
+
+  def url_column
+    {
+      header: :url,
+      data: ->(store) do
+        link_to store.url, edit_path(store), class: 'body-link'
+      end
+    }
+  end
+
+  def slug_column
+    {
+      header: :slug,
+      data: ->(store) do
+        link_to store.code, edit_path(store), class: 'body-link'
+      end
+    }
+  end
+
+  def default_column
+    {
+      header: :default,
+      data: ->(store) do
+        store.default? ? component('ui/badge').yes : component('ui/badge').no
+      end
+    }
   end
 end

--- a/admin/app/components/solidus_admin/stores/new/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/new/component.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag :resource_form, target: "_top" do %>
+  <%= page do %>
+    <%= page_header do %>
+      <%= page_header_back(back_url) %>
+      <%= page_header_title(t('.title')) %>
+      <%= page_header_actions do %>
+        <%= render component("ui/button").discard(path: back_url) %>
+        <%= render component("ui/button").save(form: form_id) %>
+      <% end %>
+    <% end %>
+
+    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+
+    <%= page_footer do %>
+      <%= render component("ui/button").save(form: form_id) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/components/solidus_admin/stores/new/component.html.erb
+++ b/admin/app/components/solidus_admin/stores/new/component.html.erb
@@ -1,18 +1,16 @@
-<%= turbo_frame_tag :resource_form, target: "_top" do %>
-  <%= page do %>
-    <%= page_header do %>
-      <%= page_header_back(back_url) %>
-      <%= page_header_title(t('.title')) %>
-      <%= page_header_actions do %>
-        <%= render component("ui/button").discard(path: back_url) %>
-        <%= render component("ui/button").save(form: form_id) %>
-      <% end %>
-    <% end %>
-
-    <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
-
-    <%= page_footer do %>
+<%= page id: :resource_form do %>
+  <%= page_header do %>
+    <%= page_header_back(back_url) %>
+    <%= page_header_title(t('.title')) %>
+    <%= page_header_actions do %>
+      <%= render component("ui/button").discard(path: back_url) %>
       <%= render component("ui/button").save(form: form_id) %>
     <% end %>
+  <% end %>
+
+  <%= render component("stores/form").new(store: @store, url: form_url, id: form_id) %>
+
+  <%= page_footer do %>
+    <%= render component("ui/button").save(form: form_id) %>
   <% end %>
 <% end %>

--- a/admin/app/components/solidus_admin/stores/new/component.rb
+++ b/admin/app/components/solidus_admin/stores/new/component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SolidusAdmin::Stores::New::Component < SolidusAdmin::Resources::New::Component
+  include SolidusAdmin::Layout::PageHelpers
+end

--- a/admin/app/components/solidus_admin/stores/new/component.yml
+++ b/admin/app/components/solidus_admin/stores/new/component.yml
@@ -1,0 +1,2 @@
+en:
+  title: "New Store"

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -74,6 +74,15 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
     )
   end
 
+  def self.delete(**options)
+    new(
+      tag: :button,
+      text: t(".delete"),
+      scheme: :danger,
+      **options
+    )
+  end
+
   def self.discard(path:, **options)
     new(
       tag: :a,

--- a/admin/app/components/solidus_admin/ui/button/component.yml
+++ b/admin/app/components/solidus_admin/ui/button/component.yml
@@ -1,6 +1,7 @@
 en:
   back: "Back"
   cancel: "Cancel"
+  delete: "Delete"
   discard: "Discard"
   save: "Save"
   submit:

--- a/admin/app/components/solidus_admin/ui/forms/select/component.rb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.rb
@@ -31,6 +31,7 @@ class SolidusAdmin::UI::Forms::Select::Component < SolidusAdmin::BaseComponent
   #   (see `ActionView::Helpers::FormOptionsHelper#options_for_select`).
   #   When +:src+ parameter is provided, use +:choices+ to provide the list of selected options only.
   # @param src [nil, String] URL of a JSON resource with options data to be loaded instead of rendering options in place.
+  # @option attributes [nil, String, Integer, Array<String, Integer>] :value which option should be selected
   # @option attributes [String] :"data-option-value-field"
   # @option attributes [String] :"data-option-label-field" when +:src+ param is passed, value and label of loaded options
   #   will be mapped to JSON response +"id"+ and +"name"+ by default. Use these parameters to map to different keys.

--- a/admin/app/controllers/solidus_admin/stores_controller.rb
+++ b/admin/app/controllers/solidus_admin/stores_controller.rb
@@ -55,7 +55,7 @@ module SolidusAdmin
         :mail_from_address,
         :default_currency,
         :cart_tax_country_iso,
-        available_locales: [],
+        available_locales: []
       )
     end
   end

--- a/admin/app/controllers/solidus_admin/stores_controller.rb
+++ b/admin/app/controllers/solidus_admin/stores_controller.rb
@@ -18,12 +18,24 @@ module SolidusAdmin
     end
 
     def destroy
-      @stores = Spree::Store.where(id: params[:id])
+      @resource = resource_class.where(id: params[:id])
 
-      Spree::Store.transaction { @stores.destroy_all }
+      failed = @resource.destroy_all.reject(&:destroyed?)
+      if failed.none?
+        flash[:notice] = t(".success")
+      else
+        failure_summary = failed.map { |record|
+          t ".error.description",
+            name: record.name,
+            reason: record.errors.full_messages.join(", ")
+        }.join("<br/>")
 
-      flash[:notice] = t(".success")
-      redirect_back_or_to stores_path, status: :see_other
+        flash[:alert] = {
+          danger: {title: t(".error.title"), message: failure_summary}
+        }
+      end
+
+      redirect_to after_destroy_path, status: :see_other
     end
 
     private

--- a/admin/app/controllers/solidus_admin/stores_controller.rb
+++ b/admin/app/controllers/solidus_admin/stores_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusAdmin
-  class StoresController < SolidusAdmin::BaseController
+  class StoresController < SolidusAdmin::ResourcesController
     include SolidusAdmin::ControllerHelpers::Search
 
     def index
@@ -28,8 +28,23 @@ module SolidusAdmin
 
     private
 
-    def store_params
-      params.require(:store).permit(:store_id, permitted_store_attributes)
+    def resource_class = Spree::Store
+
+    def resources_collection = Spree::Store
+
+    def permitted_resource_params
+      params.require(:store).permit(
+        :name,
+        :url,
+        :code,
+        :meta_description,
+        :meta_keywords,
+        :seo_title,
+        :mail_from_address,
+        :default_currency,
+        :cart_tax_country_iso,
+        available_locales: [],
+      )
     end
   end
 end

--- a/admin/config/locales/stores.en.yml
+++ b/admin/config/locales/stores.en.yml
@@ -1,4 +1,19 @@
 en:
+  activerecord:
+    attributes:
+      spree/store:
+        available_locales: Storefront Languages
+        bcc_email: BCC Email
+        cart_tax_country_iso: Tax Country
+        code: Slug
+        default: Default
+        default_currency: Default Currency
+        mail_from_address: Store Email
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        name: Store Name
+        seo_title: Page Title
+        url: URL
   solidus_admin:
     stores:
       title: "Stores"

--- a/admin/config/locales/stores.en.yml
+++ b/admin/config/locales/stores.en.yml
@@ -17,5 +17,12 @@ en:
   solidus_admin:
     stores:
       title: "Stores"
+      create:
+        success: "Store was successfully created."
       destroy:
+        error:
+          title: "Some Stores could not be removed"
+          description: "%{name}: %{reason}"
         success: "Stores were successfully removed."
+      update:
+        success: "Store was successfully updated."

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -79,7 +79,7 @@ SolidusAdmin::Engine.routes.draw do
   admin_resources :shipping_methods, only: [:index, :destroy]
   admin_resources :shipping_categories, except: [:show]
   admin_resources :stock_locations, except: [:show]
-  admin_resources :stores, only: [:index, :destroy]
+  admin_resources :stores, except: [:show]
   admin_resources :zones, except: [:show]
   admin_resources :refund_reasons, except: [:show]
   admin_resources :reimbursement_types, only: [:index]

--- a/admin/spec/components/solidus_admin/ui/button/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/button/component_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe SolidusAdmin::UI::Button::Component, type: :component do
     end
   end
 
+  describe ".delete" do
+    let(:component) { described_class.delete }
+
+    it "renders Delete button" do
+      render_inline(component)
+      expect(page).to have_button("Delete")
+    end
+  end
+
   describe ".discard" do
     let(:component) { described_class.discard(path: "/index") }
 

--- a/admin/spec/features/stores_spec.rb
+++ b/admin/spec/features/stores_spec.rb
@@ -5,20 +5,120 @@ require "spec_helper"
 describe "Stores", :js, type: :feature do
   before { sign_in create(:admin_user, email: "admin@example.com") }
 
-  it "lists stores and allows deleting them" do
-    create(:store, name: "B2C Store")
-    create(:store, name: "B2B Store")
+  describe "index page" do
+    before do
+      create(:store, name: "B2C Store")
+      create(:store, name: "B2B Store", default: true)
+      visit "/admin/stores"
+      expect(page).to have_content("B2C Store")
+      expect(page).to have_content("B2B Store")
+      expect(page).to be_axe_clean
+    end
 
-    visit "/admin/stores"
-    expect(page).to have_content("B2C Store")
-    expect(page).to have_content("B2B Store")
-    expect(page).to be_axe_clean
+    it "lists stores and allows deleting them" do
+      select_row("B2C Store")
 
-    select_row("B2C Store")
-    click_on "Delete"
-    expect(page).to have_content("Stores were successfully removed.")
-    expect(page).not_to have_content("B2C Store")
-    expect(Spree::Store.count).to eq(1)
-    expect(page).to be_axe_clean
+      accept_turbo_confirm("Are you sure you want to delete 1 store?") do
+        click_button("Delete")
+      end
+
+      expect(page).to have_content("Stores were successfully removed.")
+      expect(page).not_to have_content("B2C Store")
+      expect(page).to be_axe_clean
+    end
+
+    it "does not allow to delete default store" do
+      select_row("B2B Store")
+
+      accept_turbo_confirm("Are you sure you want to delete 1 store?") do
+        click_button("Delete")
+      end
+
+      expect(page).not_to have_content("Stores were successfully removed.")
+      expect(page).to have_content("B2B Store")
+      expect(page).to have_content("Some Stores could not be removed")
+      expect(page).to have_content("B2B Store: Cannot destroy the default Store")
+      expect(page).to be_axe_clean
+    end
+  end
+
+  describe "creating new store" do
+    before do
+      visit "/admin/stores"
+      click_on "Add new"
+      expect(page).to be_axe_clean
+    end
+
+    context "with valid form" do
+      it "saves store" do
+        fill_in "Store Name", with: "New Store"
+        fill_in "Slug", with: "new-store"
+        fill_in "URL", with: "www.new-store.com"
+        fill_in "Store Email", with: "mail@new-stores.com"
+
+        within("header") { click_on "Save" }
+
+        expect(page).to have_content("Store was successfully created")
+        expect(page).to have_content("New Store")
+        expect(page).to have_content("new-store")
+        expect(page).to have_content("www.new-store.com")
+      end
+    end
+
+    context "with invalid form" do
+      it "saves store" do
+        within("header") { click_on "Save" }
+
+        expect(page).to have_content("can't be blank", count: 4)
+      end
+    end
+  end
+
+  describe "editing existing store" do
+    before do
+      create(:store,
+        name: "B2C Store",
+        default_currency: "GBP",
+        cart_tax_country_iso: create(:country, iso: "GB").iso,
+        available_locales: %w[en])
+
+      create(:country, iso: "US")
+      visit "/admin/stores"
+      click_on "B2C Store"
+      expect(page).to be_axe_clean
+    end
+
+    it "updates store" do
+      expect(solidus_select_control("Default Currency")).to have_content("GBP")
+      expect(solidus_select_control("Tax Country")).to have_content("United Kingdom")
+      expect(solidus_select_control("Storefront Languages")).to have_content("English (US)")
+
+      fill_in "Store Name", with: "Updated Store"
+      fill_in "Slug", with: "updated-store"
+      fill_in "URL", with: "www.updated-store.com"
+      fill_in "Store Email", with: "updated-mail@new-stores.com"
+      solidus_select("USD", from: "Default Currency")
+      solidus_select("United States", from: "Tax Country")
+
+      within("header") { click_on "Save" }
+
+      expect(page).to have_content("Store was successfully updated")
+      expect(page).to have_content("Updated Store")
+      expect(page).to have_content("updated-store")
+      expect(page).to have_content("www.updated-store.com")
+
+      click_on "Updated Store"
+      expect(solidus_select_control("Default Currency")).to have_content("USD")
+      expect(solidus_select_control("Tax Country")).to have_content("United States")
+    end
+  end
+
+  describe "clicking Discard" do
+    it "redirects back to index" do
+      visit "/admin/stores"
+      click_on "Add new"
+      click_on "Discard"
+      expect(page).to have_current_path("/admin/stores")
+    end
   end
 end

--- a/admin/spec/requests/solidus_admin/stores_spec.rb
+++ b/admin/spec/requests/solidus_admin/stores_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require 'solidus_admin/testing_support/shared_examples/crud_resource_requests'
+
+RSpec.describe "SolidusAdmin::StoresController", type: :request do
+  before { create(:store, default: true) } # create a default store so that we operate on a non-default one
+
+  include_examples 'CRUD resource requests', 'store' do
+    let(:resource_class) { Spree::Store }
+    let(:valid_attributes) { { name: "Store", code: "store", url: "store.com", mail_from_address: "store@example.com" } }
+    let(:invalid_attributes) { { name: "" } }
+  end
+end

--- a/admin/spec/requests/solidus_admin/stores_spec.rb
+++ b/admin/spec/requests/solidus_admin/stores_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require 'solidus_admin/testing_support/shared_examples/crud_resource_requests'
+require "solidus_admin/testing_support/shared_examples/crud_resource_requests"
 
 RSpec.describe "SolidusAdmin::StoresController", type: :request do
   before { create(:store, default: true) } # create a default store so that we operate on a non-default one
 
-  include_examples 'CRUD resource requests', 'store' do
+  include_examples "CRUD resource requests", "store" do
     let(:resource_class) { Spree::Store }
-    let(:valid_attributes) { { name: "Store", code: "store", url: "store.com", mail_from_address: "store@example.com" } }
-    let(:invalid_attributes) { { name: "" } }
+    let(:valid_attributes) { {name: "Store", code: "store", url: "store.com", mail_from_address: "store@example.com"} }
+    let(:invalid_attributes) { {name: ""} }
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -25,7 +25,7 @@ module Spree
     self.allowed_ransackable_attributes = %w[name url code]
 
     before_save :ensure_default_exists_and_is_unique
-    before_destroy :validate_not_default
+    before_destroy :validate_not_default, prepend: true
 
     enum :reverse_charge_status, {
       disabled: 0,
@@ -73,6 +73,7 @@ module Spree
     def validate_not_default
       if default
         errors.add(:base, :cannot_destroy_default_store)
+        throw :abort
       end
     end
   end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -136,4 +136,24 @@ RSpec.describe Spree::Store, type: :model do
       expect { Spree::Store.new(reverse_charge_status: :invalid_status) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#validate_not_default" do
+    context "when deleting a default store" do
+      it "prevents deletion" do
+        store = create(:store, default: true)
+        expect(store.destroy).to eq false
+        expect(store.errors.full_messages.join).to match /Cannot destroy/
+        expect { store.reload }.not_to raise_error
+      end
+    end
+
+    context "when deleting a non-default store" do
+      it "allows deletion" do
+        create(:store, default: true)
+        store = create(:store, default: false)
+        expect(store.destroy).to be_truthy
+        expect { store.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Spree::Store, type: :model do
       it "prevents deletion" do
         store = create(:store, default: true)
         expect(store.destroy).to eq false
-        expect(store.errors.full_messages.join).to match /Cannot destroy/
+        expect(store.errors.full_messages.join).to match(/Cannot destroy/)
         expect { store.reload }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Summary

Replaces #6228.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/ace6b207-e3b3-4469-b9bc-af11f8f4436a" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/60c63bf7-ed9e-4123-93e4-c9492421abd0" />

This pull request creates the initial store creator and editor interface for `solidus_admin`. I have co-opted an old pull request implementing this feature and have verified, after rebasing against `main` and resolving merge conflicts, that it's in working order.

Since I am creating this replacement PR, I will take responsibility for resolving any issues that come up as the result of code review.

## Checklist

The original author checked off all checklist items on the original pull request #6228.

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
