### PR TITLE
[v4.7] Disallow setting payment amounts through the orders and payments APIs

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -155,7 +155,25 @@ module Spree
       end
 
       def permitted_order_attributes
-        can?(:admin, Spree::Order) ? (super + admin_order_attributes) : super
+        if can?(:admin, Spree::Order)
+          super + admin_order_attributes
+        else
+          # We need to remove the `:amount` attribute from payments_attributes
+          # for non-admin users. Unfortunately, order_attributes uses the
+          # checkout_payment_attributes instead of the payment_attributes, which
+          # needs to be able to set the amount.
+          #
+          # We're doing a deep_dup here to avoid modifying the original
+          # permitted attributes, which could have unintended side effects.
+          order_attributes = super.deep_dup
+
+          payments_attributes = order_attributes.find do |attribute|
+            attribute.is_a?(Hash) && attribute.has_key?(:payments_attributes)
+          end
+          payments_attributes[:payments_attributes] -= [:amount]
+
+          order_attributes
+        end
       end
 
       def permitted_shipment_attributes

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -11,6 +11,12 @@ module Spree
 
       class_attribute :admin_payment_attributes
       self.admin_payment_attributes = [:payment_method, :amount, :state, source: {}]
+      msg = "`Spree::Api::OrdersController.admin_payment_attributes` is deprecated."
+      deprecate(
+        admin_payment_attributes: msg,
+        "admin_payment_attributes=": msg,
+        deprecator: Spree.deprecator
+      )
 
       before_action :find_order, except: [:create, :mine, :current, :index]
       around_action :lock_order, except: [:create, :mine, :current, :index, :show]
@@ -161,6 +167,12 @@ module Spree
       end
 
       def permitted_payment_attributes
+        Spree.deprecator.warn(
+          "`Spree::Api::OrdersController#permitted_payment_attributes` is deprecated. " \
+          "This method was never actually used in this controller because " \
+          "permitted_order_attributes uses the permitted_checkout_payment_attributes " \
+          "method to determine the permitted attributes for payments."
+        )
         if can?(:admin, Spree::Payment)
           super + admin_payment_attributes
         else

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -3,6 +3,9 @@
 module Spree
   module Api
     class PaymentsController < Spree::Api::BaseController
+      class_attribute :admin_payment_attributes
+      self.admin_payment_attributes = [:amount]
+
       before_action :find_order
       around_action :lock_order, only: [:create, :update, :authorize, :capture, :purchase, :void]
       before_action :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void]
@@ -77,6 +80,14 @@ module Spree
 
       def payment_params
         params.require(:payment).permit(permitted_payment_attributes)
+      end
+
+      def permitted_payment_attributes
+        if can?(:admin, Spree::Payment)
+          super + admin_payment_attributes
+        else
+          super
+        end
       end
     end
   end

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -76,6 +76,19 @@ module Spree::Api
               }.not_to change { Spree::Payment.count }
             end
           end
+
+          context "when passing an amount" do
+            let(:attributes) { super().merge(payments_attributes: [{ payment_method_id: payment_method.id, amount: 100 }]) }
+            let!(:payment_method) { create(:check_payment_method, name: "allowed") }
+
+            it "ignores the amount parameter" do
+              expect {
+                subject
+              }.to change { Spree::Payment.count }.by(1)
+
+              expect(Spree::Payment.last.amount).to eq(0)
+            end
+          end
         end
       end
 

--- a/api/spec/requests/spree/api/payments_spec.rb
+++ b/api/spec/requests/spree/api/payments_spec.rb
@@ -45,7 +45,7 @@ module Spree::Api
           end
 
           it "can create a new payment" do
-            post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id, amount: 50}}
+            post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id}}
             expect(response.status).to eq(201)
             expect(json_response).to have_attributes(attributes)
           end
@@ -56,7 +56,6 @@ module Spree::Api
                 payment: {
                   customer_metadata: {"type" => "credit card"},
                   payment_method_id: Spree::PaymentMethod.first.id,
-                  amount: 50,
                   source_attributes: {gateway_payment_profile_id: 1}
                 }
               }
@@ -71,7 +70,7 @@ module Spree::Api
               Spree::PaymentMethod.first.update!(available_to_users: false)
 
               expect {
-                post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id, amount: 50}}
+                post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id}}
               }.not_to change { Spree::Payment.count }
               expect(response.status).to eq(404)
             end
@@ -81,7 +80,7 @@ module Spree::Api
         context "payment source is required" do
           context "no source is provided" do
             it "returns errors" do
-              post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id, amount: 50}}
+              post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id}}
               expect(response.status).to eq(422)
               expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
               expect(json_response["errors"]["source"]).to eq(["can't be blank"])
@@ -90,7 +89,7 @@ module Spree::Api
 
           context "source is provided" do
             it "can create a new payment" do
-              post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id, amount: 50, source_attributes: {gateway_payment_profile_id: 1}}}
+              post spree.api_order_payments_path(order), params: {payment: {payment_method_id: Spree::PaymentMethod.first.id, source_attributes: {gateway_payment_profile_id: 1}}}
               expect(response.status).to eq(201)
               expect(json_response).to have_attributes(attributes)
             end
@@ -103,7 +102,7 @@ module Spree::Api
         end
 
         it "cannot update a payment" do
-          put spree.api_order_payment_path(order, payment), params: {payment: {amount: 2.01}}
+          put spree.api_order_payment_path(order, payment), params: {payment: {}}
           assert_unauthorized!
         end
 

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -77,7 +77,9 @@ module Spree
           params[:payment][:source_attributes] = source_params
         end
 
-        params.require(:payment).permit(permitted_payment_attributes)
+        # Admins are allowed to set the amount of a payment, so we need to
+        # permit it here. This is not permitted for non-admin users.
+        params.require(:payment).permit(permitted_payment_attributes + [:amount])
       end
 
       def load_data

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -73,7 +73,7 @@ module Spree
 
     @@option_type_attributes = [:name, :presentation, option_values_attributes: option_value_attributes]
 
-    @@payment_attributes = [:amount, :payment_method_id, :payment_method, customer_metadata: {}]
+    @@payment_attributes = [:payment_method_id, :payment_method, customer_metadata: {}]
 
     @@product_properties_attributes = [:property_name, :value, :position]
 
@@ -165,6 +165,7 @@ module Spree
 
     @@checkout_payment_attributes = [
       payments_attributes: payment_attributes + [
+        :amount,
         source_attributes:
       ]
     ]


### PR DESCRIPTION
Backport of GHSA-c2fq-w6qj-3hj4 (merged to main via the security advisory) to v4.7. Clean cherry-pick of the three commits.