### PR TITLE
[solidus_admin] Use button for panel action

### DIFF
--- a/admin/app/components/solidus_admin/products/show/component.html.erb
+++ b/admin/app/components/solidus_admin/products/show/component.html.erb
@@ -42,6 +42,7 @@
         <%= render component("ui/panel").new(title: t(".media")) do |panel| %>
           <% panel.with_action(
             name: t(".manage_images"),
+            scheme: :secondary,
             href: spree.admin_product_images_path(@product)
           ) %>
         <% end %>
@@ -59,6 +60,7 @@
 
           <% panel.with_action(
             name: t(".manage_stock"),
+            scheme: :secondary,
             href: spree.admin_product_stock_path(@product)
           ) %>
         <% end %>
@@ -112,6 +114,7 @@
 
           <% panel.with_action(
             name: t(".manage_options"),
+            scheme: :secondary,
             href: solidus_admin.option_types_path
           ) %>
         <% end %>
@@ -119,6 +122,7 @@
         <%= render component("ui/panel").new(title: t(".specifications")) do |panel| %>
           <% panel.with_action(
             name: t(".manage_properties"),
+            scheme: :secondary,
             href: spree.admin_product_product_properties_path(@product)
           ) %>
         <% end %>

--- a/admin/app/components/solidus_admin/ui/button/component.rb
+++ b/admin/app/components/solidus_admin/ui/button/component.rb
@@ -63,6 +63,17 @@ class SolidusAdmin::UI::Button::Component < SolidusAdmin::BaseComponent
     )
   }
 
+  def self.add(path:, **options)
+    new(
+      tag: :a,
+      text: t(".add"),
+      icon: "add-line",
+      scheme: :primary,
+      href: path,
+      **options
+    )
+  end
+
   def self.back(path:, **options)
     new(
       tag: :a,

--- a/admin/app/components/solidus_admin/ui/button/component.yml
+++ b/admin/app/components/solidus_admin/ui/button/component.yml
@@ -1,4 +1,5 @@
 en:
+  add: "Add"
   back: "Back"
   cancel: "Cancel"
   delete: "Delete"

--- a/admin/app/components/solidus_admin/ui/panel/component.rb
+++ b/admin/app/components/solidus_admin/ui/panel/component.rb
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
 
 class SolidusAdmin::UI::Panel::Component < SolidusAdmin::BaseComponent
-  renders_one :action, ->(name:, href:, icon: "add-box-fill", **args) {
-    link_to(
-      icon_tag(icon, class: "w-[1.4em] h-[1.4em]") + name,
-      href,
-      **args,
-      class: "flex gap-1 hover:underline"
-    )
+  renders_one :action, ->(name:, href:, icon: "add-line", size: :m, **args) {
+    render component("ui/button").add(text: name, path: href, icon:, size:, **args)
   }
 
   renders_many :sections, ->(**args, &block) do

--- a/admin/spec/components/solidus_admin/ui/button/component_spec.rb
+++ b/admin/spec/components/solidus_admin/ui/button/component_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe SolidusAdmin::UI::Button::Component, type: :component do
     end
   end
 
+  describe ".add" do
+    let(:component) { described_class.add(path: "/index") }
+
+    it "renders Add button" do
+      render_inline(component)
+      expect(page).to have_link(href: "/index", text: "Add")
+    end
+  end
+
   describe ".back" do
     let(:component) { described_class.back(path: "/index") }
 


### PR DESCRIPTION
## Summary

Instead of a oddly styled text link we use the new button
style for actions (links) in panel footers.

#### Before

<img width="2880" height="1800" alt="Screen Shot 2026-09-11 at 09 25 07" src="https://github.com/user-attachments/assets/44dbbfde-ba2f-4c28-9d62-53c21b64fc79" />

<img width="2880" height="1800" alt="Screen Shot 2026-09-11 at 09 52 43" src="https://github.com/user-attachments/assets/70b7f8b8-96a0-4031-9fa4-cd4f1aba0f74" />

#### After

<img width="2880" height="1800" alt="Screen Shot 2026-09-11 at 09 24 28" src="https://github.com/user-attachments/assets/e53532a5-53fe-4893-ac40-410dd39e174c" />

<img width="2880" height="1800" alt="Screen Shot 2026-09-11 at 09 51 00" src="https://github.com/user-attachments/assets/a84c1ea1-bfb6-47fc-8a82-b03904fa0d2e" />

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
