### PR TITLE
Fix Shipment#item_cost overcounting a split line item (#2919)

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -133,7 +133,13 @@ module Spree
     end
 
     def item_cost
-      line_items.sum(&:total)
+      # `line_items` is a distinct join through inventory_units, so a line item
+      # split across several shipments shows up in every one of them. Prorate
+      # each line item's total by the fraction of its units that are actually
+      # in this shipment instead of counting the whole line item in each.
+      manifest.sum do |item|
+        item.line_item.total * item.quantity / item.line_item.quantity
+      end
     end
 
     def ready_or_pending?

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -210,6 +210,41 @@ RSpec.describe Spree::Shipment, type: :model do
     it "should equal line items final amount with tax" do
       expect(shipment.item_cost).to eql(11.0)
     end
+
+    # Regression test for https://github.com/solidusio/solidus/issues/2919
+    context "when a line item's units are split across shipments" do
+      let(:order) do
+        create(
+          :order_ready_to_ship,
+          line_items_attributes: [{price: 10, quantity: 2, variant:}],
+          ship_address:
+        )
+      end
+
+      let(:second_shipment) do
+        order.shipments.create!(
+          state: "pending",
+          cost: 0,
+          stock_location: shipment.stock_location
+        )
+      end
+
+      before do
+        # `line_items` is a distinct join through inventory_units, so both
+        # shipments see the same (single) line item even though each only
+        # holds one of its two units.
+        second_shipment
+        unit_to_move = shipment.inventory_units.last
+        unit_to_move.update_column(:shipment_id, second_shipment.id)
+        shipment.reload
+        second_shipment.reload
+      end
+
+      it "only counts the units actually present in each shipment, not the whole line item" do
+        expect(shipment.item_cost).to eql(11.0)
+        expect(second_shipment.item_cost).to eql(11.0)
+      end
+    end
   end
 
   describe "#total_before_tax" do


### PR DESCRIPTION
Fixes #2919.

`Shipment#item_cost` sums `line_items.sum(&:total)`, but `line_items` is a distinct join through `inventory_units`. When a line item's units are split across two shipments, both shipments see that same line item and each one's `item_cost` counts the *whole* line item's total, not just the units it actually holds. For a 2-unit line item split 1/1 across two shipments, `item_cost` doubles the real cost across the order.

Switched it to use `manifest` instead, which is already grouped per shipment (`line_item`, `variant`, `quantity` of units actually in this shipment). Each line item's total gets prorated by `quantity_in_this_shipment / line_item.quantity`. For the common case of one shipment holding all of a line item's units this is unchanged (the full total), so the existing spec covering tax still passes as-is.

Added a regression test: one line item with quantity 2, one unit moved to a second shipment, and each shipment's `item_cost` should be half the line item's total (with the old code both shipments returned the full total).
