### PR TITLE
[v4.6] Deny anonymous access to guest credit cards

### DIFF
--- a/api/spec/requests/spree/api/credit_cards_spec.rb
+++ b/api/spec/requests/spree/api/credit_cards_spec.rb
@@ -124,5 +124,51 @@ module Spree::Api
         end
       end
     end
+
+    # Regression test for the anonymous guest-card authorization flaw.
+    # An unauthenticated caller may hold a token for an order they own; that
+    # must not grant them access to another customer's guest-checkout card
+    # (user_id NULL), which the `user_id: user.id` customer rule used to match.
+    describe "#update as an anonymous attacker" do
+      # NOTE: authentication is deliberately NOT stubbed here so the real
+      # anonymous request path is exercised.
+      let!(:attacker_order) { create(:order) }
+      let!(:guest_card) { create(:credit_card, name: "Victim Guest", user: nil) }
+
+      def attack(card)
+        put spree.api_credit_card_path(card.to_param), params: {
+          order_token: attacker_order.guest_token,
+          order_id: attacker_order.number,
+          credit_card: {name: "ATTACKER WAS HERE"}
+        }
+      end
+
+      it "refuses to update a stranger's guest credit card" do
+        attack(guest_card)
+
+        expect(response.status).to eq(401)
+        expect(guest_card.reload.name).to eq("Victim Guest")
+      end
+
+      it "refuses a guest card built by a real guest checkout" do
+        guest_order = create(:order, user: nil, email: "guest@example.com")
+        payment_method = create(:credit_card_payment_method)
+        payment = Spree::PaymentCreate.new(guest_order, {
+          payment_method_id: payment_method.id,
+          source_attributes: {
+            number: "4111111111111111", month: "1", year: "#{2.years.from_now.year}",
+            verification_value: "123", name: "Real Guest Buyer"
+          }
+        }).build
+        payment.save!
+        card = payment.source.reload
+        expect(card.user_id).to be_nil
+
+        attack(card)
+
+        expect(response.status).to eq(401)
+        expect(card.reload.name).to eq("Real Guest Buyer")
+      end
+    end
   end
 end

--- a/core/app/models/spree/permission_sets/default_customer.rb
+++ b/core/app/models/spree/permission_sets/default_customer.rb
@@ -63,18 +63,18 @@ module Spree
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user
         end
-        can [:read, :update], CreditCard, user_id: user.id
+        can [:read, :update], CreditCard, user_id: user.id if user.persisted?
         can :read, Product
         can :read, ProductProperty
         can :read, Property
         can :create, Spree.user_class
-        can [:show, :update, :update_email], Spree.user_class, id: user.id
+        can [:show, :update, :update_email], Spree.user_class, id: user.id if user.persisted?
         can :read, State
         can :read, StockItem, stock_location: { active: true }
         can :read, StockLocation, active: true
         can :read, Taxon
         can :read, Taxonomy
-        can [:save_in_address_book, :remove_from_address_book], Spree.user_class, id: user.id
+        can [:save_in_address_book, :remove_from_address_book], Spree.user_class, id: user.id if user.persisted?
         can [:read, :view_out_of_stock], Variant
         can :read, Zone
       end

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -6,7 +6,7 @@ require 'cancan/matchers'
 require 'spree/testing_support/ability_helpers'
 
 RSpec.describe Spree::Ability, type: :model do
-  let(:user) { build(:user) }
+  let(:user) { create(:user) }
   let(:ability) { Spree::Ability.new(user) }
   let(:token) { nil }
 

--- a/core/spec/models/spree/permission_sets/default_customer_spec.rb
+++ b/core/spec/models/spree/permission_sets/default_customer_spec.rb
@@ -16,6 +16,38 @@ RSpec.describe Spree::PermissionSets::DefaultCustomer do
     end
   end
 
+  context "for CreditCard" do
+    let(:guest_card) { create(:credit_card, user: nil) }
+
+    context "with an anonymous (non-persisted) ability" do
+      let(:ability) { Spree::Ability.new(nil) }
+
+      # Regression test for the anonymous guest-card authorization flaw:
+      # an anonymous ability has a non-persisted placeholder user whose #id is
+      # nil, which must not match guest cards (user_id NULL) via `user_id: user.id`.
+      it "cannot read or update a guest credit card" do
+        expect(ability).not_to be_able_to(:read, guest_card)
+        expect(ability).not_to be_able_to(:update, guest_card)
+      end
+    end
+
+    context "with a persisted user" do
+      let(:user) { create(:user) }
+      let(:ability) { Spree::Ability.new(user) }
+      let(:own_card) { create(:credit_card, user: user) }
+
+      it "can read and update its own credit card" do
+        expect(ability).to be_able_to(:read, own_card)
+        expect(ability).to be_able_to(:update, own_card)
+      end
+
+      it "cannot read or update another user's or a guest credit card" do
+        expect(ability).not_to be_able_to(:update, create(:credit_card, user: create(:user)))
+        expect(ability).not_to be_able_to(:update, guest_card)
+      end
+    end
+  end
+
   context 'as Guest User' do
     context 'for Order' do
       context 'guest_token is empty string' do


### PR DESCRIPTION
Backport of GHSA-92gv-2pxv-7gjg (merged to main via the security advisory) to v4.6. One spec conflict resolved to match this branch's quoting style.