### PR TITLE
[solidus_admin] Lower base font size

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/field/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/field/component.html.erb
@@ -2,7 +2,7 @@
   <div class="flex gap-1 items-center">
     <span class="
       text-gray-700
-      font-semibold text-xs
+      font-semibold
     "><%= @label %></span>
 
     <%= render component('ui/toggletip').new(text: @tip) if @tip.present? %>
@@ -18,7 +18,7 @@
 
   <% if @hint.present? || @error.present? %>
     <div class="
-      font-normal text-xs
+      font-normal
       [:disabled~&]:text-gray-300 text-gray-500
       flex gap-1 flex-col [&>.error]:hidden [&>.error]:peer-invalid:block
     ">

--- a/admin/app/components/solidus_admin/ui/forms/select/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/select/component.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-2 w-full">
   <div class="flex gap-1 items-center">
-    <label class="text-gray-700 font-semibold text-xs" <%= tag.attributes for: @attributes[:id] %>>
+    <label class="text-gray-700 font-semibold" <%= tag.attributes for: @attributes[:id] %>>
       <%= @label %>
     </label>
     <%= render component('ui/toggletip').new(text: @tip) if @tip.present? %>
@@ -10,7 +10,7 @@
 
   <% if @hint.present? || @error.present? %>
     <div class="
-      font-normal text-xs
+      font-normal
       [:disabled~&]:text-gray-300 text-gray-500
       flex gap-1 flex-col [&>.error]:hidden [&>.error]:peer-invalid:block
     ">

--- a/admin/app/components/solidus_admin/ui/table/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/table/component.html.erb
@@ -101,7 +101,7 @@
     </colgroup>
 
     <thead
-      class="bg-gray-15 text-gray-700 text-left text-small"
+      class="bg-gray-15 text-gray-700 text-left"
       data-<%= stimulus_id %>-target="defaultHeader"
     >
       <tr>
@@ -114,7 +114,7 @@
     <% if @data.batch_actions && @data.rows.any? %>
       <thead
         data-<%= stimulus_id %>-target="batchHeader"
-        class="bg-white color-black text-xs leading-none text-left"
+        class="bg-white color-black leading-none text-left"
         hidden
       >
         <tr>

--- a/admin/app/components/solidus_admin/ui/toast/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/toast/component.html.erb
@@ -15,7 +15,7 @@
 >
   <%= icon_tag(@icon, class: 'w-[1.125rem] h-[1.125rem] mr-2 fill-current') if @icon %>
 
-  <p class="font-semibold text-xs leading-none"><%= @text %></p>
+  <p class="font-semibold leading-none"><%= @text %></p>
 
   <button
     type="button"

--- a/admin/app/views/layouts/solidus_admin/application.html.erb
+++ b/admin/app/views/layouts/solidus_admin/application.html.erb
@@ -17,7 +17,7 @@
     <meta name="turbo-refresh-scroll", content="preserve">
   </head>
 
-  <body class="bg-gray-15 font-sans">
+  <body class="bg-gray-15 font-sans text-sm">
     <%= render component("layout/skip_link").new(href: "#main") %>
     <div class="flex gap-0">
       <div class="min-w-[240px] border-r border-r-gray-100 relative">


### PR DESCRIPTION
## Summary

The current legacy admin and all new admin design mockups use 14px as base font size for body text. Without the class the browser will use whatever base font is defined in the browser (usually 16px) which looks oddly off with main nav and while switching from legacy to new admin.

#### Before

<img width="2880" height="1800" alt="Screen Shot 2026-09-11 at 09 30 06" src="https://github.com/user-attachments/assets/e4a66fc3-e267-4fdf-ad99-8587ddb34297" />

#### After

<img width="2880" height="1800" alt="Screen Shot 2026-09-11 at 09 29 49" src="https://github.com/user-attachments/assets/c37000ae-1c9e-475d-97ef-b3505010592a" />


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
