### PR TITLE
Stop claiming to restrict stock location read access (#4744)

### DIFF
--- a/core/app/models/spree/permission_sets/restricted_stock_display.rb
+++ b/core/app/models/spree/permission_sets/restricted_stock_display.rb
@@ -2,11 +2,12 @@
 
 module Spree
   module PermissionSets
-    # Read permissions for stock limited to allowed locations.
+    # Admin permissions for stock, limited to allowed locations.
     #
-    # This permission set allows users to view information about stock items and
-    # locations, both of them limited to locations they have access to.
-    # Permissions are also granted for the admin panel for items.
+    # DefaultCustomer already grants every user plain `:read` on any active
+    # stock location and its stock items, so this permission set's only
+    # meaningful, genuinely-restricted grant is `:admin` (used to gate the
+    # admin stock UI), not `:read`.
     class RestrictedStockDisplay < PermissionSets::Base
       class << self
         def privilege
@@ -20,7 +21,11 @@ module Spree
 
       def activate!
         can [:read, :admin], Spree::StockItem, stock_location_id: location_ids
-        can :read, Spree::StockLocation, id: location_ids
+        # No `can :read, Spree::StockLocation` here: every user, regardless of role,
+        # already gets `can :read, StockLocation, active: true` from the always-on
+        # `:default` role's DefaultCustomer permission set. CanCan combines rules for
+        # the same subject with OR, so a narrower grant here can't restrict that wider
+        # one — it can only ever widen it (to inactive locations) or do nothing.
       end
 
       private

--- a/core/app/models/spree/permission_sets/restricted_stock_management.rb
+++ b/core/app/models/spree/permission_sets/restricted_stock_management.rb
@@ -5,8 +5,7 @@ module Spree
     # Full permissions for stock management limited to allowed locations.
     #
     # This permission set grants full control over all stock items a user has
-    # access to their locations. Those locations are also readable by the
-    # corresponding ability.
+    # access to their locations.
     class RestrictedStockManagement < PermissionSets::Base
       class << self
         def privilege
@@ -20,7 +19,11 @@ module Spree
 
       def activate!
         can :manage, Spree::StockItem, stock_location_id: location_ids
-        can :read, Spree::StockLocation, id: location_ids
+        # No `can :read, Spree::StockLocation` here: every user, regardless of role,
+        # already gets `can :read, StockLocation, active: true` from the always-on
+        # `:default` role's DefaultCustomer permission set. CanCan combines rules for
+        # the same subject with OR, so a narrower grant here can't restrict that wider
+        # one — it can only ever widen it (to inactive locations) or do nothing.
       end
 
       private

--- a/core/spec/models/spree/permission_sets/restricted_stock_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_display_spec.rb
@@ -25,11 +25,41 @@ RSpec.describe Spree::PermissionSets::RestrictedStockDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:read, sl1) }
+    # This permission set does not grant `:read` on `StockLocation` at all (see
+    # https://github.com/solidusio/solidus/issues/4744): every user already gets
+    # `can :read, StockLocation, active: true` from the always-on `:default` role,
+    # so a narrower grant here could never actually restrict location visibility —
+    # it could only accidentally widen it to inactive locations. Neither of these
+    # inactive locations is readable through either permission set.
+    it { is_expected.to_not be_able_to(:read, sl1) }
     it { is_expected.to_not be_able_to(:read, sl2) }
 
     it { is_expected.to be_able_to(:read, item1) }
     it { is_expected.to_not be_able_to(:read, item2) }
+  end
+
+  context "when activated, with active locations" do
+    let(:sl1) { create :stock_location, active: true }
+    let(:sl2) { create :stock_location, active: true }
+
+    before do
+      described_class.new(ability).activate!
+    end
+
+    # Documents the actual, known limitation reported in #4744: DefaultCustomer
+    # grants every user `:read` on any active StockLocation, and `:read` on any
+    # StockItem at an active location, regardless of this permission set — so
+    # neither is genuinely restrictable to assigned locations once they're
+    # active. Only the `:admin` action (not granted by DefaultCustomer) stays
+    # scoped to assigned locations.
+    it { is_expected.to be_able_to(:read, sl1) }
+    it { is_expected.to be_able_to(:read, sl2) }
+
+    it { is_expected.to be_able_to(:read, item1) }
+    it { is_expected.to be_able_to(:read, item2) }
+
+    it { is_expected.to be_able_to(:admin, item1) }
+    it { is_expected.to_not be_able_to(:admin, item2) }
   end
 
   context "when not activated" do

--- a/core/spec/models/spree/permission_sets/restricted_stock_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_management_spec.rb
@@ -25,8 +25,33 @@ RSpec.describe Spree::PermissionSets::RestrictedStockManagement do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:read, sl1) }
+    # This permission set does not grant `:read` on `StockLocation` at all (see
+    # https://github.com/solidusio/solidus/issues/4744): every user already gets
+    # `can :read, StockLocation, active: true` from the always-on `:default` role,
+    # so a narrower grant here could never actually restrict location visibility —
+    # it could only accidentally widen it to inactive locations. Neither of these
+    # inactive locations is readable through either permission set.
+    it { is_expected.to_not be_able_to(:read, sl1) }
     it { is_expected.to_not be_able_to(:read, sl2) }
+
+    it { is_expected.to be_able_to(:manage, item1) }
+    it { is_expected.to_not be_able_to(:manage, item2) }
+  end
+
+  context "when activated, with active locations" do
+    let(:sl1) { create :stock_location, active: true }
+    let(:sl2) { create :stock_location, active: true }
+
+    before do
+      described_class.new(ability).activate!
+    end
+
+    # Documents the actual, known limitation reported in #4744: stock location
+    # read access is granted to every user via DefaultCustomer regardless of
+    # this permission set, including for a location the user isn't assigned to.
+    # `:manage` on `StockItem` remains correctly scoped to assigned locations.
+    it { is_expected.to be_able_to(:read, sl1) }
+    it { is_expected.to be_able_to(:read, sl2) }
 
     it { is_expected.to be_able_to(:manage, item1) }
     it { is_expected.to_not be_able_to(:manage, item2) }


### PR DESCRIPTION
Addresses #4744 (the "read access isn't actually restricted" half of it; not using a closing keyword since that issue also tracks a separate, still-open admin Stock UI UX fix this PR doesn't touch).

Implements the direction kennyadsl landed on in the issue thread: drop the `can :read, Spree::StockLocation, id: location_ids` line from `RestrictedStockManagement` rather than trying to make it actually restrictive.

The reason it can't be restrictive: DefaultCustomer grants every user, regardless of role, `can :read, StockLocation, active: true` (that's the `:default` role, which every user gets alongside whatever roles they're assigned). CanCan ORs together multiple `can` rules for the same subject, so a narrower rule elsewhere can only ever widen what's granted, never take it back down. The `id: location_ids` line in `RestrictedStockManagement` was doing nothing for active locations (already covered by DefaultCustomer) and only mattered for inactive ones, which is the opposite of "restricted".

While fixing this I found `RestrictedStockDisplay` has the identical line and the identical problem, plus one more layer: DefaultCustomer also grants plain `:read` on any `StockItem` at an active location, so that permission set's `:read` is equally unrestrictable — only its `:admin` grant (which DefaultCustomer never grants) is genuinely scoped to assigned locations. Removed the same line there and updated its spec to match.

`RestrictedStockManagement`'s `can :manage, StockItem` isn't affected by any of this — DefaultCustomer never grants `:manage`, so that stays correctly scoped to assigned locations.

Both specs previously only exercised inactive stock locations, which is how they were passing despite the bug — DefaultCustomer's grant only kicks in for `active: true`. Added an "with active locations" context to both specs that exercises the real-world case from the issue and documents which actions are and aren't actually restrictable post-fix.

Out of scope: kennyadsl also flagged that the admin Stock UI should stop showing/allowing edits on locations a user can't manage, as a follow-up UX fix. That's a separate admin-panel change I haven't touched here — #4744 should stay open for it after this merges.